### PR TITLE
adding fullname to repositories return

### DIFF
--- a/src/core/infrastructure/adapters/services/github/github.service.ts
+++ b/src/core/infrastructure/adapters/services/github/github.service.ts
@@ -1109,6 +1109,7 @@ export class GithubService
             return repos.map((repo) => ({
                 id: repo.id.toString(),
                 name: repo.name,
+                full_name: repo.full_name,
                 http_url: repo.html_url,
                 avatar_url: repo.owner.avatar_url,
                 organizationName: repo.owner.login,


### PR DESCRIPTION
**Pull Request Description**:

This pull request aims to enhance the `getRepositories` method in the `github.service.ts` file by adding the `full_name` property to the repository objects returned. This change allows for more comprehensive repository information to be retrieved from the GitHub API. The update is a minor enhancement to improve the data provided by the service. The changes are made in the `fix/get-repositories-fullname` branch and are intended to be merged into the `main` branch of the `kodustech/kodus-ai` repository.