### PR TITLE
Fixing conditional filter

### DIFF
--- a/src/core/infrastructure/adapters/services/codeBase/suggestion.service.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/suggestion.service.ts
@@ -566,7 +566,7 @@ export class SuggestionService implements ISuggestionService {
 
         let severityLevelFilterWithConditional = severityLevelFilter;
 
-        if (severityLimits) {
+        if (limitationType === LimitationType.SEVERITY) {
             severityLevelFilterWithConditional = SeverityLevel.LOW;
         }
 


### PR DESCRIPTION
[KC-1211](https://kodustech.atlassian.net/browse/KC-1211)

---

Refined the conditional logic for setting the `severityLevelFilterWithConditional` in the suggestion service. The severity level will now be overridden to `SeverityLevel.LOW` only when the `limitationType` is explicitly `LimitationType.SEVERITY`, ensuring more precise control over severity filtering based on the active limitation type.