### PR TITLE
unauthorized if role mismatch

### DIFF
--- a/src/core/infrastructure/adapters/services/auth/jwt-auth.strategy.ts
+++ b/src/core/infrastructure/adapters/services/auth/jwt-auth.strategy.ts
@@ -35,6 +35,10 @@ export class JwtStrategy extends PassportStrategy(Strategy, 'jwt') {
             throw new UnauthorizedException();
         }
 
+        if (user.role !== payload.role) {
+            throw new UnauthorizedException();
+        }
+
         delete user.password;
 
         return user;


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request enhances the JWT authentication strategy by adding a role validation check.

Previously, a user was considered authenticated if their ID was valid. With this change, the system now verifies that the role embedded in the JWT token's payload matches the user's current role as retrieved from the system. If there is a mismatch between these roles, the authentication attempt will be rejected with an `UnauthorizedException`.

This ensures that users cannot access resources with privileges based on an outdated role in their token if their role has been changed in the system.
<!-- kody-pr-summary:end -->