### PR TITLE
fixed get url gitlab

### DIFF
--- a/src/core/infrastructure/adapters/services/gitlab.service.ts
+++ b/src/core/infrastructure/adapters/services/gitlab.service.ts
@@ -78,7 +78,10 @@ import { ConfigService } from '@nestjs/config';
 import { GitCloneParams } from '@/core/domain/platformIntegrations/types/codeManagement/gitCloneParams.type';
 import { LLMProviderService, LLMModelProvider } from '@kodus/kodus-common/llm';
 import { RepositoryFile } from '@/core/domain/platformIntegrations/types/codeManagement/repositoryFile.type';
-import { isFileMatchingGlob, isFileMatchingGlobCaseInsensitive } from '@/shared/utils/glob-utils';
+import {
+    isFileMatchingGlob,
+    isFileMatchingGlobCaseInsensitive,
+} from '@/shared/utils/glob-utils';
 import { CacheService } from '@/shared/utils/cache/cache.service';
 import { MCPManagerService } from '../mcp/services/mcp-manager.service';
 
@@ -2670,7 +2673,8 @@ export class GitlabService
             }
 
             // Construct the full GitLab URL
-            const fullGitlabUrl = `https://gitlab.com/${params?.repository?.fullName}`;
+            const gitlabHost = gitlabAuthDetail.host || 'gitlab.com';
+            const fullGitlabUrl = `https://${gitlabHost}/${params?.repository?.fullName}`;
 
             return {
                 organizationId: params.organizationAndTeamData.organizationId,


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request enhances the GitLab service by modifying how repository clone URLs are constructed.

Previously, the GitLab host in the clone URL was hardcoded to `https://gitlab.com/`. This change updates the logic to dynamically retrieve the GitLab host from `gitlabAuthDetail.host`. If a specific host is not configured, it defaults back to `gitlab.com`.

This allows the system to correctly generate clone URLs for both public `gitlab.com` repositories and self-hosted or enterprise GitLab instances, improving flexibility and compatibility.
<!-- kody-pr-summary:end -->