### PR TITLE
Per-Repository Fine-Tuning Control Issue #270

### DIFF
--- a/src/config/types/general/codeReview.type.ts
+++ b/src/config/types/general/codeReview.type.ts
@@ -365,6 +365,7 @@ export enum ReviewModeConfig {
 
 export type KodyFineTuningConfig = {
     enabled: boolean;
+    fineTuningEnabled?: boolean; // Per-repository toggle (default: true)
 };
 
 export enum SuggestionType {

--- a/src/core/application/use-cases/global-parameters/update-global-fine-tuning-config.use-case.ts
+++ b/src/core/application/use-cases/global-parameters/update-global-fine-tuning-config.use-case.ts
@@ -1,0 +1,84 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { IUseCase } from '@/shared/domain/interfaces/use-case.interface';
+import { IGlobalParametersService, GLOBAL_PARAMETERS_SERVICE_TOKEN } from '@/core/domain/global-parameters/contracts/global-parameters.service.contract';
+import { GlobalParametersKey } from '@/shared/domain/enums/global-parameters-key.enum';
+import { OrganizationAndTeamData } from '@/config/types/general/organizationAndTeamData';
+import { AuthorizationService } from '@/core/infrastructure/adapters/services/permissions/authorization.service';
+import { Action, ResourceType } from '@/core/domain/permissions/enums/permissions.enum';
+import { IUser } from '@/core/domain/user/interfaces/user.interface';
+import { PinoLoggerService } from '@/core/infrastructure/adapters/services/logger/pino.service';
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+
+@Injectable()
+export class UpdateGlobalFineTuningConfigUseCase implements IUseCase {
+    constructor(
+        @Inject(GLOBAL_PARAMETERS_SERVICE_TOKEN)
+        private readonly globalParametersService: IGlobalParametersService,
+        private readonly authorizationService: AuthorizationService,
+        private readonly logger: PinoLoggerService,
+    ) {}
+
+    async execute(params: {
+        user: IUser;
+        organizationAndTeamData: OrganizationAndTeamData;
+        enabled: boolean;
+    }): Promise<boolean> {
+        const { user, organizationAndTeamData, enabled } = params;
+
+        try {
+            // Check if user has permission to manage organization settings
+            await this.authorizationService.ensure({
+                user,
+                action: Action.Manage,
+                resource: ResourceType.OrganizationSettings,
+            });
+
+            // Get current global fine-tuning configuration
+            const currentConfig = await this.globalParametersService.findByKey(
+                GlobalParametersKey.KODY_FINE_TUNING_CONFIG,
+                organizationAndTeamData,
+            );
+
+            // Update or create the configuration
+            const configValue = {
+                enabled,
+                ...(currentConfig?.configValue || {}),
+            };
+
+            await this.globalParametersService.createOrUpdateConfig(
+                GlobalParametersKey.KODY_FINE_TUNING_CONFIG,
+                configValue,
+                organizationAndTeamData,
+            );
+
+            this.logger.info({
+                message: 'Global fine-tuning configuration updated successfully',
+                context: UpdateGlobalFineTuningConfigUseCase.name,
+                metadata: {
+                    enabled,
+                    organizationId: organizationAndTeamData.organizationId,
+                    teamId: organizationAndTeamData.teamId,
+                },
+            });
+
+            return true;
+        } catch (error) {
+            if (error instanceof ForbiddenException) {
+                throw error;
+            }
+
+            this.logger.error({
+                message: 'Error updating global fine-tuning configuration',
+                context: UpdateGlobalFineTuningConfigUseCase.name,
+                error: error.message,
+                metadata: {
+                    enabled,
+                    organizationId: organizationAndTeamData.organizationId,
+                    teamId: organizationAndTeamData.teamId,
+                },
+            });
+
+            throw new BadRequestException('Failed to update global fine-tuning configuration');
+        }
+    }
+}

--- a/src/core/application/use-cases/parameters/update-fine-tuning-toggle.use-case.ts
+++ b/src/core/application/use-cases/parameters/update-fine-tuning-toggle.use-case.ts
@@ -1,0 +1,109 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { IUseCase } from '@/shared/domain/interfaces/use-case.interface';
+import { IParametersService, PARAMETERS_SERVICE_TOKEN } from '@/core/domain/parameters/contracts/parameters.service.contract';
+import { ParametersKey } from '@/shared/domain/enums/parameters-key.enum';
+import { OrganizationAndTeamData } from '@/config/types/general/organizationAndTeamData';
+import { CodeReviewConfig } from '@/config/types/general/codeReview.type';
+import { AuthorizationService } from '@/core/infrastructure/adapters/services/permissions/authorization.service';
+import { Action, ResourceType } from '@/core/domain/permissions/enums/permissions.enum';
+import { IUser } from '@/core/domain/user/interfaces/user.interface';
+import { PinoLoggerService } from '@/core/infrastructure/adapters/services/logger/pino.service';
+import { BadRequestException, ForbiddenException } from '@nestjs/common';
+
+@Injectable()
+export class UpdateFineTuningToggleUseCase implements IUseCase {
+    constructor(
+        @Inject(PARAMETERS_SERVICE_TOKEN)
+        private readonly parametersService: IParametersService,
+        private readonly authorizationService: AuthorizationService,
+        private readonly logger: PinoLoggerService,
+    ) {}
+
+    async execute(params: {
+        user: IUser;
+        organizationAndTeamData: OrganizationAndTeamData;
+        repositoryId: string;
+        fineTuningEnabled: boolean;
+    }): Promise<boolean> {
+        const { user, organizationAndTeamData, repositoryId, fineTuningEnabled } = params;
+
+        try {
+            // Check if user has permission to update code review settings for this repository
+            await this.authorizationService.ensure({
+                user,
+                action: Action.Update,
+                resource: ResourceType.CodeReviewSettings,
+                repoIds: [repositoryId],
+            });
+
+            // Get current code review configuration
+            const currentConfig = await this.parametersService.findOne({
+                configKey: ParametersKey.CODE_REVIEW_CONFIG,
+                team: { uuid: organizationAndTeamData.teamId },
+            });
+
+            if (!currentConfig) {
+                throw new BadRequestException('Code review configuration not found');
+            }
+
+            const configValue = currentConfig.configValue as {
+                repositories: any[];
+                global: any;
+            };
+
+            // Find and update the specific repository configuration
+            const repositoryIndex = configValue.repositories.findIndex(
+                (repo) => repo.id === repositoryId,
+            );
+
+            if (repositoryIndex === -1) {
+                throw new BadRequestException('Repository not found in configuration');
+            }
+
+            // Update the fine-tuning toggle for this repository
+            if (!configValue.repositories[repositoryIndex].kodyFineTuningConfig) {
+                configValue.repositories[repositoryIndex].kodyFineTuningConfig = {};
+            }
+
+            configValue.repositories[repositoryIndex].kodyFineTuningConfig.fineTuningEnabled = fineTuningEnabled;
+
+            // Save the updated configuration
+            await this.parametersService.createOrUpdateConfig(
+                ParametersKey.CODE_REVIEW_CONFIG,
+                configValue,
+                organizationAndTeamData,
+            );
+
+            this.logger.info({
+                message: 'Fine-tuning toggle updated successfully',
+                context: UpdateFineTuningToggleUseCase.name,
+                metadata: {
+                    repositoryId,
+                    fineTuningEnabled,
+                    organizationId: organizationAndTeamData.organizationId,
+                    teamId: organizationAndTeamData.teamId,
+                },
+            });
+
+            return true;
+        } catch (error) {
+            if (error instanceof ForbiddenException) {
+                throw error;
+            }
+
+            this.logger.error({
+                message: 'Error updating fine-tuning toggle',
+                context: UpdateFineTuningToggleUseCase.name,
+                error: error.message,
+                metadata: {
+                    repositoryId,
+                    fineTuningEnabled,
+                    organizationId: organizationAndTeamData.organizationId,
+                    teamId: organizationAndTeamData.teamId,
+                },
+            });
+
+            throw new BadRequestException('Failed to update fine-tuning toggle');
+        }
+    }
+}

--- a/src/core/domain/platformIntegrations/interfaces/code-management.interface.ts
+++ b/src/core/domain/platformIntegrations/interfaces/code-management.interface.ts
@@ -196,6 +196,7 @@ export interface ICodeManagementService
         includeFooter?: boolean;
         language?: string;
         organizationAndTeamData: OrganizationAndTeamData;
+        fineTuningEnabled?: boolean;
     }): Promise<string>;
 
     getRepositoryTree(params: {

--- a/src/core/infrastructure/adapters/services/azureRepos.service.ts
+++ b/src/core/infrastructure/adapters/services/azureRepos.service.ts
@@ -3564,6 +3564,7 @@ export class AzureReposService
         includeFooter?: boolean;
         language?: string;
         organizationAndTeamData: OrganizationAndTeamData;
+        fineTuningEnabled?: boolean;
     }): Promise<string> {
         const {
             suggestion,
@@ -3571,6 +3572,7 @@ export class AzureReposService
             includeHeader = true,
             includeFooter = true,
             language,
+            fineTuningEnabled = true,
         } = params;
 
         let commentBody = '';
@@ -3614,11 +3616,15 @@ export class AzureReposService
             );
 
             commentBody += this.formatSub(translations.talkToKody) + '\n';
