### PR TITLE
fix migrations not running

### DIFF
--- a/src/config/database/typeorm/migrations/1761081305000-AddCriticalIndexes.ts
+++ b/src/config/database/typeorm/migrations/1761081305000-AddCriticalIndexes.ts
@@ -1,7 +1,7 @@
 import { MigrationInterface, QueryRunner } from 'typeorm';
 
-export class AddCriticalIndexes1729876543210 implements MigrationInterface {
-    name = 'AddCriticalIndexes1729876543210';
+export class AddCriticalIndexes1761081305000 implements MigrationInterface {
+    name = 'AddCriticalIndexes1761081305000';
 
     // CRITICAL: Disable transactions for CONCURRENT index creation
     // Without this, CREATE INDEX CONCURRENTLY will fail


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Refactored the `AddCriticalIndexes` migration by updating its timestamp in both the filename and the class definition. This change ensures the migration is properly recognized and executed by the TypeORM migration runner, addressing an issue where migrations were not running.
<!-- kody-pr-summary:end -->