### PR TITLE
validate new commits to check if its only a merge

### DIFF
--- a/src/core/domain/codeBase/contracts/PullRequestManagerService.contract.ts
+++ b/src/core/domain/codeBase/contracts/PullRequestManagerService.contract.ts
@@ -1,6 +1,7 @@
 import { FileChange } from '@/config/types/general/codeReview.type';
 import { OrganizationAndTeamData } from '@/config/types/general/organizationAndTeamData';
 import { PullRequestAuthor } from '../../platformIntegrations/types/codeManagement/pullRequests.type';
+import { Commit } from '@/config/types/general/commit.type';
 
 export const PULL_REQUEST_MANAGER_SERVICE_TOKEN = Symbol(
     'PullRequestManagerService',
@@ -24,4 +25,11 @@ export interface IPullRequestManagerService {
     getPullRequestAuthorsWithCache(
         organizationAndTeamData: OrganizationAndTeamData,
     ): Promise<PullRequestAuthor[]>;
+
+    getNewCommitsSinceLastExecution(
+        organizationAndTeamData: OrganizationAndTeamData,
+        repository: { name: string; id: any },
+        pullRequest: any,
+        lastCommit?: string,
+    ): Promise<Commit[]>;
 }

--- a/src/core/infrastructure/adapters/services/azureRepos.service.ts
+++ b/src/core/infrastructure/adapters/services/azureRepos.service.ts
@@ -1089,6 +1089,24 @@ export class AzureReposService
                         }
                     }
 
+                    let commitParents = commit.parents || null;
+
+                    if (!commitParents) {
+                        try {
+                            const commitDetails =
+                                await this.azureReposRequestHelper.getCommit({
+                                    orgName,
+                                    token,
+                                    projectId,
+                                    repositoryId: repository.id,
+                                    commitId: commit.commitId,
+                                });
+                            commitParents = commitDetails.parents || [];
+                        } catch {
+                            commitParents = [];
+                        }
+                    }
+
                     return {
                         sha: commit.commitId,
                         message: commit.comment,
@@ -1100,6 +1118,7 @@ export class AzureReposService
                             username: authorName,
                             id: userId,
                         },
+                        parents: commitParents || [],
                     };
                 }),
             );

--- a/src/core/infrastructure/adapters/services/azureRepos.service.ts
+++ b/src/core/infrastructure/adapters/services/azureRepos.service.ts
@@ -1089,7 +1089,7 @@ export class AzureReposService
                         }
                     }
 
-                    let commitParents = commit.parents || null;
+                    let commitParents: string[] = commit.parents || null;
 
                     if (!commitParents) {
                         try {
@@ -1118,7 +1118,12 @@ export class AzureReposService
                             username: authorName,
                             id: userId,
                         },
-                        parents: commitParents || [],
+                        parents:
+                            commitParents
+                                ?.map((p) => ({
+                                    sha: p ?? '',
+                                }))
+                                ?.filter((p) => p.sha) ?? [],
                     };
                 }),
             );

--- a/src/core/infrastructure/adapters/services/azureRepos/azure-repos-request-helper.ts
+++ b/src/core/infrastructure/adapters/services/azureRepos/azure-repos-request-helper.ts
@@ -713,6 +713,22 @@ export class AzureReposRequestHelper {
         return data?.value ?? [];
     }
 
+    async getCommit(params: {
+        orgName: string;
+        token: string;
+        projectId: string;
+        repositoryId: string;
+        commitId: string;
+    }): Promise<any | null> {
+        const instance = await this.azureRequest(params);
+
+        const { data } = await instance.get(
+            `/${params.projectId}/_apis/git/repositories/${params.repositoryId}/commits/${params.commitId}?api-version=7.1`,
+        );
+
+        return data ?? null;
+    }
+
     async updatePullRequestDescription(params: {
         orgName: string;
         token: string;

--- a/src/core/infrastructure/adapters/services/bitbucket/bitbucket.service.ts
+++ b/src/core/infrastructure/adapters/services/bitbucket/bitbucket.service.ts
@@ -1913,7 +1913,12 @@ export class BitbucketService
                             email,
                             date: commit?.date,
                         },
-                        parents: commit?.parents?.map((p) => p.hash) || [],
+                        parents:
+                            commit?.parents
+                                ?.map((p) => ({
+                                    sha: p?.hash ?? '',
+                                }))
+                                ?.filter((p) => p.sha) ?? [],
                     };
                 })
                 .sort(

--- a/src/core/infrastructure/adapters/services/bitbucket/bitbucket.service.ts
+++ b/src/core/infrastructure/adapters/services/bitbucket/bitbucket.service.ts
@@ -1913,6 +1913,7 @@ export class BitbucketService
                             email,
                             date: commit?.date,
                         },
