### PR TITLE
remove uuid validation for org id

### DIFF
--- a/src/core/application/use-cases/auth/signup.use-case.ts
+++ b/src/core/application/use-cases/auth/signup.use-case.ts
@@ -70,7 +70,7 @@ export class SignUpUseCase implements IUseCase {
                 },
             };
 
-            if (organizationId) {
+            if (organizationId && organizationId.length > 0) {
                 user.organization = await this.organizationService.findOne({
                     uuid: organizationId,
                 });

--- a/src/core/infrastructure/http/dtos/create-user-organization.dto.ts
+++ b/src/core/infrastructure/http/dtos/create-user-organization.dto.ts
@@ -28,6 +28,5 @@ export class SignUpDTO {
 
     @IsString()
     @IsOptional()
-    @IsUUID()
     public organizationId: string;
 }


### PR DESCRIPTION
Removes the UUID validation requirement for the `organizationId` field in the sign-up DTO. This change allows users to sign up with an organization ID that is not in a UUID format.

Additionally, the sign-up use case has been updated to explicitly check if the provided `organizationId` string has a length greater than zero before attempting to find an organization, preventing lookups with empty string IDs.