### PR TITLE
Delete kody rules when deleting repository config

### DIFF
--- a/src/core/application/use-cases/platformIntegration/codeManagement/get-repository-tree.use-case.ts
+++ b/src/core/application/use-cases/platformIntegration/codeManagement/get-repository-tree.use-case.ts
@@ -42,6 +42,7 @@ export class GetRepositoryTreeUseCase implements IUseCase {
 
     public async execute(params: {
         organizationId: string;
+        teamId: string;
         repositoryId: string;
         treeType?: RepositoryTreeType;
     }) {
@@ -50,6 +51,7 @@ export class GetRepositoryTreeUseCase implements IUseCase {
                 await this.codeManagementService.getRepositoryTree({
                     organizationAndTeamData: {
                         organizationId: params.organizationId,
+                        teamId: params.teamId,
                     },
                     repositoryId: params.repositoryId,
                 });

--- a/src/core/domain/kodyRules/contracts/kodyRules.repository.contract.ts
+++ b/src/core/domain/kodyRules/contracts/kodyRules.repository.contract.ts
@@ -1,5 +1,5 @@
 import { KodyRulesEntity } from '../entities/kodyRules.entity';
-import { IKodyRule, IKodyRules } from '../interfaces/kodyRules.interface';
+import { IKodyRule, IKodyRules, KodyRulesStatus } from '../interfaces/kodyRules.interface';
 
 export const KODY_RULES_REPOSITORY_TOKEN = Symbol('KodyRulesRepository');
 
@@ -37,5 +37,11 @@ export interface IKodyRulesRepository {
     deleteRuleLogically(
         uuid: string,
         ruleId: string,
+    ): Promise<KodyRulesEntity | null>;
+    updateRulesStatusByFilter(
+        organizationId: string,
+        repositoryId: string,
+        directoryId?: string,
+        newStatus?: KodyRulesStatus,
     ): Promise<KodyRulesEntity | null>;
 }

--- a/src/core/domain/kodyRules/contracts/kodyRules.service.contract.ts
+++ b/src/core/domain/kodyRules/contracts/kodyRules.service.contract.ts
@@ -1,7 +1,8 @@
 import { IKodyRulesRepository } from './kodyRules.repository.contract';
 import { CreateKodyRuleDto } from '@/core/infrastructure/http/dtos/create-kody-rule.dto';
 import { OrganizationAndTeamData } from '@/config/types/general/organizationAndTeamData';
-import { IKodyRule } from '../interfaces/kodyRules.interface';
+import { IKodyRule, KodyRulesStatus } from '../interfaces/kodyRules.interface';
+import { KodyRulesEntity } from '../entities/kodyRules.entity';
 import { KodyRuleFilters } from '@/config/types/kodyRules.type';
 import { UserInfo } from '@/config/types/general/codeReviewSettingsLog.type';
 
@@ -21,4 +22,10 @@ export interface IKodyRulesService extends IKodyRulesRepository {
         repositoryId: string,
         directoryId: string,
     ): Promise<Partial<IKodyRule>[]>;
+    updateRulesStatusByFilter(
+        organizationId: string,
+        repositoryId: string,
+        directoryId?: string,
+        newStatus?: KodyRulesStatus,
+    ): Promise<KodyRulesEntity | null>;
 }

--- a/src/core/infrastructure/http/controllers/platformIntegration/codeManagement.controller.ts
+++ b/src/core/infrastructure/http/controllers/platformIntegration/codeManagement.controller.ts
@@ -168,6 +168,7 @@ export class CodeManagementController {
         @Query()
         query: {
             organizationId: string;
+            teamId: string;
             repositoryId: string;
             treeType?: RepositoryTreeType;
         },

--- a/src/ee/kodyRules/service/kodyRules.service.ts
+++ b/src/ee/kodyRules/service/kodyRules.service.ts
@@ -307,6 +307,50 @@ export class KodyRulesService implements IKodyRulesService {
         return this.kodyRulesRepository.deleteRule(uuid, ruleId);
     }
 
+    async updateRulesStatusByFilter(
+        organizationId: string,
+        repositoryId: string,
+        directoryId?: string,
+        newStatus: KodyRulesStatus = KodyRulesStatus.DELETED,
+    ): Promise<KodyRulesEntity | null> {
+        try {
+            const result = await this.kodyRulesRepository.updateRulesStatusByFilter(
+                organizationId,
+                repositoryId,
+                directoryId,
+                newStatus,
+            );
+
+            if (result) {
+                this.logger.log({
+                    message: 'Kody rules status updated successfully by filter',
+                    context: KodyRulesService.name,
+                    metadata: {
+                        organizationId,
+                        repositoryId,
+                        directoryId,
+                        newStatus,
+                    },
+                });
+            }
+
+            return result;
+        } catch (error) {
+            this.logger.error({
+                message: 'Error updating Kody rules status by filter',
+                context: KodyRulesService.name,
+                error: error,
+                metadata: {
+                    organizationId,
+                    repositoryId,
+                    directoryId,
+                    newStatus,
+                },
+            });
+            throw error;
+        }
+    }
+
     async deleteRuleLogically(
         uuid: string,
         ruleId: string,

--- a/src/modules/parameters.module.ts
+++ b/src/modules/parameters.module.ts
@@ -15,6 +15,9 @@ import { IntegrationModule } from './integration.module';
 import { GenerateCodeReviewParameterUseCase } from '@/core/application/use-cases/parameters/generate-code-review-paremeter.use-case';
 import { CodeReviewSettingsLogModule } from './codeReviewSettingsLog.module';
 import { PullRequestMessagesModule } from './pullRequestMessages.module';
+import { KodyRulesModule } from './kodyRules.module';
+import { KODY_RULES_SERVICE_TOKEN } from '@/core/domain/kodyRules/contracts/kodyRules.service.contract';
+import { KodyRulesService } from '@/ee/kodyRules/service/kodyRules.service';
 
 @Module({
     imports: [
@@ -25,6 +28,7 @@ import { PullRequestMessagesModule } from './pullRequestMessages.module';
         forwardRef(() => IntegrationModule),
         forwardRef(() => CodeReviewSettingsLogModule),
         forwardRef(() => PullRequestMessagesModule),
+        forwardRef(() => KodyRulesModule),
     ],
     providers: [
         ...UseCases,
@@ -37,11 +41,16 @@ import { PullRequestMessagesModule } from './pullRequestMessages.module';
             provide: PARAMETERS_REPOSITORY_TOKEN,
             useClass: ParametersRepository,
         },
+        {
+            provide: KODY_RULES_SERVICE_TOKEN,
+            useClass: KodyRulesService,
+        },
     ],
     controllers: [ParametersController],
     exports: [
         PARAMETERS_SERVICE_TOKEN,
         PARAMETERS_REPOSITORY_TOKEN,
+        KODY_RULES_SERVICE_TOKEN,
         CreateOrUpdateParametersUseCase,
         GenerateCodeReviewParameterUseCase,
     ],


### PR DESCRIPTION
This pull request implements a mechanism to disable Kody Rules when their associated repository or directory configuration is removed from the code review settings.

Key changes include:
*   **Automatic Kody Rule Deactivation**: When a repository's or a specific directory's code review configuration is deleted, all Kody Rules associated with that repository or directory will now have their status updated to `DELETED`. This ensures that rules are no longer active once their context is removed.
*   **New Service and Repository Methods**: Introduced `updateRulesStatusByFilter` methods in the `IKodyRulesService` and `IKodyRulesRepository` contracts, along with their concrete implementations, to facilitate updating Kody Rule statuses based on `organizationId`, `repositoryId`, and optional `directoryId`.
*   **Targeted Status Update**: The update logic specifically targets active Kody Rules (`KodyRulesStatus.ACTIVE`) within the specified repository or directory to change their status to `DELETED`.
*   **Logging and Error Handling**: Added logging for successful Kody Rule status updates and error handling to ensure the main configuration deletion process is not interrupted if the rule update fails.