### PR TITLE
adding agns.md to sync rules

### DIFF
--- a/src/shared/utils/kody-rules/file-patterns.ts
+++ b/src/shared/utils/kody-rules/file-patterns.ts
@@ -7,6 +7,10 @@ export const RULE_FILE_PATTERNS = [
     '.github/copilot-instructions.md',
     '.github/instructions/**/*.instructions.md',
 
+    // Agentic
+    '.agents.md',
+    '.agent.md',
+
     // Claude
     'CLAUDE.md',
     '.claude/settings.json',


### PR DESCRIPTION
Adds `.agents.md` and `.agent.md` to the list of file patterns recognized by the system's rules. This change ensures that files related to "Agentic" functionality, specifically `.agents.md` and `.agent.md`, are included in the defined file synchronization or processing rules.