### PR TITLE
sync ide rule to right folder

### DIFF
--- a/src/ee/kodyRules/service/kodyRules.service.ts
+++ b/src/ee/kodyRules/service/kodyRules.service.ts
@@ -170,6 +170,7 @@ export class KodyRulesService implements IKodyRulesService {
                 sourcePath: kodyRule?.sourcePath,
                 sourceAnchor: kodyRule?.sourceAnchor,
                 repositoryId: kodyRule?.repositoryId,
+                directoryId: kodyRule?.directoryId,
                 examples: kodyRule?.examples,
                 origin: kodyRule?.origin ?? KodyRulesOrigin.USER,
                 scope: kodyRule?.scope ?? KodyRulesScope.FILE,


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces functionality to correctly associate Kody rules with specific directories within a repository, primarily to support monorepo structures.

Key changes include:

*   **Directory Resolution for Kody Rules:** A new private method, `resolveDirectoryForFile`, has been added to identify the most specific configured directory (based on `CODE_REVIEW_CONFIG`) that a Kody rule's source file belongs to. This allows for rules to be linked to specific sub-folders within a repository.
*   **Storing Directory ID:** When creating or updating Kody rules, the system now determines the relevant `directoryId` using the new resolution logic and stores this ID with the Kody rule.
*   **Enhanced Kody Rule Creation:** The `createKodyRule` method in `kodyRules.service.ts` has been updated to persist the `directoryId` alongside other rule properties.

This enhancement ensures that Kody rules are correctly categorized and linked to their respective folders, enabling more precise management and application of rules in complex repository setups.
<!-- kody-pr-summary:end -->