### PR TITLE
fixed outputschema mcp kody rule

### DIFF
--- a/src/core/domain/codeBase/contracts/CommentManagerService.contract.ts
+++ b/src/core/domain/codeBase/contracts/CommentManagerService.contract.ts
@@ -119,5 +119,6 @@ export interface ICommentManagerService {
         codeSuggestions?: Array<CommentResult>,
         codeReviewConfig?: CodeReviewConfig,
         endReviewMessage?: string,
+        pullRequestMessagesConfig?: IPullRequestMessages,
     ): Promise<void>;
 }

--- a/src/core/infrastructure/adapters/mcp/tools/kodyRules.tools.ts
+++ b/src/core/infrastructure/adapters/mcp/tools/kodyRules.tools.ts
@@ -98,7 +98,7 @@ export class KodyRulesTools {
                             updatedAt: z.date().optional(),
                             reason: z.string().nullable().optional(),
                             scope: z.nativeEnum(KodyRulesScope).optional(),
-                            directoryId: z.string().optional(),
+                            directoryId: z.string().nullable().optional(),
                         })
                         .passthrough(),
                 ),
@@ -182,7 +182,7 @@ export class KodyRulesTools {
                             updatedAt: z.date().optional(),
                             reason: z.string().nullable().optional(),
                             scope: z.nativeEnum(KodyRulesScope).optional(),
-                            directoryId: z.string().optional(),
+                            directoryId: z.string().nullable().optional(),
                         })
                         .passthrough(),
                 ),

--- a/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/finish-comments.stage.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/finish-comments.stage.ts
@@ -157,6 +157,7 @@ export class UpdateCommentsAndGenerateSummaryStage extends BasePipelineStage<Cod
                 lineComments,
                 codeReviewConfig,
                 finalCommentBody,
+                context.pullRequestMessagesConfig,
             );
         }
 

--- a/src/core/infrastructure/adapters/services/codeBase/commentManager.service.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/commentManager.service.ts
@@ -1452,6 +1452,7 @@ ${reviewOptions}
         codeSuggestions?: Array<CommentResult>,
         codeReviewConfig?: CodeReviewConfig,
         endReviewMessage?: string,
+        pullRequestMessagesConfig?: IPullRequestMessages,
     ): Promise<void> {
         let commentBody;
 
@@ -1483,12 +1484,27 @@ ${reviewOptions}
             );
         }
 
-        await this.codeManagementService.createIssueComment({
+        const comment = await this.codeManagementService.createIssueComment({
             organizationAndTeamData,
             repository,
             prNumber,
             body: commentBody,
         });
+
+        if (
+            platformType === PlatformType.GITHUB &&
+            pullRequestMessagesConfig?.globalSettings?.hideComments
+        ) {
+            await this.codeManagementService.minimizeComment({
+                organizationAndTeamData,
+                commentId: comment?.node_id
+                    ? comment.node_id.toString()
+                    : comment.id.toString(),
+                reason: 'OUTDATED',
+            });
+        }
+
+        return comment;
     }
 
     private async getTemplateContext(


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces the following changes:

1.  **Updated Kody Rules Schema:** The `directoryId` field in the Kody Rules schema (defined in `kodyRules.tools.ts`) has been updated to explicitly allow `null` values, making it `nullable().optional()`. This provides more flexibility for cases where a directory ID might not be present.
2.  **Automatic Comment Minimization for GitHub Pull Requests:**
    *   A new `pullRequestMessagesConfig` parameter has been added to the `ICommentManagerService` contract and its implementation.
    *   This configuration is now passed through the code review pipeline's `finish-comments.stage.ts` to the `commentManagerService`.
    *   If the platform is GitHub and `pullRequestMessagesConfig.globalSettings.hideComments` is enabled, the generated review summary comment will be automatically minimized (hidden) with the reason 'OUTDATED' immediately after it is created.
    *   The `createReviewSummaryComment` method now returns the created comment object, which is necessary to obtain the comment ID for minimization.
<!-- kody-pr-summary:end -->