### PR TITLE
Adding validation to ignore files with @kody-ignore

### DIFF
--- a/src/core/infrastructure/adapters/services/kodyRules/kodyRulesSync.service.ts
+++ b/src/core/infrastructure/adapters/services/kodyRules/kodyRulesSync.service.ts
@@ -313,7 +313,8 @@ export class KodyRulesSyncService {
                         metadata: { 
                             file: f.filename,
                             repositoryId: repository.id,
-                            pullRequestNumber 
+                            pullRequestNumber,
+                            organizationAndTeamData,
                         },
                     });
                     
@@ -485,7 +486,8 @@ export class KodyRulesSyncService {
                         metadata: { 
                             file: file.path,
                             repositoryId: repository.id,
-                            syncType: 'main'
+                            syncType: 'main',
+                            organizationAndTeamData,
                         },
                     });
                     


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a new feature that allows Kody AI to ignore specific files based on an `@kody-ignore` marker.

Key changes include:

*   **File Ignoring Logic:** A new private method, `shouldIgnoreFile`, has been added to `KodyRulesSyncService`. This method checks the first and last 10 lines of a file's content for the `@kody-ignore` marker (case-insensitive).
*   **Integration into Sync Processes:**
    *   During both pull request rule synchronization (`syncPullRequestRules`) and main branch rule synchronization (`syncMainBranchRules`), files are now checked using the `shouldIgnoreFile` method.
    *   If a file is marked with `@kody-ignore`, Kody AI will log that the file is being ignored and will proceed to remove any existing Kody rules associated with that file.
    *   The file will then be skipped from further rule processing, ensuring no new rules are generated for it.

This enhancement provides developers with the ability to explicitly exclude certain files from Kody AI's rule generation and management, offering greater control over which parts of the codebase are monitored.
<!-- kody-pr-summary:end -->