### PR TITLE
Feat/improvements sync ide rules

### DIFF
--- a/src/config/types/general/codeReview.type.ts
+++ b/src/config/types/general/codeReview.type.ts
@@ -300,6 +300,7 @@ export type CodeReviewConfig = {
     isRequestChangesActive?: boolean;
     kodyRulesGeneratorEnabled?: boolean;
     reviewModeConfig?: ReviewModeConfig;
+    ideRulesSyncEnabled?: boolean;
     kodyFineTuningConfig?: KodyFineTuningConfig;
     isCommitMode?: boolean;
     configLevel?: ConfigLevel;

--- a/src/config/types/general/codeReviewConfig.type.ts
+++ b/src/config/types/general/codeReviewConfig.type.ts
@@ -1,0 +1,35 @@
+import { CodeReviewConfigWithoutLLMProvider } from './codeReview.type';
+import { OrganizationAndTeamData } from './organizationAndTeamData';
+
+export interface ICodeRepository {
+    avatar_url?: string;
+    default_branch: string;
+    http_url: string;
+    id: string;
+    language: string;
+    name: string;
+    organizationName: string;
+    selected: string;
+    visibility: 'private' | 'public';
+    directories: Array<any>;
+}
+
+export interface IFilteredCodeRepository {
+    id: string;
+    name: string;
+    isSelected: boolean;
+    directories: Array<any>;
+    directoryId?: string;
+}
+
+export interface IRepositoryCodeReviewConfig
+    extends CodeReviewConfigWithoutLLMProvider {
+    id: string;
+    name: string;
+    directories: Array<any>;
+}
+
+export interface ICodeReviewParameter {
+    global: CodeReviewConfigWithoutLLMProvider;
+    repositories: Array<IRepositoryCodeReviewConfig | IFilteredCodeRepository>;
+}

--- a/src/core/application/use-cases/kodyRules/check-sync-status.use-case.ts
+++ b/src/core/application/use-cases/kodyRules/check-sync-status.use-case.ts
@@ -63,7 +63,13 @@ export class CheckSyncStatusUseCase {
         },
     ) {}
 
