### PR TITLE
fix refresh token for third party

### DIFF
--- a/src/core/application/use-cases/auth/signup.use-case.ts
+++ b/src/core/application/use-cases/auth/signup.use-case.ts
@@ -162,7 +162,7 @@ export class SignUpUseCase implements IUseCase {
             posthogClient.userIdentify(createdUser);
             posthogClient.teamIdentify(team);
 
-            await this.sendWebhook(user, payload, user.organization.name);
+            this.sendWebhook(user, payload, user.organization.name);
 
             return createdUser.toObject();
         } catch (error) {

--- a/src/core/application/use-cases/user/join-organization.use-case.ts
+++ b/src/core/application/use-cases/user/join-organization.use-case.ts
@@ -98,7 +98,7 @@ export class JoinOrganizationUseCase implements IUseCase {
                     organization,
                     name: profile.name,
                     teamRole: TeamMemberRole.MEMBER,
-                    status: false,
+                    status: true,
                 });
             } else {
                 await this.teamMembersService.update(
@@ -109,7 +109,7 @@ export class JoinOrganizationUseCase implements IUseCase {
                         team,
                         organization,
                         teamRole: TeamMemberRole.MEMBER,
-                        status: false,
+                        status: true,
                     },
                 );
             }

--- a/src/core/infrastructure/adapters/services/auth/auth.service.ts
+++ b/src/core/infrastructure/adapters/services/auth/auth.service.ts
@@ -111,20 +111,7 @@ export class AuthService implements IAuthService {
                 uuid: payload.sub,
             });
 
-            let authDetails = refreshTokenAuth.authDetails;
-
-            // if (refreshTokenAuth.authProvider !== AuthProvider.CREDENTIALS) {
-            //     const { refreshToken, accessToken, refreshTokenExpiresAt } =
-            //         await this.refreshThirdPartyToken(
-            //             refreshTokenAuth.authDetails.refreshToken,
-            //             refreshTokenAuth.authProvider,
-            //         );
-
-            //     authDetails = {
-            //         refreshToken,
-            //         expiresAt: refreshTokenExpiresAt,
-            //     };
-            // }
+            const authDetails = refreshTokenAuth.authDetails;
 
             const teamMember = await this.teamMemberService.findOne({
                 user: { uuid: userEntity?.uuid },


### PR DESCRIPTION
This pull request introduces several changes to the authentication and organization joining processes.

Key changes include:

*   **Enhanced Third-Party Refresh Token Mechanism:**
    *   The `refreshThirdPartyToken` method, responsible for refreshing tokens with third-party providers, has been refactored to use `axios` for HTTP requests instead of `fetch`.
    *   Improved error handling and response validation have been implemented, including checks for successful HTTP status and the presence of essential token data (`refresh_token`, `access_token`, `expires_at`) in the response.
    *   When creating new authentication records after a refresh, the system now correctly persists the original `authProvider` (e.g., Google, GitHub) instead of defaulting to `CREDENTIALS`.
*   **Adjustment to Refresh Token Flow:**
    *   The logic that previously updated the `authDetails` with newly refreshed third-party tokens within the main `refresh` operation has been commented out. This means that the `authDetails` used for subsequent authentication record creation will retain their original values, rather than being updated by the latest third-party refresh.
*   **Default Active Status for New Team Members:**
    *   When a user joins an organization, their team member `status` is now automatically set to `true` (active) upon creation or update, rather than `false`. This ensures new members are immediately active within the organization.

---

This pull request introduces several enhancements and fixes across the authentication and organization management functionalities:

1.  **Improved Third-Party Refresh Token Handling**:
    *   The `refreshThirdPartyToken` method has been refactored to use `axios` for making HTTP requests, replacing the `fetch` API, which provides more robust request handling.
    *   Enhanced error handling and response data validation have been implemented for third-party token refresh operations, ensuring that essential fields like `refresh_token`, `access_token`, and `expires_at` are present in the response.
    *   The `authProvider` is now correctly passed when creating new authentication records, resolving an issue where it was always defaulting to `CREDENTIALS`.
    *   The previous logic that refreshed third-party tokens and updated `authDetails` prior to creating a new `Auth` record has been disabled.

2.  **Automatic Organization Join Activation**:
    *   When a user joins an organization, their team member status will now be automatically set to `active` (`true`), streamlining the onboarding process by removing the need for manual activation.

3.  **Non-Blocking Signup Webhook**:
    *   The webhook notification sent during the user signup process is now executed asynchronously, allowing the signup operation to complete without waiting for the webhook to finish.