### PR TITLE
fixed method mapped repo fullName

### DIFF
--- a/src/shared/utils/webhooks/azureRepos.ts
+++ b/src/shared/utils/webhooks/azureRepos.ts
@@ -84,7 +84,7 @@ export class AzureReposMappedPlatform implements IMappedPlatform {
             id: repo.id ? String(repo.id) : '',
             name: repo.name ?? '',
             language: null,
-            fullName: extractRepoFullName(pullRequest),
+            fullName: extractRepoFullName(pullRequest) ?? repo.name ?? '',
         };
     }
 

--- a/src/shared/utils/webhooks/azureRepos.ts
+++ b/src/shared/utils/webhooks/azureRepos.ts
@@ -84,7 +84,7 @@ export class AzureReposMappedPlatform implements IMappedPlatform {
             id: repo.id ? String(repo.id) : '',
             name: repo.name ?? '',
             language: null,
-            fullName: extractRepoFullName(pullRequest) ?? repo.name ?? '',
+            fullName: extractRepoFullName(pullRequest) ?? repo?.name ?? '',
         };
     }
 

--- a/src/shared/utils/webhooks/bitbucket.ts
+++ b/src/shared/utils/webhooks/bitbucket.ts
@@ -76,7 +76,10 @@ export class BitbucketMappedPlatform implements IMappedPlatform {
             id: repository?.uuid,
             name: repository?.name,
             language: null,
-            fullName: extractRepoFullName(params.payload?.pullrequest),
+            fullName:
+                extractRepoFullName(params.payload?.pullrequest) ??
+                repository.name ??
+                '',
         };
     }
 

--- a/src/shared/utils/webhooks/bitbucket.ts
+++ b/src/shared/utils/webhooks/bitbucket.ts
@@ -78,7 +78,7 @@ export class BitbucketMappedPlatform implements IMappedPlatform {
             language: null,
             fullName:
                 extractRepoFullName(params.payload?.pullrequest) ??
-                repository.name ??
+                repository?.name ??
                 '',
         };
     }

--- a/src/shared/utils/webhooks/github.ts
+++ b/src/shared/utils/webhooks/github.ts
@@ -75,7 +75,10 @@ export class GithubMappedPlatform implements IMappedPlatform {
             id: repository?.id.toString(),
             name: repository?.name,
             language: repository?.language,
-            fullName: extractRepoFullName(params?.payload?.pull_request),
+            fullName:
+                extractRepoFullName(params?.payload?.pull_request) ??
+                repository.name ??
+                '',
         };
     }
 

--- a/src/shared/utils/webhooks/github.ts
+++ b/src/shared/utils/webhooks/github.ts
@@ -77,7 +77,7 @@ export class GithubMappedPlatform implements IMappedPlatform {
             language: repository?.language,
             fullName:
                 extractRepoFullName(params?.payload?.pull_request) ??
-                repository.name ??
+                repository?.name ??
                 '',
         };
     }

--- a/src/shared/utils/webhooks/gitlab.ts
+++ b/src/shared/utils/webhooks/gitlab.ts
@@ -94,7 +94,7 @@ export class GitlabMappedPlatform implements IMappedPlatform {
             id: project?.id?.toString(),
             name: project?.name,
             language: null,
-            fullName: extractRepoFullName(mergeRequest) ?? project.name ?? '',
+            fullName: extractRepoFullName(mergeRequest) ?? project?.name ?? '',
         };
     }
 

--- a/src/shared/utils/webhooks/gitlab.ts
+++ b/src/shared/utils/webhooks/gitlab.ts
@@ -94,7 +94,7 @@ export class GitlabMappedPlatform implements IMappedPlatform {
             id: project?.id?.toString(),
             name: project?.name,
             language: null,
-            fullName: extractRepoFullName(mergeRequest),
+            fullName: extractRepoFullName(mergeRequest) ?? project.name ?? '',
         };
     }
 

--- a/src/shared/utils/webhooks/index.ts
+++ b/src/shared/utils/webhooks/index.ts
@@ -19,7 +19,7 @@ export const extractRepoFullName = (pullRequest: any): string => {
         pullRequest?.base?.repo?.full_name ||
         pullRequest?.target?.path_with_namespace ||
         pullRequest?.destination?.repository?.full_name ||
-        ''
+        null
     );
 };
 


### PR DESCRIPTION
This pull request addresses improvements in the logic for determining the `fullName` of repositories across various platforms in the `kodus-ai` project. The updates focus on enhancing the robustness of the `mapRepository` method by implementing a series of fallback mechanisms to ensure that `fullName` is always a string, thereby preventing potential issues with null or undefined values.

Changes include:
- **Azure Repos**: The `mapRepository` method now uses nullish coalescing to default `fullName` to `repo.name` if `extractRepoFullName(pullRequest)` is null or undefined, and further defaults to an empty string if necessary.
- **Bitbucket**: A fallback chain is introduced for `fullName`, prioritizing `extractRepoFullName`, then `repository.name`, and finally an empty string.
- **GitHub**: The `GithubMappedPlatform` now employs a multi-step fallback for `fullName`, starting with `extractRepoFullName` using pull request data, followed by `repository.name`, and defaulting to an empty string.
- **GitLab**: The logic for `fullName` in the GitLab webhook mapping now falls back to `project.name` and then an empty string if `extractRepoFullName(mergeRequest)` is null or undefined.
- **General**: The `extractRepoFullName` function's fallback return value is changed from an empty string to `null` when a repository full name cannot be extracted.

These changes aim to improve performance and reliability in handling repository names across different platforms.