### PR TITLE
save draft status in pull request

### DIFF
--- a/src/core/domain/pullRequests/entities/pullRequests.entity.ts
+++ b/src/core/domain/pullRequests/entities/pullRequests.entity.ts
@@ -43,6 +43,7 @@ export class PullRequestsEntity implements Entity<IPullRequests> {
     private readonly _commits: Array<ICommit>;
     private readonly _syncedEmbeddedSuggestions: boolean;
     private readonly _syncedWithIssues: boolean;
+    private readonly _isDraft: boolean;
 
     constructor(pullRequest: IPullRequests) {
         this._uuid = pullRequest.uuid;
@@ -75,6 +76,7 @@ export class PullRequestsEntity implements Entity<IPullRequests> {
             : [];
         this._syncedEmbeddedSuggestions = pullRequest.syncedEmbeddedSuggestions;
         this._syncedWithIssues = pullRequest.syncedWithIssues;
+        this._isDraft = pullRequest.isDraft ?? false;
     }
 
     toJson(): IPullRequests {
@@ -105,6 +107,7 @@ export class PullRequestsEntity implements Entity<IPullRequests> {
             commits: this._commits,
             syncedEmbeddedSuggestions: this._syncedEmbeddedSuggestions,
             syncedWithIssues: this._syncedWithIssues,
+            isDraft: this._isDraft,
         };
     }
 
@@ -136,6 +139,7 @@ export class PullRequestsEntity implements Entity<IPullRequests> {
             commits: this._commits,
             syncedEmbeddedSuggestions: this._syncedEmbeddedSuggestions,
             syncedWithIssues: this._syncedWithIssues,
+            isDraft: this._isDraft,
         };
     }
 
@@ -245,5 +249,9 @@ export class PullRequestsEntity implements Entity<IPullRequests> {
 
     get syncedWithIssues(): boolean {
         return this._syncedWithIssues;
+    }
+
+    get isDraft(): boolean {
+        return this._isDraft;
     }
 }

--- a/src/core/domain/pullRequests/interfaces/pullRequests.interface.ts
+++ b/src/core/domain/pullRequests/interfaces/pullRequests.interface.ts
@@ -38,6 +38,7 @@ export interface IPullRequests {
     syncedWithIssues?: boolean;
     suggestionsByPR?: ISuggestionByPR[];
     prLevelSuggestions?: ISuggestionByPR[];
+    isDraft: boolean;
 }
 
 export interface ICommit {

--- a/src/core/infrastructure/adapters/repositories/mongoose/schema/pullRequests.model.ts
+++ b/src/core/infrastructure/adapters/repositories/mongoose/schema/pullRequests.model.ts
@@ -64,11 +64,11 @@ export class PullRequestsModel extends CoreDocument {
         added: number;
         deleted: number;
         changes: number;
-        reviewMode: ReviewModeResponse,
+        reviewMode: ReviewModeResponse;
         codeReviewModelUsed: {
             generateSuggestions: string;
             safeguard: string;
-        }
+        };
         suggestions: Array<{
             id: string;
             relevantFile: string;
@@ -161,8 +161,10 @@ export class PullRequestsModel extends CoreDocument {
         createdAt?: string;
         updatedAt?: string;
     }>;
+
+    @Prop({ type: Boolean, required: true, default: false })
+    public isDraft: boolean;
 }
 
 export const PullRequestsSchema =
     SchemaFactory.createForClass(PullRequestsModel);
-

--- a/src/core/infrastructure/adapters/services/pullRequests/pullRequests.service.ts
+++ b/src/core/infrastructure/adapters/services/pullRequests/pullRequests.service.ts
@@ -380,6 +380,7 @@ export class PullRequestsService implements IPullRequestsService {
                     pullRequest?.number,
                 ),
                 commits: enrichedPullRequest.commits,
+                isDraft: enrichedPullRequest.isDraft ?? false,
             });
 
             if (prLevelSuggestions && prLevelSuggestions.length > 0) {
@@ -473,6 +474,7 @@ export class PullRequestsService implements IPullRequestsService {
                 syncedEmbeddedSuggestions: false,
                 syncedWithIssues: false,
                 prLevelSuggestions: [],
+                isDraft: pullRequest.isDraft ?? false,
             };
         } catch (error) {
             this.logger.log({

--- a/src/core/infrastructure/adapters/webhooks/bitbucket/bitbucketPullRequest.handler.ts
+++ b/src/core/infrastructure/adapters/webhooks/bitbucket/bitbucketPullRequest.handler.ts
@@ -372,12 +372,10 @@ export class BitbucketPullRequestHandler implements IWebhookEventHandler {
                         organizationAndTeamData,
                     );
 
-                const isDraft =
-                    pullrequest.state === 'OPEN' &&
-                    (pullrequest.draft ?? false);
+                const isDraft = pullrequest.draft ?? false;
                 const wasDraft = storedPR?.isDraft ?? false;
 
-                if (wasDraft && !isDraft) {
+                if (pullrequest.state === 'OPEN' && wasDraft && !isDraft) {
                     return true;
                 }
 

--- a/src/core/infrastructure/adapters/webhooks/bitbucket/bitbucketPullRequest.handler.ts
+++ b/src/core/infrastructure/adapters/webhooks/bitbucket/bitbucketPullRequest.handler.ts
@@ -372,6 +372,15 @@ export class BitbucketPullRequestHandler implements IWebhookEventHandler {
                         organizationAndTeamData,
                     );
 
+                const isDraft =
+                    pullrequest.state === 'OPEN' &&
+                    (pullrequest.draft ?? false);
+                const wasDraft = storedPR?.isDraft ?? false;
+
+                if (wasDraft && !isDraft) {
+                    return true;
+                }
+
                 if (storedPR && pullrequest.state === 'OPEN') {
                     const prCommit =
                         pullRequestCommits[pullRequestCommits.length - 1];


### PR DESCRIPTION
#163

add bitbucket edge case handling

---

This pull request introduces the capability to track and store the draft status of pull requests.

Key changes include:
- **Domain Model Update:** A new `isDraft` boolean property has been added to the `IPullRequests` interface and the `PullRequestsEntity` to represent whether a pull request is in a draft state.
- **Service Layer Integration:** The `PullRequestsService` has been updated to persist and retrieve the `isDraft` status when creating or fetching pull requests.
- **Bitbucket Webhook Handling:** The Bitbucket webhook handler now correctly identifies and processes the `isDraft` status from incoming Bitbucket pull request events, including specific logic to handle the transition of a pull request from a draft state to a non-draft state.