### PR TITLE
set codereview v2 default category

### DIFF
--- a/src/core/application/use-cases/parameters/update-or-create-code-review-parameter-use-case.ts
+++ b/src/core/application/use-cases/parameters/update-or-create-code-review-parameter-use-case.ts
@@ -331,6 +331,8 @@ export class UpdateOrCreateCodeReviewParameterUseCase {
         const updatedConfigValue = {
             global: {
                 ...configValue,
+                codeReviewVersion:
+                    configValue?.codeReviewVersion ?? CodeReviewVersion.v2,
                 summary: !configValue.summary
                     ? this.getDefaultPRSummaryConfig()
                     : {

--- a/src/core/application/use-cases/team/finish-setup.use-case.ts
+++ b/src/core/application/use-cases/team/finish-setup.use-case.ts
@@ -13,6 +13,7 @@ import { ParametersKey } from '@/shared/domain/enums/parameters-key.enum';
 import { SaveAllTeamMetricsHistoryUseCase } from '../metrics/save-all-metrics-history.use-case';
 import { SaveAllOrganizationMetricsHistoryUseCase } from '../organizationMetrics/save-metrics-history.use-case';
 import { SeverityLevel } from '@/shared/utils/enums/severityLevel.enum';
+import { CodeReviewVersion } from '@/config/types/general/codeReview.type';
 
 @Injectable()
 export class FinishSetupUseCase {
@@ -87,18 +88,23 @@ export class FinishSetupUseCase {
                                         reviewOptions: {
                                             security: true,
                                             code_style: true,
+                                            kody_rules: true,
                                             refactoring: true,
                                             error_handling: true,
                                             maintainability: true,
                                             potential_issues: true,
                                             documentation_and_comments: true,
                                             performance_and_optimization: true,
-                                            kody_rules: true,
+                                            breaking_changes: true,
+                                            bug: true,
+                                            performance: true,
+                                            cross_file: true,
                                         },
                                         limitationType: 'pr',
                                         maxSuggestions: 8,
                                         severityLevelFilter:
                                             SeverityLevel.MEDIUM,
+                                        codeReviewVersion: CodeReviewVersion.v2,
                                     },
                                     {
                                         teamId: teamId,

--- a/src/core/infrastructure/adapters/services/codeBase/commentAnalysis.service.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/commentAnalysis.service.ts
@@ -459,7 +459,13 @@ export class CommentAnalysisService {
                         value <= thresholds.upperThreshold,
                 ]),
             ) as { [key in keyof ReviewOptions]: boolean };
+
+            // Force specific categories to always be true
+            categories.bug = true;
+            categories.cross_file = true;
+            categories.performance = true;
             categories.kody_rules = true;
+            categories.security = true;
             categories.breaking_changes = true;
 
             const severityLevels: SeverityLevel[] = [
@@ -580,11 +586,14 @@ export class CommentAnalysisService {
             const count: CommentFrequency = {
                 categories: {
                     breaking_changes: 0,
+                    bug: 0,
                     code_style: 0,
+                    cross_file: 0,
                     documentation_and_comments: 0,
                     error_handling: 0,
                     kody_rules: 0,
                     maintainability: 0,
+                    performance: 0,
                     performance_and_optimization: 0,
                     potential_issues: 0,
                     refactoring: 0,

--- a/src/core/infrastructure/http/dtos/create-or-update-code-review-parameter.dto.ts
+++ b/src/core/infrastructure/http/dtos/create-or-update-code-review-parameter.dto.ts
@@ -229,7 +229,7 @@ class CodeReviewConfigWithoutLLMProviderDto {
 
     @IsOptional()
     @IsEnum(CodeReviewVersion)
-    codeReviewVersion?: CodeReviewVersion = CodeReviewVersion.LEGACY;
+    codeReviewVersion?: CodeReviewVersion = CodeReviewVersion.v2;
 }
 
 export class CreateOrUpdateCodeReviewParameterDto {

--- a/src/ee/codeBase/codeBaseConfig.service.ts
+++ b/src/ee/codeBase/codeBaseConfig.service.ts
@@ -314,7 +314,7 @@ export default class CodeBaseConfigService implements ICodeBaseConfigService {
                     timeWindow: 0,
                     pushesToTrigger: 0,
                 },
-                codeReviewVersion: CodeReviewVersion.LEGACY,
+                codeReviewVersion: CodeReviewVersion.v2,
             };
 
             return DEFAULT_CONFIG;
@@ -977,9 +977,11 @@ export default class CodeBaseConfigService implements ICodeBaseConfigService {
     ): Promise<string | null> {
         const configFileName = 'kodus-config.yml';
         // Garante que o diretório termine com / para construir o caminho correto
-        const normalizedPath = directoryPath.endsWith('/') ? directoryPath : `${directoryPath}/`;
+        const normalizedPath = directoryPath.endsWith('/')
+            ? directoryPath
+            : `${directoryPath}/`;
         const fullPath = `${normalizedPath}${configFileName}`;
-        
+
         const response =
             await this.codeManagementService.getRepositoryContentFile({
                 organizationAndTeamData,
@@ -1246,32 +1248,35 @@ export default class CodeBaseConfigService implements ICodeBaseConfigService {
             let kodusConfigFile: Omit<KodusConfigFile, 'version'> | null = null;
             let validationErrors = [];
             let isDeprecated = false;
-            
+
             try {
-                const directoryConfigResult = await this.getDirectoryKodusConfigFile(
-                    organizationAndTeamData,
-                    repository,
-                    directoryConfig.path,
-                    defaultBranch,
-                );
+                const directoryConfigResult =
+                    await this.getDirectoryKodusConfigFile(
+                        organizationAndTeamData,
+                        repository,
+                        directoryConfig.path,
+                        defaultBranch,
+                    );
                 kodusConfigFile = directoryConfigResult.kodusConfigFile;
                 validationErrors = directoryConfigResult.validationErrors;
                 isDeprecated = directoryConfigResult.isDeprecated ?? false;
 
                 if (kodusConfigFile) {
                     this.logger.log({
-                        message: 'Using directory-specific kodus-config.yml file',
+                        message:
+                            'Using directory-specific kodus-config.yml file',
                         context: CodeBaseConfigService.name,
-                        metadata: { 
+                        metadata: {
                             directoryPath: directoryConfig.path,
                             repository: repository.name,
-                            isDeprecated 
+                            isDeprecated,
                         },
                     });
                 }
             } catch (error) {
                 this.logger.warn({
-                    message: 'Error loading directory configuration file, falling back to database config',
+                    message:
+                        'Error loading directory configuration file, falling back to database config',
                     context: CodeBaseConfigService.name,
                     error,
                     metadata: { directoryPath: directoryConfig.path },
@@ -1305,32 +1310,31 @@ export default class CodeBaseConfigService implements ICodeBaseConfigService {
                 baseBranches: configSource.baseBranches?.length
                     ? configSource.baseBranches
                     : [defaultBranch],
-                reviewOptions: kodusConfigFile 
+                reviewOptions: kodusConfigFile
                     ? this.mergeReviewOptions(
-                        {
-                            kodusConfig: kodusConfigFile.reviewOptions,
-                            validationErrors: validationErrors,
-                        },
-                        undefined, // repo
-                        undefined, // global
-                        codeReviewVersion,
-                    )
+                          {
+                              kodusConfig: kodusConfigFile.reviewOptions,
+                              validationErrors: validationErrors,
+                          },
+                          undefined, // repo
+                          undefined, // global
+                          codeReviewVersion,
+                      )
                     : this.mergeReviewOptions(
-                        {
-                            kodusConfig: undefined,
-                            validationErrors: [],
-                        },
-                        directoryConfig.reviewOptions,
-                        undefined, // global
-                        codeReviewVersion,
-                    ),
+                          {
+                              kodusConfig: undefined,
+                              validationErrors: [],
+                          },
+                          directoryConfig.reviewOptions,
+                          undefined, // global
+                          codeReviewVersion,
+                      ),
                 summary: configSource.summary || this.DEFAULT_CONFIG.summary,
                 suggestionControl:
                     configSource.suggestionControl ||
                     this.DEFAULT_CONFIG.suggestionControl,
                 kodyRules: kodyRules,
-                ignoredTitleKeywords:
-                    configSource.ignoredTitleKeywords || [],
+                ignoredTitleKeywords: configSource.ignoredTitleKeywords || [],
                 automatedReviewActive:
                     configSource.automatedReviewActive ??
                     this.DEFAULT_CONFIG.automatedReviewActive,
@@ -1348,7 +1352,8 @@ export default class CodeBaseConfigService implements ICodeBaseConfigService {
                 kodusConfigFileOverridesWebPreferences: kodusConfigFile
                     ? true // Se veio do arquivo yml, sempre override
                     : (directoryConfig.kodusConfigFileOverridesWebPreferences ??
-                        this.DEFAULT_CONFIG.kodusConfigFileOverridesWebPreferences),
+                      this.DEFAULT_CONFIG
+                          .kodusConfigFileOverridesWebPreferences),
                 isRequestChangesActive:
                     configSource.isRequestChangesActive ??
                     this.DEFAULT_CONFIG.isRequestChangesActive,


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request sets Code Review Version 2 (v2) as the default across various configurations and enables several new code review categories by default.

Key changes include:
*   **Default Code Review Version**: The `codeReviewVersion` is now defaulted to `v2` when:
    *   New teams are set up.
    *   Code review parameters are created or updated.
    *   The system's default code review configuration is initialized.
*   **Enabled Review Categories**: The following code review categories are now enabled by default during new team setup and are always forced to `true` during comment analysis: `bug`, `cross_file`, `performance`, `kody_rules`, `security`, and `breaking_changes`. These categories are also included in comment frequency tracking.
<!-- kody-pr-summary:end -->