-            commentBody += this.formatSub(translations.feedback) + '\n\n';
+            
+            // Only include feedback text and buttons if fine-tuning is enabled
+            if (fineTuningEnabled) {
+                commentBody += this.formatSub(translations.feedback) + '\n\n';
 
-            const thumbsUpBlock = `\`\`\`\n👍\n\`\`\`\n`;
-            const thumbsDownBlock = `\`\`\`\n👎\n\`\`\`\n`;
-            commentBody += thumbsUpBlock + thumbsDownBlock;
+                const thumbsUpBlock = `\`\`\`\n👍\n\`\`\`\n`;
+                const thumbsDownBlock = `\`\`\`\n👎\n\`\`\`\n`;
+                commentBody += thumbsUpBlock + thumbsDownBlock;
+            }
         }
 
         return Promise.resolve(commentBody.trim());

--- a/src/core/infrastructure/adapters/services/bitbucket/bitbucket.service.ts
+++ b/src/core/infrastructure/adapters/services/bitbucket/bitbucket.service.ts
@@ -4121,6 +4121,7 @@ export class BitbucketService
         includeFooter?: boolean;
         language?: string;
         organizationAndTeamData: OrganizationAndTeamData;
+        fineTuningEnabled?: boolean;
     }): Promise<string> {
         const {
             suggestion,

--- a/src/core/infrastructure/adapters/services/codeBase/commentManager.service.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/commentManager.service.ts
@@ -1207,6 +1207,8 @@ ${reviewOptions}
                                 includeFooter: false, // PR-level NÃO inclui footer de interação
                                 language,
                                 organizationAndTeamData,
+                                fineTuningEnabled: codeReviewConfig.kodyFineTuningConfig?.enabled && 
+                                                 codeReviewConfig.kodyFineTuningConfig?.fineTuningEnabled,
                             },
                         );
 

