### PR TITLE
fixing kody rules filter limite

### DIFF
--- a/default-kodus-config.yml
+++ b/default-kodus-config.yml
@@ -26,8 +26,7 @@ suggestionControl:
     limitationType: 'pr'
     maxSuggestions: 9
     severityLevelFilter: 'medium'
-    # ✨ CONFIGURAÇÃO SIMPLIFICADA - Controle de filtros para Kody Rules
-    applyFiltersToKodyRules: false
+    applyFiltersToKodyRules: true
     severityLimits:
         low: 0
         medium: 0


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the default configuration for Kody Rules.

The `applyFiltersToKodyRules` setting in `default-kodus-config.yml` has been changed from `false` to `true`. This modification ensures that filters, such as severity level and limits, are now applied to Kody Rules by default, addressing an issue where these rules were not being filtered as expected.
<!-- kody-pr-summary:end -->