### PR TITLE
Fix/reset integration

### DIFF
--- a/src/core/application/use-cases/platformIntegration/codeManagement/delete-integration-and-repositories.use-case.ts
+++ b/src/core/application/use-cases/platformIntegration/codeManagement/delete-integration-and-repositories.use-case.ts
@@ -51,7 +51,7 @@ export class DeleteIntegrationAndRepositoriesUseCase {
         const { organizationId, teamId } = params;
 
         try {
-            // 1. Primeiro, obter a lista de repositórios antes de deletar as configurações
+            // 1. First, get the list of repositories before deleting the configurations
             const repositoriesIds = await this.getRepositoriesIds(teamId);
 
             this.logger.log({
@@ -64,7 +64,7 @@ export class DeleteIntegrationAndRepositoriesUseCase {
                 },
             });
 
-            // 2. Executar o deleteIntegrationUseCase existente (remove integração e config repositories)
+            // 2. Execute the existing deleteIntegrationUseCase (remove integration and config repositories)
             await this.deleteIntegrationUseCase.execute(params);
 
             this.logger.log({
@@ -73,7 +73,7 @@ export class DeleteIntegrationAndRepositoriesUseCase {
                 metadata: { organizationId, teamId },
             });
 
-            // 3. Remover repositórios do campo repositories da tabela parameters (code_review_config)
+            // 3. Remove the repositories array from the code_review_config parameter
             await this.removeRepositoriesFromCodeReviewConfig(teamId);
 
             this.logger.log({
@@ -82,7 +82,7 @@ export class DeleteIntegrationAndRepositoriesUseCase {
                 metadata: { organizationId, teamId },
             });
 
-            // 4. Deletar pullRequestMessages associadas aos repositórios
+            // 4. Delete pullRequestMessages associated with the repositories
             await this.deletePullRequestMessages(organizationId, repositoriesIds);
 
             this.logger.log({
@@ -131,7 +131,7 @@ export class DeleteIntegrationAndRepositoriesUseCase {
 
     private async getRepositoriesIds(teamId: string): Promise<string[]> {
         try {
-            // Buscar o parâmetro code_review_config para obter a lista de repositórios
+            // Get the code_review_config parameter to get the list of repositories
             const codeReviewConfig = await this.parametersService.findOne({
                 configKey: ParametersKey.CODE_REVIEW_CONFIG,
                 team: { uuid: teamId },
@@ -176,7 +176,7 @@ export class DeleteIntegrationAndRepositoriesUseCase {
                 return;
             }
 
-            // Remover o array de repositórios do configValue
+            // Remove the repositories array from the configValue
             const updatedConfigValue = {
                 ...codeReviewConfig.configValue,
                 repositories: [],
@@ -204,7 +204,6 @@ export class DeleteIntegrationAndRepositoriesUseCase {
 
     private async deletePullRequestMessages(organizationId: string, repositoriesIds: string[]): Promise<void> {
         try {
-            // Deletar mensagens para cada repositório
             const deletionPromises = repositoriesIds.map(async (repositoryId) => {
                 try {
                     const wasDeleted = await this.pullRequestMessagesService.deleteByFilter({
@@ -234,7 +233,6 @@ export class DeleteIntegrationAndRepositoriesUseCase {
                             repositoryId,
                         },
                     });
-                    // Não falhar o processo principal se houver erro em um repositório específico
                     return false;
                 }
             });
@@ -257,7 +255,6 @@ export class DeleteIntegrationAndRepositoriesUseCase {
 
     private async inactivateKodyRules(organizationId: string, repositoriesIds: string[]): Promise<void> {
         try {
-            // Inativar Kody rules para cada repositório
             const inactivationPromises = repositoriesIds.map(async (repositoryId) => {
                 try {
                     const result = await this.kodyRulesService.updateRulesStatusByFilter(
@@ -288,7 +285,7 @@ export class DeleteIntegrationAndRepositoriesUseCase {
                             repositoryId,
                         },
                     });
-                    // Não falhar o processo principal se houver erro em um repositório específico
+                    // Do not fail the main process if there is an error in a specific repository
                     return null;
                 }
             });

--- a/src/core/application/use-cases/platformIntegration/codeManagement/delete-integration-and-repositories.use-case.ts
+++ b/src/core/application/use-cases/platformIntegration/codeManagement/delete-integration-and-repositories.use-case.ts
@@ -260,7 +260,7 @@ export class DeleteIntegrationAndRepositoriesUseCase {
                     const result = await this.kodyRulesService.updateRulesStatusByFilter(
                         organizationId,
                         repositoryId,
-                        undefined, // directoryId - undefined para inativar todas as rules do repositório
+                        undefined,
                         KodyRulesStatus.DELETED,
                     );
 

--- a/src/core/application/use-cases/platformIntegration/codeManagement/delete-integration-and-repositories.use-case.ts
+++ b/src/core/application/use-cases/platformIntegration/codeManagement/delete-integration-and-repositories.use-case.ts
@@ -1,0 +1,311 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { DeleteIntegrationUseCase } from './delete-integration.use-case';
+import { INTEGRATION_CONFIG_SERVICE_TOKEN } from '@/core/domain/integrationConfigs/contracts/integration-config.service.contracts';
+import { IIntegrationConfigService } from '@/core/domain/integrationConfigs/contracts/integration-config.service.contracts';
+import { PARAMETERS_SERVICE_TOKEN } from '@/core/domain/parameters/contracts/parameters.service.contract';
+import { IParametersService } from '@/core/domain/parameters/contracts/parameters.service.contract';
+import { PULL_REQUEST_MESSAGES_SERVICE_TOKEN } from '@/core/domain/pullRequestMessages/contracts/pullRequestMessages.service.contract';
+import { IPullRequestMessagesService } from '@/core/domain/pullRequestMessages/contracts/pullRequestMessages.service.contract';
+import { KODY_RULES_SERVICE_TOKEN } from '@/core/domain/kodyRules/contracts/kodyRules.service.contract';
+import { IKodyRulesService } from '@/core/domain/kodyRules/contracts/kodyRules.service.contract';
+import { IntegrationConfigKey } from '@/shared/domain/enums/Integration-config-key.enum';
+import { ParametersKey } from '@/shared/domain/enums/parameters-key.enum';
+import { KodyRulesStatus } from '@/core/domain/kodyRules/interfaces/kodyRules.interface';
+import { ConfigLevel } from '@/config/types/general/pullRequestMessages.type';
+import { PinoLoggerService } from '@/core/infrastructure/adapters/services/logger/pino.service';
+import { REQUEST } from '@nestjs/core';
+
+@Injectable()
+export class DeleteIntegrationAndRepositoriesUseCase {
+    constructor(
+        private readonly deleteIntegrationUseCase: DeleteIntegrationUseCase,
+
+        @Inject(INTEGRATION_CONFIG_SERVICE_TOKEN)
+        private readonly integrationConfigService: IIntegrationConfigService,
+
+        @Inject(PARAMETERS_SERVICE_TOKEN)
+        private readonly parametersService: IParametersService,
+
+        @Inject(PULL_REQUEST_MESSAGES_SERVICE_TOKEN)
+        private readonly pullRequestMessagesService: IPullRequestMessagesService,
+
+        @Inject(KODY_RULES_SERVICE_TOKEN)
+        private readonly kodyRulesService: IKodyRulesService,
+
+        private readonly logger: PinoLoggerService,
+
+        @Inject(REQUEST)
+        private readonly request: Request & {
+            user: {
+                organization: { uuid: string };
+                uuid: string;
+                email: string;
+            };
+        },
+    ) {}
+
+    async execute(params: {
+        organizationId: string;
+        teamId: string;
+    }): Promise<void> {
+        const { organizationId, teamId } = params;
+
+        try {
+            // 1. Primeiro, obter a lista de repositórios antes de deletar as configurações
+            const repositoriesIds = await this.getRepositoriesIds(teamId);
+
+            this.logger.log({
+                message: 'Starting complete integration and repositories deletion',
+                context: DeleteIntegrationAndRepositoriesUseCase.name,
+                metadata: {
+                    organizationId,
+                    teamId,
+                    repositoriesCount: repositoriesIds.length,
+                },
+            });
+
+            // 2. Executar o deleteIntegrationUseCase existente (remove integração e config repositories)
+            await this.deleteIntegrationUseCase.execute(params);
+
+            this.logger.log({
+                message: 'Integration deleted successfully',
+                context: DeleteIntegrationAndRepositoriesUseCase.name,
+                metadata: { organizationId, teamId },
+            });
+
+            // 3. Remover repositórios do campo repositories da tabela parameters (code_review_config)
+            await this.removeRepositoriesFromCodeReviewConfig(teamId);
+
+            this.logger.log({
+                message: 'Repositories removed from code review config',
+                context: DeleteIntegrationAndRepositoriesUseCase.name,
+                metadata: { organizationId, teamId },
+            });
+
+            // 4. Deletar pullRequestMessages associadas aos repositórios
+            await this.deletePullRequestMessages(organizationId, repositoriesIds);
+
+            this.logger.log({
+                message: 'Pull request messages deleted successfully',
+                context: DeleteIntegrationAndRepositoriesUseCase.name,
+                metadata: {
+                    organizationId,
+                    teamId,
+                    repositoriesCount: repositoriesIds.length,
+                },
+            });
+
+            // 5. Inativar Kody rules associadas aos repositórios
+            await this.inactivateKodyRules(organizationId, repositoriesIds);
+
+            this.logger.log({
+                message: 'Kody rules inactivated successfully',
+                context: DeleteIntegrationAndRepositoriesUseCase.name,
+                metadata: {
+                    organizationId,
+                    teamId,
+                    repositoriesCount: repositoriesIds.length,
+                },
+            });
+
+            this.logger.log({
+                message: 'Complete integration and repositories deletion finished successfully',
+                context: DeleteIntegrationAndRepositoriesUseCase.name,
+                metadata: {
+                    organizationId,
+                    teamId,
+                    repositoriesCount: repositoriesIds.length,
+                },
+            });
+
+        } catch (error) {
+            this.logger.error({
+                message: 'Error during complete integration and repositories deletion',
+                context: DeleteIntegrationAndRepositoriesUseCase.name,
+                error: error,
+                metadata: { organizationId, teamId },
+            });
+            throw error;
+        }
+    }
+
+    private async getRepositoriesIds(teamId: string): Promise<string[]> {
+        try {
+            // Buscar o parâmetro code_review_config para obter a lista de repositórios
+            const codeReviewConfig = await this.parametersService.findOne({
+                configKey: ParametersKey.CODE_REVIEW_CONFIG,
+                team: { uuid: teamId },
+            });
+
+            if (!codeReviewConfig?.configValue?.repositories) {
+                this.logger.warn({
+                    message: 'No repositories found in code review config',
+                    context: DeleteIntegrationAndRepositoriesUseCase.name,
+                    metadata: { teamId },
+                });
+                return [];
+            }
+
+            const repositories = codeReviewConfig.configValue.repositories;
+            return repositories.map((repo: any) => repo.id.toString());
+
+        } catch (error) {
+            this.logger.error({
+                message: 'Error getting repositories IDs',
+                context: DeleteIntegrationAndRepositoriesUseCase.name,
+                error: error,
+                metadata: { teamId },
+            });
+            return [];
+        }
+    }
+
+    private async removeRepositoriesFromCodeReviewConfig(teamId: string): Promise<void> {
+        try {
+            const codeReviewConfig = await this.parametersService.findOne({
+                configKey: ParametersKey.CODE_REVIEW_CONFIG,
+                team: { uuid: teamId },
+            });
+
+            if (!codeReviewConfig) {
+                this.logger.warn({
+                    message: 'Code review config not found',
+                    context: DeleteIntegrationAndRepositoriesUseCase.name,
+                    metadata: { teamId },
+                });
+                return;
+            }
+
+            // Remover o array de repositórios do configValue
+            const updatedConfigValue = {
+                ...codeReviewConfig.configValue,
+                repositories: [],
+            };
+
+            await this.parametersService.createOrUpdateConfig(
+                ParametersKey.CODE_REVIEW_CONFIG,
+                updatedConfigValue,
+                {
+                    organizationId: this.request.user.organization.uuid,
+                    teamId,
+                },
+            );
+
+        } catch (error) {
+            this.logger.error({
+                message: 'Error removing repositories from code review config',
+                context: DeleteIntegrationAndRepositoriesUseCase.name,
+                error: error,
+                metadata: { teamId },
+            });
+            throw error;
+        }
+    }
+
+    private async deletePullRequestMessages(organizationId: string, repositoriesIds: string[]): Promise<void> {
+        try {
+            // Deletar mensagens para cada repositório
+            const deletionPromises = repositoriesIds.map(async (repositoryId) => {
+                try {
+                    const wasDeleted = await this.pullRequestMessagesService.deleteByFilter({
+                        organizationId,
+                        repositoryId,
+                        configLevel: ConfigLevel.REPOSITORY,
+                    });
+
+                    this.logger.log({
+                        message: 'Pull request messages deletion attempt',
+                        context: DeleteIntegrationAndRepositoriesUseCase.name,
+                        metadata: {
+                            organizationId,
+                            repositoryId,
+                            wasDeleted,
+                        },
+                    });
+
+                    return wasDeleted;
+                } catch (error) {
+                    this.logger.error({
+                        message: 'Error deleting pull request messages for repository',
+                        context: DeleteIntegrationAndRepositoriesUseCase.name,
+                        error: error,
+                        metadata: {
+                            organizationId,
+                            repositoryId,
+                        },
+                    });
+                    // Não falhar o processo principal se houver erro em um repositório específico
+                    return false;
+                }
+            });
+
+            await Promise.all(deletionPromises);
+
+        } catch (error) {
+            this.logger.error({
+                message: 'Error deleting pull request messages',
+                context: DeleteIntegrationAndRepositoriesUseCase.name,
+                error: error,
+                metadata: {
+                    organizationId,
+                    repositoriesCount: repositoriesIds.length,
+                },
+            });
+            throw error;
+        }
+    }
+
+    private async inactivateKodyRules(organizationId: string, repositoriesIds: string[]): Promise<void> {
+        try {
+            // Inativar Kody rules para cada repositório
+            const inactivationPromises = repositoriesIds.map(async (repositoryId) => {
+                try {
+                    const result = await this.kodyRulesService.updateRulesStatusByFilter(
+                        organizationId,
+                        repositoryId,
+                        undefined, // directoryId - undefined para inativar todas as rules do repositório
+                        KodyRulesStatus.DELETED,
+                    );
+
+                    this.logger.log({
+                        message: 'Kody rules inactivation attempt',
+                        context: DeleteIntegrationAndRepositoriesUseCase.name,
+                        metadata: {
+                            organizationId,
+                            repositoryId,
+                            wasInactivated: !!result,
+                        },
+                    });
+
+                    return result;
+                } catch (error) {
+                    this.logger.error({
+                        message: 'Error inactivating Kody rules for repository',
+                        context: DeleteIntegrationAndRepositoriesUseCase.name,
+                        error: error,
+                        metadata: {
+                            organizationId,
+                            repositoryId,
+                        },
+                    });
+                    // Não falhar o processo principal se houver erro em um repositório específico
+                    return null;
+                }
+            });
+
+            await Promise.all(inactivationPromises);
+
+        } catch (error) {
+            this.logger.error({
+                message: 'Error inactivating Kody rules',
+                context: DeleteIntegrationAndRepositoriesUseCase.name,
+                error: error,
+                metadata: {
+                    organizationId,
+                    repositoriesCount: repositoriesIds.length,
+                },
+            });
+            throw error;
+        }
+    }
+}

--- a/src/core/application/use-cases/platformIntegration/codeManagement/index.ts
+++ b/src/core/application/use-cases/platformIntegration/codeManagement/index.ts
@@ -15,6 +15,7 @@ import { CreatePRCodeReviewUseCase } from './create-prs-code-review.use-case';
 import { GetCodeReviewStartedUseCase } from './get-code-review-started.use-case';
 import { FinishOnboardingUseCase } from './finish-onboarding.use-case';
 import { DeleteIntegrationUseCase } from './delete-integration.use-case';
+import { DeleteIntegrationAndRepositoriesUseCase } from './delete-integration-and-repositories.use-case';
 import { GetRepositoryTreeUseCase } from './get-repository-tree.use-case';
 
 export default [
@@ -35,5 +36,6 @@ export default [
     GetCodeReviewStartedUseCase,
     FinishOnboardingUseCase,
     DeleteIntegrationUseCase,
+    DeleteIntegrationAndRepositoriesUseCase,
     GetRepositoryTreeUseCase,
 ];

--- a/src/core/infrastructure/http/controllers/platformIntegration/codeManagement.controller.ts
+++ b/src/core/infrastructure/http/controllers/platformIntegration/codeManagement.controller.ts
@@ -17,6 +17,7 @@ import { GetCodeReviewStartedUseCase } from '@/core/application/use-cases/platfo
 import { FinishOnboardingDTO } from '../../dtos/finish-onboarding.dto';
 import { FinishOnboardingUseCase } from '@/core/application/use-cases/platformIntegration/codeManagement/finish-onboarding.use-case';
 import { DeleteIntegrationUseCase } from '@/core/application/use-cases/platformIntegration/codeManagement/delete-integration.use-case';
+import { DeleteIntegrationAndRepositoriesUseCase } from '@/core/application/use-cases/platformIntegration/codeManagement/delete-integration-and-repositories.use-case';
 import { GetRepositoryTreeUseCase } from '@/core/application/use-cases/platformIntegration/codeManagement/get-repository-tree.use-case';
 import { RepositoryTreeType } from '@/shared/utils/enums/repositoryTree.enum';
 
@@ -38,6 +39,7 @@ export class CodeManagementController {
         private readonly getCodeReviewStartedUseCase: GetCodeReviewStartedUseCase,
         private readonly finishOnboardingUseCase: FinishOnboardingUseCase,
         private readonly deleteIntegrationUseCase: DeleteIntegrationUseCase,
+        private readonly deleteIntegrationAndRepositoriesUseCase: DeleteIntegrationAndRepositoriesUseCase,
         private readonly getRepositoryTreeUseCase: GetRepositoryTreeUseCase,
     ) {}
 
@@ -168,6 +170,13 @@ export class CodeManagementController {
         @Query() query: { organizationId: string; teamId: string },
     ) {
         return await this.deleteIntegrationUseCase.execute(query);
+    }
+
+    @Delete('/delete-integration-and-repositories')
+    public async deleteIntegrationAndRepositories(
+        @Query() query: { organizationId: string; teamId: string },
+    ) {
+        return await this.deleteIntegrationAndRepositoriesUseCase.execute(query);
     }
 
     @Get('/get-repository-tree')

--- a/src/modules/platformIntegration.module.ts
+++ b/src/modules/platformIntegration.module.ts
@@ -54,6 +54,7 @@ import { IssuesModule } from './issues.module';
 import { CodeReviewSettingsLogModule } from './codeReviewSettingsLog.module';
 import { McpAgentModule } from './mcpAgent.module';
 import { GetAdditionalInfoHelper } from '@/shared/utils/helpers/getAdditionalInfo.helper';
+import { PullRequestMessagesModule } from './pullRequestMessages.module';
 @Module({
     imports: [
         forwardRef(() => IntegrationModule),
@@ -83,6 +84,7 @@ import { GetAdditionalInfoHelper } from '@/shared/utils/helpers/getAdditionalInf
         forwardRef(() => BitbucketModule),
         forwardRef(() => IssuesModule),
         forwardRef(() => CodeReviewSettingsLogModule),
+        forwardRef(() => PullRequestMessagesModule),
         PullRequestsModule,
         McpAgentModule,
     ],


### PR DESCRIPTION
This pull request introduces a new comprehensive functionality to delete a platform integration and all its associated data.

The changes include:
- **New Use Case for Comprehensive Deletion:** A new `DeleteIntegrationAndRepositoriesUseCase` has been added. This use case orchestrates a complete cleanup process for a platform integration.
- **Extended Deletion Scope:** Beyond deleting the core integration configuration, the new use case now also:
    - Removes the list of associated repositories from the `code_review_config` parameter for the specific team.
    - Deletes all pull request messages linked to the repositories that were part of the integration.
    - Inactivates Kody rules that were associated with these repositories by setting their status to 'DELETED'.
- **New API Endpoint:** A new DELETE endpoint `/delete-integration-and-repositories` has been added to the `CodeManagementController`. This endpoint allows triggering the comprehensive integration and repository deletion process for a given organization and team.
- **Module Dependency Update:** The `PullRequestMessagesModule` has been added to the `PlatformIntegrationModule` imports to support the deletion of pull request messages by the new use case.

This enhancement provides a more robust "reset" or "uninstall" mechanism for platform integrations, ensuring that all related configurations and data are properly cleaned up when an integration is removed.