### PR TITLE
add organization id as metadata to service calls

### DIFF
--- a/src/core/domain/codeBase/contracts/ASTAnalysisService.contract.ts
+++ b/src/core/domain/codeBase/contracts/ASTAnalysisService.contract.ts
@@ -16,6 +16,7 @@ export const AST_ANALYSIS_SERVICE_TOKEN = Symbol('ASTAnalysisService');
 export interface IASTAnalysisService {
     awaitTask(
         taskId: string,
+        organizationAndTeamData: OrganizationAndTeamData,
         options?: {
             timeout?: number;
             interval?: number;

--- a/src/core/infrastructure/http/controllers/codeBase.controller.ts
+++ b/src/core/infrastructure/http/controllers/codeBase.controller.ts
@@ -76,7 +76,10 @@ export class CodeBaseController {
                 body.filePaths || [],
             );
 
-        await this.codeASTAnalysisService.awaitTask(taskId);
+        await this.codeASTAnalysisService.awaitTask(taskId, {
+            organizationId: this.request.user?.organization.uuid,
+            teamId,
+        });
 
         const result = taskId;
 

--- a/src/ee/codeReview/fileReviewContextPreparation/file-review-context-preparation.service.ts
+++ b/src/ee/codeReview/fileReviewContextPreparation/file-review-context-preparation.service.ts
@@ -118,6 +118,7 @@ export class FileReviewContextPreparation extends BaseFileReviewContextPreparati
             try {
                 const { task: astTask } = await this.astService.awaitTask(
                     fileContext.tasks.astAnalysis.taskId,
+                    fileContext.organizationAndTeamData,
                     {
                         timeout: 600000, // 10 minutes
                     },
@@ -151,6 +152,7 @@ export class FileReviewContextPreparation extends BaseFileReviewContextPreparati
 
                 const { task: impactTask } = await this.astService.awaitTask(
                     taskId,
+                    fileContext.organizationAndTeamData,
                     {
                         timeout: 600000, // 10 minutes
                     },
@@ -234,9 +236,13 @@ export class FileReviewContextPreparation extends BaseFileReviewContextPreparati
                 return file.fileContent || file.content || null;
             }
 
-            const { task } = await this.astService.awaitTask(taskId, {
-                timeout: 600000, // 10 minutes
-            });
+            const { task } = await this.astService.awaitTask(
+                taskId,
+                context.organizationAndTeamData,
+                {
+                    timeout: 600000, // 10 minutes
+                },
+            );
 
             if (!task || task.status !== TaskStatus.TASK_STATUS_COMPLETED) {
                 this.logger.warn({


### PR DESCRIPTION
This pull request introduces changes to the `kodus-ai` repository aimed at enhancing the handling of metadata in service calls by incorporating organization-specific information. The key updates include:

1. **Interface Update**: The `IASTAnalysisService` interface in `ASTAnalysisService.contract.ts` has been updated to include the `organizationAndTeamData` parameter in the `awaitTask` method, aligning its signature with other methods in the interface.

2. **Controller Modification**: In `codeBase.controller.ts`, the `awaitTask` call has been modified to pass `organizationId` and `teamId`. However, this introduces a potential issue where `organizationId` might be `undefined` if the user is not present in the request, potentially causing errors in downstream services.

3. **Service Adaptation**: The `file-review-context-preparation.service.ts` file has been updated to include `organizationAndTeamData` in multiple `awaitTask` calls, reflecting the changes in the method's signature.

4. **gRPC Metadata Refactoring**: The `codeASTAnalysis.service.ts` file has been refactored to improve gRPC metadata handling by introducing a `createMetadata` helper method. This method standardizes the addition of an `x-task-key` header with the organization ID, enhancing multi-tenancy support and correcting a bug related to task ID usage in `awaitTask`. Additionally, type definitions for `organizationAndTeamData` have been refined from `any` to a specific type.