### PR TITLE
Update English and Portuguese translations for review cadence descrip…

### DIFF
--- a/src/shared/utils/translations/dictionaries/en-US.json
+++ b/src/shared/utils/translations/dictionaries/en-US.json
@@ -96,10 +96,10 @@
     },
     "reviewCadenceInfo": {
         "automaticTitle": "Automatic Review",
-        "automaticDesc": "Kody will automatically review every push to this PR.",
+        "automaticDesc": "Kody reviews this PR automatically on every push.",
         "autoPauseTitle": "Auto-Pause Mode",
-        "autoPauseDesc": "Kody reviews the first push automatically, then pauses if you make {pushes}+ pushes in {timeWindow} minutes. Use @kody resume to continue.",
+        "autoPauseDesc": "Kody reviews automatically but pauses after rapid changes ({pushes}+ pushes in {timeWindow} minutes). Use @kody resume to continue.",
         "manualTitle": "Manual Review",
-        "manualDesc": "Kody only reviews when you request with @kody start-review command."
+        "manualDesc": "Kody reviews the first push automatically, then only when you request with @kody start-review."
     }
 }

--- a/src/shared/utils/translations/dictionaries/pt-BR.json
+++ b/src/shared/utils/translations/dictionaries/pt-BR.json
@@ -96,10 +96,10 @@
     },
     "reviewCadenceInfo": {
         "automaticTitle": "Review Automático",
-        "automaticDesc": "Kody irá revisar automaticamente cada push nesta PR.",
+        "automaticDesc": "Kody revisa esta PR automaticamente em cada push.",
         "autoPauseTitle": "Modo Auto-Pause",
-        "autoPauseDesc": "Kody revisa o primeiro push automaticamente, depois pausa se você fizer {pushes}+ pushes em {timeWindow} minutos. Use @kody resume para continuar.",
+        "autoPauseDesc": "Kody revisa automaticamente mas pausa após mudanças rápidas ({pushes}+ pushes em {timeWindow} minutos). Use @kody resume para continuar.",
         "manualTitle": "Review Manual",
-        "manualDesc": "Kody apenas revisa quando você solicita com o comando @kody start-review."
+        "manualDesc": "Kody revisa o primeiro push automaticamente, depois apenas quando você solicita com @kody start-review."
     }
 }


### PR DESCRIPTION
…tions

- Revised the automatic, auto-pause, and manual review descriptions for clarity and consistency in both English and Portuguese translation files.
- Enhanced phrasing to improve user understanding of Kody's review behavior.

---

<!-- kody-pr-summary:start -->
Updated the English and Portuguese translations for the review cadence descriptions.

Specifically, these changes:
- Made the "Automatic Review" description more concise.
- Rephrased the "Auto-Pause Mode" description for improved clarity and conciseness.
- Clarified the "Manual Review" description to state that Kody performs an initial automatic review on the first push, even in manual mode, before requiring explicit `@kody start-review` commands.
<!-- kody-pr-summary:end -->