### PR TITLE
Fixing get kody rules

### DIFF
--- a/src/ee/codeBase/codeBaseConfig.service.ts
+++ b/src/ee/codeBase/codeBaseConfig.service.ts
@@ -1033,6 +1033,7 @@ export default class CodeBaseConfigService implements ICodeBaseConfigService {
                 kodyRulesForDirectory,
                 reviewModeConfig,
                 kodyFineTuningConfig,
+                kodyRulesEntity,
             ] = await Promise.all([
                 this.parametersService.findByKey(
                     ParametersKey.LANGUAGE_CONFIG,
@@ -1046,10 +1047,21 @@ export default class CodeBaseConfigService implements ICodeBaseConfigService {
                 ),
                 this.getReviewModeConfigParameter(organizationAndTeamData),
                 this.getKodyFineTuningConfigParameter(organizationAndTeamData),
+                this.kodyRulesService.findByOrganizationId(
+                    organizationAndTeamData.organizationId,
+                ),
             ]);
 
-            // As rules já vêm filtradas para o diretório específico
-            const kodyRules = kodyRulesForDirectory;
+            const repositoryKodyRules =
+                this.kodyRulesValidationService.filterKodyRules(
+                    kodyRulesEntity?.toObject()?.rules,
+                    repository.id,
+                ).filter((rule) => rule?.directoryId !== directoryConfig.id);
+
+            const kodyRules = [
+                ...repositoryKodyRules,
+                ...kodyRulesForDirectory,
+            ];
 
             const config: CodeReviewConfig = {
                 ignorePaths: directoryConfig.ignorePaths || [],


### PR DESCRIPTION
Enhances the retrieval of Kody rules for a specific directory during code review configuration. Previously, only rules explicitly defined for the directory were considered. This change now includes relevant Kody rules defined at the organization level, filtered by the current repository. To avoid duplication, any repository-level rules that are also specifically tied to the current directory are excluded from the repository set before being combined with the directory-specific rules. This ensures a more comprehensive set of applicable Kody rules for the directory, incorporating both directory-specific and broader repository/organization-level configurations.