### PR TITLE
fixed method validation connection

### DIFF
--- a/src/core/infrastructure/adapters/services/integrations/integration.service.ts
+++ b/src/core/infrastructure/adapters/services/integrations/integration.service.ts
@@ -58,16 +58,13 @@ export class IntegrationService implements IIntegrationService {
         }[]
     > {
         try {
-            const [projectManagementConnection, codeManagementConnection] =
-                await Promise.all([
-                    this.projectManagementService.verifyConnection(params),
-                    this.codeManagementService.verifyConnection(params),
-                ]);
+            const [codeManagementConnection] = await Promise.all([
+                this.codeManagementService.verifyConnection(params),
+            ]);
 
-            return [
-                projectManagementConnection,
-                codeManagementConnection,
-            ]?.filter((connection) => connection);
+            return [codeManagementConnection]?.filter(
+                (connection) => connection,
+            );
         } catch (error) {
             throw new BadRequestException(error);
         }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Updated the `verifyConnection` method in `IntegrationService` to only verify the connection for code management services. Previously, this method attempted to verify both project management and code management connections. The verification for project management services has been removed.
<!-- kody-pr-summary:end -->