### PR TITLE
adding isSelected filter to repo get

### DIFF
--- a/src/core/infrastructure/http/controllers/platformIntegration/codeManagement.controller.ts
+++ b/src/core/infrastructure/http/controllers/platformIntegration/codeManagement.controller.ts
@@ -40,7 +40,7 @@ export class CodeManagementController {
 
     @Get('/repositories/org')
     public async getRepositories(
-        @Query() query: { teamId: string; organizationSelected: any },
+        @Query() query: { teamId: string; organizationSelected: any; isSelected?: boolean },
     ) {
         return this.getRepositoriesUseCase.execute(query);
     }


### PR DESCRIPTION
This pull request introduces a new feature to the `kodus-ai` repository, specifically adding an `isSelected` filter to the repository retrieval functionality. The changes are made in the `feat/repo-cockpit-filter` branch and are intended to be merged into the `main` branch. 

Key updates include:

1. **Error Handling and Filtering in Use Case**: 
   - The `GetRepositoriesUseCase` in `get-repositories.ts` has been enhanced with error handling that includes logging. This aims to improve the robustness of the code. However, there are noted opportunities for further improvements in making error handling safer and ensuring code consistency.
   - A new filtering capability has been added to this use case, allowing for more refined data retrieval.

2. **Controller Update**:
   - The `getRepositories` endpoint in `codeManagement.controller.ts` has been updated to accept a new optional boolean query parameter, `isSelected`. 
   - The type definition for the query parameters has been modified to accommodate this new field, allowing users to filter repositories based on their selection status.

These changes enhance the functionality of the repository management feature by allowing users to filter repositories based on the `isSelected` status, while also improving error handling within the application.