+                        parents: commit?.parents?.map((p) => p.hash) || [],
                     };
                 })
                 .sort(

--- a/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/validate-new-commits.stage.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/validate-new-commits.stage.ts
@@ -1,0 +1,173 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { BasePipelineStage } from '../../../pipeline/base-stage.abstract';
+import { CodeReviewPipelineContext } from '../context/code-review-pipeline.context';
+import {
+    AUTOMATION_EXECUTION_SERVICE_TOKEN,
+    IAutomationExecutionService,
+} from '@/core/domain/automation/contracts/automation-execution.service';
+import {
+    PULL_REQUEST_MANAGER_SERVICE_TOKEN,
+    IPullRequestManagerService,
+} from '@/core/domain/codeBase/contracts/PullRequestManagerService.contract';
+import { PinoLoggerService } from '../../../logger/pino.service';
+import { AutomationStatus } from '@/core/domain/automation/enums/automation-status';
+import { PipelineStatus } from '../../../pipeline/interfaces/pipeline-context.interface';
+
+@Injectable()
+export class ValidateNewCommitsStage extends BasePipelineStage<CodeReviewPipelineContext> {
+    stageName = 'ValidateNewCommitsStage';
+
+    constructor(
+        @Inject(AUTOMATION_EXECUTION_SERVICE_TOKEN)
+        private automationExecutionService: IAutomationExecutionService,
+        @Inject(PULL_REQUEST_MANAGER_SERVICE_TOKEN)
+        private pullRequestHandlerService: IPullRequestManagerService,
+
+        private logger: PinoLoggerService,
+    ) {
+        super();
+    }
+
+    protected override async executeStage(
+        context: CodeReviewPipelineContext,
+    ): Promise<CodeReviewPipelineContext> {
+        const lastExecution =
+            await this.automationExecutionService.findLatestExecutionByFilters({
+                status: AutomationStatus.SUCCESS,
+                teamAutomation: { uuid: context.teamAutomationId },
+                pullRequestNumber: context.pullRequest.number,
+                repositoryId: context?.repository?.id,
+            });
+
+        if (!lastExecution?.dataExecution?.lastAnalyzedCommit) {
+            this.logger.log({
+                message:
+                    'No last analyzed commit found, skipping commit validation',
+                context: this.stageName,
+                metadata: {
+                    organizationAndTeamData: context.organizationAndTeamData,
+                    repository: context.repository.name,
+                    pullRequestNumber: context.pullRequest.number,
+                },
+            });
+
+            return context;
+        }
+
+        const lastExecutionResult = {
+            commentId: lastExecution?.dataExecution?.commentId,
+            noteId: lastExecution?.dataExecution?.noteId,
+            threadId: lastExecution?.dataExecution?.threadId,
+            lastAnalyzedCommit:
+                lastExecution?.dataExecution?.lastAnalyzedCommit,
+        };
+
+        const updatedContext = this.updateContext(context, (draft) => {
+            draft.lastExecution = lastExecutionResult;
+        });
+
+        const commits =
+            await this.pullRequestHandlerService.getNewCommitsSinceLastExecution(
+                updatedContext.organizationAndTeamData,
+                updatedContext.repository,
+                updatedContext.pullRequest,
+                lastExecutionResult.lastAnalyzedCommit,
+            );
+
+        if (!commits || commits?.length === 0) {
+            this.logger.warn({
+                message: 'No new commits found since last execution',
+                context: this.stageName,
+                metadata: {
+                    organizationAndTeamData:
+                        updatedContext.organizationAndTeamData,
+                    repository: updatedContext.repository.name,
+                    pullRequestNumber: updatedContext.pullRequest.number,
+                },
+            });
+
+            return this.updateContext(updatedContext, (draft) => {
+                draft.status = PipelineStatus.SKIP;
+            });
+        }
+
+        this.logger.log({
+            message: `Fetched ${commits.length} new commits for PR#${updatedContext.pullRequest.number}`,
+            context: this.stageName,
+            metadata: {
+                organizationAndTeamData: updatedContext.organizationAndTeamData,
+                repository: updatedContext.repository.name,
+                pullRequestNumber: updatedContext.pullRequest.number,
+            },
+        });
+
+        let isOnlyMerge = false;
+
+        const mergeCommits = commits.filter(
+            (commit) => commit.parents?.length > 1,
+        );
+
+        if (mergeCommits.length > 0) {
+            const allNewCommitShas = new Set(commits.map((c) => c.sha));
+            const commitMap = new Map(commits.map((c) => [c.sha, c]));
+
+            const mergedCommitTracker = new Set();
+
+            const findAncestorsInPush = (sha) => {
+                if (
+                    !allNewCommitShas.has(sha) ||
+                    mergedCommitTracker.has(sha)
+                ) {
+                    return;
+                }
+
+                mergedCommitTracker.add(sha);
+                const commit = commitMap.get(sha);
+                commit.parents.forEach((parent) =>
+                    findAncestorsInPush(parent.sha),
+                );
+            };
+
+            for (const commit of mergeCommits) {
+                mergedCommitTracker.add(commit.sha);
+
+                for (let i = 1; i < commit.parents.length; i++) {
+                    findAncestorsInPush(commit.parents[i].sha);
+                }
+            }
+
+            if (mergedCommitTracker.size === allNewCommitShas.size) {
+                isOnlyMerge = true;
+            }
+        }
+
+        if (isOnlyMerge) {
+            this.logger.warn({
+                message: `Skipping code review for PR#${updatedContext.pullRequest.number} - Only merge commits found`,
+                context: this.stageName,
+                metadata: {
+                    organizationAndTeamData:
+                        updatedContext.organizationAndTeamData,
+                    repository: updatedContext.repository.name,
+                    pullRequestNumber: updatedContext.pullRequest.number,
+                },
+            });
+
+            return this.updateContext(updatedContext, (draft) => {
+                draft.status = PipelineStatus.SKIP;
+            });
+        }
+
+        this.logger.log({
+            message: `Processing ${commits.length} commits for PR#${updatedContext.pullRequest.number}`,
+            context: this.stageName,
+            metadata: {
+                organizationAndTeamData: updatedContext.organizationAndTeamData,
+                repository: updatedContext.repository.name,
+                pullRequestNumber: updatedContext.pullRequest.number,
+            },
+        });
+
+        return updatedContext;
+    }
+}

--- a/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/strategies/code-review-pipeline.strategy.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/strategies/code-review-pipeline.strategy.ts
@@ -16,6 +16,7 @@ import { BasePipelineStage } from '../../../pipeline/base-stage.abstract';
 import { ProcessFilesPrLevelReviewStage } from '../stages/process-files-pr-level-review.stage';
 import { CreatePrLevelCommentsStage } from '../stages/create-pr-level-comments.stage';
 import { CreateFileCommentsStage } from '../stages/create-file-comments.stage';
+import { ValidateNewCommitsStage } from '../stages/validate-new-commits.stage';
 
 @Injectable()
 export class CodeReviewPipelineStrategy
@@ -23,6 +24,7 @@ export class CodeReviewPipelineStrategy
 {
     constructor(
         private readonly validateConfigStage: ValidateConfigStage,
+        private readonly validateNewCommitsStage: ValidateNewCommitsStage,
         private readonly fetchChangedFilesStage: FetchChangedFilesStage,
         private readonly initialCommentStage: InitialCommentStage,
         private readonly processFilesPrLevelReviewStage: ProcessFilesPrLevelReviewStage,
@@ -37,6 +39,7 @@ export class CodeReviewPipelineStrategy
     configureStages(): BasePipelineStage<CodeReviewPipelineContext>[] {
         return [
             this.validateConfigStage,
+            this.validateNewCommitsStage,
             this.fetchChangedFilesStage,
             this.initialCommentStage,
             this.processFilesPrLevelReviewStage,

--- a/src/core/infrastructure/adapters/services/github/github.service.ts
+++ b/src/core/infrastructure/adapters/services/github/github.service.ts
@@ -3163,6 +3163,7 @@ export class GithubService
                     ...commit?.commit?.author,
                     username: commit?.author?.login,
                 },
+                parents: commit?.parents?.map((p) => p.sha) || [],
             }))
             ?.sort((a, b) => {
                 return (

--- a/src/core/infrastructure/adapters/services/github/github.service.ts
+++ b/src/core/infrastructure/adapters/services/github/github.service.ts
@@ -3163,7 +3163,10 @@ export class GithubService
                     ...commit?.commit?.author,
                     username: commit?.author?.login,
                 },
-                parents: commit?.parents?.map((p) => p.sha) || [],
+                parents:
+                    commit?.parents
+                        ?.map((p) => ({ sha: p?.sha ?? '' }))
+                        ?.filter((p) => p.sha) ?? [],
             }))
             ?.sort((a, b) => {
                 return (

--- a/src/core/infrastructure/adapters/services/gitlab.service.ts
+++ b/src/core/infrastructure/adapters/services/gitlab.service.ts
@@ -1921,6 +1921,7 @@ export class GitlabService
                         username: user ? user.username : null,
                         id: user && user.id ? user.id : null,
                     },
+                    parents: commit?.parent_ids || [],
                 };
             }),
         );

