### PR TITLE
Add v2 prompt overrides support in code review configuration

### DIFF
--- a/src/config/types/general/codeReview.type.ts
+++ b/src/config/types/general/codeReview.type.ts
@@ -315,6 +315,35 @@ export type CodeReviewConfig = {
     runOnDraft?: boolean;
     codeReviewVersion?: CodeReviewVersion;
     byokConfig?: BYOKConfig;
+    /**
+     * Optional overrides for v2 prompts (categories and severity guidance only).
+     * These influence only the v2 system prompt used during suggestion generation.
+     */
+    v2PromptOverrides?: {
+        categories?: {
+            /**
+             * Additional or replacement description bullets for each label.
+             * Labels are fixed to: bug, performance, security.
+             */
+            descriptions?: {
+                bug?: string;
+                performance?: string;
+                security?: string;
+            };
+        };
+        severity?: {
+            /**
+             * Optional flag bullet points per level to guide classification.
+             * Levels are fixed to: critical, high, medium, low.
+             */
+            flags?: {
+                critical?: string;
+                high?: string;
+                medium?: string;
+                low?: string;
+            };
+        };
+    };
     // This is the default branch of the repository, used only during the review process
     // This field is populated dynamically from the API (GitHub/GitLab) and should NOT be saved to the database
     // It represents the repository's default branch (e.g., 'main', 'develop') that comes from the code management platform

--- a/src/core/application/use-cases/parameters/index.ts
+++ b/src/core/application/use-cases/parameters/index.ts
@@ -8,6 +8,8 @@ import { ListCodeReviewAutomationLabelsUseCase } from './list-code-review-automa
 import { UpdateCodeReviewParameterRepositoriesUseCase } from './update-code-review-parameter-repositories-use-case';
 import { UpdateOrCreateCodeReviewParameterUseCase } from './update-or-create-code-review-parameter-use-case';
 import { PreviewPrSummaryUseCase } from './preview-pr-summary.use-case';
+import { ListCodeReviewV2DefaultsUseCase } from './list-code-review-v2-defaults.use-case';
+import { ListCodeReviewAutomationLabelsWithStatusUseCase } from './list-code-review-automation-labels-with-status.use-case';
 
 export const UseCases = [
     CreateOrUpdateParametersUseCase,
@@ -20,4 +22,6 @@ export const UseCases = [
     GenerateCodeReviewParameterUseCase,
     DeleteRepositoryCodeReviewParameterUseCase,
     PreviewPrSummaryUseCase,
+    ListCodeReviewV2DefaultsUseCase,
+    ListCodeReviewAutomationLabelsWithStatusUseCase,
 ];

--- a/src/core/application/use-cases/parameters/list-code-review-automation-labels-with-status.use-case.ts
+++ b/src/core/application/use-cases/parameters/list-code-review-automation-labels-with-status.use-case.ts
@@ -1,0 +1,87 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { CodeReviewVersion } from '@/config/types/general/codeReview.type';
+import {
+    CODE_BASE_CONFIG_SERVICE_TOKEN,
+    ICodeBaseConfigService,
+} from '@/core/domain/codeBase/contracts/CodeBaseConfigService.contract';
+import { ListCodeReviewAutomationLabelsUseCase } from './list-code-review-automation-labels-use-case';
+import { PinoLoggerService } from '@/core/infrastructure/adapters/services/logger/pino.service';
+
+@Injectable()
+export class ListCodeReviewAutomationLabelsWithStatusUseCase {
+    constructor(
+        private readonly listLabelsUseCase: ListCodeReviewAutomationLabelsUseCase,
+        @Inject(CODE_BASE_CONFIG_SERVICE_TOKEN)
+        private readonly codeBaseConfigService: ICodeBaseConfigService,
+        private readonly logger: PinoLoggerService,
+        @Inject(REQUEST)
+        private readonly request: Request & {
+            user?: { organization?: { uuid: string } };
+        },
+    ) {}
+
+    async execute(params: {
+        codeReviewVersion?: CodeReviewVersion;
+        teamId?: string;
+        repositoryId?: string;
+    }) {
+        const { codeReviewVersion, teamId, repositoryId } = params || {};
+
+        const labels = this.listLabelsUseCase.execute(codeReviewVersion);
+
+        // Only v2 supports overrides, and only if repo context is provided
+        if (
+            codeReviewVersion !== CodeReviewVersion.v2 ||
+            !teamId ||
+            !repositoryId
+        ) {
+            return labels;
+        }
+
+        try {
+            const organizationId = this.request?.user?.organization?.uuid;
+            const config = await this.codeBaseConfigService.getConfig(
+                { organizationId, teamId },
+                { name: '', id: repositoryId },
+            );
+
+            const ov = config?.v2PromptOverrides || {};
+            const has = (t?: string) => !!(t && t.trim().length);
+
+            const overridesStatus = {
+                categories: {
+                    bug: has(ov?.categories?.descriptions?.bug)
+                        ? 'custom'
+                        : 'default',
+                    performance: has(ov?.categories?.descriptions?.performance)
+                        ? 'custom'
+                        : 'default',
+                    security: has(ov?.categories?.descriptions?.security)
+                        ? 'custom'
+                        : 'default',
+                },
+                severity: {
+                    critical: has(ov?.severity?.flags?.critical)
+                        ? 'custom'
+                        : 'default',
+                    high: has(ov?.severity?.flags?.high) ? 'custom' : 'default',
+                    medium: has(ov?.severity?.flags?.medium)
+                        ? 'custom'
+                        : 'default',
+                    low: has(ov?.severity?.flags?.low) ? 'custom' : 'default',
+                },
+            } as const;
+
+            return { ...labels, overridesStatus };
+        } catch (error) {
+            this.logger.warn({
+                message: 'Failed to enrich labels with overrides status; returning labels only',
+                context: ListCodeReviewAutomationLabelsWithStatusUseCase.name,
+                error,
+                metadata: { teamId, repositoryId },
+            });
+            return labels;
+        }
+    }
+}

--- a/src/core/application/use-cases/parameters/list-code-review-automation-labels-with-status.use-case.ts
+++ b/src/core/application/use-cases/parameters/list-code-review-automation-labels-with-status.use-case.ts
@@ -36,16 +36,15 @@ export class ListCodeReviewAutomationLabelsWithStatusUseCase {
             !teamId ||
             !repositoryId
         ) {
-            return labels;
+            return { labels };
         }
+        const organizationId = this.request?.user?.organization?.uuid;
+        const config = await this.codeBaseConfigService.getConfig(
+            { organizationId, teamId },
+            { name: '', id: repositoryId },
+        );
 
         try {
-            const organizationId = this.request?.user?.organization?.uuid;
-            const config = await this.codeBaseConfigService.getConfig(
-                { organizationId, teamId },
-                { name: '', id: repositoryId },
-            );
-
             const ov = config?.v2PromptOverrides || {};
             const has = (t?: string) => !!(t && t.trim().length);
 
@@ -73,15 +72,23 @@ export class ListCodeReviewAutomationLabelsWithStatusUseCase {
                 },
             } as const;
 
-            return { ...labels, overridesStatus };
+            return { labels, overridesStatus };
         } catch (error) {
             this.logger.warn({
-                message: 'Failed to enrich labels with overrides status; returning labels only',
+                message:
+                    'Failed to enrich labels with overrides status; returning labels only',
                 context: ListCodeReviewAutomationLabelsWithStatusUseCase.name,
+
                 error,
-                metadata: { teamId, repositoryId },
+                metadata: {
+                    organizationAndTeamData: {
+                        organizationId,
+                        teamId,
+                    },
+                    repositoryId,
+                },
             });
-            return labels;
+            return { labels };
         }
     }
 }

