### PR TITLE
Removing sugestion embed code

### DIFF
--- a/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/process-files-review.stage.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/process-files-review.stage.ts
@@ -864,8 +864,18 @@ export class ProcessFilesReview extends BasePipelineStage<CodeReviewPipelineCont
                     context?.codeReviewConfig?.kodyFineTuningConfig?.enabled,
                 );
 
+            const keepedSuggestions: Partial<CodeSuggestion>[] = getDataPipelineKodyFineTunning?.keepedSuggestions?.map(suggestion => {
+                const { suggestionEmbed, ...rest } = suggestion as any;
+                return rest;
+            });
+
+            const discardedSuggestions: Partial<CodeSuggestion>[] = getDataPipelineKodyFineTunning?.discardedSuggestions?.map(suggestion => {
+                const { suggestionEmbed, ...rest } = suggestion as any;
+                return rest;
+            });
+
             discardedSuggestionsByKodyFineTuning.push(
-                ...getDataPipelineKodyFineTunning.discardedSuggestions.map(
+                ...discardedSuggestions.map(
                     (suggestion) => {
                         suggestion.priorityStatus =
                             PriorityStatus.DISCARDED_BY_KODY_FINE_TUNING;
@@ -880,8 +890,7 @@ export class ProcessFilesReview extends BasePipelineStage<CodeReviewPipelineCont
                     context?.pullRequest?.number,
                     file,
                     patchWithLinesStr,
-                    getDataPipelineKodyFineTunning?.keepedSuggestions ??
-                        suggestionsWithId,
+                    keepedSuggestions,
                     context?.codeReviewConfig?.languageResultPrompt,
                     reviewModeResponse,
                 );
@@ -891,8 +900,7 @@ export class ProcessFilesReview extends BasePipelineStage<CodeReviewPipelineCont
 
             discardedSuggestionsBySafeGuard.push(
                 ...this.suggestionService.getDiscardedSuggestions(
-                    getDataPipelineKodyFineTunning?.keepedSuggestions ??
-                        suggestionsWithId,
+                    keepedSuggestions,
                     safeGuardResponse?.suggestions || [],
                     PriorityStatus.DISCARDED_BY_SAFEGUARD,
                 ),


### PR DESCRIPTION
**Pull Request Description**:

This pull request focuses on refining the suggestion handling mechanism within the Kody Fine Tuning step of the code review pipeline. Specifically, it extracts `keepedSuggestions` and `discardedSuggestions` from the fine-tuning results and removes the `suggestionEmbed` property from these lists. These processed lists are then utilized in the subsequent safeguard filtering and suggestion processing steps. This change aims to streamline the suggestion processing workflow by eliminating unnecessary data.