### PR TITLE
add new methods save logs in lote

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,7 +10,6 @@ services:
                 max-file: '10'
         ports:
             - '3001:3001'
-            - '9229:9229'
         environment:
             - ENV=production
             - API_NODE_ENV=production

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -10,6 +10,7 @@ services:
                 max-file: '10'
         ports:
             - '3001:3001'
+            - '9229:9229'
         environment:
             - ENV=production
             - API_NODE_ENV=production

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -5,6 +5,7 @@ module.exports = {
             script: './dist/main.js', // Caminho atualizado
             out_file: '/app/logs/kodus-orchestrator/out.log',
             error_file: '/app/logs/kodus-orchestrator/error.log',
+            node_args: '--heapsnapshot-signal=SIGUSR2 --prof',
             env_homolog: {
                 API_NODE_ENV: 'homolog',
             },

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -5,7 +5,7 @@ module.exports = {
             script: './dist/main.js', // Caminho atualizado
             out_file: '/app/logs/kodus-orchestrator/out.log',
             error_file: '/app/logs/kodus-orchestrator/error.log',
-            node_args: '--heapsnapshot-signal=SIGUSR2 --prof',
+            node_args: '--heapsnapshot-signal=SIGUSR2',
             env_homolog: {
                 API_NODE_ENV: 'homolog',
             },

--- a/src/core/domain/log/contracts/log.repository.contracts.ts
+++ b/src/core/domain/log/contracts/log.repository.contracts.ts
@@ -5,6 +5,7 @@ export const LOG_REPOSITORY_TOKEN = Symbol('LogRepository');
 
 export interface ILogRepository {
     create(log: Omit<ILog, 'uuid'>): Promise<LogEntity | void>;
+    createMany(logs: Array<Omit<ILog, 'uuid'>>): Promise<void>;
     update(
         filter: Partial<ILog>,
         data: Partial<ILog>,

--- a/src/core/infrastructure/adapters/repositories/mongoose/log.repository.ts
+++ b/src/core/infrastructure/adapters/repositories/mongoose/log.repository.ts
@@ -17,6 +17,22 @@ export class LogDatabaseRepository implements ILogRepository {
         private readonly logModel: Model<LogModel>,
     ) {}
 
+    // Em LogRepository
+    async createMany(logs: Array<Omit<ILog, 'uuid'>>): Promise<void> {
+        if (!logs || logs.length === 0) {
+            return;
+        }
+        try {
+            await this.logModel.insertMany(logs, { ordered: false });
+        } catch (error) {
+            console.error(
+                'Erro ao inserir logs em lote (batch) no repositório:',
+                error,
+            );
+            throw error;
+        }
+    }
+
     async findOne(filter?: Partial<ILog>): Promise<LogEntity> {
         try {
             const log = await this.logModel.findOne(filter).exec();

--- a/src/core/infrastructure/adapters/repositories/mongoose/schema/log.model.ts
+++ b/src/core/infrastructure/adapters/repositories/mongoose/schema/log.model.ts
@@ -5,6 +5,10 @@ import { Prop, SchemaFactory, Schema } from '@nestjs/mongoose';
     collection: 'log',
     timestamps: true,
     autoIndex: true,
+    writeConcern: {
+        w: 1,
+        j: true,
+    },
 })
 export class LogModel extends CoreDocument {
     @Prop({ type: String })

--- a/src/core/infrastructure/adapters/services/logger/log.service.ts
+++ b/src/core/infrastructure/adapters/services/logger/log.service.ts
@@ -14,6 +14,10 @@ export class LogService implements ILogService {
         private readonly logRepository: ILogRepository,
     ) {}
 
+    createMany(logs: Array<Omit<ILog, 'uuid'>>): Promise<void> {
+        return this.logRepository.createMany(logs);
+    }
+
     findOne(filter?: Partial<ILog>): Promise<LogEntity> {
         return this.logRepository.findOne(filter);
     }


### PR DESCRIPTION
This pull request introduces several enhancements and modifications to the `kodus-ai` repository, specifically targeting the logging functionality and production configuration:

1. **Production Docker Compose Configuration**:
   - Adds a port mapping for `9229:9229` in `docker-compose.prod.yml`, which is typically used for Node.js debugging.

2. **PM2 Configuration**:
   - Updates `ecosystem.config.js` to include Node.js arguments for enabling heap snapshots and V8 profiling.

3. **Log Repository Enhancements**:
   - Introduces a `createMany` method in `log.repository.ts` within the `LogDatabaseRepository`. This method allows for efficient batch insertion of log entries, includes input validation for empty arrays, uses MongoDB's `insertMany` with `ordered: false` for resilience, and incorporates error handling that logs issues to the console and re-throws exceptions.

4. **Log Service Enhancements**:
   - Adds a `createMany` method to `log.service.ts` in the `LogService`, enabling batch creation of log entries by delegating the operation to the `logRepository`.

5. **Pino Logger Service Enhancements**:
   - Introduces a log buffering and batching mechanism in `pino.service.ts` within the `PinoLoggerService`. Logs are collected in a buffer and flushed to a persistent store (`logService.createMany`) periodically or when the buffer reaches its maximum size, optimizing logging performance.
   - New methods are added for managing the flush interval (`startFlushInterval`, `stopFlushInterval`), flushing logs (`flushLogs`), and handling errors during this process (`handleFlushError`).
   - Integrates graceful shutdown via `onModuleDestroy`.
   - Updates the `saveLogToDB` method to utilize the new buffering logic.
   - Re-establishes pino-pretty transport options within `baseLogger` and makes minor adjustments in `handleLog` related to early returns and child logger creation.