--- a/src/core/application/use-cases/parameters/list-code-review-v2-defaults.use-case.ts
+++ b/src/core/application/use-cases/parameters/list-code-review-v2-defaults.use-case.ts
@@ -1,0 +1,11 @@
+import { Injectable } from '@nestjs/common';
+import { getV2DefaultsText } from '@/shared/utils/codeReview/v2Defaults';
+
+@Injectable()
+export class ListCodeReviewV2DefaultsUseCase {
+    execute() {
+        // Returns string-only defaults, ready for UI textareas
+        return getV2DefaultsText();
+    }
+}
+

--- a/src/core/infrastructure/adapters/services/codeBase/llmAnalysis.service.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/llmAnalysis.service.ts
@@ -370,6 +370,8 @@ ${JSON.stringify(context?.suggestions, null, 2) || 'No suggestions provided'}
             organizationAndTeamData: context?.organizationAndTeamData,
             relevantContent: fileContext?.relevantContent,
             prSummary: context?.pullRequest?.body,
+            // v2-only prompt customization (categories and severity guidance)
+            v2PromptOverrides: context?.codeReviewConfig?.v2PromptOverrides,
         };
 
         return baseContext;

--- a/src/core/infrastructure/http/controllers/parameters.controller.ts
+++ b/src/core/infrastructure/http/controllers/parameters.controller.ts
@@ -1,6 +1,7 @@
 import { CreateOrUpdateParametersUseCase } from '@/core/application/use-cases/parameters/create-or-update-use-case';
 import { FindByKeyParametersUseCase } from '@/core/application/use-cases/parameters/find-by-key-use-case';
 import { ListCodeReviewAutomationLabelsUseCase } from '@/core/application/use-cases/parameters/list-code-review-automation-labels-use-case';
