### PR TITLE
Feat/pr reactions

### DIFF
--- a/src/core/domain/codeReviewFeedback/enums/codeReviewCommentReaction.enum.ts
+++ b/src/core/domain/codeReviewFeedback/enums/codeReviewCommentReaction.enum.ts
@@ -1,14 +1,26 @@
 export enum GitHubReaction {
     THUMBS_UP = '+1',
     THUMBS_DOWN = '-1',
+    EYES = 'eyes',
+    HOORAY = 'hooray',
+    CONFUSED = 'confused',
 }
 
 export enum GitlabReaction {
     THUMBS_UP = 'thumbsup',
     THUMBS_DOWN = 'thumbsdown',
+    EYES = 'eyes',
+    TADA = 'tada',
+    CONFUSED = 'confused',
 }
 
 export enum CountingType {
     CREATE = 'create',
     REVOKE = 'revoke',
+}
+
+export enum ReviewStatusReaction {
+    START = 'start',
+    SUCCESS = 'success',
+    ERROR = 'error',
 }

--- a/src/core/domain/platformIntegrations/interfaces/code-management.interface.ts
+++ b/src/core/domain/platformIntegrations/interfaces/code-management.interface.ts
@@ -20,6 +20,10 @@ import { GitCloneParams } from '../types/codeManagement/gitCloneParams.type';
 import { Commit } from '@/config/types/general/commit.type';
 import { PullRequestState } from '@/shared/domain/enums/pullRequestState.enum';
 import { RepositoryFile } from '../types/codeManagement/repositoryFile.type';
+import {
+    GitHubReaction,
+    GitlabReaction,
+} from '@/core/domain/codeReviewFeedback/enums/codeReviewCommentReaction.enum';
 
 export interface ICodeManagementService
     extends ICommonPlatformIntegrationService {
@@ -223,4 +227,34 @@ export interface ICodeManagementService
         repository: Partial<Repository>;
         prNumber: number;
     }): Promise<PullRequestReviewState | null>;
+
+    addReactionToPR?(params: {
+        organizationAndTeamData: OrganizationAndTeamData;
+        repository: { id?: string; name?: string };
+        prNumber: number;
+        reaction: GitHubReaction | GitlabReaction;
+    }): Promise<void>;
+
+    addReactionToComment?(params: {
+        organizationAndTeamData: OrganizationAndTeamData;
+        repository: { id?: string; name?: string };
+        prNumber: number;
+        commentId: number;
+        reaction: GitHubReaction | GitlabReaction;
+    }): Promise<void>;
+
+    removeReactionsFromPR?(params: {
+        organizationAndTeamData: OrganizationAndTeamData;
+        repository: { id?: string; name?: string };
+        prNumber: number;
+        reactions: (GitHubReaction | GitlabReaction)[];
+    }): Promise<void>;
+
+    removeReactionsFromComment?(params: {
+        organizationAndTeamData: OrganizationAndTeamData;
+        repository: { id?: string; name?: string };
+        prNumber: number;
+        commentId: number;
+        reactions: (GitHubReaction | GitlabReaction)[];
+    }): Promise<void>;
 }

--- a/src/core/infrastructure/adapters/services/automation/processAutomation/strategies/automationCodeReview.ts
+++ b/src/core/infrastructure/adapters/services/automation/processAutomation/strategies/automationCodeReview.ts
@@ -88,6 +88,7 @@ export class AutomationCodeReviewService
             teamAutomationId,
             origin,
             action,
+            triggerCommentId,
         } = payload;
 
         let execution: IAutomationExecution | null = null;
@@ -152,6 +153,7 @@ export class AutomationCodeReviewService
                     origin || 'automation',
                     action,
                     execution.uuid,
+                    triggerCommentId,
                 );
 
             await this._handleExecutionCompletion(execution, result, payload);