--- a/src/core/infrastructure/adapters/services/gitlab.service.ts
+++ b/src/core/infrastructure/adapters/services/gitlab.service.ts
@@ -1921,7 +1921,10 @@ export class GitlabService
                         username: user ? user.username : null,
                         id: user && user.id ? user.id : null,
                     },
-                    parents: commit?.parent_ids || [],
+                    parents:
+                        commit?.parent_ids
+                            ?.map((p) => ({ sha: p ?? '' }))
+                            ?.filter((p) => p.sha) ?? [],
                 };
             }),
         );

--- a/src/ee/codeReview/strategies/code-review-pipeline.strategy.ee.ts
+++ b/src/ee/codeReview/strategies/code-review-pipeline.strategy.ee.ts
@@ -19,6 +19,7 @@ import { ProcessFilesPrLevelReviewStage } from '@/core/infrastructure/adapters/s
 import { CreatePrLevelCommentsStage } from '@/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/create-pr-level-comments.stage';
 import { CreateFileCommentsStage } from '@/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/create-file-comments.stage';
 import { CodeAnalysisASTCleanupStage } from '../stages/code-analysis-ast-cleanup.stage';
+import { ValidateNewCommitsStage } from '@/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/validate-new-commits.stage';
 
 @Injectable()
 export class CodeReviewPipelineStrategyEE