--- a/src/core/infrastructure/adapters/services/github/github.service.ts
+++ b/src/core/infrastructure/adapters/services/github/github.service.ts
@@ -5298,6 +5298,7 @@ export class GithubService
         includeFooter?: boolean;
         language?: string;
         organizationAndTeamData: OrganizationAndTeamData;
+        fineTuningEnabled?: boolean;
     }): Promise<string> {
         const {
             suggestion,
@@ -5305,6 +5306,7 @@ export class GithubService
             includeHeader = true,
             includeFooter = true,
             language,
+            fineTuningEnabled = true,
         } = params;
 
         let commentBody = '';
@@ -5348,9 +5350,13 @@ export class GithubService
             );
 
             commentBody += this.formatSub(translations.talkToKody) + '\n';
-            commentBody +=
-                this.formatSub(translations.feedback) +
-                '<!-- kody-codereview -->&#8203;\n&#8203;';
+            
+            // Only include feedback text and buttons if fine-tuning is enabled
+            if (fineTuningEnabled) {
+                commentBody +=
+                    this.formatSub(translations.feedback) +
+                    '<!-- kody-codereview -->&#8203;\n&#8203;';
+            }
         }
 
         return Promise.resolve(commentBody.trim());

--- a/src/core/infrastructure/adapters/services/gitlab.service.ts
+++ b/src/core/infrastructure/adapters/services/gitlab.service.ts
@@ -3167,6 +3167,7 @@ export class GitlabService
         includeFooter?: boolean;
         language?: string;
         organizationAndTeamData: OrganizationAndTeamData;
