### PR TITLE
improve get owner by outh user github

### DIFF
--- a/src/core/infrastructure/adapters/services/github/github.service.ts
+++ b/src/core/infrastructure/adapters/services/github/github.service.ts
@@ -62,7 +62,10 @@ import { decrypt, encrypt } from '@/shared/utils/crypto';
 import { AuthMode } from '@/core/domain/platformIntegrations/enums/codeManagement/authMode.enum';
 import { CodeManagementConnectionStatus } from '@/shared/utils/decorators/validate-code-management-integration.decorator';
 import { CacheService } from '@/shared/utils/cache/cache.service';
-import { GitHubReaction, GitlabReaction } from '@/core/domain/codeReviewFeedback/enums/codeReviewCommentReaction.enum';
+import {
+    GitHubReaction,
+    GitlabReaction,
+} from '@/core/domain/codeReviewFeedback/enums/codeReviewCommentReaction.enum';
 import {
     getTranslationsForLanguageByCategory,
     TranslationsCategory,
@@ -455,12 +458,14 @@ export class GithubService
      * @returns owner correto para usar nas chamadas de API
      */
     private async getCorrectOwner(
-        githubAuthDetail: any,
+        githubAuthDetail: GithubAuthDetail,
         octokit: any,
     ): Promise<string> {
         // Usar cache do accountType se disponível
         if (githubAuthDetail.accountType) {
             if (githubAuthDetail.accountType === 'organization') {
+                return githubAuthDetail.org;
+            } else if (githubAuthDetail.authMode === AuthMode.OAUTH) {
                 return githubAuthDetail.org;
             } else {
                 // Para contas pessoais, usar o nome do usuário autenticado


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Refined the `getCorrectOwner` method in the GitHub service to accurately determine the repository owner for API calls.

Key changes include:
*   **Improved OAuth Owner Resolution**: The method now explicitly uses the `org` property from `githubAuthDetail` as the owner when the authentication mode (`authMode`) is `OAUTH`, ensuring correct owner identification for OAuth-based integrations.
*   **Enhanced Type Safety**: Updated the `githubAuthDetail` parameter type from `any` to `GithubAuthDetail` in the `getCorrectOwner` method signature for better code clarity and type checking.
*   **Code Formatting**: Adjusted an import statement for better readability.
<!-- kody-pr-summary:end -->