-    async execute(teamId: string, repositoryId?: string) {
+    async execute(
+        teamId: string,
+        repositoryId?: string,
+    ): Promise<{
+        ideRulesSyncEnabledFirstTime: boolean;
+        kodyRulesGeneratorEnabledFirstTime: boolean;
+    }> {
         const syncStatusFlags = {
             ideRulesSyncEnabledFirstTime: true,
             kodyRulesGeneratorEnabledFirstTime: true,
@@ -114,12 +120,14 @@ export class CheckSyncStatusUseCase {
             const kodyRulesGeneratorEnabled =
                 currentRepositoryConfig.kodyRulesGeneratorEnabled;
 
-            if (kodyRulesGeneratorEnabled) {
+            if (
+                platformConfig.configValue.kodyLearningStatus ===
+                KodyLearningStatus.DISABLED
+            ) {
                 syncStatusFlags.kodyRulesGeneratorEnabledFirstTime = false;
             } else {
                 syncStatusFlags.kodyRulesGeneratorEnabledFirstTime =
-                    platformConfig.configValue.kodyLearningStatus ===
-                    KodyLearningStatus.DISABLED;
+                    kodyRulesGeneratorEnabled;
             }
 
             return syncStatusFlags;

--- a/src/core/application/use-cases/kodyRules/check-sync-status.use-case.ts
+++ b/src/core/application/use-cases/kodyRules/check-sync-status.use-case.ts
@@ -1,0 +1,160 @@
+import { CommentAnalysisService } from '@/core/infrastructure/adapters/services/codeBase/commentAnalysis.service';
+import { PinoLoggerService } from '@/core/infrastructure/adapters/services/logger/pino.service';
+import { CodeManagementService } from '@/core/infrastructure/adapters/services/platformIntegration/codeManagement.service';
+import { GenerateKodyRulesDTO } from '@/core/infrastructure/http/dtos/generate-kody-rules.dto';
+import { Inject, Injectable } from '@nestjs/common';
+
+import { CreateOrUpdateKodyRulesUseCase } from './create-or-update.use-case';
+import {
+    CreateKodyRuleDto,
+    KodyRuleSeverity,
+} from '@/core/infrastructure/http/dtos/create-kody-rule.dto';
+import {
+    IKodyRule,
+    KodyRulesStatus,
+} from '@/core/domain/kodyRules/interfaces/kodyRules.interface';
+import { FindRulesInOrganizationByRuleFilterKodyRulesUseCase } from './find-rules-in-organization-by-filter.use-case';
+import { generateDateFilter } from '@/shared/utils/transforms/date';
+import {
+    IIntegrationConfigService,
+    INTEGRATION_CONFIG_SERVICE_TOKEN,
+} from '@/core/domain/integrationConfigs/contracts/integration-config.service.contracts';
+import {
+    IIntegrationService,
+    INTEGRATION_SERVICE_TOKEN,
+} from '@/core/domain/integrations/contracts/integration.service.contracts';
+import { IntegrationConfigKey } from '@/shared/domain/enums/Integration-config-key.enum';
+import { Repositories } from '@/core/domain/platformIntegrations/types/codeManagement/repositories.type';
+import {
+    IParametersService,
+    PARAMETERS_SERVICE_TOKEN,
+} from '@/core/domain/parameters/contracts/parameters.service.contract';
+import { ParametersKey } from '@/shared/domain/enums/parameters-key.enum';
+import { KodyLearningStatus } from '@/core/domain/parameters/types/configValue.type';
+import { ParametersEntity } from '@/core/domain/parameters/entities/parameters.entity';
+import { OrganizationAndTeamData } from '@/config/types/general/organizationAndTeamData';
+import { SendRulesNotificationUseCase } from './send-rules-notification.use-case';
+import { REQUEST } from '@nestjs/core';
+import {
+    ICodeRepository,
+    ICodeReviewParameter,
+    IRepositoryCodeReviewConfig,
+} from '@/config/types/general/codeReviewConfig.type';
+
+@Injectable()
+export class CheckSyncStatusUseCase {
+    constructor(
+        @Inject(INTEGRATION_SERVICE_TOKEN)
+        private readonly integrationService: IIntegrationService,
+
+        @Inject(INTEGRATION_CONFIG_SERVICE_TOKEN)
+        private readonly integrationConfigService: IIntegrationConfigService,
+
+        @Inject(PARAMETERS_SERVICE_TOKEN)
+        private readonly parametersService: IParametersService,
+
+        private readonly findRulesInOrganizationByRuleFilterKodyRulesUseCase: FindRulesInOrganizationByRuleFilterKodyRulesUseCase,
+
+        private readonly logger: PinoLoggerService,
+
+        @Inject(REQUEST)
+        private readonly request: Request & {
+            user: { organization: { uuid: string } };
+        },
+    ) {}
+
+    async execute(teamId: string, repositoryId?: string) {
+        const syncStatusFlags = {
+            ideRulesSyncEnabledFirstTime: true,
+            kodyRulesGeneratorEnabledFirstTime: true,
+        };
+
+        const organizationAndTeamData = {
+            organizationId: this.request.user.organization.uuid,
+            teamId: teamId,
+        };
+
+        const platformConfig = await this.parametersService.findByKey(
+            ParametersKey.PLATFORM_CONFIGS,
+            organizationAndTeamData,
+        );
+
+        try {
+            const codeReviewConfigs: ICodeReviewParameter =
+                await this.getCodeReviewConfigs(organizationAndTeamData);
+
+            const currentRepositoryConfig = codeReviewConfigs.repositories.find(
+                (repository: IRepositoryCodeReviewConfig) =>
+                    repository.id === repositoryId,
+            ) as IRepositoryCodeReviewConfig;
+
+            // Se não encontrou o repositório, retorna configuração padrão
+            if (!currentRepositoryConfig) {
+                return syncStatusFlags;
+            }
+
+            const ideRulesSyncEnabled =
+                currentRepositoryConfig.ideRulesSyncEnabled;
+
+            if (!ideRulesSyncEnabled) {
+                const rules =
+                    await this.findRulesInOrganizationByRuleFilterKodyRulesUseCase.execute(
+                        organizationAndTeamData.organizationId,
+                        {},
+                        repositoryId,
+                    );
+
+                const ideRules = rules.find((rule) =>
+                    rule.rules.find((r: IKodyRule) => r.sourcePath),
+                );
+
+                syncStatusFlags.ideRulesSyncEnabledFirstTime = !ideRules;
+            }
+
+            const kodyRulesGeneratorEnabled =
+                currentRepositoryConfig.kodyRulesGeneratorEnabled;
+
+            if (kodyRulesGeneratorEnabled) {
+                syncStatusFlags.kodyRulesGeneratorEnabledFirstTime = false;
+            } else {
+                syncStatusFlags.kodyRulesGeneratorEnabledFirstTime =
+                    platformConfig.configValue.kodyLearningStatus ===
+                    KodyLearningStatus.DISABLED;
+            }
+
+            return syncStatusFlags;
+        } catch (error) {
+            this.logger.error({
+                message: 'Error checking sync status',
+                error,
+                context: CheckSyncStatusUseCase.name,
+                metadata: {
+                    organizationId: this.request.user.organization.uuid,
+                    teamId,
+                    repositoryId,
+                },
+            });
+
+            return syncStatusFlags;
+        }
+    }
+
+    private async getCodeReviewConfigs(
+        organizationAndTeamData: OrganizationAndTeamData,
+    ): Promise<ICodeReviewParameter> {
+        const codeReviewConfig = await this.parametersService.findByKey(
+            ParametersKey.CODE_REVIEW_CONFIG,
+            organizationAndTeamData,
+        );
+
+        return codeReviewConfig?.configValue;
+    }
+
+    private async getFormattedRepositories(
+        organizationAndTeamData: OrganizationAndTeamData,
+    ) {
+        return await this.integrationConfigService.findIntegrationConfigFormatted<
+            ICodeRepository[]
+        >(IntegrationConfigKey.REPOSITORIES, organizationAndTeamData);
+    }
+}

--- a/src/core/application/use-cases/kodyRules/index.ts
+++ b/src/core/application/use-cases/kodyRules/index.ts
@@ -1,5 +1,6 @@
 import { AddLibraryKodyRulesUseCase } from './add-library-kody-rules.use-case';
 import { ChangeStatusKodyRulesUseCase } from './change-status-kody-rules.use-case';
+import { CheckSyncStatusUseCase } from './check-sync-status.use-case';
 import { CreateOrUpdateKodyRulesUseCase } from './create-or-update.use-case';
 import { DeleteByOrganizationIdKodyRulesUseCase } from './delete-by-organization-id.use-case';
 import { DeleteRuleInOrganizationByIdKodyRulesUseCase } from './delete-rule-in-organization-by-id.use-case';
@@ -24,4 +25,5 @@ export const UseCases = [
     ChangeStatusKodyRulesUseCase,
     SendRulesNotificationUseCase,
     SyncSelectedRepositoriesKodyRulesUseCase,
+    CheckSyncStatusUseCase,
 ];

--- a/src/core/application/use-cases/parameters/update-or-create-code-review-parameter-use-case.ts
+++ b/src/core/application/use-cases/parameters/update-or-create-code-review-parameter-use-case.ts
@@ -31,44 +31,17 @@ import {
     ActionType,
     ConfigLevel,
 } from '@/config/types/general/codeReviewSettingsLog.type';
+import {
+    ICodeRepository,
+    ICodeReviewParameter,
+    IFilteredCodeRepository,
+} from '@/config/types/general/codeReviewConfig.type';
 
-interface Body {
+interface CodeReviewParameterBody {
     organizationAndTeamData: OrganizationAndTeamData;
     configValue: any;
     repositoryId?: string;
     directoryId?: string;
-}
-
-interface ICodeRepository {
-    avatar_url?: string;
-    default_branch: string;
-    http_url: string;
-    id: string;
-    language: string;
-    name: string;
-    organizationName: string;
-    selected: string;
-    visibility: 'private' | 'public';
-    directories: Array<any>;
-}
-
-interface IFilteredCodeRepository {
-    id: string;
-    name: string;
-    isSelected: boolean;
-    directories: Array<any>;
-    directoryId?: string;
-}
-
-interface IRepositoryCodeReviewConfig
-    extends CodeReviewConfigWithoutLLMProvider {
-    id: string;
-    name: string;
-    directories: Array<any>;
-}
-interface ICodeReviewParameter {
-    global: CodeReviewConfigWithoutLLMProvider;
-    repositories: Array<IRepositoryCodeReviewConfig | IFilteredCodeRepository>;
 }
 
 @Injectable()
@@ -95,9 +68,16 @@ export class UpdateOrCreateCodeReviewParameterUseCase {
         private readonly logger: PinoLoggerService,
     ) {}
 
-    async execute(body: Body): Promise<ParametersEntity | boolean> {
+    async execute(
+        body: CodeReviewParameterBody,
+    ): Promise<ParametersEntity | boolean> {
         try {
-            const { organizationAndTeamData, configValue, repositoryId, directoryId } = body;
+            const {
+                organizationAndTeamData,
+                configValue,
+                repositoryId,
+                directoryId,
+            } = body;
 
             if (!organizationAndTeamData.organizationId) {
                 organizationAndTeamData.organizationId =
@@ -561,7 +541,7 @@ export class UpdateOrCreateCodeReviewParameterUseCase {
         return true;
     }
 
-    private handleError(error: any, body: Body) {
+    private handleError(error: any, body: CodeReviewParameterBody) {
         this.logger.error({
             message:
                 'Error creating or updating code review configuration parameter',

--- a/src/core/infrastructure/http/dtos/create-or-update-code-review-parameter.dto.ts
+++ b/src/core/infrastructure/http/dtos/create-or-update-code-review-parameter.dto.ts
@@ -199,13 +199,17 @@ class CodeReviewConfigWithoutLLMProviderDto {
 
     @IsOptional()
     @IsBoolean()
+    ideRulesSyncEnabled?: boolean;
+
+    @IsOptional()
+    @IsBoolean()
     kodyRulesGeneratorEnabled?: boolean;
 
     @IsOptional()
     @ValidateNested()
     @Type(() => ReviewCadenceDto)
     reviewCadence?: ReviewCadenceDto;
-  
+
     @IsOptional()
     @IsBoolean()
     runOnDraft?: boolean;

--- a/src/modules/kodyRules.module.ts
+++ b/src/modules/kodyRules.module.ts
@@ -27,6 +27,7 @@ import { SyncSelectedRepositoriesKodyRulesUseCase } from '@/core/application/use
 import { UsersModule } from './user.module';
 import { OrganizationModule } from './organization.module';
 import { CodeReviewSettingsLogModule } from './codeReviewSettingsLog.module';
+import { GlobalCacheModule } from './cache.module';
 
 @Module({
     imports: [
@@ -45,6 +46,7 @@ import { CodeReviewSettingsLogModule } from './codeReviewSettingsLog.module';
         forwardRef(() => OrganizationModule),
         forwardRef(() => CodeReviewSettingsLogModule),
         KodyRulesValidationModule,
+        GlobalCacheModule,
     ],
     providers: [
         ...UseCases,

--- a/test/unit/core/application/use-cases/kodyRules/check-sync-status.use-case.spec.ts
+++ b/test/unit/core/application/use-cases/kodyRules/check-sync-status.use-case.spec.ts
@@ -1,0 +1,723 @@
+import { Test } from '@nestjs/testing';
+import { CheckSyncStatusUseCase } from '@/core/application/use-cases/kodyRules/check-sync-status.use-case';
+import { INTEGRATION_SERVICE_TOKEN } from '@/core/domain/integrations/contracts/integration.service.contracts';
+import { INTEGRATION_CONFIG_SERVICE_TOKEN } from '@/core/domain/integrationConfigs/contracts/integration-config.service.contracts';
+import { PARAMETERS_SERVICE_TOKEN } from '@/core/domain/parameters/contracts/parameters.service.contract';
+import { FindRulesInOrganizationByRuleFilterKodyRulesUseCase } from '@/core/application/use-cases/kodyRules/find-rules-in-organization-by-filter.use-case';
+import { PinoLoggerService } from '@/core/infrastructure/adapters/services/logger/pino.service';
+import { ParametersKey } from '@/shared/domain/enums/parameters-key.enum';
+import { KodyLearningStatus } from '@/core/domain/parameters/types/configValue.type';
+import { KodyRulesStatus } from '@/core/domain/kodyRules/interfaces/kodyRules.interface';
+import { REQUEST } from '@nestjs/core';
+
+describe('CheckSyncStatusUseCase', () => {
+    let useCase: CheckSyncStatusUseCase;
+    let mockIntegrationService: any;
+    let mockIntegrationConfigService: any;
+    let mockParametersService: any;
+    let mockFindRulesUseCase: any;
+    let mockLogger: any;
+    let mockRequest: any;
+
+    const mockOrgData = {
+        organizationId: 'org-123',
+        teamId: 'team-456',
+    };
+
+    const mockPlatformConfig = {
+        configValue: {
+            kodyLearningStatus: KodyLearningStatus.ENABLED,
+        },
+    };
+
+    const mockCodeReviewConfig = {
+        configValue: {
+            repositories: [
+                {
+                    id: 'repo-1',
+                    ideRulesSyncEnabled: true,
+                    kodyRulesGeneratorEnabled: true,
+                },
+                {
+                    id: 'repo-2',
+                    ideRulesSyncEnabled: false,
+                    kodyRulesGeneratorEnabled: false,
+                },
+            ],
+        },
+    };
+
+    const mockRules = [
+        {
+            rules: [
+                {
+                    sourcePath: '/path/to/rule',
+                    status: KodyRulesStatus.ACTIVE,
+                },
+            ],
+        },
+    ];
+
+    beforeEach(async () => {
+        mockIntegrationService = {
+            findIntegrationConfigFormatted: jest.fn(),
+        };
+
+        mockIntegrationConfigService = {
+            findIntegrationConfigFormatted: jest.fn(),
+        };
+
+        mockParametersService = {
+            findByKey: jest.fn(),
+        };
+
+        mockFindRulesUseCase = {
+            execute: jest.fn(),
+        };
+
+        mockLogger = {
+            error: jest.fn(),
+        };
+
+        mockRequest = {
+            user: {
+                organization: {
+                    uuid: 'org-123',
+                },
+            },
+        };
+
+        const module = await Test.createTestingModule({
+            providers: [
+                CheckSyncStatusUseCase,
+                {
+                    provide: INTEGRATION_SERVICE_TOKEN,
+                    useValue: mockIntegrationService,
+                },
+                {
+                    provide: INTEGRATION_CONFIG_SERVICE_TOKEN,
+                    useValue: mockIntegrationConfigService,
+                },
+                {
+                    provide: PARAMETERS_SERVICE_TOKEN,
+                    useValue: mockParametersService,
+                },
+                {
+                    provide: FindRulesInOrganizationByRuleFilterKodyRulesUseCase,
+                    useValue: mockFindRulesUseCase,
+                },
+                {
+                    provide: PinoLoggerService,
+                    useValue: mockLogger,
+                },
+                {
+                    provide: REQUEST,
+                    useValue: mockRequest,
+                },
+            ],
+        }).compile();
+
+        useCase = module.get<CheckSyncStatusUseCase>(CheckSyncStatusUseCase);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('execute', () => {
+        it('deve retornar configuração padrão quando ideRulesSyncEnabled é true e kodyRulesGeneratorEnabled é true', async () => {
+            mockParametersService.findByKey
+                .mockResolvedValueOnce(mockPlatformConfig)
+                .mockResolvedValueOnce(mockCodeReviewConfig);
+
+            const result = await useCase.execute('team-456', 'repo-1');
+
+            expect(result).toEqual({
+                ideRulesSyncEnabledFirstTime: true,
+                kodyRulesGeneratorEnabledFirstTime: false,
+            });
+
+            expect(mockParametersService.findByKey).toHaveBeenCalledWith(
+                ParametersKey.PLATFORM_CONFIGS,
+                mockOrgData,
+            );
+            expect(mockParametersService.findByKey).toHaveBeenCalledWith(
+                ParametersKey.CODE_REVIEW_CONFIG,
+                mockOrgData,
+            );
+        });
+
+        it('deve retornar ideRulesSyncEnabledFirstTime como false quando ideRulesSyncEnabled é false e existem regras IDE', async () => {
+            const modifiedCodeReviewConfig = {
+                configValue: {
+                    repositories: [
+                        {
+                            id: 'repo-2',
+                            ideRulesSyncEnabled: false,
+                            kodyRulesGeneratorEnabled: false,
+                        },
+                    ],
+                },
+            };
+
+            mockParametersService.findByKey
+                .mockResolvedValueOnce(mockPlatformConfig)
+                .mockResolvedValueOnce(modifiedCodeReviewConfig);
+
+            mockFindRulesUseCase.execute.mockResolvedValue(mockRules);
+
+            const result = await useCase.execute('team-456', 'repo-2');
+
+            expect(result).toEqual({
+                ideRulesSyncEnabledFirstTime: false,
+                kodyRulesGeneratorEnabledFirstTime: false,
+            });
+
+            expect(mockFindRulesUseCase.execute).toHaveBeenCalledWith(
+                'org-123',
+                {},
+                'repo-2',
+            );
+        });
+
+        it('deve retornar ideRulesSyncEnabledFirstTime como true quando ideRulesSyncEnabled é false e não existem regras IDE', async () => {
+            const modifiedCodeReviewConfig = {
+                configValue: {
+                    repositories: [
+                        {
+                            id: 'repo-2',
+                            ideRulesSyncEnabled: false,
+                            kodyRulesGeneratorEnabled: false,
+                        },
+                    ],
+                },
+            };
+
+            mockParametersService.findByKey
+                .mockResolvedValueOnce(mockPlatformConfig)
+                .mockResolvedValueOnce(modifiedCodeReviewConfig);
+
+            mockFindRulesUseCase.execute.mockResolvedValue([]);
+
+            const result = await useCase.execute('team-456', 'repo-2');
+
+            expect(result).toEqual({
+                ideRulesSyncEnabledFirstTime: true,
+                kodyRulesGeneratorEnabledFirstTime: false,
+            });
+        });
+
+        it('deve retornar kodyRulesGeneratorEnabledFirstTime como false quando kodyRulesGeneratorEnabled é true', async () => {
+            const modifiedCodeReviewConfig = {
+                configValue: {
+                    repositories: [
+                        {
+                            id: 'repo-1',
+                            ideRulesSyncEnabled: true,
+                            kodyRulesGeneratorEnabled: true,
+                        },
+                    ],
+                },
+            };
+
+            mockParametersService.findByKey
+                .mockResolvedValueOnce(mockPlatformConfig)
+                .mockResolvedValueOnce(modifiedCodeReviewConfig);
+
+            const result = await useCase.execute('team-456', 'repo-1');
+
+            expect(result).toEqual({
+                ideRulesSyncEnabledFirstTime: true,
+                kodyRulesGeneratorEnabledFirstTime: false,
+            });
+        });
+
+        it('deve retornar kodyRulesGeneratorEnabledFirstTime como true quando kodyRulesGeneratorEnabled é false e kodyLearningStatus é DISABLED', async () => {
+            const disabledPlatformConfig = {
+                configValue: {
+                    kodyLearningStatus: KodyLearningStatus.DISABLED,
+                },
+            };
+
+            const modifiedCodeReviewConfig = {
+                configValue: {
+                    repositories: [
+                        {
+                            id: 'repo-2',
+                            ideRulesSyncEnabled: true,
+                            kodyRulesGeneratorEnabled: false,
+                        },
+                    ],
+                },
+            };
+
+            mockParametersService.findByKey
+                .mockResolvedValueOnce(disabledPlatformConfig)
+                .mockResolvedValueOnce(modifiedCodeReviewConfig);
+
+            const result = await useCase.execute('team-456', 'repo-2');
+
+            expect(result).toEqual({
+                ideRulesSyncEnabledFirstTime: true,
+                kodyRulesGeneratorEnabledFirstTime: true,
+            });
+        });
+
+        it('deve retornar kodyRulesGeneratorEnabledFirstTime como false quando kodyRulesGeneratorEnabled é false e kodyLearningStatus é ENABLED', async () => {
+            const modifiedCodeReviewConfig = {
+                configValue: {
+                    repositories: [
+                        {
+                            id: 'repo-2',
+                            ideRulesSyncEnabled: true,
+                            kodyRulesGeneratorEnabled: false,
+                        },
+                    ],
+                },
+            };
+
+            mockParametersService.findByKey
+                .mockResolvedValueOnce(mockPlatformConfig)
+                .mockResolvedValueOnce(modifiedCodeReviewConfig);
+
+            const result = await useCase.execute('team-456', 'repo-2');
+
+            expect(result).toEqual({
+                ideRulesSyncEnabledFirstTime: true,
+                kodyRulesGeneratorEnabledFirstTime: false,
+            });
+        });
+
+        it('deve retornar configuração padrão quando ocorre erro', async () => {
+            mockParametersService.findByKey
+                .mockResolvedValueOnce(mockPlatformConfig)
+                .mockRejectedValueOnce(new Error('Database error'));
+
+            const result = await useCase.execute('team-456', 'repo-1');
+
+            expect(result).toEqual({
+                ideRulesSyncEnabledFirstTime: true,
+                kodyRulesGeneratorEnabledFirstTime: true,
+            });
+
+            expect(mockLogger.error).toHaveBeenCalledWith({
+                message: 'Error checking sync status',
+                error: expect.any(Error),
+                context: 'CheckSyncStatusUseCase',
+                metadata: {
+                    organizationId: 'org-123',
+                    teamId: 'team-456',
+                    repositoryId: 'repo-1',
+                },
+            });
+        });
+
+        it('deve funcionar sem repositoryId e retornar configuração padrão', async () => {
+            mockParametersService.findByKey
+                .mockResolvedValueOnce(mockPlatformConfig)
+                .mockResolvedValueOnce(mockCodeReviewConfig);
+
+            const result = await useCase.execute('team-456');
+
+            expect(result).toEqual({
+                ideRulesSyncEnabledFirstTime: true,
+                kodyRulesGeneratorEnabledFirstTime: true,
+            });
+        });
+
+        it('deve lidar com repositório não encontrado retornando configuração padrão', async () => {
+            const codeReviewConfigWithUnknownRepo = {
+                configValue: {
+                    repositories: [
+                        {
+                            id: 'repo-1',
+                            ideRulesSyncEnabled: true,
+                            kodyRulesGeneratorEnabled: true,
+                        },
+                    ],
+                },
+            };
+
+            mockParametersService.findByKey
+                .mockResolvedValueOnce(mockPlatformConfig)
+                .mockResolvedValueOnce(codeReviewConfigWithUnknownRepo);
+
+            const result = await useCase.execute('team-456', 'unknown-repo');
+
+            expect(result).toEqual({
+                ideRulesSyncEnabledFirstTime: true,
+                kodyRulesGeneratorEnabledFirstTime: true,
+            });
+        });
+
+        it('deve lidar com repositório não encontrado quando ideRulesSyncEnabled é false', async () => {
+            const codeReviewConfigWithUnknownRepo = {
+                configValue: {
+                    repositories: [
+                        {
+                            id: 'repo-1',
+                            ideRulesSyncEnabled: false,
+                            kodyRulesGeneratorEnabled: false,
+                        },
+                    ],
+                },
+            };
+
+            mockParametersService.findByKey
+                .mockResolvedValueOnce(mockPlatformConfig)
+                .mockResolvedValueOnce(codeReviewConfigWithUnknownRepo);
+
+            mockFindRulesUseCase.execute.mockResolvedValue([]);
+
+            const result = await useCase.execute('team-456', 'unknown-repo');
+
+            expect(result).toEqual({
+                ideRulesSyncEnabledFirstTime: true,
+                kodyRulesGeneratorEnabledFirstTime: true,
+            });
+        });
+
+        // Novos testes específicos para regras de negócio
+        describe('Regras de negócio específicas', () => {
+            it('deve retornar ideRulesSyncEnabledFirstTime=false quando ideRulesSyncEnabled=false E existem regras com sourcePath', async () => {
+                const configWithIdeDisabled = {
+                    configValue: {
+                        repositories: [
+                            {
+                                id: 'repo-3',
+                                ideRulesSyncEnabled: false,
+                                kodyRulesGeneratorEnabled: true,
+                            },
+                        ],
+                    },
+                };
+
+                const rulesWithSourcePath = [
+                    {
+                        rules: [
+                            {
+                                sourcePath: '/path/to/ide/rule',
+                                status: KodyRulesStatus.ACTIVE,
+                            },
+                        ],
+                    },
+                ];
+
+                mockParametersService.findByKey
+                    .mockResolvedValueOnce(mockPlatformConfig)
+                    .mockResolvedValueOnce(configWithIdeDisabled);
+
+                mockFindRulesUseCase.execute.mockResolvedValue(rulesWithSourcePath);
+
+                const result = await useCase.execute('team-456', 'repo-3');
+
+                expect(result).toEqual({
+                    ideRulesSyncEnabledFirstTime: false, // Não é primeira vez (já tem regras IDE)
+                    kodyRulesGeneratorEnabledFirstTime: false, // Não é primeira vez (está habilitado)
+                });
+
+                expect(mockFindRulesUseCase.execute).toHaveBeenCalledWith(
+                    'org-123',
+                    {},
+                    'repo-3',
+                );
+            });
+
+            it('deve retornar ideRulesSyncEnabledFirstTime=true quando ideRulesSyncEnabled=false E NÃO existem regras com sourcePath', async () => {
+                const configWithIdeDisabled = {
+                    configValue: {
+                        repositories: [
+                            {
+                                id: 'repo-4',
+                                ideRulesSyncEnabled: false,
+                                kodyRulesGeneratorEnabled: false,
+                            },
+                        ],
+                    },
+                };
+
+                const rulesWithoutSourcePath = [
+                    {
+                        rules: [
+                            {
+                                // Sem sourcePath - regra não é IDE
+                                status: KodyRulesStatus.ACTIVE,
+                            },
+                        ],
+                    },
+                ];
+
+                mockParametersService.findByKey
+                    .mockResolvedValueOnce(mockPlatformConfig)
+                    .mockResolvedValueOnce(configWithIdeDisabled);
+
+                mockFindRulesUseCase.execute.mockResolvedValue(rulesWithoutSourcePath);
+
+                const result = await useCase.execute('team-456', 'repo-4');
+
+                expect(result).toEqual({
+                    ideRulesSyncEnabledFirstTime: true, // É primeira vez (não tem regras IDE)
+                    kodyRulesGeneratorEnabledFirstTime: false, // Não é primeira vez (kodyLearningStatus=ENABLED)
+                });
+            });
+
+            it('deve retornar ideRulesSyncEnabledFirstTime=true quando ideRulesSyncEnabled=false E não existem regras', async () => {
+                const configWithIdeDisabled = {
+                    configValue: {
+                        repositories: [
+                            {
+                                id: 'repo-5',
+                                ideRulesSyncEnabled: false,
+                                kodyRulesGeneratorEnabled: false,
+                            },
+                        ],
+                    },
+                };
+
+                mockParametersService.findByKey
+                    .mockResolvedValueOnce(mockPlatformConfig)
+                    .mockResolvedValueOnce(configWithIdeDisabled);
+
+                mockFindRulesUseCase.execute.mockResolvedValue([]);
+
+                const result = await useCase.execute('team-456', 'repo-5');
+
+                expect(result).toEqual({
+                    ideRulesSyncEnabledFirstTime: true, // É primeira vez (não tem regras)
+                    kodyRulesGeneratorEnabledFirstTime: false, // Não é primeira vez (kodyLearningStatus=ENABLED)
+                });
+            });
+
+            it('deve retornar ideRulesSyncEnabledFirstTime=true quando ideRulesSyncEnabled=false E regras existem mas nenhuma tem sourcePath', async () => {
+                const configWithIdeDisabled = {
+                    configValue: {
+                        repositories: [
+                            {
+                                id: 'repo-6',
+                                ideRulesSyncEnabled: false,
+                                kodyRulesGeneratorEnabled: false,
+                            },
+                        ],
+                    },
+                };
+
+                const rulesWithoutSourcePath = [
+                    {
+                        rules: [
+                            {
+                                // Sem sourcePath
+                                status: KodyRulesStatus.ACTIVE,
+                            },
+                        ],
+                    },
+                    {
+                        rules: [
+                            {
+                                // Sem sourcePath também
+                                status: KodyRulesStatus.INACTIVE,
+                            },
+                        ],
+                    },
+                ];
+
+                mockParametersService.findByKey
+                    .mockResolvedValueOnce(mockPlatformConfig)
+                    .mockResolvedValueOnce(configWithIdeDisabled);
+
+                mockFindRulesUseCase.execute.mockResolvedValue(rulesWithoutSourcePath);
+
+                const result = await useCase.execute('team-456', 'repo-6');
+
+                expect(result).toEqual({
+                    ideRulesSyncEnabledFirstTime: true, // É primeira vez (nenhuma regra tem sourcePath)
+                    kodyRulesGeneratorEnabledFirstTime: false, // Não é primeira vez (kodyLearningStatus=ENABLED)
+                });
+            });
+
+            it('deve retornar kodyRulesGeneratorEnabledFirstTime=false quando kodyRulesGeneratorEnabled=true (independente do IDE)', async () => {
+                const configWithKodyEnabled = {
+                    configValue: {
+                        repositories: [
+                            {
+                                id: 'repo-7',
+                                ideRulesSyncEnabled: false, // IDE desabilitado
+                                kodyRulesGeneratorEnabled: true, // Kody habilitado
+                            },
+                        ],
+                    },
+                };
+
+                mockParametersService.findByKey
+                    .mockResolvedValueOnce(mockPlatformConfig)
+                    .mockResolvedValueOnce(configWithKodyEnabled);
+
+                mockFindRulesUseCase.execute.mockResolvedValue([]);
+
+                const result = await useCase.execute('team-456', 'repo-7');
+
+                expect(result).toEqual({
+                    ideRulesSyncEnabledFirstTime: true, // É primeira vez (não tem regras IDE)
+                    kodyRulesGeneratorEnabledFirstTime: false, // Não é primeira vez (está habilitado)
+                });
+            });
+
+            it('deve retornar kodyRulesGeneratorEnabledFirstTime=true quando kodyRulesGeneratorEnabled=false E kodyLearningStatus=DISABLED', async () => {
+                const disabledPlatformConfig = {
+                    configValue: {
+                        kodyLearningStatus: KodyLearningStatus.DISABLED,
+                    },
+                };
+
+                const configWithKodyDisabled = {
+                    configValue: {
+                        repositories: [
+                            {
+                                id: 'repo-8',
+                                ideRulesSyncEnabled: true,
+                                kodyRulesGeneratorEnabled: false, // Kody desabilitado
+                            },
+                        ],
+                    },
+                };
+
+                mockParametersService.findByKey
+                    .mockResolvedValueOnce(disabledPlatformConfig)
+                    .mockResolvedValueOnce(configWithKodyDisabled);
+
+                const result = await useCase.execute('team-456', 'repo-8');
+
+                expect(result).toEqual({
+                    ideRulesSyncEnabledFirstTime: true, // É primeira vez (IDE habilitado)
+                    kodyRulesGeneratorEnabledFirstTime: true, // É primeira vez (kodyLearningStatus=DISABLED)
+                });
+            });
+
+            it('deve retornar kodyRulesGeneratorEnabledFirstTime=false quando kodyRulesGeneratorEnabled=false E kodyLearningStatus=ENABLED', async () => {
+                const configWithKodyDisabled = {
+                    configValue: {
+                        repositories: [
+                            {
+                                id: 'repo-9',
+                                ideRulesSyncEnabled: true,
+                                kodyRulesGeneratorEnabled: false, // Kody desabilitado
+                            },
+                        ],
+                    },
+                };
+
+                mockParametersService.findByKey
+                    .mockResolvedValueOnce(mockPlatformConfig) // kodyLearningStatus=ENABLED
+                    .mockResolvedValueOnce(configWithKodyDisabled);
+
+                const result = await useCase.execute('team-456', 'repo-9');
+
+                expect(result).toEqual({
+                    ideRulesSyncEnabledFirstTime: true, // É primeira vez (IDE habilitado)
+                    kodyRulesGeneratorEnabledFirstTime: false, // Não é primeira vez (kodyLearningStatus=ENABLED)
+                });
+            });
+
+            it('deve validar ambas as props independentemente - IDE false com regras, Kody false com ENABLED', async () => {
+                const configWithBothDisabled = {
+                    configValue: {
+                        repositories: [
+                            {
+                                id: 'repo-10',
+                                ideRulesSyncEnabled: false, // IDE desabilitado
+                                kodyRulesGeneratorEnabled: false, // Kody desabilitado
+                            },
+                        ],
+                    },
+                };
+
+                const rulesWithSourcePath = [
+                    {
+                        rules: [
+                            {
+                                sourcePath: '/path/to/ide/rule',
+                                status: KodyRulesStatus.ACTIVE,
+                            },
+                        ],
+                    },
+                ];
+
+                mockParametersService.findByKey
+                    .mockResolvedValueOnce(mockPlatformConfig) // kodyLearningStatus=ENABLED
+                    .mockResolvedValueOnce(configWithBothDisabled);
+
+                mockFindRulesUseCase.execute.mockResolvedValue(rulesWithSourcePath);
+
+                const result = await useCase.execute('team-456', 'repo-10');
+
+                expect(result).toEqual({
+                    ideRulesSyncEnabledFirstTime: false, // Não é primeira vez (tem regras IDE)
+                    kodyRulesGeneratorEnabledFirstTime: false, // Não é primeira vez (kodyLearningStatus=ENABLED)
+                });
+            });
+
+            it('deve validar ambas as props independentemente - IDE false sem regras, Kody false com DISABLED', async () => {
+                const disabledPlatformConfig = {
+                    configValue: {
+                        kodyLearningStatus: KodyLearningStatus.DISABLED,
+                    },
+                };
+
+                const configWithBothDisabled = {
+                    configValue: {
+                        repositories: [
+                            {
+                                id: 'repo-11',
+                                ideRulesSyncEnabled: false, // IDE desabilitado
+                                kodyRulesGeneratorEnabled: false, // Kody desabilitado
+                            },
+                        ],
+                    },
+                };
+
+                mockParametersService.findByKey
+                    .mockResolvedValueOnce(disabledPlatformConfig) // kodyLearningStatus=DISABLED
+                    .mockResolvedValueOnce(configWithBothDisabled);
+
+                mockFindRulesUseCase.execute.mockResolvedValue([]); // Sem regras
+
+                const result = await useCase.execute('team-456', 'repo-11');
+
+                expect(result).toEqual({
+                    ideRulesSyncEnabledFirstTime: true, // É primeira vez (não tem regras IDE)
+                    kodyRulesGeneratorEnabledFirstTime: true, // É primeira vez (kodyLearningStatus=DISABLED)
+                });
+            });
+        });
+    });
+
+    describe('getCodeReviewConfigs', () => {
+        it('deve retornar configValue do codeReviewConfig', async () => {
+            mockParametersService.findByKey.mockResolvedValue(mockCodeReviewConfig);
+
+            const result = await useCase['getCodeReviewConfigs'](mockOrgData);
+
+            expect(result).toEqual(mockCodeReviewConfig.configValue);
+            expect(mockParametersService.findByKey).toHaveBeenCalledWith(
+                ParametersKey.CODE_REVIEW_CONFIG,
+                mockOrgData,
+            );
+        });
+    });
+
+    describe('getFormattedRepositories', () => {
+        it('deve chamar integrationConfigService com parâmetros corretos', async () => {
+            const mockRepositories = [{ id: 'repo-1', name: 'Repository 1' }];
+            mockIntegrationConfigService.findIntegrationConfigFormatted.mockResolvedValue(
+                mockRepositories,
+            );
+
+            const result = await useCase['getFormattedRepositories'](mockOrgData);
+
+            expect(result).toEqual(mockRepositories);
+            expect(mockIntegrationConfigService.findIntegrationConfigFormatted).toHaveBeenCalledWith(
+                'repositories',
+                mockOrgData,
+            );
+        });
+    });
+});

--- a/test/unit/core/infrastructure/http/controllers/kodyRules.controller.spec.ts
+++ b/test/unit/core/infrastructure/http/controllers/kodyRules.controller.spec.ts
@@ -1,0 +1,254 @@
+import { Test } from '@nestjs/testing';
+import { KodyRulesController } from '@/core/infrastructure/http/controllers/kodyRules.controller';
+import { CreateOrUpdateKodyRulesUseCase } from '@/core/application/use-cases/kodyRules/create-or-update.use-case';
+import { FindByOrganizationIdKodyRulesUseCase } from '@/core/application/use-cases/kodyRules/find-by-organization-id.use-case';
+import { FindRuleInOrganizationByIdKodyRulesUseCase } from '@/core/application/use-cases/kodyRules/find-rule-in-organization-by-id.use-case';
+import { FindRulesInOrganizationByRuleFilterKodyRulesUseCase } from '@/core/application/use-cases/kodyRules/find-rules-in-organization-by-filter.use-case';
+import { DeleteByOrganizationIdKodyRulesUseCase } from '@/core/application/use-cases/kodyRules/delete-by-organization-id.use-case';
+import { DeleteRuleInOrganizationByIdKodyRulesUseCase } from '@/core/application/use-cases/kodyRules/delete-rule-in-organization-by-id.use-case';
+import { FindLibraryKodyRulesUseCase } from '@/core/application/use-cases/kodyRules/find-library-kody-rules.use-case';
+import { AddLibraryKodyRulesUseCase } from '@/core/application/use-cases/kodyRules/add-library-kody-rules.use-case';
+import { GenerateKodyRulesUseCase } from '@/core/application/use-cases/kodyRules/generate-kody-rules.use-case';
+import { ChangeStatusKodyRulesUseCase } from '@/core/application/use-cases/kodyRules/change-status-kody-rules.use-case';
+import { CheckSyncStatusUseCase } from '@/core/application/use-cases/kodyRules/check-sync-status.use-case';
+import { CacheService } from '@/shared/utils/cache/cache.service';
+import { REQUEST } from '@nestjs/core';
+
+describe('KodyRulesController', () => {
+    let controller: KodyRulesController;
+    let mockCreateOrUpdateUseCase: any;
+    let mockFindByOrganizationIdUseCase: any;
+    let mockFindRuleInOrganizationByIdUseCase: any;
+    let mockFindRulesInOrganizationByRuleFilterUseCase: any;
+    let mockDeleteByOrganizationIdUseCase: any;
+    let mockDeleteRuleInOrganizationByIdUseCase: any;
+    let mockFindLibraryUseCase: any;
+    let mockAddLibraryUseCase: any;
+    let mockGenerateUseCase: any;
+    let mockChangeStatusUseCase: any;
+    let mockCheckSyncStatusUseCase: any;
+    let mockCacheService: any;
+    let mockRequest: any;
+
+    const mockSyncStatusResult = {
+        ideRulesSyncEnabledFirstTime: true,
+        kodyRulesGeneratorEnabledFirstTime: false,
+    };
+
+    beforeEach(async () => {
+        mockCreateOrUpdateUseCase = {
+            execute: jest.fn(),
+        };
+
+        mockFindByOrganizationIdUseCase = {
+            execute: jest.fn(),
+        };
+
+        mockFindRuleInOrganizationByIdUseCase = {
+            execute: jest.fn(),
+        };
+
+        mockFindRulesInOrganizationByRuleFilterUseCase = {
+            execute: jest.fn(),
+        };
+
+        mockDeleteByOrganizationIdUseCase = {
+            execute: jest.fn(),
+        };
+
+        mockDeleteRuleInOrganizationByIdUseCase = {
+            execute: jest.fn(),
+        };
+
+        mockFindLibraryUseCase = {
+            execute: jest.fn(),
+        };
+
+        mockAddLibraryUseCase = {
+            execute: jest.fn(),
+        };
+
+        mockGenerateUseCase = {
+            execute: jest.fn(),
+        };
+
+        mockChangeStatusUseCase = {
+            execute: jest.fn(),
+        };
+
+        mockCheckSyncStatusUseCase = {
+            execute: jest.fn(),
+        };
+
+        mockCacheService = {
+            getFromCache: jest.fn(),
+            addToCache: jest.fn(),
+        };
+
+        mockRequest = {
+            user: {
+                organization: {
+                    uuid: 'org-123',
+                },
+            },
+        };
+
+        const module = await Test.createTestingModule({
+            controllers: [KodyRulesController],
+            providers: [
+                {
+                    provide: CreateOrUpdateKodyRulesUseCase,
+                    useValue: mockCreateOrUpdateUseCase,
+                },
+                {
+                    provide: FindByOrganizationIdKodyRulesUseCase,
+                    useValue: mockFindByOrganizationIdUseCase,
+                },
+                {
+                    provide: FindRuleInOrganizationByIdKodyRulesUseCase,
+                    useValue: mockFindRuleInOrganizationByIdUseCase,
+                },
+                {
+                    provide: FindRulesInOrganizationByRuleFilterKodyRulesUseCase,
+                    useValue: mockFindRulesInOrganizationByRuleFilterUseCase,
+                },
+                {
+                    provide: DeleteByOrganizationIdKodyRulesUseCase,
+                    useValue: mockDeleteByOrganizationIdUseCase,
+                },
+                {
+                    provide: DeleteRuleInOrganizationByIdKodyRulesUseCase,
+                    useValue: mockDeleteRuleInOrganizationByIdUseCase,
+                },
+                {
+                    provide: FindLibraryKodyRulesUseCase,
+                    useValue: mockFindLibraryUseCase,
+                },
+                {
+                    provide: AddLibraryKodyRulesUseCase,
+                    useValue: mockAddLibraryUseCase,
+                },
+                {
+                    provide: GenerateKodyRulesUseCase,
+                    useValue: mockGenerateUseCase,
+                },
+                {
+                    provide: ChangeStatusKodyRulesUseCase,
+                    useValue: mockChangeStatusUseCase,
+                },
+                {
+                    provide: CheckSyncStatusUseCase,
+                    useValue: mockCheckSyncStatusUseCase,
+                },
+                {
+                    provide: CacheService,
+                    useValue: mockCacheService,
+                },
+                {
+                    provide: REQUEST,
+                    useValue: mockRequest,
+                },
+            ],
+        }).compile();
+
+        controller = module.get<KodyRulesController>(KodyRulesController);
+    });
+
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('checkSyncStatus', () => {
+        it('deve retornar resultado do cache quando disponível', async () => {
+            const teamId = 'team-456';
+            const repositoryId = 'repo-789';
+            const expectedCacheKey = 'check-sync-status:org-123:team-456:repo-789';
+
+            mockCacheService.getFromCache.mockResolvedValue(mockSyncStatusResult);
+
+            const result = await controller.checkSyncStatus(teamId, repositoryId);
+
+            expect(result).toEqual(mockSyncStatusResult);
+            expect(mockCacheService.getFromCache).toHaveBeenCalledWith(expectedCacheKey);
+            expect(mockCheckSyncStatusUseCase.execute).not.toHaveBeenCalled();
+            expect(mockCacheService.addToCache).not.toHaveBeenCalled();
+        });
+
+        it('deve executar use case e salvar no cache quando não há cache', async () => {
+            const teamId = 'team-456';
+            const repositoryId = 'repo-789';
+            const expectedCacheKey = 'check-sync-status:org-123:team-456:repo-789';
+
+            mockCacheService.getFromCache.mockResolvedValue(null);
+            mockCheckSyncStatusUseCase.execute.mockResolvedValue(mockSyncStatusResult);
+
+            const result = await controller.checkSyncStatus(teamId, repositoryId);
+
+            expect(result).toEqual(mockSyncStatusResult);
+            expect(mockCacheService.getFromCache).toHaveBeenCalledWith(expectedCacheKey);
+            expect(mockCheckSyncStatusUseCase.execute).toHaveBeenCalledWith(teamId, repositoryId);
+            expect(mockCacheService.addToCache).toHaveBeenCalledWith(
+                expectedCacheKey,
+                mockSyncStatusResult,
+                900000, // 15 minutos em milissegundos
+            );
+        });
+
+        it('deve gerar cache key correta sem repositoryId', async () => {
+            const teamId = 'team-456';
+            const expectedCacheKey = 'check-sync-status:org-123:team-456:no-repo';
+
+            mockCacheService.getFromCache.mockResolvedValue(null);
+            mockCheckSyncStatusUseCase.execute.mockResolvedValue(mockSyncStatusResult);
+
+            const result = await controller.checkSyncStatus(teamId);
+
+            expect(result).toEqual(mockSyncStatusResult);
+            expect(mockCacheService.getFromCache).toHaveBeenCalledWith(expectedCacheKey);
+            expect(mockCheckSyncStatusUseCase.execute).toHaveBeenCalledWith(teamId, undefined);
+            expect(mockCacheService.addToCache).toHaveBeenCalledWith(
+                expectedCacheKey,
+                mockSyncStatusResult,
+                900000,
+            );
+        });
+
+        it('deve gerar cache key correta com repositoryId undefined', async () => {
+            const teamId = 'team-456';
+            const repositoryId = undefined;
+            const expectedCacheKey = 'check-sync-status:org-123:team-456:no-repo';
+
+            mockCacheService.getFromCache.mockResolvedValue(null);
+            mockCheckSyncStatusUseCase.execute.mockResolvedValue(mockSyncStatusResult);
+
+            const result = await controller.checkSyncStatus(teamId, repositoryId);
+
+            expect(result).toEqual(mockSyncStatusResult);
+            expect(mockCacheService.getFromCache).toHaveBeenCalledWith(expectedCacheKey);
+            expect(mockCheckSyncStatusUseCase.execute).toHaveBeenCalledWith(teamId, undefined);
+            expect(mockCacheService.addToCache).toHaveBeenCalledWith(
+                expectedCacheKey,
+                mockSyncStatusResult,
+                900000,
+            );
+        });
+
+        it('deve usar organization UUID correto na cache key', async () => {
+            const teamId = 'team-456';
+            const repositoryId = 'repo-789';
+            const expectedCacheKey = 'check-sync-status:org-123:team-456:repo-789';
+
+            mockCacheService.getFromCache.mockResolvedValue(null);
+            mockCheckSyncStatusUseCase.execute.mockResolvedValue(mockSyncStatusResult);
+
+            await controller.checkSyncStatus(teamId, repositoryId);
+
+            expect(mockCacheService.getFromCache).toHaveBeenCalledWith(expectedCacheKey);
+            expect(mockCacheService.addToCache).toHaveBeenCalledWith(
+                expectedCacheKey,
+                mockSyncStatusResult,
+                900000,
+            );
+        });
+    });
+});


### PR DESCRIPTION
This pull request introduces enhancements to the management and monitoring of IDE rules synchronization and Kody rule generation.

Key changes include:

*   **Repository-Level IDE Rules Sync Configuration**: The `ideRulesSyncEnabled` setting, which controls the synchronization of IDE-based rules, can now be configured independently for each repository. This provides more granular control compared to the previous global setting.
*   **New API for Sync Status Check**: A new endpoint (`GET /kody-rules/check-sync-status`) has been added. This endpoint provides the "first-time" status for both IDE rules synchronization and Kody rule generation for a specific repository, which can be used to guide user onboarding or feature activation. The endpoint also incorporates caching to improve performance.
*   **New API for Manual IDE Rules Sync**: An endpoint (`POST /kody-rules/sync-ide-rules`) is introduced to allow manual triggering of IDE rule synchronization for a given repository.
*   **Enhanced Code Review Configuration Structure**: Internal data types for code review configurations have been updated to support these new repository-specific settings, ensuring consistency and maintainability.