### PR TITLE
Fix/personalize pr messages

### DIFF
--- a/src/core/application/use-cases/pullRequestMessages/create-or-update-pull-request-messages.use-case.ts
+++ b/src/core/application/use-cases/pullRequestMessages/create-or-update-pull-request-messages.use-case.ts
@@ -30,10 +30,8 @@ export class CreateOrUpdatePullRequestMessagesUseCase implements IUseCase {
         pullRequestMessages.organizationId =
             this.request.user.organization.uuid;
 
-        if (pullRequestMessages?.repositoryId === 'global') {
-            pullRequestMessages.configLevel = ConfigLevel.GLOBAL;
-        } else {
-            pullRequestMessages.configLevel = ConfigLevel.REPOSITORY;
+        if (pullRequestMessages?.configLevel === ConfigLevel.GLOBAL) {
+            pullRequestMessages.repositoryId = 'global';
         }
 
         const existingPullRequestMessage = await this.findExistingConfiguration(

--- a/src/core/application/use-cases/pullRequestMessages/create-or-update-pull-request-messages.use-case.ts
+++ b/src/core/application/use-cases/pullRequestMessages/create-or-update-pull-request-messages.use-case.ts
@@ -30,10 +30,10 @@ export class CreateOrUpdatePullRequestMessagesUseCase implements IUseCase {
         pullRequestMessages.organizationId =
             this.request.user.organization.uuid;
 
-        if (pullRequestMessages?.repositoryId) {
-            pullRequestMessages.configLevel = ConfigLevel.REPOSITORY;
-        } else {
+        if (pullRequestMessages?.repositoryId === 'global') {
             pullRequestMessages.configLevel = ConfigLevel.GLOBAL;
+        } else {
+            pullRequestMessages.configLevel = ConfigLevel.REPOSITORY;
         }
 
         const existingPullRequestMessage = await this.findExistingConfiguration(

--- a/src/core/application/use-cases/pullRequestMessages/create-or-update-pull-request-messages.use-case.ts
+++ b/src/core/application/use-cases/pullRequestMessages/create-or-update-pull-request-messages.use-case.ts
@@ -43,10 +43,6 @@ export class CreateOrUpdatePullRequestMessagesUseCase implements IUseCase {
         );
 
         if (existingPullRequestMessage) {
-            // Mapear id para uuid se existir
-            if (pullRequestMessages.id && !pullRequestMessages.uuid) {
-                pullRequestMessages.uuid = pullRequestMessages.id;
-            }
             await this.pullRequestMessagesService.update(pullRequestMessages);
             return;
         }

--- a/src/core/application/use-cases/pullRequestMessages/find-by-repository-id.use-case.ts
+++ b/src/core/application/use-cases/pullRequestMessages/find-by-repository-id.use-case.ts
@@ -32,12 +32,10 @@ export class FindByRepositoryIdPullRequestMessagesUseCase implements IUseCase {
             });
         }
 
-        // Se não encontrou resultado, retorna null
         if (!result) {
-            return null;
+            return;
         }
 
-        // Converte para objeto sem os prefixos _
         return result.toJson();
     }
 }

--- a/src/core/application/use-cases/pullRequestMessages/find-by-repository-id.use-case.ts
+++ b/src/core/application/use-cases/pullRequestMessages/find-by-repository-id.use-case.ts
@@ -18,17 +18,26 @@ export class FindByRepositoryIdPullRequestMessagesUseCase implements IUseCase {
             throw new Error('Repository ID and organization ID are required');
         }
 
+        let result;
         if (repositoryId === 'global') {
-            return await this.pullRequestMessagesService.find({
+            result = await this.pullRequestMessagesService.findOne({
                 organizationId,
                 configLevel: ConfigLevel.GLOBAL,
             });
+        } else {
+            result = await this.pullRequestMessagesService.findOne({
+                repositoryId: repositoryId.toLowerCase(),
+                organizationId,
+                configLevel: ConfigLevel.REPOSITORY,
+            });
         }
 
-        return await this.pullRequestMessagesService.find({
-            repositoryId: repositoryId.toLowerCase(),
-            organizationId,
-            configLevel: ConfigLevel.REPOSITORY,
-        });
+        // Se não encontrou resultado, retorna null
+        if (!result) {
+            return null;
+        }
+
+        // Converte para objeto sem os prefixos _
+        return result.toJson();
     }
 }

--- a/src/core/domain/pullRequestMessages/entities/pullRequestMessages.entity.ts
+++ b/src/core/domain/pullRequestMessages/entities/pullRequestMessages.entity.ts
@@ -10,7 +10,6 @@ import {
 export class PullRequestMessagesEntity implements Entity<IPullRequestMessages> {
     private readonly _uuid: string;
     private readonly _organizationId: string;
-    private readonly _teamId: string;
     private readonly _configLevel: ConfigLevel;
     private readonly _repositoryId?: string;
     private readonly _startReviewMessage?: IPullRequestMessageContent;
@@ -19,7 +18,6 @@ export class PullRequestMessagesEntity implements Entity<IPullRequestMessages> {
     constructor(pullRequestMessages: IPullRequestMessages) {
         this._uuid = pullRequestMessages.uuid;
         this._organizationId = pullRequestMessages.organizationId;
-        this._teamId = pullRequestMessages.teamId;
         this._configLevel = pullRequestMessages.configLevel;
         this._repositoryId = pullRequestMessages.repositoryId;
         this._startReviewMessage = pullRequestMessages.startReviewMessage;
@@ -30,7 +28,6 @@ export class PullRequestMessagesEntity implements Entity<IPullRequestMessages> {
         return {
             uuid: this._uuid,
             organizationId: this._organizationId,
-            teamId: this._teamId,
             configLevel: this._configLevel,
             repositoryId: this._repositoryId,
             startReviewMessage: this._startReviewMessage,
@@ -42,7 +39,6 @@ export class PullRequestMessagesEntity implements Entity<IPullRequestMessages> {
         return {
             uuid: this._uuid,
             organizationId: this._organizationId,
-            teamId: this._teamId,
             configLevel: this._configLevel,
             repositoryId: this._repositoryId,
             startReviewMessage: this._startReviewMessage,
@@ -56,10 +52,6 @@ export class PullRequestMessagesEntity implements Entity<IPullRequestMessages> {
 
     get organizationId(): string {
         return this._organizationId;
-    }
-
-    get teamId(): string {
-        return this._teamId;
     }
 
     get configLevel(): ConfigLevel {

--- a/src/core/domain/pullRequestMessages/interfaces/pullRequestMessages.interface.ts
+++ b/src/core/domain/pullRequestMessages/interfaces/pullRequestMessages.interface.ts
@@ -12,7 +12,6 @@ export interface IPullRequestMessageContent {
 export interface IPullRequestMessages {
     uuid?: string;
     organizationId: string;
-    teamId: string;
     configLevel: ConfigLevel;
     repositoryId?: string;
     startReviewMessage?: IPullRequestMessageContent;

--- a/src/core/domain/pullRequestMessages/interfaces/pullRequestMessages.interface.ts
+++ b/src/core/domain/pullRequestMessages/interfaces/pullRequestMessages.interface.ts
@@ -10,8 +10,7 @@ export interface IPullRequestMessageContent {
 }
 
 export interface IPullRequestMessages {
-    id?: string;
-    uuid: string;
+    uuid?: string;
     organizationId: string;
     teamId: string;
     configLevel: ConfigLevel;

--- a/src/core/infrastructure/adapters/repositories/mongoose/pullRequestMessages.repository.ts
+++ b/src/core/infrastructure/adapters/repositories/mongoose/pullRequestMessages.repository.ts
@@ -5,7 +5,10 @@ import { PullRequestMessagesEntity } from '@/core/domain/pullRequestMessages/ent
 import { PullRequestMessagesModel } from './schema/pullRequestMessages.model';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
-import { mapSimpleModelToEntity } from '@/shared/infrastructure/repositories/mappers';
+import {
+    mapSimpleModelsToEntities,
+    mapSimpleModelToEntity,
+} from '@/shared/infrastructure/repositories/mappers';
 
 @Injectable()
 export class PullRequestMessagesRepository
@@ -17,7 +20,7 @@ export class PullRequestMessagesRepository
     ) {}
 
     async create(
-        pullRequestMessages: IPullRequestMessages,
+        pullRequestMessages: Omit<IPullRequestMessages, 'uuid'>,
     ): Promise<PullRequestMessagesEntity> {
         const saved =
             await this.pullRequestMessagesModel.create(pullRequestMessages);
@@ -42,16 +45,41 @@ export class PullRequestMessagesRepository
     async find(
         filter?: Partial<IPullRequestMessages>,
     ): Promise<PullRequestMessagesEntity[]> {
-        return this.pullRequestMessagesModel.find(filter);
+        try {
+            const docs = await this.pullRequestMessagesModel
+                .find(filter)
+                .exec();
+            return mapSimpleModelsToEntities(docs, PullRequestMessagesEntity);
+        } catch (error) {
+            throw error;
+        }
     }
 
     async findOne(
         filter?: Partial<IPullRequestMessages>,
     ): Promise<PullRequestMessagesEntity | null> {
-        return this.pullRequestMessagesModel.findOne(filter);
+        try {
+            const doc = await this.pullRequestMessagesModel
+                .findOne(filter)
+                .exec();
+            return doc
+                ? mapSimpleModelToEntity(doc, PullRequestMessagesEntity)
+                : null;
+        } catch (error) {
+            throw error;
+        }
     }
 
     async findById(uuid: string): Promise<PullRequestMessagesEntity | null> {
-        return this.pullRequestMessagesModel.findById(uuid);
+        try {
+            const doc = await this.pullRequestMessagesModel
+                .findById(uuid)
+                .exec();
+            return doc
+                ? mapSimpleModelToEntity(doc, PullRequestMessagesEntity)
+                : null;
+        } catch (error) {
+            throw error;
+        }
     }
 }

--- a/src/core/infrastructure/adapters/repositories/mongoose/schema/pullRequestMessages.model.ts
+++ b/src/core/infrastructure/adapters/repositories/mongoose/schema/pullRequestMessages.model.ts
@@ -23,7 +23,7 @@ export class PullRequestMessagesModel extends CoreDocument {
 
     @Prop({
         type: {
-            content: { type: String, required: true },
+            content: { type: String, required: false },
             status: {
                 type: String,
                 required: true,
@@ -40,7 +40,7 @@ export class PullRequestMessagesModel extends CoreDocument {
 
     @Prop({
         type: {
-            content: { type: String, required: true },
+            content: { type: String, required: false },
             status: {
                 type: String,
                 required: true,

--- a/src/core/infrastructure/http/dtos/pull-request-messages.dto.ts
+++ b/src/core/infrastructure/http/dtos/pull-request-messages.dto.ts
@@ -1,5 +1,5 @@
 import { PullRequestMessageStatus, PullRequestMessageType } from '@/config/types/general/pullRequestMessages.type';
-import { IsObject, IsString } from 'class-validator';
+import { IsObject, IsOptional, IsString } from 'class-validator';
 
 export class PullRequestMessagesDto {
     @IsString()
@@ -14,6 +14,7 @@ export class PullRequestMessagesDto {
     @IsString()
     public status: PullRequestMessageStatus;
 
+    @IsOptional()
     @IsString()
     public content: string;
 

--- a/src/core/infrastructure/http/dtos/pull-request-messages.dto.ts
+++ b/src/core/infrastructure/http/dtos/pull-request-messages.dto.ts
@@ -6,9 +6,6 @@ export class PullRequestMessagesDto {
     public organizationId?: string;
 
     @IsString()
-    public teamId: string;
-
-    @IsString()
     public pullRequestMessageType: PullRequestMessageType;
 
     @IsString()


### PR DESCRIPTION
This pull request addresses several issues and improvements related to pull request message handling in the `kodustech/kodus-ai` repository. The changes include:

1. **Configuration Logic Update**: The logic for determining the configuration level (`GLOBAL` or `REPOSITORY`) in `create-or-update-pull-request-messages.use-case.ts` has been updated. However, there is a potential bug where configurations without a `repositoryId` are incorrectly classified as `REPOSITORY` level.

2. **Refactoring Fetch Logic**: In `find-by-repository-id.use-case.ts`, the use case has been refactored to use `findOne` instead of `find` for fetching a single pull request message configuration. It also adds logic to handle cases where no configuration is found, returning the result as a JSON object.

3. **Interface Simplification**: The `IPullRequestMessages` interface in `pullRequestMessages.interface.ts` has been updated by making the `uuid` property optional and removing the `id` and `teamId` properties. This simplifies the data model, but making `uuid` optional could cause issues in code that expects it to be present.

4. **Repository Implementation Fixes**: The repository implementation in `pullRequestMessages.repository.ts` has been corrected to ensure methods return domain entities instead of persistence-layer models. The `create` method's signature has been improved for better type safety. However, redundant `try...catch` blocks have been introduced, which could be removed to simplify the code.

5. **DTO Update**: The `PullRequestMessagesDto` in `pull-request-messages.dto.ts` has been updated by making the `content` property optional and removing the `teamId` property. A potential issue is noted where the TypeScript type for `content` was not updated to reflect its optional status, which could lead to runtime errors.

These changes aim to improve the handling and configuration of pull request messages, though some potential issues have been identified that may need further attention.