### PR TITLE
Fix/llm providers for extract prompts

### DIFF
--- a/src/core/infrastructure/adapters/services/codeBase/llmAnalysis.service.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/llmAnalysis.service.ts
@@ -1018,7 +1018,7 @@ ${JSON.stringify(context?.suggestions, null, 2) || 'No suggestions provided'}
     ) {
         try {
             let llm = this.llmProviderService.getLLMProvider({
-                model: MODEL_STRATEGIES[provider].modelName,
+                model: provider,
                 temperature: 0,
                 callbacks: [this.tokenTracker],
             });

--- a/test/unit/core/infrastructure/adapters/services/codeBase/llmAnalysis.service.spec.ts
+++ b/test/unit/core/infrastructure/adapters/services/codeBase/llmAnalysis.service.spec.ts
@@ -1,0 +1,189 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LLMAnalysisService } from '@/core/infrastructure/adapters/services/codeBase/llmAnalysis.service';
+import { LLMProviderService } from '@/core/infrastructure/adapters/services/llmProviders/llmProvider.service';
+import { PinoLoggerService } from '@/core/infrastructure/adapters/services/logger/pino.service';
+import { LLM_PROVIDER_SERVICE_TOKEN } from '@/core/infrastructure/adapters/services/llmProviders/llmProvider.service.contract';
+import { LLMModelProvider } from '@/core/infrastructure/adapters/services/llmProviders/llmModelProvider.helper';
+
+describe('LLMAnalysisService', () => {
+    let service: LLMAnalysisService;
+    let llmProviderService: jest.Mocked<LLMProviderService>;
+    let logger: jest.Mocked<PinoLoggerService>;
+
+    beforeEach(async () => {
+        const mockLLMProviderService = {
+            getLLMProvider: jest.fn().mockReturnValue({
+                bind: jest.fn().mockReturnThis(),
+                withConfig: jest.fn().mockReturnThis(),
+                withFallbacks: jest.fn().mockReturnThis(),
+                invoke: jest.fn().mockResolvedValue('mock response'),
+            }),
+        };
+
+        const mockLogger = {
+            error: jest.fn(),
+            log: jest.fn(),
+            warn: jest.fn(),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                LLMAnalysisService,
+                {
+                    provide: LLM_PROVIDER_SERVICE_TOKEN,
+                    useValue: mockLLMProviderService,
+                },
+                {
+                    provide: PinoLoggerService,
+                    useValue: mockLogger,
+                },
+            ],
+        }).compile();
+
+        service = module.get<LLMAnalysisService>(LLMAnalysisService);
+        llmProviderService = module.get<LLMProviderService>(LLM_PROVIDER_SERVICE_TOKEN) as jest.Mocked<LLMProviderService>;
+        logger = module.get<PinoLoggerService>(PinoLoggerService) as jest.Mocked<PinoLoggerService>;
+    });
+
+    describe('Provider Integration Tests', () => {
+        it('should correctly call LLMProviderService with enum provider (not modelName)', async () => {
+            const provider = LLMModelProvider.OPENAI_GPT_4O_MINI;
+            
+            // Mock the private method to test provider usage
+            const createChain = (service as any).createExtractSuggestionsProviderChain.bind(service);
+            
+            await createChain(
+                { organizationId: 'test', teamId: 'test' },
+                123,
+                provider,
+                {}
+            );
+
+            // Verify that getLLMProvider was called with the enum provider, not modelName
+            expect(llmProviderService.getLLMProvider).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    model: provider, // Should be 'openai:gpt-4o-mini', not 'gpt-4o-mini'
+                    temperature: 0,
+                    callbacks: expect.any(Array),
+                })
+            );
+        });
+
+        it('should work with all supported providers', async () => {
+            const providers = [
+                LLMModelProvider.OPENAI_GPT_4O,
+                LLMModelProvider.OPENAI_GPT_4O_MINI,
+                LLMModelProvider.GEMINI_2_5_PRO,
+                LLMModelProvider.CLAUDE_3_5_SONNET,
+                LLMModelProvider.NOVITA_DEEPSEEK_V3,
+            ];
+
+            for (const provider of providers) {
+                llmProviderService.getLLMProvider.mockClear();
+                
+                const createChain = (service as any).createExtractSuggestionsProviderChain.bind(service);
+                
+                await expect(createChain(
+                    { organizationId: 'test', teamId: 'test' },
+                    123,
+                    provider,
+                    {}
+                )).resolves.not.toThrow();
+
+                expect(llmProviderService.getLLMProvider).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        model: provider,
+                    })
+                );
+            }
+        });
+
+        it('should handle different chain creation methods consistently', async () => {
+            const provider = LLMModelProvider.OPENAI_GPT_4O;
+            const mockOrgTeamData = { organizationId: 'test', teamId: 'test' };
+
+            // Test different chain creation methods
+            const chainMethods = [
+                'createValidateImplementedSuggestionsChain',
+                'createSelectReviewModeChain',
+                'createSeverityAnalysisChain',
+            ];
+
+            for (const methodName of chainMethods) {
+                if (typeof (service as any)[methodName] === 'function') {
+                    llmProviderService.getLLMProvider.mockClear();
+                    
+                    const method = (service as any)[methodName].bind(service);
+                    
+                    await expect(method(
+                        mockOrgTeamData,
+                        123,
+                        provider,
+                        {}
+                    )).resolves.not.toThrow();
+
+                    expect(llmProviderService.getLLMProvider).toHaveBeenCalledWith(
+                        expect.objectContaining({
+                            model: provider, // Must be enum, not modelName
+                        })
+                    );
+                }
+            }
+        });
+
+        it('should never pass modelName directly to LLMProviderService', async () => {
+            const provider = LLMModelProvider.OPENAI_GPT_4O_MINI;
+            
+            // Test all chain creation methods to ensure none use modelName
+            const allMethods = Object.getOwnPropertyNames(Object.getPrototypeOf(service))
+                .filter(name => name.includes('Chain') && typeof (service as any)[name] === 'function');
+
+            for (const methodName of allMethods) {
+                try {
+                    llmProviderService.getLLMProvider.mockClear();
+                    
+                    const method = (service as any)[methodName].bind(service);
+                    await method(
+                        { organizationId: 'test', teamId: 'test' },
+                        123,
+                        provider,
+                        {}
+                    );
+
+                    // Check all calls to ensure none use just the modelName
+                    const calls = llmProviderService.getLLMProvider.mock.calls;
+                    calls.forEach(call => {
+                        const options = call[0];
+                        if (options && options.model) {
+                            // Model should be enum (contains ':') not just modelName
+                            expect(options.model).toContain(':');
+                            expect(options.model).not.toBe('gpt-4o-mini'); // Specific check for the bug
+                        }
+                    });
+                } catch (error) {
+                    // Some methods might throw due to missing dependencies, that's OK
+                    // We're just checking the provider usage pattern
+                }
+            }
+        });
+    });
+
+    describe('Error Handling', () => {
+        it('should handle LLMProviderService errors gracefully', async () => {
+            llmProviderService.getLLMProvider.mockImplementation(() => {
+                throw new Error('Provider error');
+            });
+
+            const createChain = (service as any).createExtractSuggestionsProviderChain.bind(service);
+            
+            await expect(createChain(
+                { organizationId: 'test', teamId: 'test' },
+                123,
+                LLMModelProvider.OPENAI_GPT_4O_MINI,
+                {}
+            )).rejects.toThrow();
+
+            expect(logger.error).toHaveBeenCalled();
+        });
+    });
+}); 

