### PR TITLE
Adding validation to apply link

### DIFF
--- a/src/core/infrastructure/adapters/repositories/mongoose/pullRequests.repository.ts
+++ b/src/core/infrastructure/adapters/repositories/mongoose/pullRequests.repository.ts
@@ -249,10 +249,20 @@ export class PullRequestsRepository implements IPullRequestsRepository {
                     $addFields: {
                         files: {
                             $filter: {
-                                input: '$files',
+                                input: { $ifNull: ['$files', []] },
                                 as: 'file',
                                 cond: {
-                                    $gt: [{ $size: '$$file.suggestions' }, 0],
+                                    $gt: [
+                                        {
+                                            $size: {
+                                                $ifNull: [
+                                                    '$$file.suggestions',
+                                                    [],
+                                                ],
+                                            },
+                                        },
+                                        0,
+                                    ],
                                 },
                             },
                         },

--- a/src/core/infrastructure/adapters/services/codeBase/commentManager.service.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/commentManager.service.ts
@@ -37,6 +37,11 @@ import {
     MODEL_STRATEGIES,
     LLMModelProvider,
 } from '../llmProviders/llmModelProvider.helper';
+import { ParametersKey } from '@/shared/domain/enums/parameters-key.enum';
+import {
+    IParametersService,
+    PARAMETERS_SERVICE_TOKEN,
+} from '@/core/domain/parameters/contracts/parameters.service.contract';
 
 @Injectable()
 export class CommentManagerService implements ICommentManagerService {
@@ -47,6 +52,8 @@ export class CommentManagerService implements ICommentManagerService {
         private readonly logger: PinoLoggerService,
         @Inject(LLM_PROVIDER_SERVICE_TOKEN)
         private readonly llmProviderService: LLMProviderService,
+        @Inject(PARAMETERS_SERVICE_TOKEN)
+        private readonly parametersService: IParametersService,
     ) {
         this.llmResponseProcessor = new LLMResponseProcessor(logger);
     }
@@ -835,10 +842,17 @@ ${reviewOptionsMarkdown}
                 jsonMode: true,
             });
 
+            const language = (
+                await this.parametersService.findByKey(
+                    ParametersKey.LANGUAGE_CONFIG,
+                    organizationAndTeamData,
+                )
+            )?.configValue;
+
             const chain = RunnableSequence.from([
                 async (input: any) => {
                     const systemPrompt =
-                        prompt_repeated_suggestion_clustering_system();
+                        prompt_repeated_suggestion_clustering_system(language);
 
                     return [
                         {

--- a/src/shared/utils/langchainCommon/prompts/repeatedCodeReviewSuggestionClustering.ts
+++ b/src/shared/utils/langchainCommon/prompts/repeatedCodeReviewSuggestionClustering.ts
@@ -1,4 +1,4 @@
-export const prompt_repeated_suggestion_clustering_system = () => {
+export const prompt_repeated_suggestion_clustering_system = (language: string) => {
     return `
 You are an expert senior software engineer specializing in code review, software engineering principles, and identifying improvements in code quality. Additionally, you have a reputation as a tough, no-nonsense reviewer who is not afraid to be critical (this is crucial).
 
@@ -51,6 +51,8 @@ Rules for identifying and grouping similar suggestions:
     - Focus on the solution without mentioning specific files or line numbers
     - Be generic enough to apply to all occurrences of the issue
     - Start with "Please" or an action verb
+11. This step should only be applied when the primary suggestion (suggestion used in the problemDescription) uses the kody_rules label:
+mention in the problemDescription the kody_rule hyperlink in the same markdown format that is in the suggestionContent of the original suggestion: [text to be displayed](url)
 </analysis_rules>
 
 <output_format>
@@ -69,6 +71,8 @@ At the end of the analysis, the output should be in the following JSON format:
 }
 \`\`\`
 </output_format>
+
+All your answers must be in ${language} language
 
 Below is my list of code suggestions for you to do your analysis.
 `;


### PR DESCRIPTION
This pull request focuses on enhancing the `replaceKodyRuleIdsWithLinks` method within the `kodyRulesAnalysis.service.ts` file. The modification ensures that suggestions for replacing Kody Rule IDs with links are processed only when their label is `LabelType.KODY_RULES`. This is implemented by enclosing the existing logic for ID detection and link generation within a conditional block. Additionally, an import statement for `LabelType` has been introduced to facilitate this update.