### PR TITLE
Feat/add new schema auth bitbucket

### DIFF
--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
         "@google/generative-ai": "^0.24.1",
         "@kodus/flow": "0.1.20",
         "@kodus/kodus-common": "^1.2.6",
-        "@kodus/kodus-proto": "https://registry.npmjs.org/@kodus/kodus-proto/-/kodus-proto-3.1.2.tgz",
+        "@kodus/kodus-proto": "https://registry.npmjs.org/@kodus/kodus-proto/-/kodus-proto-3.1.3.tgz",
         "@langchain/anthropic": "^0.3.27",
         "@langchain/cohere": "^0.3.4",
         "@langchain/community": "0.3.55",

--- a/src/core/domain/authIntegrations/types/bitbucket-auth-detail.type.ts
+++ b/src/core/domain/authIntegrations/types/bitbucket-auth-detail.type.ts
@@ -4,4 +4,5 @@ export type BitbucketAuthDetail = {
     username: string;
     appPassword: string;
     authMode: AuthMode;
+    email?: string;
 };

--- a/src/core/domain/platformIntegrations/types/codeManagement/gitCloneParams.type.ts
+++ b/src/core/domain/platformIntegrations/types/codeManagement/gitCloneParams.type.ts
@@ -7,6 +7,7 @@ export type GitCloneParams = {
     branch?: string;
     auth?: {
         type?: AuthMode;
+        username?: string;
         token?: string;
         org?: string;
     };

--- a/src/core/infrastructure/adapters/services/bitbucket/bitbucket.service.ts
+++ b/src/core/infrastructure/adapters/services/bitbucket/bitbucket.service.ts
@@ -2709,6 +2709,7 @@ export class BitbucketService
         code?: string;
         token?: string;
         username?: string;
+        email?: string;
     }): Promise<{ success: boolean; status?: CreateAuthIntegrationStatus }> {
         try {
             let res: {
@@ -2728,6 +2729,7 @@ export class BitbucketService
                     organizationAndTeamData: params.organizationAndTeamData,
                     token: params.token,
                     username: params.username,
+                    email: params.email,
                 });
             }
 
@@ -2948,7 +2950,9 @@ export class BitbucketService
         try {
             const bitbucketAPI = new Bitbucket({
                 auth: {
-                    username: bitbucketAuthDetail.username,
+                    username:
+                        bitbucketAuthDetail.email ??
+                        bitbucketAuthDetail.username,
                     password: decrypt(bitbucketAuthDetail.appPassword),
                 },
             });
@@ -3010,13 +3014,14 @@ export class BitbucketService
         organizationAndTeamData: OrganizationAndTeamData;
         username: string;
         token: string;
+        email?: string;
     }): Promise<{ success: boolean; status?: CreateAuthIntegrationStatus }> {
         try {
-            const { organizationAndTeamData, token, username } = params;
+            const { organizationAndTeamData, token, username, email } = params;
 
             const bitbucketAPI = new Bitbucket({
                 auth: {
-                    username,
+                    username: email ?? username,
                     password: token,
                 },
             });
@@ -3034,7 +3039,9 @@ export class BitbucketService
             const checkRepos = await this.checkRepositoryPermissions({
                 bitbucketAPI,
             });
-            if (!checkRepos.success) return checkRepos;
+            if (!checkRepos.success) {
+                return checkRepos;
+            }
 
             const integration = await this.integrationService.findOne({
                 organization: {
@@ -3048,6 +3055,7 @@ export class BitbucketService
                 username: username,
                 appPassword: encrypt(token),
                 authMode: AuthMode.TOKEN,
+                email: email,
             };
 
             await this.handleIntegration(

--- a/src/core/infrastructure/adapters/services/bitbucket/bitbucket.service.ts
+++ b/src/core/infrastructure/adapters/services/bitbucket/bitbucket.service.ts
@@ -259,7 +259,6 @@ export class BitbucketService
             if (!bitbucketAuthDetail) {
                 throw new BadRequestException('Installation not found');
             }
-            // Construct the full Bitbucket URL
             const fullBitbucketUrl = `https://bitbucket.org/${params?.repository?.fullName}`;
 
             return {
@@ -270,6 +269,7 @@ export class BitbucketService
                 branch: params?.repository?.defaultBranch,
                 provider: PlatformType.BITBUCKET,
                 auth: {
+                    username: bitbucketAuthDetail.username,
                     type: bitbucketAuthDetail.authMode,
                     token: decrypt(bitbucketAuthDetail.appPassword),
                 },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1897,9 +1897,9 @@
   resolved "https://us-central1-npm.pkg.dev/kodus-infra-prod/kodus-pkg/@kodus/kodus-common/-/@kodus/kodus-common-1.2.6.tgz#64ace559bf8db687cf234386ca24752028016925"
   integrity sha512-bP3+viL6HWFu8zYzcj5J2SH9j1X58fiHJJLNCMaArMqzBH1KJNTAL81Ab4CrAiQ1yYOlpuDbVNeQM1N6z449hQ==
 
-"@kodus/kodus-proto@https://registry.npmjs.org/@kodus/kodus-proto/-/kodus-proto-3.1.2.tgz":
-  version "3.1.2"
-  resolved "https://registry.npmjs.org/@kodus/kodus-proto/-/kodus-proto-3.1.2.tgz#a3f057987563fa93e50c35908f835aee06d211d6"
+"@kodus/kodus-proto@https://registry.npmjs.org/@kodus/kodus-proto/-/kodus-proto-3.1.3.tgz":
+  version "3.1.3"
+  resolved "https://registry.npmjs.org/@kodus/kodus-proto/-/kodus-proto-3.1.3.tgz#7e9614898fa13dd091714efdfbbf132ead8bf003"
 
 "@kwsites/file-exists@^1.1.1":
   version "1.1.1"


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request enhances Bitbucket integration by introducing support for an optional email address in authentication details.

Key changes include:
-   **Bitbucket Authentication Details:** The `BitbucketAuthDetail` type now includes an optional `email` field to store the user's email.
-   **Integration Creation:** When creating a new Bitbucket authentication, an optional `email` can be provided. This email will be used as the username for Bitbucket API authentication, falling back to the existing `username` if not provided. The email is also persisted as part of the authentication details.
-   **API Authentication:** Bitbucket API calls (e.g., for checking repository permissions or creating integrations) will now prioritize using the stored `email` for authentication, if available, otherwise using the `username`.
-   **Git Clone Parameters:** The `username` from the Bitbucket authentication details is now explicitly included in the generated `GitCloneParams` for cloning repositories.

This update provides more flexibility for Bitbucket integrations by allowing authentication using an email address.
<!-- kody-pr-summary:end -->