### PR TITLE
Fixing log when copy directory config

### DIFF
--- a/src/core/application/use-cases/parameters/copy-code-review-parameter.use-case.ts
+++ b/src/core/application/use-cases/parameters/copy-code-review-parameter.use-case.ts
@@ -331,7 +331,7 @@ export class CopyCodeReviewParameterUseCase {
                               id: sourceRepository.id,
                               name: sourceRepository.name,
                           },
-                directory: {
+                targetDirectory: {
                     id: "",
                     path: body.targetDirectoryPath,
                 },

--- a/src/core/domain/codeReviewSettingsLog/entities/codeReviewSettingsLog.entity.ts
+++ b/src/core/domain/codeReviewSettingsLog/entities/codeReviewSettingsLog.entity.ts
@@ -23,7 +23,7 @@ export class CodeReviewSettingsLogEntity
         name?: string;
     };
     private readonly _directory?: {
-        id: string;
+        id?: string;
         path?: string;
     };
     private readonly _changedData: ChangedData[];
@@ -111,7 +111,7 @@ export class CodeReviewSettingsLogEntity
     }
 
     get directory(): {
-        id: string;
+        id?: string;
         path?: string;
     } {
         return this._directory;

--- a/src/core/domain/codeReviewSettingsLog/interfaces/codeReviewSettingsLog.interface.ts
+++ b/src/core/domain/codeReviewSettingsLog/interfaces/codeReviewSettingsLog.interface.ts
@@ -15,7 +15,7 @@ export interface ICodeReviewSettingsLog {
         name?: string;
     };
     directory?: {
-        id: string;
+        id?: string;
         path?: string;
     };
     changedData: ChangedData[];

--- a/src/core/infrastructure/adapters/services/codeReviewSettingsLog/unifiedLog.handler.ts
+++ b/src/core/infrastructure/adapters/services/codeReviewSettingsLog/unifiedLog.handler.ts
@@ -25,7 +25,7 @@ export interface BaseLogParams {
     actionType: ActionType;
     configLevel?: ConfigLevel;
     repository?: { id: string; name?: string };
-    directory?: { id: string; path?: string };
+    directory?: { id?: string; path?: string };
 }
 
 export interface UnifiedLogParams extends BaseLogParams {


### PR DESCRIPTION
This pull request introduces dedicated logging for operations where code review configurations are copied to a specific directory.

Previously, the logging system primarily supported copying configurations between repositories. This change enhances the logging capabilities to accurately record when a user copies code review settings from a source (either a repository or global settings) to a target directory path.

Key changes include:
*   **New Log Type for Directory Copies**: A specific log entry is now generated for "Directory Configuration Copied" actions, detailing the source repository/global settings and the target directory path.
*   **Optional Directory ID in Logs**: The `id` field for directory information within log entities and interfaces has been made optional (`id?: string`). This accommodates scenarios where a directory might be identified solely by its path without a specific ID.
*   **Refactored Log Handling**: The internal log handling for copy operations has been refined to distinguish between copying to a repository and copying to a directory, ensuring the correct log details are captured for each scenario.

This ensures a more precise and comprehensive audit trail for code review setting changes, particularly for directory-level configurations.