+        fineTuningEnabled?: boolean;
     }): Promise<string> {
         const {
             suggestion,
@@ -3174,6 +3175,7 @@ export class GitlabService
             includeHeader = true,
             includeFooter = true,
             language,
+            fineTuningEnabled = true,
         } = params;
 
         let commentBody = '';
@@ -3217,7 +3219,11 @@ export class GitlabService
             );
 
             commentBody += this.formatSub(translations.talkToKody) + '\n';
-            commentBody += this.formatSub(translations.feedback);
+            
+            // Only include feedback text if fine-tuning is enabled
+            if (fineTuningEnabled) {
+                commentBody += this.formatSub(translations.feedback);
+            }
         }
 
         return Promise.resolve(commentBody.trim());

--- a/src/core/infrastructure/adapters/services/messageBroker/consumers/codeReviewFeedback.consumer.ts
+++ b/src/core/infrastructure/adapters/services/messageBroker/consumers/codeReviewFeedback.consumer.ts
@@ -1,9 +1,11 @@
 import { SaveCodeReviewFeedbackUseCase } from '@/core/application/use-cases/codeReviewFeedback/save-feedback.use-case';
 import { PinoLoggerService } from '../../logger/pino.service';
 import { RabbitSubscribe } from '@golevelup/nestjs-rabbitmq';
-import { Injectable } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
 import { RabbitmqConsumeErrorFilter } from '@/shared/infrastructure/filters/rabbitmq-consume-error.exception';
 import { UseFilters } from '@nestjs/common';
+import { ICodeBaseConfigService } from '@/ee/codeBase/codeBaseConfig.service.interface';
+import { CODE_BASE_CONFIG_SERVICE_TOKEN } from '@/ee/codeBase/codeBaseConfig.service.interface';
 
 @UseFilters(RabbitmqConsumeErrorFilter)
 @Injectable()
