### PR TITLE
Fix/kody rules severity tags

### DIFF
--- a/src/ee/kodyRules/service/kodyRules.service.ts
+++ b/src/ee/kodyRules/service/kodyRules.service.ts
@@ -56,7 +56,7 @@ export class KodyRulesService implements IKodyRulesService {
             const normalized = entity.toObject();
             normalized.rules = normalized.rules.map((rule) => ({
                 ...rule,
-                severity: rule.severity?.toLowerCase() as any,
+                severity: rule.severity?.toLowerCase(),
             }));
             return KodyRulesEntity.create(normalized);
         });


### PR DESCRIPTION
This pull request addresses the standardization of the 'severity' field for Kody rules within the `kodus-ai` repository. The changes ensure that the 'severity' field is consistently stored in lowercase during creation, update, and retrieval operations. Additionally, the `find` method in `kodyRules.service.ts` has been refactored to enhance type safety and improve code clarity. The source branch for these changes is `fix/kody-rules-severity-tags`, and the target branch is `main`.