+import { ListCodeReviewV2DefaultsUseCase } from '@/core/application/use-cases/parameters/list-code-review-v2-defaults.use-case';
 import { UpdateCodeReviewParameterRepositoriesUseCase } from '@/core/application/use-cases/parameters/update-code-review-parameter-repositories-use-case';
 import { UpdateOrCreateCodeReviewParameterUseCase } from '@/core/application/use-cases/parameters/update-or-create-code-review-parameter-use-case';
 
@@ -15,6 +16,7 @@ import {
     UseGuards,
 } from '@nestjs/common';
 import { Response } from 'express';
+import { ListCodeReviewAutomationLabelsWithStatusUseCase } from '@/core/application/use-cases/parameters/list-code-review-automation-labels-with-status.use-case';
 
 import { CreateOrUpdateCodeReviewParameterDto } from '../dtos/create-or-update-code-review-parameter.dto';
 import { GenerateKodusConfigFileUseCase } from '@/core/application/use-cases/parameters/generate-kodus-config-file.use-case';
@@ -52,6 +54,8 @@ export class ParametersController {
         private readonly generateCodeReviewParameterUseCase: GenerateCodeReviewParameterUseCase,
         private readonly deleteRepositoryCodeReviewParameterUseCase: DeleteRepositoryCodeReviewParameterUseCase,
         private readonly previewPrSummaryUseCase: PreviewPrSummaryUseCase,
+        private readonly listCodeReviewV2DefaultsUseCase: ListCodeReviewV2DefaultsUseCase,
+        private readonly listCodeReviewAutomationLabelsWithStatusUseCase: ListCodeReviewAutomationLabelsWithStatusUseCase,
     ) {}
 
     //#region Parameters