@@ -11,6 +13,8 @@ export class CodeReviewFeedbackConsumer {
     constructor(
         private readonly saveCodeReviewFeedbackUseCase: SaveCodeReviewFeedbackUseCase,
         private readonly logger: PinoLoggerService,
+        @Inject(CODE_BASE_CONFIG_SERVICE_TOKEN)
+        private readonly codeBaseConfigService: ICodeBaseConfigService,
     ) {}
 
     @RabbitSubscribe({
@@ -29,6 +33,22 @@ export class CodeReviewFeedbackConsumer {
 
         if (payload) {
             try {
+                // Check if fine-tuning is enabled for this repository
+                const isFineTuningEnabled = await this.checkFineTuningEnabled(payload);
+                
+                if (!isFineTuningEnabled) {
+                    this.logger.debug({
+                        message: `Fine-tuning disabled for repository, skipping feedback processing for team ${payload.teamId}`,
+                        context: CodeReviewFeedbackConsumer.name,
+                        metadata: {
+                            teamId: payload.teamId,
+                            organizationId: payload.organizationId,
+                            timestamp: new Date().toISOString(),
+                        },
+                    });
+                    return; // Skip processing if fine-tuning is disabled
+                }
+
                 await this.saveCodeReviewFeedbackUseCase.execute(payload);
                 this.logger.debug({
                     message: `Code review feedback processing for team ${payload.teamId} completed successfully.`,
@@ -64,6 +84,46 @@ export class CodeReviewFeedbackConsumer {
             });
 
             throw new Error('Invalid message: no payload');
+        }
+    }
+
+    private async checkFineTuningEnabled(payload: any): Promise<boolean> {
+        try {
+            // Extract repository information from payload
+            // This assumes the payload contains repository information
+            // You may need to adjust this based on the actual payload structure
+            const repositoryId = payload.repositoryId || payload.repository?.id;
+            const repositoryName = payload.repositoryName || payload.repository?.name;
+            
+            if (!repositoryId || !repositoryName) {
+                this.logger.warn({
+                    message: 'Repository information not found in payload, defaulting to fine-tuning enabled',
+                    context: CodeReviewFeedbackConsumer.name,
+                    metadata: { payload },
+                });
+                return true; // Default to enabled if we can't determine repository
+            }
+
+            const organizationAndTeamData = {
+                organizationId: payload.organizationId,
+                teamId: payload.teamId,
+            };
+
+            const config = await this.codeBaseConfigService.getConfig(
+                organizationAndTeamData,
+                { id: repositoryId, name: repositoryName },
+            );
+
+            return config.kodyFineTuningConfig?.enabled && 
+                   config.kodyFineTuningConfig?.fineTuningEnabled;
+        } catch (error) {
+            this.logger.error({
+                message: 'Error checking fine-tuning configuration, defaulting to enabled',
+                context: CodeReviewFeedbackConsumer.name,
+                error: error.message,
+                metadata: { payload },
+            });
+            return true; // Default to enabled on error
         }
     }
 }

--- a/src/core/infrastructure/adapters/services/platformIntegration/codeManagement.service.ts
+++ b/src/core/infrastructure/adapters/services/platformIntegration/codeManagement.service.ts
@@ -1084,6 +1084,7 @@ export class CodeManagementService implements ICodeManagementService {
         includeFooter?: boolean;
         language?: string;
         organizationAndTeamData: OrganizationAndTeamData;
+        fineTuningEnabled?: boolean;
     }): Promise<string> {
         const type = await this.getTypeIntegration(
             params.organizationAndTeamData,
@@ -1099,6 +1100,7 @@ export class CodeManagementService implements ICodeManagementService {
             includeFooter: params.includeFooter ?? true,
             language: params.language,
             organizationAndTeamData: params.organizationAndTeamData,
+            fineTuningEnabled: params.fineTuningEnabled ?? true,
         });
     }
 

--- a/src/core/infrastructure/http/controllers/fine-tuning.controller.ts
+++ b/src/core/infrastructure/http/controllers/fine-tuning.controller.ts
@@ -1,0 +1,81 @@
+import { Controller, Post, Body, Param, UseGuards } from '@nestjs/common';
+import { UpdateFineTuningToggleUseCase } from '@/core/application/use-cases/parameters/update-fine-tuning-toggle.use-case';
+import { UpdateGlobalFineTuningConfigUseCase } from '@/core/application/use-cases/global-parameters/update-global-fine-tuning-config.use-case';
+import { PolicyGuard } from '@/core/infrastructure/adapters/services/permissions/policy.guard';
+import { checkRepoPermissions, checkPermissions } from '@/core/infrastructure/adapters/services/permissions/policy.handlers';
+import { Action, ResourceType } from '@/core/domain/permissions/enums/permissions.enum';
+import { REQUEST } from '@nestjs/core';
+import { Inject } from '@nestjs/common';
+import { Request } from 'express';
+
+export class UpdateFineTuningToggleDto {
+    fineTuningEnabled: boolean;
+}
+
+export class UpdateGlobalFineTuningConfigDto {
+    enabled: boolean;
+}
+
+@Controller('fine-tuning')
+export class FineTuningController {
+    constructor(
+        private readonly updateFineTuningToggleUseCase: UpdateFineTuningToggleUseCase,
+        private readonly updateGlobalFineTuningConfigUseCase: UpdateGlobalFineTuningConfigUseCase,
+        @Inject(REQUEST)
+        private readonly request: Request & {
+            user: { uuid: string; organization: { uuid: string } };
+        },
+    ) {}
+
+    @Post('repository/:repositoryId/toggle')
+    @UseGuards(
+        PolicyGuard(
+            checkRepoPermissions(Action.Update, ResourceType.CodeReviewSettings, {
+                key: { params: 'repositoryId' },
+            }),
+        ),
+    )
+    async updateRepositoryToggle(
+        @Param('repositoryId') repositoryId: string,
+        @Body() body: UpdateFineTuningToggleDto,
+    ) {
+        if (!this.request.user?.uuid) {
+            throw new Error('User not authenticated');
+        }
+
+        const organizationAndTeamData = {
+            organizationId: this.request.user.organization.uuid,
+            teamId: this.request.user.organization.uuid, // Assuming teamId is same as organizationId for now
+        };
+
+        return this.updateFineTuningToggleUseCase.execute({
+            user: this.request.user,
+            organizationAndTeamData,
+            repositoryId,
+            fineTuningEnabled: body.fineTuningEnabled,
+        });
+    }
+
+    @Post('global/config')
+    @UseGuards(
+        PolicyGuard(
+            checkPermissions(Action.Manage, ResourceType.OrganizationSettings),
+        ),
+    )
+    async updateGlobalConfig(@Body() body: UpdateGlobalFineTuningConfigDto) {
+        if (!this.request.user?.uuid) {
+            throw new Error('User not authenticated');
+        }
+
+        const organizationAndTeamData = {
+            organizationId: this.request.user.organization.uuid,
+            teamId: this.request.user.organization.uuid, // Assuming teamId is same as organizationId for now
+        };
+
+        return this.updateGlobalFineTuningConfigUseCase.execute({
+            user: this.request.user,
+            organizationAndTeamData,
+            enabled: body.enabled,
+        });
+    }
+}

--- a/src/core/infrastructure/http/controllers/ruleLike.controller.ts
+++ b/src/core/infrastructure/http/controllers/ruleLike.controller.ts
@@ -7,6 +7,7 @@ import {
     Param,
     Query,
     Inject,
+    BadRequestException,
 } from '@nestjs/common';
 import { ProgrammingLanguage } from '@/shared/domain/enums/programming-language.enum';
 import { IRuleLikeService } from '@/core/domain/kodyRules/contracts/ruleLike.service.contract';
@@ -20,6 +21,8 @@ import { GetTopRulesByLanguageUseCase } from '@/core/application/use-cases/rule-
 import { FindRuleLikesUseCase } from '@/core/application/use-cases/rule-like/find-rule-likes.use-case';
 import { GetAllRuleLikesUseCase } from '@/core/application/use-cases/rule-like/get-all-rules-likes.use-case';
 import { GetAllRulesWithLikesUseCase } from '@/core/application/use-cases/rule-like/get-all-rules-with-likes.use-case';
+import { ICodeBaseConfigService } from '@/ee/codeBase/codeBaseConfig.service.interface';
+import { CODE_BASE_CONFIG_SERVICE_TOKEN } from '@/ee/codeBase/codeBaseConfig.service.interface';
 
 @Controller('rule-like')
 export class RuleLikeController {
@@ -36,15 +39,33 @@ export class RuleLikeController {
         private readonly request: Request & {
             user: { uuid: string; organization: { uuid: string } };
         },
+        @Inject(CODE_BASE_CONFIG_SERVICE_TOKEN)
+        private readonly codeBaseConfigService: ICodeBaseConfigService,
     ) {}
 
     @Post(':ruleId/feedback')
     async setFeedback(
         @Param('ruleId') ruleId: string,
         @Body() body: SetRuleFeedbackDto,
+        @Query('repositoryId') repositoryId?: string,
+        @Query('repositoryName') repositoryName?: string,
     ) {
         if (!this.request.user?.uuid) {
             throw new Error('User not authenticated');
+        }
+
+        // Check if fine-tuning is enabled for this repository
+        if (repositoryId && repositoryName) {
+            const isFineTuningEnabled = await this.checkFineTuningEnabled(
+                repositoryId,
+                repositoryName,
+            );
+            
+            if (!isFineTuningEnabled) {
+                throw new BadRequestException(
+                    'Fine-tuning is disabled for this repository. Feedback cannot be saved.',
+                );
+            }
         }
 
         return this.setRuleLikeUseCase.execute(
@@ -101,5 +122,28 @@ export class RuleLikeController {
     @Get('all-rules-with-feedback')
     async getAllRulesWithFeedback() {
         return this.getAllRulesWithLikesUseCase.execute();
+    }
+
+    private async checkFineTuningEnabled(
+        repositoryId: string,
+        repositoryName: string,
+    ): Promise<boolean> {
+        try {
+            const organizationAndTeamData = {
+                organizationId: this.request.user.organization.uuid,
+                teamId: this.request.user.organization.uuid, // Assuming teamId is same as organizationId for now
+            };
+
+            const config = await this.codeBaseConfigService.getConfig(
+                organizationAndTeamData,
+                { id: repositoryId, name: repositoryName },
+            );
+
+            return config.kodyFineTuningConfig?.enabled && 
+                   config.kodyFineTuningConfig?.fineTuningEnabled;
+        } catch (error) {
+            // Default to enabled on error to avoid breaking existing functionality
+            return true;
+        }
     }
 }

--- a/src/ee/codeBase/codeBaseConfig.service.ts
+++ b/src/ee/codeBase/codeBaseConfig.service.ts
@@ -252,7 +252,10 @@ export default class CodeBaseConfigService implements ICodeBaseConfigService {
                     language?.configValue ||
                     this.DEFAULT_CONFIG.languageResultPrompt,
                 reviewModeConfig,
-                kodyFineTuningConfig,
+                kodyFineTuningConfig: {
+                    ...kodyFineTuningConfig,
+                    fineTuningEnabled: repoConfig.kodyFineTuningConfig?.fineTuningEnabled ?? kodyFineTuningConfig.fineTuningEnabled,
+                },
                 pullRequestApprovalActive:
                     (isParameterValidInConfigFile(
                         'pullRequestApprovalActive',
@@ -1096,6 +1099,7 @@ export default class CodeBaseConfigService implements ICodeBaseConfigService {
 
         return {
             enabled: enableService,
+            fineTuningEnabled: true, // Default to true for per-repository toggle
         };
     }
 
@@ -1432,7 +1436,10 @@ export default class CodeBaseConfigService implements ICodeBaseConfigService {
                     language?.configValue ||
                     this.DEFAULT_CONFIG.languageResultPrompt,
                 reviewModeConfig,
-                kodyFineTuningConfig,
+                kodyFineTuningConfig: {
+                    ...kodyFineTuningConfig,
+                    fineTuningEnabled: configSource.kodyFineTuningConfig?.fineTuningEnabled ?? kodyFineTuningConfig.fineTuningEnabled,
+                },
                 pullRequestApprovalActive:
                     configSource.pullRequestApprovalActive ??
                     this.DEFAULT_CONFIG.pullRequestApprovalActive,

--- a/src/ee/codeReview/stages/kody-fine-tuning.stage.ts
+++ b/src/ee/codeReview/stages/kody-fine-tuning.stage.ts
@@ -14,7 +14,8 @@ export class KodyFineTuningStage extends BasePipelineStage<CodeReviewPipelineCon
     protected async executeStage(
         context: CodeReviewPipelineContext,
     ): Promise<CodeReviewPipelineContext> {
-        if (!context.codeReviewConfig.kodyFineTuningConfig?.enabled) {
+        if (!context.codeReviewConfig.kodyFineTuningConfig?.enabled || 
+            !context.codeReviewConfig.kodyFineTuningConfig?.fineTuningEnabled) {
             return context;
         }
 


### PR DESCRIPTION
This change adds a per-repository fine-tuning toggle and a global configuration option. When fine-tuning is disabled for a repository, the system hides feedback UI (👍/👎 buttons and related text) and ignores feedback events from the UI, API, and CLI. This helps teams with weak signals (e.g., junior-only repos) avoid polluting the fine-tuning dataset. The toggle defaults to enabled for backward compatibility, and only Owners and Repo Admins can change repository settings, while global configuration is restricted to organization owners. The implementation updates all platform services (GitHub, GitLab, Bitbucket, Azure Repos) to conditionally render feedback elements based on the configuration.