### PR TITLE
removing cache for pr executions

### DIFF
--- a/src/core/infrastructure/http/controllers/pullRequest.controller.ts
+++ b/src/core/infrastructure/http/controllers/pullRequest.controller.ts
@@ -34,8 +34,6 @@ export class PullRequestController {
     }
 
     @Get('/executions')
-    @UseInterceptors(CacheInterceptor)
-    @CacheTTL(300000) // 5 minutos em milliseconds
     public async getPullRequestExecutions(
         @Query() query: EnrichedPullRequestsQueryDto,
     ): Promise<PaginatedEnrichedPullRequestsResponse> {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Removed caching for the `GET /pull-request/executions` endpoint. This change ensures that requests to retrieve pull request executions will no longer serve cached data and will always fetch the latest information.
<!-- kody-pr-summary:end -->