### PR TITLE
Fixing get last commit analyzed data

### DIFF
--- a/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/create-file-comments.stage.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/create-file-comments.stage.ts
@@ -120,17 +120,25 @@ export class CreateFileCommentsStage extends BasePipelineStage<CodeReviewPipelin
                 },
             });
 
-            const lastExecution =
-                await this.findLastTeamAutomationCodeReviewExecution(
-                    context.organizationAndTeamData.teamId,
-                    context.pullRequest.number,
-                    context.repository.id,
+            const commits =
+                await this.codeManagementService.getCommitsForPullRequestForCodeReview(
+                    {
+                        organizationAndTeamData:
+                            context.organizationAndTeamData,
+                        repository: context.repository,
+                        prNumber: context.pullRequest.number,
+                    },
                 );
+
+            if (!commits?.length) {
+                return context;
+            }
+
+            const lastAnalyzedCommit = commits[commits.length - 1];
 
             return this.updateContext(context, (draft) => {
                 draft.lineComments = [];
-                draft.lastAnalyzedCommit =
-                    lastExecution?.dataExecution?.lastAnalyzedCommit;
+                draft.lastAnalyzedCommit = lastAnalyzedCommit;
             });
         }
 


### PR DESCRIPTION
This pull request addresses an issue in the `kodus-ai` repository by refactoring the method used to determine the last analyzed commit in the code review pipeline. The changes are made in the `create-file-comments.stage.ts` file. Previously, the process relied on execution history to identify the last commit. The update now directly fetches the commit list for the pull request and uses what is presumed to be the last commit from that list when no suggestions are found. This modification removes the dependency on previous execution history but may introduce a potential issue related to data sorting. The changes are being merged from the `hotfix/pr-looping` branch into the `main` branch.