--- a/test/unit/core/infrastructure/adapters/services/llmProviders/llmProvider.service.spec.ts
+++ b/test/unit/core/infrastructure/adapters/services/llmProviders/llmProvider.service.spec.ts
@@ -1,0 +1,219 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { LLMProviderService } from '@/core/infrastructure/adapters/services/llmProviders/llmProvider.service';
+import { PinoLoggerService } from '@/core/infrastructure/adapters/services/logger/pino.service';
+import { LLMModelProvider, MODEL_STRATEGIES } from '@/core/infrastructure/adapters/services/llmProviders/llmModelProvider.helper';
+
+describe('LLMProviderService', () => {
+    let service: LLMProviderService;
+    let logger: jest.Mocked<PinoLoggerService>;
+
+    beforeEach(async () => {
+        const mockLogger = {
+            error: jest.fn(),
+            log: jest.fn(),
+            warn: jest.fn(),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                LLMProviderService,
+                {
+                    provide: PinoLoggerService,
+                    useValue: mockLogger,
+                },
+            ],
+        }).compile();
+
+        service = module.get<LLMProviderService>(LLMProviderService);
+        logger = module.get<PinoLoggerService>(PinoLoggerService) as jest.Mocked<PinoLoggerService>;
+
+        // Mock environment variables
+        process.env.API_LLM_PROVIDER_MODEL = 'auto';
+        process.env.API_OPEN_AI_API_KEY = 'test-key';
+        process.env.API_ANTHROPIC_API_KEY = 'test-key';
+        process.env.API_GOOGLE_AI_API_KEY = 'test-key';
+        process.env.API_VERTEX_AI_API_KEY = Buffer.from(JSON.stringify({
+            type: 'service_account',
+            project_id: 'test-project',
+            private_key_id: 'test-key-id',
+            private_key: 'test-key',
+            client_email: 'test@test.com',
+            client_id: 'test-id',
+            auth_uri: 'https://accounts.google.com/o/oauth2/auth',
+            token_uri: 'https://oauth2.googleapis.com/token',
+        })).toString('base64');
+        process.env.API_NOVITA_AI_API_KEY = 'test-key';
+    });
+
+    describe('Provider Configuration Validation', () => {
+        it('should have all enum providers configured in MODEL_STRATEGIES', () => {
+            const enumValues = Object.values(LLMModelProvider);
+            const strategyKeys = Object.keys(MODEL_STRATEGIES);
+
+            enumValues.forEach(provider => {
+                expect(strategyKeys).toContain(provider);
+            });
+        });
+
+        it('should be able to create LLM providers for all configured models', () => {
+            const enumValues = Object.values(LLMModelProvider);
+
+            enumValues.forEach(provider => {
+                expect(() => {
+                    // Test with mock options to avoid actual API calls
+                    const mockOptions = {
+                        model: provider,
+                        temperature: 0,
+                        callbacks: [],
+                        maxTokens: 1000,
+                        jsonMode: false,
+                    };
+
+                    // This should not throw an error for supported providers
+                    service.getLLMProvider(mockOptions);
+                }).not.toThrow();
+            });
+        });
+
+        it('should not use modelName directly as model parameter', () => {
+            // This test ensures we never pass MODEL_STRATEGIES[provider].modelName
+            // directly to getLLMProvider, which was the root cause of the bug
+            
+            const provider = LLMModelProvider.OPENAI_GPT_4O_MINI;
+            const modelName = MODEL_STRATEGIES[provider].modelName; // 'gpt-4o-mini'
+            
+            // Using modelName directly should cause an error or fallback
+            const mockOptions = {
+                model: modelName, // This is WRONG - should be provider enum
+                temperature: 0,
+                callbacks: [],
+                maxTokens: 1000,
+                jsonMode: false,
+            };
+
+            // This should either work with fallback or log an error
+            const result = service.getLLMProvider(mockOptions);
+            expect(result).toBeDefined();
+            
+            // If it uses fallback, it should log an error
+            if (logger.error.mock.calls.length > 0) {
+                expect(logger.error).toHaveBeenCalledWith(
+                    expect.objectContaining({
+                        message: expect.stringContaining('Unsupported provider'),
+                    })
+                );
+            }
+        });
+
+        it('should correctly handle enum provider values', () => {
+            const provider = LLMModelProvider.OPENAI_GPT_4O_MINI;
+            
+            const mockOptions = {
+                model: provider, // This is CORRECT
+                temperature: 0,
+                callbacks: [],
+                maxTokens: 1000,
+                jsonMode: false,
+            };
+
+            const result = service.getLLMProvider(mockOptions);
+            expect(result).toBeDefined();
+            
+            // Should not log any errors when using correct provider enum
+            expect(logger.error).not.toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: expect.stringContaining('Unsupported provider'),
+                })
+            );
+        });
+
+        it('should handle jsonMode correctly for different providers', () => {
+            const openAIProvider = LLMModelProvider.OPENAI_GPT_4O;
+            const geminiProvider = LLMModelProvider.GEMINI_2_5_PRO;
+
+            [openAIProvider, geminiProvider].forEach(provider => {
+                const mockOptions = {
+                    model: provider,
+                    temperature: 0,
+                    callbacks: [],
+                    maxTokens: 1000,
+                    jsonMode: true,
+                };
+
+                expect(() => {
+                    service.getLLMProvider(mockOptions);
+                }).not.toThrow();
+            });
+        });
+
+        it('should validate MODEL_STRATEGIES configuration', () => {
+            Object.entries(MODEL_STRATEGIES).forEach(([key, strategy]) => {
+                expect(strategy).toHaveProperty('provider');
+                expect(strategy).toHaveProperty('factory');
+                expect(strategy).toHaveProperty('modelName');
+                expect(strategy).toHaveProperty('defaultMaxTokens');
+                expect(typeof strategy.factory).toBe('function');
+                expect(typeof strategy.modelName).toBe('string');
+                expect(typeof strategy.defaultMaxTokens).toBe('number');
+            });
+        });
+
+        it('should handle invalid provider gracefully with fallback', () => {
+            // This test reproduces the exact error from the user's stack trace
+            logger.error.mockClear();
+            
+            // Someone is passing 'gpt-4o' instead of 'openai:gpt-4o'
+            const mockOptions = {
+                model: 'gpt-4o', // ❌ This is what causes the error
+                temperature: 0,
+                callbacks: [],
+                maxTokens: 1000,
+                jsonMode: false,
+            };
+
+            // This should work but use fallback and log error
+            const result = service.getLLMProvider(mockOptions);
+            expect(result).toBeDefined();
+            
+            // Should log the error about unsupported provider with current metadata format
+            expect(logger.error).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: 'Unsupported provider: gpt-4o',
+                    metadata: expect.objectContaining({
+                        requestedModel: 'gpt-4o',
+                        temperature: 0,
+                        maxTokens: 1000,
+                        jsonMode: false,
+                    }),
+                })
+            );
+        });
+
+
+    });
+
+    describe('Self-hosted mode', () => {
+        beforeEach(() => {
+            process.env.API_LLM_PROVIDER_MODEL = 'custom-model';
+            process.env.API_OPENAI_FORCE_BASE_URL = 'http://localhost:8080';
+        });
+
+        afterEach(() => {
+            process.env.API_LLM_PROVIDER_MODEL = 'auto';
+            delete process.env.API_OPENAI_FORCE_BASE_URL;
+        });
+
+        it('should use self-hosted configuration when not in auto mode', () => {
+            const mockOptions = {
+                model: LLMModelProvider.OPENAI_GPT_4O,
+                temperature: 0,
+                callbacks: [],
+                maxTokens: 1000,
+                jsonMode: false,
+            };
+
+            const result = service.getLLMProvider(mockOptions);
+            expect(result).toBeDefined();
+        });
+    });
+}); 


### PR DESCRIPTION
This pull request refactors the `getLLMProvider` call within the `createValidateImplementedSuggestionsChain` function in the `llmAnalysis.service.ts` file. The change involves passing the `provider` enum directly, ensuring consistency with other similar calls in the service. This update is part of the `fix/llm-providers-for-extract-prompts` branch and is targeted for merging into the `main` branch of the `kodustech/kodus-ai` repository.