### PR TITLE
fixing error docker certs connection

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -17,12 +17,10 @@ services:
         volumes:
             - .:/usr/src/app:delegated
             - /usr/src/app/node_modules
+            - ./certs:/usr/src/app/certs:ro
         networks:
             - kodus-backend-services
             - shared-network
-        secrets:
-            - source: ast_root_ca
-              target: certs/ca_cert.pem
 
     db_postgres:
         build:
@@ -66,7 +64,3 @@ networks:
         external: true
     shared-network:
         external: true
-
-secrets:
-  ast_root_ca:
-    file: ./certs/ca_cert.pem

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,6 +4,7 @@ services:
         container_name: ${CONTAINER_NAME}
         volumes:
             - log_volume:/app/logs
+            - ./certs:/usr/src/app/certs:ro
         logging:
             driver: json-file
             options:
@@ -22,9 +23,6 @@ services:
         networks:
             - shared-network
         restart: unless-stopped
-        secrets:
-            - source: ast_root_ca
-              target: certs/ca_cert.pem
 
 volumes:
     log_volume:
@@ -32,7 +30,3 @@ volumes:
 networks:
     shared-network:
         external: true
-
-secrets:
-  ast_root_ca:
-    file: ./certs/ca_cert.pem

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -4,6 +4,7 @@ services:
     container_name: ${CONTAINER_NAME}
     volumes:
       - log_volume:/app/logs
+      - ./certs:/usr/src/app/certs:ro
     logging:
       driver: json-file
       options:
@@ -19,9 +20,6 @@ services:
     networks:
       - shared-network
     restart: unless-stopped
-    secrets:
-      - source: ast_root_ca
-        target: certs/ca_cert.pem
 
 volumes:
   log_volume:
@@ -29,7 +27,3 @@ volumes:
 networks:
   shared-network:
     external: true
-
-secrets:
-  ast_root_ca:
-    file: ./certs/ca_cert.pem

--- a/src/ee/configs/microservices/ast-options.ts
+++ b/src/ee/configs/microservices/ast-options.ts
@@ -4,19 +4,16 @@ import { ClientProviderOptions, Transport } from '@nestjs/microservices';
 import { resolve } from 'path';
 import { cwd } from 'process';
 
-const rootCa = fs.readFileSync(resolve(cwd(), './certs/ca_cert.pem'));
-
 function buildGrpcCredentials(): ChannelCredentials {
-    const caPath = resolve(process.cwd(), 'certs/ca_cert.pem');
+    const caPath = resolve(cwd(), 'certs/ca_cert.pem');
     if (fs.existsSync(caPath)) {
         const rootCa = fs.readFileSync(caPath);
         return credentials.createSsl(rootCa);
     }
-
     return credentials.createInsecure();
 }
 
-export const AST_MICROSERVICE_OPTIONS = {
+export const AST_MICROSERVICE_OPTIONS: ClientProviderOptions = {
     name: 'AST_MICROSERVICE',
     transport: Transport.GRPC,
     options: {
@@ -31,4 +28,4 @@ export const AST_MICROSERVICE_OPTIONS = {
         },
         credentials: buildGrpcCredentials(),
     },
-} as ClientProviderOptions;
+};


### PR DESCRIPTION
This pull request addresses the issue of Docker certificate connection errors by modifying the Docker Compose configurations and refactoring the AST microservice configuration. 

In the `docker-compose.dev.yml`, the `kodus-orchestrator` service now uses a direct volume mount of a local `./certs` directory, configured as read-only, instead of Docker secrets for certificate management. Similarly, in the `docker-compose.prod.yml`, a volume mount for the local `./certs` directory is added to the `kodus-orchestrator` service, making the certificates available in read-only mode. The `docker-compose.qa.yml` is updated to include a read-only volume mount that maps a local `./certs` directory to `/usr/src/app/certs` inside the `kodus-orchestrator` container, likely for SSL/TLS certificates.

Additionally, the `src/ee/configs/microservices/ast-options.ts` file is refactored to update the CA certificate path definition within the `buildGrpcCredentials` function and improve the typing of `AST_MICROSERVICE_OPTIONS` with a type annotation for better clarity and type safety.