### PR TITLE
fix get pr executions filters

### DIFF
--- a/src/core/infrastructure/adapters/repositories/typeorm/automationExecution.repository.ts
+++ b/src/core/infrastructure/adapters/repositories/typeorm/automationExecution.repository.ts
@@ -142,14 +142,12 @@ export class AutomationExecutionRepository
         filter?: Partial<IAutomationExecution>,
     ): Promise<AutomationExecutionEntity[]> {
         try {
-            const whereConditions = this.getFilterConditions(filter);
-
             // Determine which relations to load based on the filter
             const relations = ['teamAutomation', 'codeReviewExecutions'];
-            
+
             // Only load deep nested relations if the filter requires them
             if (filter?.teamAutomation) {
-                const teamAutomationFilter = filter.teamAutomation as any;
+                const teamAutomationFilter = filter.teamAutomation;
                 if (teamAutomationFilter.team) {
                     relations.push('teamAutomation.team');
                     if (teamAutomationFilter.team.organization) {
@@ -159,7 +157,7 @@ export class AutomationExecutionRepository
             }
 
             const findOneOptions: FindManyOptions<AutomationExecutionModel> = {
-                where: whereConditions,
+                where: filter as FindOptionsWhere<AutomationExecutionModel>,
                 relations,
             };
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request refactors the `getPrExecutions` method within the `AutomationExecutionRepository` to fix and simplify how filters are applied.

Previously, the `filter` object was processed through a `getFilterConditions` method before being used in the database query. This change removes the intermediate `getFilterConditions` step and directly passes the provided `filter` object to TypeORM's `where` clause. This streamlines the filtering logic, ensuring that the input filter is directly and correctly applied when retrieving automation execution records. Additionally, an unnecessary `any` type assertion for `teamAutomationFilter` has been removed, improving type safety.
<!-- kody-pr-summary:end -->