### PR TITLE
[fix] user joining to organization should have `owner` role, not `user`

### DIFF
--- a/src/core/application/use-cases/user/join-organization.use-case.ts
+++ b/src/core/application/use-cases/user/join-organization.use-case.ts
@@ -12,8 +12,8 @@ import {
     TEAM_SERVICE_TOKEN,
 } from '@/core/domain/team/contracts/team.service.contract';
 import {
-    TEAM_MEMBERS_SERVICE_TOKEN,
     ITeamMemberService,
+    TEAM_MEMBERS_SERVICE_TOKEN,
 } from '@/core/domain/teamMembers/contracts/teamMembers.service.contracts';
 import { TeamMemberRole } from '@/core/domain/teamMembers/enums/teamMemberRole.enum';
 import {
@@ -119,7 +119,7 @@ export class JoinOrganizationUseCase implements IUseCase {
                     uuid: user.uuid,
                 },
                 {
-                    role: [UserRole.USER],
+                    role: [UserRole.OWNER],
                     status: STATUS.AWAITING_APPROVAL,
                     organization,
                 },


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request addresses an issue where users joining an organization were incorrectly assigned the `USER` role.

The change modifies the `JoinOrganizationUseCase` to ensure that when a user joins an organization, they are automatically assigned the `OWNER` role instead of the `USER` role.
<!-- kody-pr-summary:end -->