### PR TITLE
Fix/last analyzed commit

### DIFF
--- a/src/config/database/typeorm/migrations/1749579680002-addPrNumberAndRepositoryIdinAutomationExecutionTable.ts
+++ b/src/config/database/typeorm/migrations/1749579680002-addPrNumberAndRepositoryIdinAutomationExecutionTable.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddPrNumberAndRepositoryIdinAutomationExecutionTable1749579680002 implements MigrationInterface {
+    name = 'AddPrNumberAndRepositoryIdinAutomationExecutionTable1749579680002'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "automation_execution"
+            ADD "pullRequestNumber" integer
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "automation_execution"
+            ADD "repositoryId" character varying
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "automation_execution" DROP COLUMN "repositoryId"
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "automation_execution" DROP COLUMN "pullRequestNumber"
+        `);
+    }
+
+}

--- a/src/core/application/use-cases/platformIntegration/codeManagement/create-prs-code-review.use-case.ts
+++ b/src/core/application/use-cases/platformIntegration/codeManagement/create-prs-code-review.use-case.ts
@@ -79,7 +79,9 @@ export class CreatePRCodeReviewUseCase implements IUseCase {
             status: AutomationStatus.ERROR,
             dataExecution: {},
             teamAutomation: { uuid: codeReviewAutomationId },
-            origin: ""
+            origin: "",
+            pullRequestNumber: null,
+            repositoryId: null
         }
 
         await this.automationExecutionService.register(startedCodeReview)

--- a/src/core/domain/automation/entities/automation-execution.entity.ts
+++ b/src/core/domain/automation/entities/automation-execution.entity.ts
@@ -10,6 +10,8 @@ export class AutomationExecutionEntity implements IAutomationExecution {
     private _status: AutomationStatus;
     private _errorMessage?: string;
     private _dataExecution?: any;
+    private _pullRequestNumber?: number;
+    private _repositoryId?: string;
     private _teamAutomation?: Partial<ITeamAutomation>;
     private _origin?: string;
 
@@ -24,6 +26,8 @@ export class AutomationExecutionEntity implements IAutomationExecution {
         this._status = automationExecution.status;
         this._errorMessage = automationExecution.errorMessage;
         this._dataExecution = automationExecution.dataExecution;
+        this._pullRequestNumber = automationExecution?.pullRequestNumber;
+        this._repositoryId = automationExecution?.repositoryId;
         this._teamAutomation = automationExecution.teamAutomation;
         this._origin = automationExecution.origin;
     }
@@ -58,6 +62,14 @@ export class AutomationExecutionEntity implements IAutomationExecution {
 
     public get dataExecution(): any {
         return this._dataExecution;
+    }
+
+    public get pullRequestNumber(): number {
+        return this._pullRequestNumber;
+    }
+
+    public get repositoryId(): string {
+        return this._repositoryId;
     }
 
     public get teamAutomation(): Partial<IAutomation> {

--- a/src/core/domain/automation/interfaces/automation-execution.interface.ts
+++ b/src/core/domain/automation/interfaces/automation-execution.interface.ts
@@ -8,6 +8,8 @@ export interface IAutomationExecution {
     status: AutomationStatus;
     errorMessage?: string;
     dataExecution?: any;
+    pullRequestNumber?: number;
+    repositoryId?: string;
     teamAutomation?: Partial<ITeamAutomation>;
     origin: string;
 }

--- a/src/core/infrastructure/adapters/repositories/typeorm/schema/automationExecution.model.ts
+++ b/src/core/infrastructure/adapters/repositories/typeorm/schema/automationExecution.model.ts
@@ -18,6 +18,12 @@ export class AutomationExecutionModel extends CoreModel {
     @Column({ type: 'jsonb', nullable: true })
     dataExecution: any;
 
+    @Column({ nullable: true })
+    pullRequestNumber?: number;
+
+    @Column({ nullable: true })
+    repositoryId?: string;
+
     @ManyToOne(
         () => TeamAutomationModel,
         (teamAutomation) => teamAutomation.executions,

--- a/src/core/infrastructure/adapters/services/automation/processAutomation/strategies/automationCodeReview.ts
+++ b/src/core/infrastructure/adapters/services/automation/processAutomation/strategies/automationCodeReview.ts
@@ -144,6 +144,7 @@ export class AutomationCodeReviewService
                             commentId: result.commentId,
                             noteId: result.noteId,
                             threadId: result.threadId,
+                            repositoryId: repository?.id,
                         },
                         teamAutomationId,
                         'System',
@@ -201,6 +202,8 @@ export class AutomationCodeReviewService
             dataExecution: data,
             teamAutomation: { uuid: teamAutomationId },
             origin,
+            pullRequestNumber: data?.pullRequestNumber,
+            repositoryId: data?.repositoryId,
         };
 
         this.automationExecutionService.register(automationExecution);

--- a/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/fetch-changed-files.stage.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/fetch-changed-files.stage.ts
@@ -42,6 +42,8 @@ export class FetchChangedFilesStage extends BasePipelineStage<CodeReviewPipeline
                 {
                     status: AutomationStatus.SUCCESS,
                     teamAutomation: { uuid: context.teamAutomationId },
+                    pullRequestNumber: context.pullRequest.number,
+                    repositoryId: context?.repository?.id,
                 },
             );
 

--- a/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/process-files-review.stage.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/process-files-review.stage.ts
@@ -614,6 +614,7 @@ export class ProcessFilesReview extends BasePipelineStage<CodeReviewPipelineCont
                 await this.findLastTeamAutomationCodeReviewExecution(
                     organizationAndTeamData.teamId,
                     pullRequest.number,
+                    repository.id,
                     platformType,
                 );
 
@@ -628,6 +629,7 @@ export class ProcessFilesReview extends BasePipelineStage<CodeReviewPipelineCont
     private async findLastTeamAutomationCodeReviewExecution(
         teamAutomationId: string,
         pullRequestNumber: number,
+        repositoryId: string,
         platformType: string,
     ) {
         const lastTeamAutomationCodeReviewExecution: AutomationExecutionEntity =
@@ -636,6 +638,8 @@ export class ProcessFilesReview extends BasePipelineStage<CodeReviewPipelineCont
                 {
                     status: AutomationStatus.SUCCESS,
                     teamAutomation: { uuid: teamAutomationId },
+                    pullRequestNumber: pullRequestNumber,
+                    repositoryId: repositoryId,
                 },
             );
 


### PR DESCRIPTION
This pull request addresses enhancements and fixes related to the handling of automation executions in the `kodus-ai` repository. The changes focus on improving the logging and querying of automation execution data by incorporating additional context, specifically the `pullRequestNumber` and `repositoryId`.

Key modifications include:

1. **Method Enhancements**:
   - The `registerFailedAutomationExecution` method in `create-prs-code-review.use-case.ts` now logs `origin`, `pullRequestNumber`, and `repositoryId` for failed automation executions, with the latter two initialized to `null`.

2. **Entity and Interface Updates**:
   - The `AutomationExecutionEntity` is extended with optional properties `_pullRequestNumber` and `_repositoryId`, accessible via new getter methods.
   - The `IAutomationExecution` interface now includes `pullRequestNumber` and `repositoryId` as optional properties, allowing for more detailed context storage.

3. **Repository Refactoring**:
   - The `findLatestExecutionByDataExecutionFilter` method in `automationExecution.repository.ts` is refactored to use a two-step query strategy, prioritizing new dedicated columns for PR number and repository ID before falling back to a legacy JSONB field approach.

4. **Service Enhancements**:
   - The `AutomationCodeReviewService` now includes `repositoryId` in the data for automation executions, ensuring both `pullRequestNumber` and `repositoryId` are top-level properties in new records.

5. **Pipeline Stage Updates**:
   - The filtering logic in `fetch-changed-files.stage.ts` and `process-files-review.stage.ts` is updated to incorporate `pullRequestNumber` and `repositoryId`, with suggestions for refining the inclusion of `repositoryId` to enhance maintainability.

These changes aim to improve the accuracy and completeness of data related to automation executions, particularly in the context of code review processes.