### PR TITLE
add new option hide comments

### DIFF
--- a/src/core/application/use-cases/pullRequestMessages/create-or-update-pull-request-messages.use-case.ts
+++ b/src/core/application/use-cases/pullRequestMessages/create-or-update-pull-request-messages.use-case.ts
@@ -87,11 +87,11 @@ export class CreateOrUpdatePullRequestMessagesUseCase implements IUseCase {
                 existingEndMessage:
                     existingPullRequestMessage?.endReviewMessage,
                 directoryPath:
-                    await this.getAdditionalInfoHelper.getDirectoryPathByOrganizationAndRepository(
+                    (await this.getAdditionalInfoHelper.getDirectoryPathByOrganizationAndRepository(
                         pullRequestMessages.organizationId,
                         pullRequestMessages.repositoryId,
                         pullRequestMessages.directoryId,
-                    ) || '',
+                    )) || '',
                 isUpdate,
             };
             await this.codeReviewSettingsLogService.registerPullRequestMessagesLog(

--- a/src/core/domain/codeBase/contracts/CommentManagerService.contract.ts
+++ b/src/core/domain/codeBase/contracts/CommentManagerService.contract.ts
@@ -10,7 +10,10 @@ import { OrganizationAndTeamData } from '@/config/types/general/organizationAndT
 import { LLMModelProvider } from '@kodus/kodus-common/llm';
 import { PlatformType } from '@/shared/domain/enums/platform-type.enum';
 import { ISuggestionByPR } from '../../pullRequests/interfaces/pullRequests.interface';
-import { IPullRequestMessageContent, IPullRequestMessages } from '../../pullRequestMessages/interfaces/pullRequestMessages.interface';
+import {
+    IPullRequestMessageContent,
+    IPullRequestMessages,
+} from '../../pullRequestMessages/interfaces/pullRequestMessages.interface';
 
 export const COMMENT_MANAGER_SERVICE_TOKEN = Symbol('CommentManagerService');
 
@@ -23,7 +26,7 @@ export interface ICommentManagerService {
         language: string,
         platformType: string,
         codeReviewConfig?: CodeReviewConfig,
-        startReviewMessage?: string,
+        pullRequestMessages?: IPullRequestMessages,
     ): Promise<{ commentId: number; noteId: number; threadId?: number }>;
 
     generateSummaryPR(
@@ -46,6 +49,7 @@ export interface ICommentManagerService {
         codeSuggestions?: Array<CommentResult>,
         codeReviewConfig?: CodeReviewConfig,
         threadId?: number,
+        finalCommentBody?: string,
     ): Promise<void>;
 
     updateSummarizationInPR(
@@ -114,6 +118,6 @@ export interface ICommentManagerService {
         language?: string,
         codeSuggestions?: Array<CommentResult>,
         codeReviewConfig?: CodeReviewConfig,
-        endReviewMessage?: IPullRequestMessageContent,
+        endReviewMessage?: string,
     ): Promise<void>;
 }

--- a/src/core/domain/pullRequestMessages/entities/pullRequestMessages.entity.ts
+++ b/src/core/domain/pullRequestMessages/entities/pullRequestMessages.entity.ts
@@ -3,9 +3,7 @@ import {
     IPullRequestMessageContent,
     IPullRequestMessages,
 } from '../interfaces/pullRequestMessages.interface';
-import {
-    ConfigLevel,
-} from '@/config/types/general/pullRequestMessages.type';
+import { ConfigLevel } from '@/config/types/general/pullRequestMessages.type';
 
 export class PullRequestMessagesEntity implements Entity<IPullRequestMessages> {
     private readonly _uuid: string;
@@ -15,6 +13,9 @@ export class PullRequestMessagesEntity implements Entity<IPullRequestMessages> {
     private readonly _startReviewMessage?: IPullRequestMessageContent;
     private readonly _endReviewMessage?: IPullRequestMessageContent;
     private readonly _directoryId?: string;
+    private readonly _globalSettings?: {
+        hideComments?: boolean;
+    };
     private readonly _directoryPath?: string;
 
     constructor(pullRequestMessages: IPullRequestMessages) {
@@ -25,6 +26,7 @@ export class PullRequestMessagesEntity implements Entity<IPullRequestMessages> {
         this._startReviewMessage = pullRequestMessages.startReviewMessage;
         this._endReviewMessage = pullRequestMessages.endReviewMessage;
         this._directoryId = pullRequestMessages.directoryId;
+        this._globalSettings = pullRequestMessages.globalSettings;
     }
 
     toJson(): IPullRequestMessages {
@@ -36,6 +38,7 @@ export class PullRequestMessagesEntity implements Entity<IPullRequestMessages> {
             startReviewMessage: this._startReviewMessage,
             endReviewMessage: this._endReviewMessage,
             directoryId: this._directoryId,
+            globalSettings: this._globalSettings,
         };
     }
 
@@ -48,6 +51,7 @@ export class PullRequestMessagesEntity implements Entity<IPullRequestMessages> {
             startReviewMessage: this._startReviewMessage,
             endReviewMessage: this._endReviewMessage,
             directoryId: this._directoryId,
+            globalSettings: this._globalSettings,
         };
     }
 
@@ -77,6 +81,10 @@ export class PullRequestMessagesEntity implements Entity<IPullRequestMessages> {
 
     get directoryId(): string | undefined {
         return this._directoryId;
+    }
+
+    get globalSettings(): { hideComments?: boolean } | undefined {
+        return this._globalSettings;
     }
 
     public static create(

--- a/src/core/domain/pullRequestMessages/interfaces/pullRequestMessages.interface.ts
+++ b/src/core/domain/pullRequestMessages/interfaces/pullRequestMessages.interface.ts
@@ -1,7 +1,6 @@
 import {
     ConfigLevel,
     PullRequestMessageStatus,
-    PullRequestMessageType,
 } from '@/config/types/general/pullRequestMessages.type';
 
 export interface IPullRequestMessageContent {
@@ -17,4 +16,7 @@ export interface IPullRequestMessages {
     startReviewMessage?: IPullRequestMessageContent;
     endReviewMessage?: IPullRequestMessageContent;
     directoryId?: string;
+    globalSettings?: {
+        hideComments?: boolean;
+    };
 }

--- a/src/core/infrastructure/adapters/repositories/mongoose/schema/pullRequestMessages.model.ts
+++ b/src/core/infrastructure/adapters/repositories/mongoose/schema/pullRequestMessages.model.ts
@@ -57,6 +57,22 @@ export class PullRequestMessagesModel extends CoreDocument {
 
     @Prop({ type: String, required: false })
     directoryId: string;
+
+    @Prop({
+        type: {
+            hideComments: {
+                type: Boolean,
+                default: false,
+                required: false,
+            },
+        },
+        _id: false,
+        required: false,
+        default: { hideComments: false },
+    })
+    globalSettings: {
+        hideComments: boolean;
+    };
 }
 
 export const PullRequestMessagesSchema = SchemaFactory.createForClass(

--- a/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/finish-comments.stage.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/finish-comments.stage.ts
@@ -28,7 +28,6 @@ export class UpdateCommentsAndGenerateSummaryStage extends BasePipelineStage<Cod
         const {
             lastExecution,
             codeReviewConfig,
-            overallComments,
             repository,
             pullRequest,
             organizationAndTeamData,
@@ -64,10 +63,10 @@ export class UpdateCommentsAndGenerateSummaryStage extends BasePipelineStage<Cod
                 message: `Generating summary for PR#${pullRequest.number}`,
                 context: this.stageName,
                 metadata: {
-                        organizationAndTeamData,
-                        prNumber: context.pullRequest.number,
-                        repository: context.repository,
-                    },
+                    organizationAndTeamData,
+                    prNumber: context.pullRequest.number,
+                    repository: context.repository,
+                },
             });
 
             const changedFiles = context.changedFiles.map((file) => ({
@@ -95,13 +94,12 @@ export class UpdateCommentsAndGenerateSummaryStage extends BasePipelineStage<Cod
             );
         }
 
+        const startReviewMessage =
+            context.pullRequestMessagesConfig?.startReviewMessage;
         const endReviewMessage =
             context.pullRequestMessagesConfig?.endReviewMessage;
 
-        if (
-            !context.pullRequestMessagesConfig?.startReviewMessage &&
-            !endReviewMessage
-        ) {
+        if (!endReviewMessage) {
             await this.commentManagerService.updateOverallComment(
                 organizationAndTeamData,
                 pullRequest.number,
@@ -113,22 +111,41 @@ export class UpdateCommentsAndGenerateSummaryStage extends BasePipelineStage<Cod
                 codeReviewConfig,
                 initialCommentData.threadId,
             );
-        } else {
-            if (
-                endReviewMessage &&
-                endReviewMessage.status === PullRequestMessageStatus.INACTIVE
-            ) {
-                this.logger.log({
-                    message: `Skipping comment for PR#${context.pullRequest.number} with finish review message because it is inactive`,
-                    context: UpdateCommentsAndGenerateSummaryStage.name,
-                    metadata: {
-                        organizationAndTeamData,
-                        prNumber: context.pullRequest.number,
-                        repository: context.repository,
-                    },
-                });
-                return context;
-            }
+            return context;
+        }
+
+        if (endReviewMessage.status === PullRequestMessageStatus.INACTIVE) {
+            return context;
+        }
+
+        if (
+            endReviewMessage.status === PullRequestMessageStatus.ACTIVE &&
+            startReviewMessage &&
+            startReviewMessage.status === PullRequestMessageStatus.ACTIVE
+        ) {
+            const finalCommentBody = endReviewMessage.content;
+
+            await this.commentManagerService.updateOverallComment(
+                organizationAndTeamData,
+                pullRequest.number,
+                repository,
+                initialCommentData.commentId,
+                initialCommentData.noteId,
+                platformType,
+                lineComments,
+                codeReviewConfig,
+                initialCommentData.threadId,
+                finalCommentBody,
+            );
+            return context;
+        }
+
+        if (
+            endReviewMessage.status === PullRequestMessageStatus.ACTIVE &&
+            (!startReviewMessage ||
+                startReviewMessage.status === PullRequestMessageStatus.INACTIVE)
+        ) {
+            const finalCommentBody = endReviewMessage.content;
 
             await this.commentManagerService.createComment(
                 organizationAndTeamData,
@@ -139,7 +156,7 @@ export class UpdateCommentsAndGenerateSummaryStage extends BasePipelineStage<Cod
                 context.codeReviewConfig?.languageResultPrompt ?? 'en-US',
                 lineComments,
                 codeReviewConfig,
-                endReviewMessage,
+                finalCommentBody,
             );
         }
 

--- a/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/initial-comment.stage.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/initial-comment.stage.ts
@@ -10,13 +10,11 @@ import { PlatformType } from '@/shared/domain/enums/platform-type.enum';
 import {
     ConfigLevel,
     PullRequestMessageStatus,
-    PullRequestMessageType,
 } from '@/config/types/general/pullRequestMessages.type';
 import {
     PULL_REQUEST_MESSAGES_SERVICE_TOKEN,
     IPullRequestMessagesService,
 } from '@/core/domain/pullRequestMessages/contracts/pullRequestMessages.service.contract';
-import { GLOBAL_MODULE_METADATA } from '@nestjs/common/constants';
 import { IPullRequestMessages } from '@/core/domain/pullRequestMessages/interfaces/pullRequestMessages.interface';
 
 @Injectable()
@@ -107,7 +105,7 @@ export class InitialCommentStage extends BasePipelineStage<CodeReviewPipelineCon
             context.codeReviewConfig?.languageResultPrompt ?? 'en-US',
             context.platformType,
             context.codeReviewConfig,
-            startReviewMessage?.content,
+            pullRequestMessagesConfig,
         );
 
         return this.updateContext(context, (draft) => {

--- a/src/core/infrastructure/adapters/services/codeBase/commentManager.service.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/commentManager.service.ts
@@ -421,13 +421,26 @@ export class CommentManagerService implements ICommentManagerService {
                 PlatformType.GITHUB === platformType &&
                 pullRequestMessages?.globalSettings?.hideComments
             ) {
-                await this.codeManagementService.minimizeComment({
-                    organizationAndTeamData,
-                    commentId: comment.node_id
-                        ? comment.node_id.toString()
-                        : comment.id.toString(),
-                    reason: 'OUTDATED',
-                });
+                try {
+                    await this.codeManagementService.minimizeComment({
+                        organizationAndTeamData,
+                        commentId: comment?.node_id
+                            ? comment.node_id.toString()
+                            : comment.id.toString(),
+                        reason: 'OUTDATED',
+                    });
+                } catch (error) {
+                    this.logger.warn({
+                        message: `Comment created but failed to minimize for PR#${prNumber}: ${error.message}`,
+                        context: CommentManagerService.name,
+                        metadata: {
+                            organizationAndTeamData,
+                            prNumber,
+                            repository: repository.name,
+                            commentId: comment?.id,
+                        },
+                    });
+                }
             }
 
             const commentId = Number(comment?.id) || null;

--- a/src/core/infrastructure/adapters/services/codeBase/commentManager.service.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/commentManager.service.ts
@@ -42,7 +42,10 @@ interface ClusteredSuggestion {
     problemDescription?: string;
     actionStatement?: string;
 }
-import { IPullRequestMessageContent } from '@/core/domain/pullRequestMessages/interfaces/pullRequestMessages.interface';
+import {
+    IPullRequestMessageContent,
+    IPullRequestMessages,
+} from '@/core/domain/pullRequestMessages/interfaces/pullRequestMessages.interface';
 import {
     MessageTemplateProcessor,
     PlaceholderContext,
@@ -366,12 +369,12 @@ export class CommentManagerService implements ICommentManagerService {
         language: string,
         platformType: PlatformType,
         codeReviewConfig?: CodeReviewConfig,
-        startReviewMessage?: string,
+        pullRequestMessages?: IPullRequestMessages,
     ): Promise<{ commentId: number; noteId: number; threadId?: number }> {
         try {
             let commentBody;
 
-            if (startReviewMessage?.length > 0) {
+            if (pullRequestMessages?.startReviewMessage?.content?.length > 0) {
                 const placeholderContext = await this.getTemplateContext(
                     changedFiles,
                     organizationAndTeamData,
@@ -382,7 +385,7 @@ export class CommentManagerService implements ICommentManagerService {
                 );
 
                 const rawBody = await this.messageProcessor.processTemplate(
-                    startReviewMessage,
+                    pullRequestMessages?.startReviewMessage?.content,
                     placeholderContext,
                 );
                 commentBody = this.sanitizeBitbucketMarkdown(
@@ -413,6 +416,19 @@ export class CommentManagerService implements ICommentManagerService {
                     body: commentBody,
                 },
             );
+
+            if (
+                PlatformType.GITHUB === platformType &&
+                pullRequestMessages?.globalSettings?.hideComments
+            ) {
+                await this.codeManagementService.minimizeComment({
+                    organizationAndTeamData,
+                    commentId: comment.node_id
+                        ? comment.node_id.toString()
+                        : comment.id.toString(),
+                    reason: 'OUTDATED',
+                });
+            }
 
             const commentId = Number(comment?.id) || null;
 
@@ -472,15 +488,20 @@ export class CommentManagerService implements ICommentManagerService {
         codeSuggestions?: Array<CommentResult>,
         codeReviewConfig?: CodeReviewConfig,
         threadId?: number,
+        finalCommentBody?: string,
     ): Promise<void> {
         try {
-            const commentBody = await this.generateLastReviewCommenBody(
-                organizationAndTeamData,
-                prNumber,
-                platformType,
-                codeSuggestions,
-                codeReviewConfig,
-            );
+            let commentBody = finalCommentBody;
+
+            if (!commentBody || commentBody === '') {
+                commentBody = await this.generateLastReviewCommenBody(
+                    organizationAndTeamData,
+                    prNumber,
+                    platformType,
+                    codeSuggestions,
+                    codeReviewConfig,
+                );
+            }
 
             await this.codeManagementService.updateIssueComment({
                 organizationAndTeamData,
@@ -1417,12 +1438,12 @@ ${reviewOptions}
         language?: string,
         codeSuggestions?: Array<CommentResult>,
         codeReviewConfig?: CodeReviewConfig,
-        endReviewMessage?: IPullRequestMessageContent,
+        endReviewMessage?: string,
     ): Promise<void> {
         let commentBody;
 
         if (endReviewMessage) {
-            commentBody = endReviewMessage.content;
+            commentBody = endReviewMessage;
 
             const placeholderContext = await this.getTemplateContext(
                 changedFiles,
@@ -1434,7 +1455,7 @@ ${reviewOptions}
             );
 
             const rawBody = await this.messageProcessor.processTemplate(
-                endReviewMessage.content,
+                endReviewMessage,
                 placeholderContext,
             );
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a new configuration option to control the visibility of AI-generated comments on pull requests.

Key changes include:
-   **Added `hideComments` global setting**: A new boolean option, `hideComments`, has been added to the `globalSettings` within the pull request messages configuration (`IPullRequestMessages`).
-   **Minimize initial comments**: When the `hideComments` setting is enabled, the initial AI-generated comment on GitHub pull requests will be automatically minimized.
-   **Refactored comment management**: The `CommentManagerService` has been updated to accept the full pull request messages configuration, allowing it to access and apply global settings like `hideComments`.
-   **Enhanced final comment handling**: The process for updating or creating the final review comment has been refined to allow the direct provision of the final comment body, improving flexibility in how review summaries are posted.
<!-- kody-pr-summary:end -->