### PR TITLE
Merging repositories data

### DIFF
--- a/src/core/application/use-cases/platformIntegration/codeManagement/create-repositories.ts
+++ b/src/core/application/use-cases/platformIntegration/codeManagement/create-repositories.ts
@@ -62,6 +62,7 @@ export class CreateRepositoriesUseCase implements IUseCase {
             await this.codeManagementService.createOrUpdateIntegrationConfig({
                 configKey: IntegrationConfigKey.REPOSITORIES,
                 configValue: params.repositories,
+                type: params.type,
                 organizationAndTeamData: {
                     teamId: teamId,
                     organizationId: organizationId,
@@ -97,10 +98,6 @@ export class CreateRepositoriesUseCase implements IUseCase {
             if (teams && teams?.length > 1) {
                 this.savePlatformConfig(teamId, organizationId);
             }
-
-            await this.syncSelectedRepositoriesKodyRulesUseCase.execute({
-                teamId,
-            });
 
             return {
                 status: true,

--- a/src/core/domain/integrationConfigs/contracts/integration-config.service.contracts.ts
+++ b/src/core/domain/integrationConfigs/contracts/integration-config.service.contracts.ts
@@ -14,6 +14,7 @@ export interface IIntegrationConfigService
         payload: any,
         integrationId: any,
         organizationAndTeamData: OrganizationAndTeamData,
+        type?: "replace" | "append",
     ): Promise<IntegrationConfigEntity>;
     findIntegrationConfigFormatted<T>(
         configKey: IntegrationConfigKey,

--- a/src/core/infrastructure/adapters/services/azureRepos.service.ts
+++ b/src/core/infrastructure/adapters/services/azureRepos.service.ts
@@ -1994,6 +1994,7 @@ export class AzureReposService
                 params.configValue,
                 integration?.uuid,
                 params.organizationAndTeamData,
+                params.type,
             );
 
             this.createWebhook(params.organizationAndTeamData);

--- a/src/core/infrastructure/adapters/services/bitbucket/bitbucket.service.ts
+++ b/src/core/infrastructure/adapters/services/bitbucket/bitbucket.service.ts
@@ -2805,6 +2805,7 @@ export class BitbucketService
         organizationAndTeamData: OrganizationAndTeamData;
         configKey: IntegrationConfigKey;
         configValue: any;
+        type?: "replace" | "append";
     }): Promise<void> {
         try {
             const integration = await this.integrationService.findOne({
@@ -2824,6 +2825,7 @@ export class BitbucketService
                 params.configValue,
                 integration?.uuid,
                 params.organizationAndTeamData,
+                params.type,
             );
 
             this.createWebhook(params.organizationAndTeamData);

--- a/src/core/infrastructure/adapters/services/github/github.service.ts
+++ b/src/core/infrastructure/adapters/services/github/github.service.ts
@@ -235,6 +235,7 @@ export class GithubService
                 params.configValue,
                 integration?.uuid,
                 params.organizationAndTeamData,
+                params.type,
             );
 
             const githubAuthDetail = await this.getGithubAuthDetails(

--- a/src/core/infrastructure/adapters/services/gitlab.service.ts
+++ b/src/core/infrastructure/adapters/services/gitlab.service.ts
@@ -400,6 +400,7 @@ export class GitlabService
                 params.configValue,
                 integration?.uuid,
                 params.organizationAndTeamData,
+                params.type,
             );
 
             this.createMergeRequestWebhook({

--- a/src/core/infrastructure/http/controllers/platformIntegration/codeManagement.controller.ts
+++ b/src/core/infrastructure/http/controllers/platformIntegration/codeManagement.controller.ts
@@ -112,7 +112,7 @@ export class CodeManagementController {
         checkPermissions(Action.Create, ResourceType.CodeReviewSettings),
     )
     public async createRepositories(
-        @Body() body: { repositories: Repository[]; teamId: string },
+        @Body() body: { repositories: Repository[]; teamId: string; type?: "replace" | "append" },
     ) {
         return this.createRepositoriesUseCase.execute(body);
     }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces an enhanced mechanism for saving integrated repositories, allowing users to either replace the existing list or append new repositories.

Key changes include:

*   **Flexible Repository Saving**: A new optional `type` parameter (`"replace"` or `"append"`) has been added to the `createRepositories` functionality.
    *   When `type` is set to `"append"`, new repositories provided in the payload will be added to the existing list of configured repositories. Duplicate repositories (identified by their ID) will be ignored to prevent redundant entries.
    *   If `type` is `"replace"` or not specified, the provided list of repositories will completely overwrite the current configuration, maintaining the previous behavior.
*   **API and Service Layer Updates**: The `createRepositories` API endpoint and all relevant code management services (GitHub, GitLab, Bitbucket, Azure Repos) have been updated to accept and process this new `type` parameter, ensuring the chosen saving method is applied.
*   **Decoupled Kody Rule Synchronization**: The immediate synchronization of Kody rules, which previously occurred after saving repositories, has been removed from the `createRepositories` use case. This suggests that Kody rule synchronization is now handled by a different process or trigger.

This enhancement provides more granular control over repository management, enabling incremental updates without requiring a full replacement of the repository list.
<!-- kody-pr-summary:end -->