### PR TITLE
Hotfix/common-parser-provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
         "@golevelup/nestjs-rabbitmq": "^6.0.2",
         "@google/generative-ai": "^0.24.1",
         "@kodus/flow": "^0.1.0",
-        "@kodus/kodus-common": "^1.2.0",
+        "@kodus/kodus-common": "^1.2.1",
         "@kodus/kodus-proto": "https://registry.npmjs.org/@kodus/kodus-proto/-/kodus-proto-3.1.2.tgz",
         "@langchain/anthropic": "^0.3.25",
         "@langchain/cohere": "^0.3.4",

--- a/packages/kodus-common/package.json
+++ b/packages/kodus-common/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "https://github.com/kodustech/kodus-common"
     },
-    "version": "1.2.0",
+    "version": "1.2.1",
     "publishConfig": {
         "access": "public",
         "registry": "https://us-central1-npm.pkg.dev/$GAR_PROJECT_ID/kodus-pkg/"

--- a/packages/kodus-common/src/llm/builder.ts
+++ b/packages/kodus-common/src/llm/builder.ts
@@ -96,7 +96,10 @@ class PromptBuilderWithProviders {
      *
      * This parser will be used to parse the output of the LLM.
      * @param type The type of the parser to be used.
-     * @param parser The parser to be used. Only used with `ParserType.CUSTOM`.
+     * @param parserOrSchema The parser instance or Zod schema to be used.
+     * @param config Optional configuration for the parser. Only used for Zod parsers.
+     * - `provider`: The main LLM provider to use. @default LLMModelProvider.OPENAI_GPT_4O_MINI
+     * - `fallbackProvider`: An optional fallback LLM provider. @default LLMModelProvider.OPENAI_GPT_4O
      * @template NewOutputType The expected output type of the parser.
      * @returns The ConfigurablePromptBuilder instance for chaining.
      */
@@ -111,6 +114,10 @@ class PromptBuilderWithProviders {
     setParser<NewOutputType extends AnyZodObject>(
         type: ParserType.ZOD,
         parserOrSchema: NewOutputType,
+        config?: Pick<
+            PromptRunnerParams<void, NewOutputType>,
+            'provider' | 'fallbackProvider'
+        >,
     ): ConfigurablePromptBuilderWithoutPayload<
         z.infer<NewOutputType>,
         ParserType.ZOD

--- a/packages/kodus-common/src/llm/parser.ts
+++ b/packages/kodus-common/src/llm/parser.ts
@@ -143,7 +143,8 @@ export class ZodOutputParser<T extends AnyZodObject> extends BaseOutputParser {
         const result = await this.config.promptRunnerService
             .builder()
             .setProviders({
-                main: this.config.provider || LLMModelProvider.OPENAI_GPT_4O,
+                main:
+                    this.config.provider || LLMModelProvider.OPENAI_GPT_4O_MINI,
                 fallback:
                     this.config.fallbackProvider ||
                     LLMModelProvider.OPENAI_GPT_4O,

--- a/src/core/infrastructure/adapters/services/codeBase/llmAnalysis.service.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/llmAnalysis.service.ts
@@ -565,7 +565,10 @@ ${JSON.stringify(context?.suggestions, null, 2) || 'No suggestions provided'}
                     main: provider,
                     fallback: fallbackProvider,
                 })
-                .setParser(ParserType.ZOD, schema)
+                .setParser(ParserType.ZOD, schema, {
+                    provider: LLMModelProvider.OPENAI_GPT_4O_MINI,
+                    fallbackProvider: LLMModelProvider.OPENAI_GPT_4O,
+                })
                 .setLLMJsonMode(true)
                 .setPayload(payload)
                 .addPrompt({

--- a/src/ee/codeBase/kodyRulesAnalysis.service.ts
+++ b/src/ee/codeBase/kodyRulesAnalysis.service.ts
@@ -607,7 +607,10 @@ export class KodyRulesAnalysisService implements IKodyRulesAnalysisService {
                 main: provider,
                 fallback: fallbackProvider,
             })
-            .setParser(ParserType.ZOD, kodyRulesClassifierSchema)
+            .setParser(ParserType.ZOD, kodyRulesClassifierSchema, {
+                provider: LLMModelProvider.OPENAI_GPT_4O_MINI,
+                fallbackProvider: LLMModelProvider.OPENAI_GPT_4O,
+            })
             .setLLMJsonMode(true)
             .setTemperature(0)
             .setPayload(context)

--- a/yarn.lock
+++ b/yarn.lock
@@ -2321,10 +2321,10 @@
     zod "^4.0.14"
     zod-from-json-schema "^0.4.2"
 
-"@kodus/kodus-common@^1.2.0":
-  version "1.2.0"
-  resolved "https://us-central1-npm.pkg.dev/kodus-infra-prod/kodus-pkg/@kodus/kodus-common/-/@kodus/kodus-common-1.2.0.tgz#23c91c16c763a73279229f782f892e27b0667cc4"
-  integrity sha512-wH6yvuYLR83df6SJXQj4o5LdGJZFi/VaBV5eKN1PPUynesoaCq78PP7Um3Q+om9x9TmlwTO/COgOQrILSbA0PQ==
+"@kodus/kodus-common@^1.2.1":
+  version "1.2.1"
+  resolved "https://us-central1-npm.pkg.dev/kodus-infra-prod/kodus-pkg/@kodus/kodus-common/-/@kodus/kodus-common-1.2.1.tgz#9e9367d666508a464ab7a91ba38afb5abf474d29"
+  integrity sha512-IjQhiFDNhz75wo9XzJorPj6yK6wyYMhlbaYwFPcutU0o3XkHRliSNN6q4bKp51E2LPU7vN3PyXZ7fIUdJG4/DQ==
 
 "@kodus/kodus-proto@https://registry.npmjs.org/@kodus/kodus-proto/-/kodus-proto-3.1.2.tgz":
   version "3.1.2"


### PR DESCRIPTION
Add explicit providers for zod llm fallback

---

This pull request addresses a hotfix in the `kodus-ai` repository by enhancing the configuration of ZOD parsers across various components. The changes include:

1. **PromptBuilder Enhancement**: In `packages/kodus-common/src/llm/builder.ts`, the `PromptBuilder` is improved by allowing specific provider and fallback provider configurations for ZOD parsers through a new `config` parameter in the `setParser` method, along with updated JSDoc.

2. **Default Provider Update**: In `packages/kodus-common/src/llm/parser.ts`, the default main provider for the JSON correction chain in the `ZodOutputParser` is updated from `OPENAI_GPT_4O` to `OPENAI_GPT_4O_MINI`, likely optimizing for cost and performance.

3. **Zod Parser Configuration**: In `src/core/infrastructure/adapters/services/codeBase/llmAnalysis.service.ts`, the Zod parser configuration is updated within the `filterSuggestionsSafeGuard` method to specify LLM providers for fixing parsing errors, enhancing the robustness of structured data processing.

4. **Kody Rules Analysis Update**: In `src/ee/codeBase/kodyRulesAnalysis.service.ts`, the Kody Rules analysis service is updated to use specific OpenAI models for Zod schema parsing in the classifier by passing provider options to the `.setParser()` method.

These updates collectively improve the handling and configuration of ZOD parsers, enhancing the system's efficiency and reliability.