### PR TITLE
fix ignore paths

### DIFF
--- a/src/shared/utils/codeBase/ignorePaths/generated/paths.json
+++ b/src/shared/utils/codeBase/ignorePaths/generated/paths.json
@@ -763,7 +763,6 @@
         "**/*.dSYM/**",
         "**/*.su",
         "**/*.idb",
-        "**/*.mod*",
         "**/*.cmd",
         "**/.tmp_versions/**",
         "**/modules.order",


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Removes the `**/*.mod*` pattern from the list of ignored paths. This change ensures that files matching this pattern are no longer excluded from code base analysis.
<!-- kody-pr-summary:end -->