--- a/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/context/code-review-pipeline.context.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/context/code-review-pipeline.context.ts
@@ -43,6 +43,7 @@ export interface CodeReviewPipelineContext extends PipelineContext {
     origin: string;
     action: string;
     platformType: PlatformType;
+    triggerCommentId?: number | string;
 
     codeReviewConfig?: CodeReviewConfig;
     automaticReviewStatus?: AutomaticReviewStatus;

--- a/src/core/infrastructure/adapters/services/github/github.service.ts
+++ b/src/core/infrastructure/adapters/services/github/github.service.ts
@@ -3427,12 +3427,21 @@ export class GithubService
     }
 
     async addReactionToPR(params: {
-        organizationAndTeamData: any;
+        organizationAndTeamData: OrganizationAndTeamData;
         repository: { id?: string; name?: string };
         prNumber: number;
         reaction: GitHubReaction | GitlabReaction;
     }): Promise<void> {
         try {
+            if (!params.repository.name) {
+                this.logger.warn({
+                    message: 'Repository name is required for GitHub reactions',
+                    context: GithubService.name,
+                    metadata: params,
+                });
+                return;
+            }
+
             const githubAuthDetail = await this.getGithubAuthDetails(
                 params.organizationAndTeamData,
             );
@@ -3462,13 +3471,22 @@ export class GithubService
     }
 
     async addReactionToComment(params: {
-        organizationAndTeamData: any;
+        organizationAndTeamData: OrganizationAndTeamData;
         repository: { id?: string; name?: string };
         prNumber: number;
         commentId: number;
         reaction: GitHubReaction | GitlabReaction;
     }): Promise<void> {
         try {
+            if (!params.repository.name) {
+                this.logger.warn({
+                    message: 'Repository name is required for GitHub reactions',
+                    context: GithubService.name,
+                    metadata: params,
+                });
+                return;
+            }
+
             const githubAuthDetail = await this.getGithubAuthDetails(
                 params.organizationAndTeamData,
             );
@@ -3498,12 +3516,21 @@ export class GithubService
     }
 
     async removeReactionsFromPR(params: {
-        organizationAndTeamData: any;
+        organizationAndTeamData: OrganizationAndTeamData;
         repository: { id?: string; name?: string };
         prNumber: number;
         reactions: (GitHubReaction | GitlabReaction)[];
     }): Promise<void> {
         try {
+            if (!params.repository.name) {
+                this.logger.warn({
+                    message: 'Repository name is required for GitHub reactions',
+                    context: GithubService.name,
+                    metadata: params,
+                });
+                return;
+            }
+
             const githubAuthDetail = await this.getGithubAuthDetails(
                 params.organizationAndTeamData,
             );
@@ -3523,14 +3550,16 @@ export class GithubService
                 params.reactions.includes(r.content as GitHubReaction),
             );
 
-            for (const reaction of reactionsToRemove) {
-                await octokit.rest.reactions.deleteForIssue({
-                    owner: githubAuthDetail.org,
-                    repo: params.repository.name,
-                    issue_number: params.prNumber,
-                    reaction_id: reaction.id,
-                });
-            }
+            await Promise.all(
+                reactionsToRemove.map((reaction) =>
+                    octokit.rest.reactions.deleteForIssue({
+                        owner: githubAuthDetail.org,
+                        repo: params.repository.name,
+                        issue_number: params.prNumber,
+                        reaction_id: reaction.id,
+                    }),
+                ),
+            );
 
             this.logger.log({
                 message: `Removed reactions from PR#${params.prNumber}`,
@@ -3548,13 +3577,22 @@ export class GithubService
     }
 
     async removeReactionsFromComment(params: {
-        organizationAndTeamData: any;
+        organizationAndTeamData: OrganizationAndTeamData;
         repository: { id?: string; name?: string };
         prNumber: number;
         commentId: number;
         reactions: (GitHubReaction | GitlabReaction)[];
     }): Promise<void> {
         try {
+            if (!params.repository.name) {
+                this.logger.warn({
+                    message: 'Repository name is required for GitHub reactions',
+                    context: GithubService.name,
+                    metadata: params,
+                });
+                return;
+            }
+
             const githubAuthDetail = await this.getGithubAuthDetails(
                 params.organizationAndTeamData,
             );
@@ -3573,14 +3611,16 @@ export class GithubService
                 params.reactions.includes(r.content as GitHubReaction),
             );
 
-            for (const reaction of reactionsToRemove) {
-                await octokit.rest.reactions.deleteForIssueComment({
-                    owner: githubAuthDetail.org,
-                    repo: params.repository.name,
-                    comment_id: params.commentId,
-                    reaction_id: reaction.id,
-                });
-            }
+            await Promise.all(
+                reactionsToRemove.map((reaction) =>
+                    octokit.rest.reactions.deleteForIssueComment({
+                        owner: githubAuthDetail.org,
+                        repo: params.repository.name,
+                        comment_id: params.commentId,
+                        reaction_id: reaction.id,
+                    }),
+                ),
+            );
 
             this.logger.log({
                 message: `Removed reactions from comment ${params.commentId}`,

--- a/src/core/infrastructure/adapters/services/github/github.service.ts
+++ b/src/core/infrastructure/adapters/services/github/github.service.ts
@@ -62,7 +62,7 @@ import { decrypt, encrypt } from '@/shared/utils/crypto';
 import { AuthMode } from '@/core/domain/platformIntegrations/enums/codeManagement/authMode.enum';
 import { CodeManagementConnectionStatus } from '@/shared/utils/decorators/validate-code-management-integration.decorator';
 import { CacheService } from '@/shared/utils/cache/cache.service';
-import { GitHubReaction } from '@/core/domain/codeReviewFeedback/enums/codeReviewCommentReaction.enum';
+import { GitHubReaction, GitlabReaction } from '@/core/domain/codeReviewFeedback/enums/codeReviewCommentReaction.enum';
 import {
     getTranslationsForLanguageByCategory,
     TranslationsCategory,
@@ -3426,6 +3426,177 @@ export class GithubService
         }
     }
 
+    async addReactionToPR(params: {
+        organizationAndTeamData: any;
+        repository: { id?: string; name?: string };
+        prNumber: number;
+        reaction: GitHubReaction | GitlabReaction;
+    }): Promise<void> {
+        try {
+            const githubAuthDetail = await this.getGithubAuthDetails(
+                params.organizationAndTeamData,
+            );
+            const octokit = await this.instanceOctokit(
+                params.organizationAndTeamData,
+            );
+
+            await octokit.rest.reactions.createForIssue({
+                owner: githubAuthDetail.org,
+                repo: params.repository.name,
+                issue_number: params.prNumber,
+                content: params.reaction as GitHubReaction,
+            });
+
+            this.logger.log({
+                message: `Added reaction ${params.reaction} to PR#${params.prNumber}`,
+                context: GithubService.name,
+            });
+        } catch (error) {
+            this.logger.error({
+                message: `Error adding reaction to PR#${params.prNumber}`,
+                context: GithubService.name,
+                error: error,
+                metadata: params,
+            });
+        }
+    }
+
+    async addReactionToComment(params: {
+        organizationAndTeamData: any;
+        repository: { id?: string; name?: string };
+        prNumber: number;
+        commentId: number;
+        reaction: GitHubReaction | GitlabReaction;
+    }): Promise<void> {
+        try {
+            const githubAuthDetail = await this.getGithubAuthDetails(
+                params.organizationAndTeamData,
+            );
+            const octokit = await this.instanceOctokit(
+                params.organizationAndTeamData,
+            );
+
+            await octokit.rest.reactions.createForIssueComment({
+                owner: githubAuthDetail.org,
+                repo: params.repository.name,
+                comment_id: params.commentId,
+                content: params.reaction as GitHubReaction,
+            });
+
+            this.logger.log({
+                message: `Added reaction ${params.reaction} to comment ${params.commentId}`,
+                context: GithubService.name,
+            });
+        } catch (error) {
+            this.logger.error({
+                message: `Error adding reaction to comment ${params.commentId}`,
+                context: GithubService.name,
+                error: error,
+                metadata: params,
+            });
+        }
+    }
+
+    async removeReactionsFromPR(params: {
+        organizationAndTeamData: any;
+        repository: { id?: string; name?: string };
+        prNumber: number;
+        reactions: (GitHubReaction | GitlabReaction)[];
+    }): Promise<void> {
+        try {
+            const githubAuthDetail = await this.getGithubAuthDetails(
+                params.organizationAndTeamData,
+            );
+            const octokit = await this.instanceOctokit(
+                params.organizationAndTeamData,
+            );
+
+            const existingReactions = await octokit.rest.reactions.listForIssue(
+                {
+                    owner: githubAuthDetail.org,
+                    repo: params.repository.name,
+                    issue_number: params.prNumber,
+                },
+            );
+
+            const reactionsToRemove = existingReactions.data.filter((r: any) =>
+                params.reactions.includes(r.content as GitHubReaction),
+            );
+
+            for (const reaction of reactionsToRemove) {
+                await octokit.rest.reactions.deleteForIssue({
+                    owner: githubAuthDetail.org,
+                    repo: params.repository.name,
+                    issue_number: params.prNumber,
+                    reaction_id: reaction.id,
+                });
+            }
+
+            this.logger.log({
+                message: `Removed reactions from PR#${params.prNumber}`,
+                context: GithubService.name,
+                metadata: { reactionsRemoved: reactionsToRemove.length },
+            });
+        } catch (error) {
+            this.logger.error({
+                message: `Error removing reactions from PR#${params.prNumber}`,
+                context: GithubService.name,
+                error: error,
+                metadata: params,
+            });
+        }
+    }
+
+    async removeReactionsFromComment(params: {
+        organizationAndTeamData: any;
+        repository: { id?: string; name?: string };
+        prNumber: number;
+        commentId: number;
+        reactions: (GitHubReaction | GitlabReaction)[];
+    }): Promise<void> {
+        try {
+            const githubAuthDetail = await this.getGithubAuthDetails(
+                params.organizationAndTeamData,
+            );
+            const octokit = await this.instanceOctokit(
+                params.organizationAndTeamData,
+            );
+
+            const existingReactions =
+                await octokit.rest.reactions.listForIssueComment({
+                    owner: githubAuthDetail.org,
+                    repo: params.repository.name,
+                    comment_id: params.commentId,
+                });
+
+            const reactionsToRemove = existingReactions.data.filter((r: any) =>
+                params.reactions.includes(r.content as GitHubReaction),
+            );
+
+            for (const reaction of reactionsToRemove) {
+                await octokit.rest.reactions.deleteForIssueComment({
+                    owner: githubAuthDetail.org,
+                    repo: params.repository.name,
+                    comment_id: params.commentId,
+                    reaction_id: reaction.id,
+                });
+            }
+
+            this.logger.log({
+                message: `Removed reactions from comment ${params.commentId}`,
+                context: GithubService.name,
+                metadata: { reactionsRemoved: reactionsToRemove.length },
+            });
+        } catch (error) {
+            this.logger.error({
+                message: `Error removing reactions from comment ${params.commentId}`,
+                context: GithubService.name,
+                error: error,
+                metadata: params,
+            });
+        }
+    }
+
     async updateDescriptionInPullRequest(params: any): Promise<any | null> {
         const { organizationAndTeamData, repository, prNumber, summary } =
             params;
@@ -5031,9 +5202,7 @@ export class GithubService
                 return false;
             }
 
-            const octokit = await this.instanceOctokit(
-                organizationAndTeamData,
-            );
+            const octokit = await this.instanceOctokit(organizationAndTeamData);
 
             const repositories =
                 await this.findOneByOrganizationAndTeamDataAndConfigKey(

--- a/src/core/infrastructure/adapters/services/gitlab.service.ts
+++ b/src/core/infrastructure/adapters/services/gitlab.service.ts
@@ -2377,12 +2377,21 @@ export class GitlabService
     }
 
     async addReactionToPR(params: {
-        organizationAndTeamData: any;
+        organizationAndTeamData: OrganizationAndTeamData;
         repository: { id?: string; name?: string };
         prNumber: number;
         reaction: GitHubReaction | GitlabReaction;
     }): Promise<void> {
         try {
+            if (!params.repository.id) {
+                this.logger.warn({
+                    message: 'Repository ID is required for GitLab reactions',
+                    context: GitlabService.name,
+                    metadata: params,
+                });
+                return;
+            }
+
             const gitlabAuthDetail = await this.getAuthDetails(
                 params.organizationAndTeamData,
             );
@@ -2409,13 +2418,22 @@ export class GitlabService
     }
 
     async addReactionToComment(params: {
-        organizationAndTeamData: any;
+        organizationAndTeamData: OrganizationAndTeamData;
         repository: { id?: string; name?: string };
         prNumber: number;
         commentId: number;
         reaction: GitHubReaction | GitlabReaction;
     }): Promise<void> {
         try {
+            if (!params.repository.id) {
+                this.logger.warn({
+                    message: 'Repository ID is required for GitLab reactions',
+                    context: GitlabService.name,
+                    metadata: params,
+                });
+                return;
+            }
+
             const gitlabAuthDetail = await this.getAuthDetails(
                 params.organizationAndTeamData,
             );
@@ -2443,12 +2461,21 @@ export class GitlabService
     }
 
     async removeReactionsFromPR(params: {
-        organizationAndTeamData: any;
+        organizationAndTeamData: OrganizationAndTeamData;
         repository: { id?: string; name?: string };
         prNumber: number;
         reactions: (GitHubReaction | GitlabReaction)[];
     }): Promise<void> {
         try {
+            if (!params.repository.id) {
+                this.logger.warn({
+                    message: 'Repository ID is required for GitLab reactions',
+                    context: GitlabService.name,
+                    metadata: params,
+                });
+                return;
+            }
+
             const gitlabAuthDetail = await this.getAuthDetails(
                 params.organizationAndTeamData,
             );
@@ -2463,13 +2490,15 @@ export class GitlabService
                 params.reactions.includes(award.name),
             );
 
-            for (const award of awardsToRemove) {
-                await gitlabAPI.MergeRequestAwardEmojis.remove(
-                    params.repository.id,
-                    params.prNumber,
-                    award.id,
-                );
-            }
+            await Promise.all(
+                awardsToRemove.map((award) =>
+                    gitlabAPI.MergeRequestAwardEmojis.remove(
+                        params.repository.id,
+                        params.prNumber,
+                        award.id,
+                    ),
+                ),
+            );
 
             this.logger.log({
                 message: `Removed reactions from MR#${params.prNumber}`,
@@ -2487,13 +2516,22 @@ export class GitlabService
     }
 
     async removeReactionsFromComment(params: {
-        organizationAndTeamData: any;
+        organizationAndTeamData: OrganizationAndTeamData;
         repository: { id?: string; name?: string };
         prNumber: number;
         commentId: number;
         reactions: (GitHubReaction | GitlabReaction)[];
     }): Promise<void> {
         try {
+            if (!params.repository.id) {
+                this.logger.warn({
+                    message: 'Repository ID is required for GitLab reactions',
+                    context: GitlabService.name,
+                    metadata: params,
+                });
+                return;
+            }
+
             const gitlabAuthDetail = await this.getAuthDetails(
                 params.organizationAndTeamData,
             );
@@ -2509,14 +2547,16 @@ export class GitlabService
                 params.reactions.includes(award.name),
             );
 
-            for (const award of awardsToRemove) {
-                await gitlabAPI.MergeRequestNoteAwardEmojis.remove(
-                    params.repository.id,
-                    params.prNumber,
-                    params.commentId,
-                    award.id,
-                );
-            }
+            await Promise.all(
+                awardsToRemove.map((award) =>
+                    gitlabAPI.MergeRequestNoteAwardEmojis.remove(
+                        params.repository.id,
+                        params.prNumber,
+                        params.commentId,
+                        award.id,
+                    ),
+                ),
+            );
 
             this.logger.log({
                 message: `Removed reactions from note ${params.commentId} on MR#${params.prNumber}`,

--- a/src/core/infrastructure/adapters/services/gitlab.service.ts
+++ b/src/core/infrastructure/adapters/services/gitlab.service.ts
@@ -9,6 +9,7 @@ import {
 } from '@/core/domain/platformIntegrations/types/codeManagement/pullRequests.type';
 import { Repositories } from '@/core/domain/platformIntegrations/types/codeManagement/repositories.type';
 import { PlatformType } from '@/shared/domain/enums/platform-type.enum';
+import { GitlabReaction, GitHubReaction } from '@/core/domain/codeReviewFeedback/enums/codeReviewCommentReaction.enum';
 
 import { IntegrationServiceDecorator } from '@/shared/utils/decorators/integration-service.decorator';
 import { BadRequestException, Inject, Injectable } from '@nestjs/common';
@@ -2373,6 +2374,163 @@ export class GitlabService
                     },
                 },
             }));
+    }
+
+    async addReactionToPR(params: {
+        organizationAndTeamData: any;
+        repository: { id?: string; name?: string };
+        prNumber: number;
+        reaction: GitHubReaction | GitlabReaction;
+    }): Promise<void> {
+        try {
+            const gitlabAuthDetail = await this.getAuthDetails(
+                params.organizationAndTeamData,
+            );
+            const gitlabAPI = this.instanceGitlabApi(gitlabAuthDetail);
+
+            await gitlabAPI.MergeRequestAwardEmojis.award(
+                params.repository.id,
+                params.prNumber,
+                params.reaction,
+            );
+
+            this.logger.log({
+                message: `Added reaction ${params.reaction} to MR#${params.prNumber}`,
+                context: GitlabService.name,
+            });
+        } catch (error) {
+            this.logger.error({
+                message: `Error adding reaction to MR#${params.prNumber}`,
+                context: GitlabService.name,
+                error: error,
+                metadata: params,
+            });
+        }
+    }
+
+    async addReactionToComment(params: {
+        organizationAndTeamData: any;
+        repository: { id?: string; name?: string };
+        prNumber: number;
+        commentId: number;
+        reaction: GitHubReaction | GitlabReaction;
+    }): Promise<void> {
+        try {
+            const gitlabAuthDetail = await this.getAuthDetails(
+                params.organizationAndTeamData,
+            );
+            const gitlabAPI = this.instanceGitlabApi(gitlabAuthDetail);
+
+            await gitlabAPI.MergeRequestNoteAwardEmojis.award(
+                params.repository.id,
+                params.prNumber,
+                params.commentId,
+                params.reaction,
+            );
+
+            this.logger.log({
+                message: `Added reaction ${params.reaction} to note ${params.commentId} on MR#${params.prNumber}`,
+                context: GitlabService.name,
+            });
+        } catch (error) {
+            this.logger.error({
+                message: `Error adding reaction to note ${params.commentId}`,
+                context: GitlabService.name,
+                error: error,
+                metadata: params,
+            });
+        }
+    }
+
+    async removeReactionsFromPR(params: {
+        organizationAndTeamData: any;
+        repository: { id?: string; name?: string };
+        prNumber: number;
+        reactions: (GitHubReaction | GitlabReaction)[];
+    }): Promise<void> {
+        try {
+            const gitlabAuthDetail = await this.getAuthDetails(
+                params.organizationAndTeamData,
+            );
+            const gitlabAPI = this.instanceGitlabApi(gitlabAuthDetail);
+
+            const awards = await gitlabAPI.MergeRequestAwardEmojis.all(
+                params.repository.id,
+                params.prNumber,
+            );
+
+            const awardsToRemove = awards.filter((award: any) =>
+                params.reactions.includes(award.name),
+            );
+
+            for (const award of awardsToRemove) {
+                await gitlabAPI.MergeRequestAwardEmojis.remove(
+                    params.repository.id,
+                    params.prNumber,
+                    award.id,
+                );
+            }
+
+            this.logger.log({
+                message: `Removed reactions from MR#${params.prNumber}`,
+                context: GitlabService.name,
+                metadata: { awardsRemoved: awardsToRemove.length },
+            });
+        } catch (error) {
+            this.logger.error({
+                message: `Error removing reactions from MR#${params.prNumber}`,
+                context: GitlabService.name,
+                error: error,
+                metadata: params,
+            });
+        }
+    }
+
+    async removeReactionsFromComment(params: {
+        organizationAndTeamData: any;
+        repository: { id?: string; name?: string };
+        prNumber: number;
+        commentId: number;
+        reactions: (GitHubReaction | GitlabReaction)[];
+    }): Promise<void> {
+        try {
+            const gitlabAuthDetail = await this.getAuthDetails(
+                params.organizationAndTeamData,
+            );
+            const gitlabAPI = this.instanceGitlabApi(gitlabAuthDetail);
+
+            const awards = await gitlabAPI.MergeRequestNoteAwardEmojis.all(
+                params.repository.id,
+                params.prNumber,
+                params.commentId,
+            );
+
+            const awardsToRemove = awards.filter((award: any) =>
+                params.reactions.includes(award.name),
+            );
+
+            for (const award of awardsToRemove) {
+                await gitlabAPI.MergeRequestNoteAwardEmojis.remove(
+                    params.repository.id,
+                    params.prNumber,
+                    params.commentId,
+                    award.id,
+                );
+            }
+
+            this.logger.log({
+                message: `Removed reactions from note ${params.commentId} on MR#${params.prNumber}`,
+                context: GitlabService.name,
+                metadata: { awardsRemoved: awardsToRemove.length },
+            });
+        } catch (error) {
+            this.logger.error({
+                message: `Error removing reactions from note ${params.commentId}`,
+                context: GitlabService.name,
+                error: error,
+                metadata: params,
+            });
+        }
     }
 
     async getLanguageRepository(params: {

--- a/src/core/infrastructure/adapters/services/platformIntegration/codeManagement.service.ts
+++ b/src/core/infrastructure/adapters/services/platformIntegration/codeManagement.service.ts
@@ -28,6 +28,10 @@ import { GitCloneParams } from '@/core/domain/platformIntegrations/types/codeMan
 import { PullRequestState } from '@/shared/domain/enums/pullRequestState.enum';
 import { RepositoryFile } from '@/core/domain/platformIntegrations/types/codeManagement/repositoryFile.type';
 import { CommitLeadTimeForChange } from '@/core/domain/platformIntegrations/types/codeManagement/commitLeadTimeForChange.type';
+import {
+    GitHubReaction,
+    GitlabReaction,
+} from '@/core/domain/codeReviewFeedback/enums/codeReviewCommentReaction.enum';
 
 @Injectable()
 export class CodeManagementService implements ICodeManagementService {
@@ -1181,5 +1185,87 @@ export class CodeManagementService implements ICodeManagementService {
             this.platformIntegrationFactory.getCodeManagementService(type);
 
         return codeManagementService.getReviewStatusByPullRequest(params);
+    }
+
+    async addReactionToPR(params: {
+        organizationAndTeamData: OrganizationAndTeamData;
+        repository: { id?: string; name?: string };
+        prNumber: number;
+        reaction: GitHubReaction | GitlabReaction;
+    }): Promise<void> {
+        const type = await this.getTypeIntegration(
+            params.organizationAndTeamData,
+        );
+
+        if (!type) {
+            return;
+        }
+
+        const codeManagementService =
+            this.platformIntegrationFactory.getCodeManagementService(type);
+
+        return codeManagementService.addReactionToPR?.(params);
+    }
+
+    async addReactionToComment(params: {
+        organizationAndTeamData: OrganizationAndTeamData;
+        repository: { id?: string; name?: string };
+        prNumber: number;
+        commentId: number;
+        reaction: GitHubReaction | GitlabReaction;
+    }): Promise<void> {
+        const type = await this.getTypeIntegration(
+            params.organizationAndTeamData,
+        );
+
+        if (!type) {
+            return;
+        }
+
+        const codeManagementService =
+            this.platformIntegrationFactory.getCodeManagementService(type);
+
+        return codeManagementService.addReactionToComment?.(params);
+    }
+
+    async removeReactionsFromPR(params: {
+        organizationAndTeamData: OrganizationAndTeamData;
+        repository: { id?: string; name?: string };
+        prNumber: number;
+        reactions: (GitHubReaction | GitlabReaction)[];
+    }): Promise<void> {
+        const type = await this.getTypeIntegration(
+            params.organizationAndTeamData,
+        );
+
+        if (!type) {
+            return;
+        }
+
+        const codeManagementService =
+            this.platformIntegrationFactory.getCodeManagementService(type);
+
+        return codeManagementService.removeReactionsFromPR?.(params);
+    }
+
+    async removeReactionsFromComment(params: {
+        organizationAndTeamData: OrganizationAndTeamData;
+        repository: { id?: string; name?: string };
+        prNumber: number;
+        commentId: number;
+        reactions: (GitHubReaction | GitlabReaction)[];
+    }): Promise<void> {
+        const type = await this.getTypeIntegration(
+            params.organizationAndTeamData,
+        );
+
+        if (!type) {
+            return;
+        }
+
+        const codeManagementService =
+            this.platformIntegrationFactory.getCodeManagementService(type);
+
+        return codeManagementService.removeReactionsFromComment?.(params);
     }
 }

--- a/src/core/infrastructure/adapters/webhooks/azureRepos/azureReposPullRequest.handler.ts
+++ b/src/core/infrastructure/adapters/webhooks/azureRepos/azureReposPullRequest.handler.ts
@@ -320,6 +320,7 @@ export class AzureReposPullRequestHandler implements IWebhookEventHandler {
                         ...payload,
                         action: 'synchronize',
                         origin: 'command',
+                        triggerCommentId: comment?.id,
                     },
                 };
 

--- a/src/core/infrastructure/adapters/webhooks/bitbucket/bitbucketPullRequest.handler.ts
+++ b/src/core/infrastructure/adapters/webhooks/bitbucket/bitbucketPullRequest.handler.ts
@@ -276,6 +276,7 @@ export class BitbucketPullRequestHandler implements IWebhookEventHandler {
                         ...payload,
                         action: 'synchronize',
                         origin: 'command',
+                        triggerCommentId: comment?.id,
                     },
                 };
 

--- a/src/core/infrastructure/adapters/webhooks/github/githubPullRequest.handler.ts
+++ b/src/core/infrastructure/adapters/webhooks/github/githubPullRequest.handler.ts
@@ -357,6 +357,7 @@ export class GitHubPullRequestHandler implements IWebhookEventHandler {
                         ...payload,
                         action: 'synchronize',
                         origin: 'command',
+                        triggerCommentId: comment?.id,
                         pull_request:
                             pullRequestData ||
                             pullRequest ||

--- a/src/core/infrastructure/adapters/webhooks/gitlab/gitlabPullRequest.handler.ts
+++ b/src/core/infrastructure/adapters/webhooks/gitlab/gitlabPullRequest.handler.ts
@@ -250,6 +250,7 @@ export class GitLabMergeRequestHandler implements IWebhookEventHandler {
                             ...payload,
                             action: 'synchronize',
                             origin: 'command',
+                            triggerCommentId: comment?.id,
                         },
                     };
 

--- a/src/ee/automation/runCodeReview.use-case.ts
+++ b/src/ee/automation/runCodeReview.use-case.ts
@@ -232,6 +232,7 @@ export class RunCodeReviewAutomationUseCase {
                     origin: sanitizedPayload?.origin,
                     action,
                     byokConfig,
+                    triggerCommentId: sanitizedPayload?.triggerCommentId,
                 },
             );
         } catch (error) {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces a new feature to provide real-time visual feedback on the status of automated code review processes directly within Pull Requests (PRs) or their comments on GitHub and GitLab.

Key changes include:
*   **Reaction Management**: New capabilities to add and remove specific reactions to PRs and individual comments on supported platforms (GitHub and GitLab).
*   **Status Reactions**: Defines a set of reactions (`eyes`, `hooray`/`tada`, `confused`) to indicate the `START`, `SUCCESS`, or `ERROR` status of a code review pipeline.
*   **Automated Feedback**: The code review pipeline now automatically applies these status reactions:
    *   An "eyes" reaction is added when a code review starts.
    *   This initial reaction is removed and replaced with a "hooray" (GitHub) or "tada" (GitLab) reaction upon successful completion.
    *   If the review encounters an error, the initial reaction is removed and replaced with a "confused" reaction.
*   **Contextual Reactions**: If a code review is triggered by a specific comment, the status reactions will be applied directly to that comment instead of the main PR.
*   **Platform Integration**: Concrete implementations for managing these reactions have been added for GitHub and GitLab, ensuring platform-specific API calls are handled correctly. Azure Repos is explicitly excluded from this reaction feature.

This enhancement improves the user experience by offering immediate and clear visual cues about the progress and outcome of automated code reviews.
<!-- kody-pr-summary:end -->