@@ -104,10 +108,23 @@ export class ParametersController {
     )
     public async listCodeReviewAutomationLabels(
         @Query('codeReviewVersion') codeReviewVersion?: CodeReviewVersion,
+        @Query('teamId') teamId?: string,
+        @Query('repositoryId') repositoryId?: string,
     ) {
-        return this.listCodeReviewAutomationLabelsUseCase.execute(
+        return this.listCodeReviewAutomationLabelsWithStatusUseCase.execute({
             codeReviewVersion,
-        );
+            teamId,
+            repositoryId,
+        });
+    }
+
+    @Get('/list-code-review-v2-defaults')
+    @UseGuards(PolicyGuard)
+    @CheckPolicies(
+        checkPermissions(Action.Read, ResourceType.CodeReviewSettings),
+    )
+    public async listCodeReviewV2Defaults() {
+        return this.listCodeReviewV2DefaultsUseCase.execute();
     }
 
     @Post('/create-or-update-code-review')

--- a/src/core/infrastructure/http/dtos/create-or-update-code-review-parameter.dto.ts
+++ b/src/core/infrastructure/http/dtos/create-or-update-code-review-parameter.dto.ts
@@ -150,6 +150,65 @@ class PathInstructionDto {
     instructions?: string;
 }
 
+// -------------------- v2 Prompt Overrides DTOs (must be declared before usage) --------------------
+class V2PromptOverridesSeverityFlagsDto {
+    @IsOptional()
+    @IsString()
+    critical?: string;
+
+    @IsOptional()
+    @IsString()
+    high?: string;
+
+    @IsOptional()
+    @IsString()
+    medium?: string;
+
+    @IsOptional()
+    @IsString()
+    low?: string;
+}
+
+class V2PromptOverridesSeverityDto {
+    @IsOptional()
+    @ValidateNested()
+    @Type(() => V2PromptOverridesSeverityFlagsDto)
+    flags?: V2PromptOverridesSeverityFlagsDto;
+}
+
+class V2PromptOverridesCategoriesDescriptionsDto {
+    @IsOptional()
+    @IsString()
+    bug?: string;
+
+    @IsOptional()
+    @IsString()
+    performance?: string;
+
+    @IsOptional()
+    @IsString()
+    security?: string;
+}
+
+class V2PromptOverridesCategoriesDto {
+    @IsOptional()
+    @ValidateNested()
+    @Type(() => V2PromptOverridesCategoriesDescriptionsDto)
+    descriptions?: V2PromptOverridesCategoriesDescriptionsDto;
+}
+
+class V2PromptOverridesDto {
+    @IsOptional()
+    @ValidateNested()
+    @Type(() => V2PromptOverridesCategoriesDto)
+    categories?: V2PromptOverridesCategoriesDto;
+
+    @IsOptional()
+    @ValidateNested()
+    @Type(() => V2PromptOverridesSeverityDto)
+    severity?: V2PromptOverridesSeverityDto;
+}
+
 class CodeReviewConfigWithoutLLMProviderDto {
     @IsOptional()
     @IsString()
@@ -230,6 +289,12 @@ class CodeReviewConfigWithoutLLMProviderDto {
     @IsOptional()
     @IsEnum(CodeReviewVersion)
     codeReviewVersion?: CodeReviewVersion = CodeReviewVersion.v2;
+
+    // v2-only prompt overrides (categories and severity guidance)
+    @IsOptional()
+    @ValidateNested()
+    @Type(() => V2PromptOverridesDto)
+    v2PromptOverrides?: V2PromptOverridesDto;
 }
 
 export class CreateOrUpdateCodeReviewParameterDto {

--- a/src/ee/codeBase/codeBaseConfig.service.ts
+++ b/src/ee/codeBase/codeBaseConfig.service.ts
@@ -311,18 +311,25 @@ export default class CodeBaseConfigService implements ICodeBaseConfigService {
     ): CodeReviewConfig['v2PromptOverrides'] {
         if (!overrides) return undefined;
 
+        const sanitizeString = (value: any): string | undefined => {
+            if (typeof value === 'string' && value.trim().length > 0) {
+                return value.trim();
+            }
+            return undefined;
+        };
+
         const categories = overrides.categories?.descriptions
             ? {
                   descriptions: {
-                      bug:
-                          overrides.categories.descriptions.bug?.trim() ||
-                          undefined,
-                      performance:
-                          overrides.categories.descriptions.performance?.trim() ||
-                          undefined,
-                      security:
-                          overrides.categories.descriptions.security?.trim() ||
-                          undefined,
+                      bug: sanitizeString(
+                          overrides.categories.descriptions.bug,
+                      ),
+                      performance: sanitizeString(
+                          overrides.categories.descriptions.performance,
+                      ),
+                      security: sanitizeString(
+                          overrides.categories.descriptions.security,
+                      ),
                   },
               }
             : undefined;
@@ -330,13 +337,12 @@ export default class CodeBaseConfigService implements ICodeBaseConfigService {
         const severity = overrides.severity?.flags
             ? {
                   flags: {
-                      critical:
-                          overrides.severity.flags.critical?.trim() ||
-                          undefined,
-                      high: overrides.severity.flags.high?.trim() || undefined,
-                      medium:
-                          overrides.severity.flags.medium?.trim() || undefined,
-                      low: overrides.severity.flags.low?.trim() || undefined,
+                      critical: sanitizeString(
+                          overrides.severity.flags.critical,
+                      ),
+                      high: sanitizeString(overrides.severity.flags.high),
+                      medium: sanitizeString(overrides.severity.flags.medium),
+                      low: sanitizeString(overrides.severity.flags.low),
                   },
               }
             : undefined;

--- a/src/shared/utils/codeReview/v2Defaults.ts
+++ b/src/shared/utils/codeReview/v2Defaults.ts
@@ -1,0 +1,71 @@
+// Default guidance for Code Review v2 categories and severity (string-only).
+// These strings are newline-separated to render easily in textareas.
+
+export const V2_DEFAULT_CATEGORY_DESCRIPTIONS_TEXT = {
+    bug: [
+        'Execution breaks: Code throws unhandled exceptions',
+        "Wrong results: Output doesn't match expected behavior",
+        'Resource leaks: Unclosed files, connections, memory accumulation',
+        'State corruption: Invalid object/data states',
+        'Logic errors: Control flow produces incorrect outcomes',
+        'Race conditions: Concurrent access causes inconsistent state or duplicates',
+        "Incorrect measurements: Metrics/timings that don't reflect actual operations",
+        'Invariant violations: Broken constraints (size limits, uniqueness, etc.)',
+        'Async timing bugs: Variables captured incorrectly in async closures',
+    ].join('\n'),
+    performance: [
+        'Algorithm complexity: O(n²) when O(n) is possible',
+        'Redundant operations: Duplicate calculations or unnecessary loops',
+        'Memory waste: Large allocations or leaks over time',
+        'Blocking operations: Synchronous I/O in critical paths',
+        'Database inefficiency: N+1, missing indexes, full scans',
+        'Cache misses: Not leveraging available caching mechanisms',
+    ].join('\n'),
+    security: [
+        'Injection vulnerabilities: SQL/NoSQL/command/LDAP injection',
+        'AuthZ/AuthN flaws: Missing checks, privilege escalation',
+        'Data exposure: Sensitive data in logs, responses, or errors',
+        'Crypto issues: Weak algorithms, hardcoded keys, improper validation',
+        'Input validation gaps: Missing sanitization or bounds checks',
+        'Session management: Predictable tokens or missing expiration',
+    ].join('\n'),
+};
+
+export const V2_DEFAULT_SEVERITY_FLAGS_TEXT = {
+    critical: [
+        'Application crash/downtime',
+        'Data loss/corruption',
+        'Security breach (unauthorized access/data exfiltration)',
+        'Critical operation failure (auth/payment/authorization)',
+        'Direct financial loss operations',
+        'Memory leaks that inevitably crash production',
+    ].join('\n'),
+    high: [
+        'Important functionality broken',
+        'Memory leaks that cause eventual crash',
+        'Performance degradation affecting UX under normal load',
+        'Security issues with indirect exploitation paths',
+        'Financial calculation errors affecting revenue',
+    ].join('\n'),
+    medium: [
+        'Partially broken functionality',
+        'Performance issues in specific scenarios',
+        'Security weaknesses requiring specific conditions',
+        'Incorrect but recoverable data',
+        'Non-critical business logic errors with workarounds',
+    ].join('\n'),
+    low: [
+        'Minor performance overhead',
+        'Low-risk security improvements',
+        'Incorrect metrics/logs',
+        'Rarely affecting few users',
+        'Edge-case issues',
+    ].join('\n'),
+};
+
+export function getV2DefaultsText() {
+    return {
+        categories: { ...V2_DEFAULT_CATEGORY_DESCRIPTIONS_TEXT },
+        severity: { ...V2_DEFAULT_SEVERITY_FLAGS_TEXT },
+    };
+}

--- a/src/shared/utils/langchainCommon/prompts/configuration/codeReview.ts
+++ b/src/shared/utils/langchainCommon/prompts/configuration/codeReview.ts
@@ -493,12 +493,15 @@ export const prompt_codereview_system_gemini_v2 = (
     const overrides = payload?.v2PromptOverrides || {};
 
     // Build dynamic bullet lists with safe fallbacks
-    const limitText = (text: string, max = 2000) =>
+    const limitText = (text: string, max = 2000): string =>
         text.length > max ? text.slice(0, max) : text;
     const getTextOrDefault = (
         text: string | undefined,
         fallbackText: string,
-    ) => (text && text.trim().length ? limitText(text.trim()) : fallbackText);
+    ): string =>
+        text && typeof text === 'string' && text.trim().length
+            ? limitText(text.trim())
+            : fallbackText;
 
     const defaultBug = V2_DEFAULT_CATEGORY_DESCRIPTIONS_TEXT.bug;
     const defaultPerf = V2_DEFAULT_CATEGORY_DESCRIPTIONS_TEXT.performance;

--- a/src/shared/utils/langchainCommon/prompts/configuration/codeReview.ts
+++ b/src/shared/utils/langchainCommon/prompts/configuration/codeReview.ts
@@ -1,4 +1,8 @@
 import { LimitationType } from '@/config/types/general/codeReview.type';
+import {
+    V2_DEFAULT_CATEGORY_DESCRIPTIONS_TEXT,
+    V2_DEFAULT_SEVERITY_FLAGS_TEXT,
+} from '@/shared/utils/codeReview/v2Defaults';
 
 export interface CodeReviewPayload {
     limitationType?: LimitationType;
@@ -8,6 +12,24 @@ export interface CodeReviewPayload {
     patchWithLinesStr?: string;
     relevantContent?: string | null;
     prSummary?: string;
+    // v2-only prompt overrides injected via analysis context
+    v2PromptOverrides?: {
+        categories?: {
+            descriptions?: {
+                bug?: string;
+                performance?: string;
+                security?: string;
+            };
+        };
+        severity?: {
+            flags?: {
+                critical?: string;
+                high?: string;
+                medium?: string;
+                low?: string;
+            };
+        };
+    };
 }
 
 export const prompt_codereview_system_main = () => {
@@ -439,6 +461,8 @@ Your final output should be **ONLY** a JSON object with the following structure:
 `;
 };
 
+// NOTE: v2 overrides are applied directly in prompt_codereview_system_gemini_v2
+
 export const prompt_codereview_user_gemini = (payload: CodeReviewPayload) => {
     const maxSuggestionsNote =
         payload?.limitationType === 'file' && payload?.maxSuggestionsParams
@@ -466,6 +490,43 @@ export const prompt_codereview_system_gemini_v2 = (
     payload: CodeReviewPayload,
 ) => {
     const languageNote = payload?.languageResultPrompt || 'en-US';
+    const overrides = payload?.v2PromptOverrides || {};
+
+    // Build dynamic bullet lists with safe fallbacks
+    const limitText = (text: string, max = 2000) =>
+        text.length > max ? text.slice(0, max) : text;
+    const getTextOrDefault = (
+        text: string | undefined,
+        fallbackText: string,
+    ) => (text && text.trim().length ? limitText(text.trim()) : fallbackText);
+
+    const defaultBug = V2_DEFAULT_CATEGORY_DESCRIPTIONS_TEXT.bug;
+    const defaultPerf = V2_DEFAULT_CATEGORY_DESCRIPTIONS_TEXT.performance;
+    const defaultSec = V2_DEFAULT_CATEGORY_DESCRIPTIONS_TEXT.security;
+
+    const bugText = getTextOrDefault(
+        overrides?.categories?.descriptions?.bug,
+        defaultBug,
+    );
+    const perfText = getTextOrDefault(
+        overrides?.categories?.descriptions?.performance,
+        defaultPerf,
+    );
+    const secText = getTextOrDefault(
+        overrides?.categories?.descriptions?.security,
+        defaultSec,
+    );
+
+    const defaultCritical = V2_DEFAULT_SEVERITY_FLAGS_TEXT.critical;
+    const defaultHigh = V2_DEFAULT_SEVERITY_FLAGS_TEXT.high;
+    const defaultMedium = V2_DEFAULT_SEVERITY_FLAGS_TEXT.medium;
+    const defaultLow = V2_DEFAULT_SEVERITY_FLAGS_TEXT.low;
+
+    const sev = overrides?.severity?.flags || {};
+    const criticalText = getTextOrDefault(sev.critical, defaultCritical);
+    const highText = getTextOrDefault(sev.high, defaultHigh);
+    const mediumText = getTextOrDefault(sev.medium, defaultMedium);
+    const lowText = getTextOrDefault(sev.low, defaultLow);
 
     return `You are Kody Bug-Hunter, a senior engineer specialized in identifying verifiable issues through mental code execution. Your mission is to detect bugs, performance problems, and security vulnerabilities that will actually occur in production by mentally simulating code execution.
 
@@ -506,15 +567,7 @@ For each critical code section, mentally execute with these scenarios:
 
 ### BUG
 A bug exists when mental simulation reveals:
-- **Execution breaks**: Code throws unhandled exceptions
-- **Wrong results**: Output doesn't match expected behavior
-- **Resource leaks**: Unclosed files, connections, memory that accumulates over time
-- **State corruption**: Invalid object/data states
-- **Logic errors**: Control flow produces incorrect outcomes
-- **Race conditions**: Concurrent access causing inconsistent state or duplicate operations
-- **Incorrect measurements**: Metrics, timings, or counters that don't reflect actual operations
-- **Invariant violations**: System constraints broken (size limits exceeded, duplicates in unique collections)
-- **Async timing bugs**: Variables captured incorrectly in closures, especially in loops
+${bugText}
 
 ### Asynchronous Execution Analysis
 When analyzing asynchronous code (setTimeout, setInterval, Promises, callbacks):
@@ -525,54 +578,27 @@ When analyzing asynchronous code (setTimeout, setInterval, Promises, callbacks):
 
 ### PERFORMANCE
 A performance issue exists when mental simulation reveals:
-- **Algorithm complexity**: O(n²) or worse when O(n) is possible
-- **Redundant operations**: Duplicate calculations, unnecessary loops
-- **Memory waste**: Large allocations for small data, memory leaks over time
-- **Blocking operations**: Synchronous I/O in critical paths
-- **Database inefficiency**: N+1 queries, missing indexes, full table scans
-- **Cache misses**: Not utilizing available caching mechanisms
+${perfText}
 
 ### SECURITY
 A security vulnerability exists when mental simulation reveals:
-- **Injection vulnerabilities**: SQL, NoSQL, command, LDAP injection
-- **Authentication/Authorization flaws**: Missing checks, privilege escalation
-- **Data exposure**: Sensitive data in logs, responses, or error messages
-- **Cryptographic issues**: Weak algorithms, hardcoded keys, improper validation
-- **Input validation**: Missing sanitization, boundary checking
-- **Session management**: Predictable tokens, missing expiration
+${secText}
 
 ## Severity Assessment
 
 For each confirmed issue, evaluate severity based on impact and scope:
 
 **CRITICAL** - Immediate and severe impact
-- Application crash/downtime
-- Data loss/corruption
-- Security vulnerabilities allowing unauthorized access/data breach
-- Critical operation failure (authentication, payment, authorization)
-- Financial operations with direct monetary loss
-- Memory leaks that will cause inevitable crashes in production
+${criticalText}
 
 **HIGH** - Significant but not immediate impact
-- Important functionality broken
-- Memory leaks causing eventual crash
-- Performance degradation affecting user experience
-- Security issues with indirect exploitation paths
-- Financial calculation errors affecting revenue
+${highText}
 
 **MEDIUM** - Moderate impact
-- Partially broken functionality
-- Performance issues in specific scenarios
-- Security weaknesses requiring specific conditions
-- Incorrect but recoverable data
-- Non-critical business logic errors with workarounds
+${mediumText}
 
 **LOW** - Minimal impact
-- Minor performance overhead
-- Low-risk security improvements
-- Incorrect metrics/logs
-- Affects few users rarely
-- Edge case issues
+${lowText}
 
 ## Analysis Rules
 
@@ -616,6 +642,7 @@ For each confirmed issue, evaluate severity based on impact and scope:
 5. **Detect verifiable issues** where behavior is definitively problematic
 6. **Confirm with available context** - must be provable with given information
 7. **Assess severity** of confirmed issues based on impact and scope
+
 
 ## Output Requirements
 


### PR DESCRIPTION
- Introduced `v2PromptOverrides` in `CodeReviewConfig` type to allow customization of prompt categories and severity guidance.
- Updated relevant services and controllers to handle new v2 prompt overrides.
- Added DTOs for v2 prompt overrides to ensure proper validation and structure.
- Enhanced prompt generation logic to utilize v2 overrides for dynamic bullet lists in code review analysis.

---

<!-- kody-pr-summary:start -->
This pull request introduces support for customizing the system prompt used by Code Review v2, allowing users to override the default descriptions for code review categories and severity levels.

Key changes include:

*   **V2 Prompt Overrides Configuration**: Added a new `v2PromptOverrides` field to the `CodeReviewConfig` type. This allows users to define custom descriptions for `bug`, `performance`, and `security` categories, and custom flag bullet points for `critical`, `high`, `medium`, and `low` severity levels. These overrides are specifically applied to the v2 system prompt.
*   **API Endpoints for Overrides**:
    *   The existing `GET /parameters/list-code-review-automation-labels` endpoint was enhanced to include the `overridesStatus` for v2 categories and severity, indicating whether each element is using a 'custom' or 'default' definition for a given repository.
    *   A new `GET /parameters/list-code-review-v2-defaults` endpoint was added to retrieve the default text for v2 prompt categories and severity flags, providing a baseline for customization.
*   **LLM Integration**: The `v2PromptOverrides` are now passed to the LLM analysis service, ensuring that the AI model incorporates these custom guidelines when generating code review suggestions for v2.
*   **Dynamic Prompt Generation**: The `prompt_codereview_system_gemini_v2` function was updated to dynamically inject the custom category descriptions and severity flags into the system prompt. If no overrides are provided, or if they are empty, the system falls back to predefined default texts.
*   **Configuration Management**: DTOs were added to support the creation and update of `v2PromptOverrides` via the API. The configuration service was updated to read and sanitize these overrides from repository-level and global settings.
*   **Default Prompt Texts**: New utility functions and constants were introduced to define and retrieve the default, newline-separated descriptions for v2 categories and severity, which serve as fallbacks and can be displayed in the UI.
<!-- kody-pr-summary:end -->