### PR TITLE
Fixing severity level filter

### DIFF
--- a/src/core/infrastructure/adapters/services/codeBase/suggestion.service.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/suggestion.service.ts
@@ -566,7 +566,7 @@ export class SuggestionService implements ISuggestionService {
 
         let severityLevelFilterWithConditional = severityLevelFilter;
 
-        if (severityLimits) {
+        if (limitationType === LimitationType.SEVERITY) {
             severityLevelFilterWithConditional = SeverityLevel.LOW;
         }
 


### PR DESCRIPTION
This pull request fixes an issue with the severity level filter in the `SuggestionService`.

The change refines the condition under which the `severityLevelFilterWithConditional` is set to `SeverityLevel.LOW`. Previously, this occurred if `severityLimits` were present. Now, it is specifically applied only when the `limitationType` is `LimitationType.SEVERITY`. This ensures the severity level filter is correctly adjusted to `LOW` only when a severity-based limitation is active, preventing incorrect filtering in other scenarios.