### PR TITLE
fixed method get config by directory

### DIFF
--- a/src/ee/codeBase/codeBaseConfig.service.ts
+++ b/src/ee/codeBase/codeBaseConfig.service.ts
@@ -1160,36 +1160,76 @@ export default class CodeBaseConfigService implements ICodeBaseConfigService {
                 return this.getConfig(organizationAndTeamData, repository);
             }
 
-            // Função para normalizar paths (remover barra inicial para comparação consistente)
             const normalizePath = (path: string): string => {
                 return path.startsWith('/') ? path.substring(1) : path;
             };
 
-            // Encontrar diretórios configurados que são afetados pelos arquivos alterados
-            const matchingDirectories = repoConfig.directories.filter(
-                (dir: any) => {
-                    const normalizedDirPath = normalizePath(dir.path);
-                    return affectedPaths.some((filePath: string) => {
-                        const normalizedFilePath = normalizePath(filePath);
-                        return (
-                            normalizedFilePath === normalizedDirPath ||
-                            normalizedFilePath.startsWith(
-                                normalizedDirPath + '/',
-                            )
+            const isPathCoveredByDirectory = (
+                normalizedDir: string,
+                normalizedFile: string,
+            ): boolean => {
+                if (normalizedDir === '') {
+                    return true;
+                }
+
+                return (
+                    normalizedFile === normalizedDir ||
+                    normalizedFile.startsWith(normalizedDir + '/')
+                );
+            };
+
+            const directoryMatchers = repoConfig.directories.map(
+                (dir: any) => ({
+                    dir,
+                    normalizedPath: normalizePath(dir.path),
+                }),
+            );
+
+            const matchingDirectories = directoryMatchers.filter(
+                ({ normalizedPath }) =>
+                    affectedPaths.some((filePath: string) => {
+                        const normalizedFile = normalizePath(filePath);
+                        return isPathCoveredByDirectory(
+                            normalizedPath,
+                            normalizedFile,
                         );
-                    });
+                    }),
+            );
+
+            const hasNotClassifiedPaths = affectedPaths.some(
+                (filePath: string) => {
+                    const normalizedFile = normalizePath(filePath);
+
+                    return !matchingDirectories.some(({ normalizedPath }) =>
+                        isPathCoveredByDirectory(
+                            normalizedPath,
+                            normalizedFile,
+                        ),
+                    );
                 },
             );
 
-            if (matchingDirectories.length === 0) {
+            // Agrupar diretórios configurados atingidos e sinalizar paths fora de qualquer config
+            const groupedDirectories = matchingDirectories.map(
+                ({ dir }) => dir,
+            );
+
+            if (groupedDirectories.length > 0 && hasNotClassifiedPaths) {
+                groupedDirectories.push({ name: 'not classified', path: null });
+            }
+
+            if (groupedDirectories.length === 0) {
                 // Nenhum diretório configurado afetado, usar config normal (repo ou global)
                 return this.getConfig(organizationAndTeamData, repository);
             }
 
-            if (matchingDirectories.length === 1) {
+            if (
+                groupedDirectories.length === 1 &&
+                groupedDirectories[0]?.path !== null
+            ) {
                 // Apenas um diretório configurado afetado, usar sua config
                 return this.buildConfigFromDirectory(
-                    matchingDirectories[0],
+                    groupedDirectories[0],
                     organizationAndTeamData,
                     repository,
                 );
@@ -1477,12 +1517,14 @@ export default class CodeBaseConfigService implements ICodeBaseConfigService {
         const paths = new Set<string>();
 
         files.forEach((file) => {
-            const parts = file.filename.split('/');
+            const lastSlashIndex = file.filename.lastIndexOf('/');
 
-            // Gerar todos os caminhos possíveis (do mais específico ao mais geral)
-            for (let i = parts.length - 1; i > 0; i--) {
-                const path = parts.slice(0, i).join('/');
-                paths.add(path);
+            if (lastSlashIndex > 0) {
+                const directoryPath = file.filename.substring(
+                    0,
+                    lastSlashIndex,
+                );
+                paths.add(directoryPath);
             }
         });
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces several refinements to how configurations are retrieved based on changed files and their associated directories.

Key changes include:

*   **Refined Affected Path Calculation:** The `getAffectedPaths` method now identifies only the immediate parent directory for each changed file, rather than generating all possible parent paths. This provides a more precise list of directories directly impacted by file changes.
*   **Enhanced Directory Matching Logic:** The `getConfigByDirectory` method now uses a dedicated helper function (`isPathCoveredByDirectory`) for more robust and consistent path comparisons, especially when dealing with root-level directories.
*   **Introduction of "Not Classified" Paths:** The system can now detect if some changed files do not fall under any explicitly configured directory. If such "unclassified" paths exist alongside files that *are* covered by configured directories, a special "not classified" entry is added to the list of matched directories. This allows for distinct handling when not all changes align with defined directory configurations.
*   **Improved Single Directory Configuration Handling:** The logic for applying a configuration based on a single matched directory has been updated to explicitly exclude the "not classified" entry, ensuring that a specific directory's configuration is only applied when a single, actual configured directory is affected.
<!-- kody-pr-summary:end -->