### PR TITLE
Fixing default config

### DIFF
--- a/src/core/application/use-cases/parameters/update-or-create-code-review-parameter-use-case.ts
+++ b/src/core/application/use-cases/parameters/update-or-create-code-review-parameter-use-case.ts
@@ -119,7 +119,7 @@ export class UpdateOrCreateCodeReviewParameterUseCase {
             generatePRSummary: true,
             customInstructions: '',
             behaviourForExistingDescription:
-                BehaviourForExistingDescription.REPLACE,
+                BehaviourForExistingDescription.CONCATENATE,
         };
     }
 

--- a/src/core/infrastructure/adapters/services/codeBase/commentAnalysis.service.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/commentAnalysis.service.ts
@@ -27,6 +27,7 @@ import {
     prompt_KodyRulesGeneratorUser,
 } from '@/shared/utils/langchainCommon/prompts/kodyRulesGenerator';
 import {
+    BehaviourForExistingDescription,
     CodeReviewConfig,
     ReviewOptions,
 } from '@/config/types/general/codeReview.type';
@@ -387,6 +388,11 @@ export class CommentAnalysisService {
                 suggestionControl: {
                     ...defaultConfig.suggestionControl,
                     severityLevelFilter: SeverityLevel.HIGH,
+                },
+                summary: {
+                    ...defaultConfig.summary,
+                    behaviourForExistingDescription:
+                        BehaviourForExistingDescription.CONCATENATE,
                 },
                 kodyRulesGeneratorEnabled: true,
             };


### PR DESCRIPTION
This pull request addresses the default configuration for handling existing descriptions in pull request summaries within the `kodus-ai` repository. The changes are made in two files:

1. In `src/core/application/use-cases/parameters/update-or-create-code-review-parameter-use-case.ts`, the default behavior for handling existing descriptions in PR summaries is updated from `REPLACE` to `CONCATENATE` in the `getDefaultPRSummaryConfig` method.

2. In `src/core/infrastructure/adapters/services/codeBase/commentAnalysis.service.ts`, a new option, `behaviourForExistingDescription`, is added to the summary settings. The configuration generation logic is updated to set this option to `CONCATENATE`, while maintaining other existing summary defaults. The necessary `BehaviourForExistingDescription` type is also imported to support this enhancement.