### PR TITLE
fix(auth-guard): add health endpoint to auth-exceptions

### DIFF
--- a/src/core/infrastructure/adapters/services/auth/jwt-auth.guard.ts
+++ b/src/core/infrastructure/adapters/services/auth/jwt-auth.guard.ts
@@ -72,6 +72,7 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
             '/gitlab/webhook',
             '/bitbucket/webhook',
             '/azure-repos/webhook',
+            '/health'
         ];
 
         // Allow access to public routes


### PR DESCRIPTION
In a kubernetes-setup the `health`-endpoint is used for the readiness- and startup-probes, to update a pod without downtime.

The health-endpoint should in my opinion therefore be excluded from the auth-guard.