### PR TITLE
add feature flag

### DIFF
--- a/scripts/fetch-env-prod.sh
+++ b/scripts/fetch-env-prod.sh
@@ -139,6 +139,8 @@ KEYS=(
     "/prod/kodus-orchestrator/API_MCP_SERVER_ENABLED"
     "/prod/kodus-orchestrator/API_KODUS_SERVICE_MCP_MANAGER"
     "/prod/kodus-orchestrator/API_KODUS_MCP_SERVER_URL"
+
+    "/prod/kodus-orchestrator/API_OPENROUTER_KEY"
 )
 
 # Lista de todas as chaves que você precisa

--- a/scripts/fetch-env-qa.sh
+++ b/scripts/fetch-env-qa.sh
@@ -139,6 +139,8 @@ KEYS=(
     "/qa/kodus-orchestrator/API_MCP_SERVER_ENABLED"
     "/qa/kodus-orchestrator/API_KODUS_SERVICE_MCP_MANAGER"
     "/qa/kodus-orchestrator/API_KODUS_MCP_SERVER_URL"
+
+    "/qa/kodus-orchestrator/API_OPENROUTER_KEY"
 )
 
 # Lista de todas as chaves que você precisa


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the environment variable fetching scripts for both production (`fetch-env-prod.sh`) and QA (`fetch-env-qa.sh`) environments.

Specifically, it adds `API_OPENROUTER_KEY` to the list of keys to be retrieved from the respective environment's parameter store (e.g., `/prod/kodus-orchestrator/API_OPENROUTER_KEY` for production and `/qa/kodus-orchestrator/API_OPENROUTER_KEY` for QA). This ensures that the `API_OPENROUTER_KEY` is available for use by the `kodus-orchestrator` service in these environments.
<!-- kody-pr-summary:end -->