@@ -26,6 +27,7 @@ export class CodeReviewPipelineStrategyEE
 {
     constructor(
         private readonly validateConfigStage: ValidateConfigStage,
+        private readonly validateNewCommitsStage: ValidateNewCommitsStage,
         private readonly fetchChangedFilesStage: FetchChangedFilesStage,
         private readonly initialCommentStage: InitialCommentStage,
         private readonly kodyFineTuningStage: KodyFineTuningStage,
@@ -47,6 +49,7 @@ export class CodeReviewPipelineStrategyEE
     configureStages(): PipelineStage<CodeReviewPipelineContext>[] {
         return [
             this.validateConfigStage,
+            this.validateNewCommitsStage,
             this.fetchChangedFilesStage,
             this.initialCommentStage,
             this.kodyFineTuningStage,

--- a/src/modules/codeReviewPipeline.module.ts
+++ b/src/modules/codeReviewPipeline.module.ts
@@ -35,6 +35,7 @@ import { CreateFileCommentsStage } from '@/core/infrastructure/adapters/services
 import { CodeAnalysisASTCleanupStage } from '@/ee/codeReview/stages/code-analysis-ast-cleanup.stage';
 import { TeamAutomationModule } from './teamAutomation.module';
 import { PullRequestMessagesModule } from './pullRequestMessages.module';
+import { ValidateNewCommitsStage } from '@/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/validate-new-commits.stage';
 
 @Module({
     imports: [
@@ -58,6 +59,7 @@ import { PullRequestMessagesModule } from './pullRequestMessages.module';
         CodeReviewPipelineStrategyEE,
         // Stages
         ValidateConfigStage,
+        ValidateNewCommitsStage,
         FetchChangedFilesStage,
         InitialCommentStage,
         BatchCreationStage,


### PR DESCRIPTION
This pull request introduces a new feature to the `kodus-ai` repository, specifically targeting the validation of new commits in pull requests. The main focus is to check if the new commits are solely from a merge operation. Key changes include:

1. **Interface and Service Updates**:
   - The `IPullRequestManagerService` interface is updated with a new method, `getNewCommitsSinceLastExecution`, to retrieve new commits since the last execution.
   - A corresponding service method is implemented in `pullRequestManager.service.ts` to fetch and filter these commits.

2. **Pipeline Enhancements**:
   - A new pipeline stage, `ValidateNewCommitsStage`, is introduced to check for new commits since the last successful analysis. It identifies and skips analysis if the new commits are exclusively from a merge operation.
   - This stage is integrated into the code review pipeline strategy, positioned after configuration validation and before file fetching, allowing for efficient early termination if necessary.

3. **Commit Data Enrichment**:
   - Enhancements across various services (`azureRepos.service.ts`, `bitbucket.service.ts`, `github.service.ts`, `gitlab.service.ts`) include the addition of parent commit data to the commit objects, ensuring comprehensive commit information is available for analysis.

4. **Refactoring and Performance Improvements**:
   - The `FetchChangedFilesStage` is refactored to improve separation of concerns and performance by relying on pre-populated context data instead of direct database calls.

Overall, this pull request aims to improve the robustness and efficiency of the code review process by ensuring that only relevant new commits are analyzed, thereby optimizing the workflow and maintaining code quality.