### PR TITLE
add check propertie check has date create config review

### DIFF
--- a/src/core/application/use-cases/parameters/find-by-key-use-case.ts
+++ b/src/core/application/use-cases/parameters/find-by-key-use-case.ts
@@ -81,6 +81,43 @@ export class FindByKeyParametersUseCase {
             };
 
             return response;
+        } else if (parameter.configKey === ParametersKey.CODE_REVIEW_CONFIG) {
+            /**
+             * TEMPORARY LOGIC: Show/hide code review version toggle based on user registration date
+             *
+             * Purpose: Gradually migrate users from legacy to v2 engine
+             * - Users registered BEFORE 2025-09-11: Can see version toggle (legacy + v2)
+             * - Users registered ON/AFTER 2025-09-11: Only see v2 (no toggle)
+             *
+             * This logic should be REMOVED after all clients migrate to v2 engine
+             * TODO: Remove this temporary logic after client migration completion
+             */
+            const cutoffYear = 2025;
+            const cutoffMonth = 8; // September (0-indexed)
+            const cutoffDay = 11;
+
+            const paramYear = parameter.createdAt.getUTCFullYear();
+            const paramMonth = parameter.createdAt.getUTCMonth();
+            const paramDay = parameter.createdAt.getUTCDate();
+
+            const showToggleCodeReviewVersion =
+                paramYear < cutoffYear ||
+                (paramYear === cutoffYear && paramMonth < cutoffMonth) ||
+                (paramYear === cutoffYear &&
+                    paramMonth === cutoffMonth &&
+                    paramDay < cutoffDay);
+
+            return {
+                configKey: parameter.configKey,
+                configValue: {
+                    ...parameter.configValue,
+                    showToggleCodeReviewVersion,
+                },
+                team: parameter.team,
+                uuid: parameter.uuid,
+                createdAt: parameter.createdAt,
+                updatedAt: parameter.updatedAt,
+            };
         } else {
             return {
                 configKey: parameter.configKey,

--- a/src/core/domain/parameters/entities/parameters.entity.ts
+++ b/src/core/domain/parameters/entities/parameters.entity.ts
@@ -7,12 +7,16 @@ export class ParametersEntity implements IParameters {
     private _configKey: ParametersKey;
     private _configValue: any;
     private _team?: Partial<ITeam>;
+    private _createdAt?: Date;
+    private _updatedAt?: Date;
 
     constructor(parameters: IParameters | Partial<IParameters>) {
         this._uuid = parameters.uuid;
         this._configKey = parameters.configKey;
         this._configValue = parameters.configValue;
         this._team = parameters.team;
+        this._createdAt = parameters.createdAt;
+        this._updatedAt = parameters.updatedAt;
     }
 
     public static create(parameters: IParameters | Partial<IParameters>) {
@@ -33,5 +37,13 @@ export class ParametersEntity implements IParameters {
 
     public get team() {
         return this._team;
+    }
+
+    public get createdAt() {
+        return this._createdAt;
+    }
+
+    public get updatedAt() {
+        return this._updatedAt;
     }
 }

--- a/src/core/domain/parameters/interfaces/parameters.interface.ts
+++ b/src/core/domain/parameters/interfaces/parameters.interface.ts
@@ -1,4 +1,3 @@
-
 import { ITeam } from '../../team/interfaces/team.interface';
 import { ParametersKey } from '@/shared/domain/enums/parameters-key.enum';
 
@@ -7,4 +6,6 @@ export interface IParameters {
     configKey: ParametersKey;
     configValue: any;
     team?: Partial<ITeam>;
+    createdAt?: Date;
+    updatedAt?: Date;
 }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces `createdAt` and `updatedAt` fields to the `Parameters` entity and interface, enabling date-based logic for parameter configurations.

Specifically, for the `CODE_REVIEW_CONFIG` parameter, a temporary logic has been implemented in the `FindByKeyParametersUseCase`. This logic determines the visibility of a `showToggleCodeReviewVersion` flag based on the parameter's `createdAt` date:
*   If the `CODE_REVIEW_CONFIG` parameter was created before September 11, 2025, the `showToggleCodeReviewVersion` flag will be set to `true`, allowing users to see a toggle for switching between legacy and v2 code review engines.
*   If the parameter was created on or after September 11, 2025, the `showToggleCodeReviewVersion` flag will be set to `false`, meaning users will only see the v2 engine without the version toggle.

This temporary measure aims to facilitate a gradual migration of users from the legacy code review engine to the v2 engine.
<!-- kody-pr-summary:end -->