### PR TITLE
Add processEndReviewMessageTemplate method to CommentManagerService

### DIFF
--- a/src/core/domain/codeBase/contracts/CommentManagerService.contract.ts
+++ b/src/core/domain/codeBase/contracts/CommentManagerService.contract.ts
@@ -29,6 +29,16 @@ export interface ICommentManagerService {
         pullRequestMessages?: IPullRequestMessages,
     ): Promise<{ commentId: number; noteId: number; threadId?: number }>;
 
+    processEndReviewMessageTemplate(
+        template: string,
+        changedFiles: FileChange[],
+        organizationAndTeamData: OrganizationAndTeamData,
+        prNumber: number,
+        codeReviewConfig?: CodeReviewConfig,
+        language?: string,
+        platformType?: PlatformType,
+    ): Promise<string>;
+
     generateSummaryPR(
         pullRequest: any,
         repository: { name: string; id: string },

--- a/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/finish-comments.stage.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/finish-comments.stage.ts
@@ -142,7 +142,16 @@ export class UpdateCommentsAndGenerateSummaryStage extends BasePipelineStage<Cod
                 (startReviewMessage.status === PullRequestMessageStatus.ONLY_WHEN_OPENED &&
                     !context.lastExecution))
         ) {
-            const finalCommentBody = endReviewMessage.content;
+            const finalCommentBody =
+                await this.commentManagerService.processEndReviewMessageTemplate(
+                    endReviewMessage.content,
+                    context.changedFiles,
+                    organizationAndTeamData,
+                    pullRequest.number,
+                    codeReviewConfig,
+                    codeReviewConfig?.languageResultPrompt ?? 'en-US',
+                    platformType,
+                );
 
             await this.commentManagerService.updateOverallComment(
                 organizationAndTeamData,

--- a/src/core/infrastructure/adapters/services/codeBase/commentManager.service.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/commentManager.service.ts
@@ -561,6 +561,32 @@ export class CommentManagerService implements ICommentManagerService {
         }
     }
 
+    async processEndReviewMessageTemplate(
+        template: string,
+        changedFiles: FileChange[],
+        organizationAndTeamData: OrganizationAndTeamData,
+        prNumber: number,
+        codeReviewConfig?: CodeReviewConfig,
+        language?: string,
+        platformType?: PlatformType,
+    ): Promise<string> {
+        const placeholderContext = await this.getTemplateContext(
+            changedFiles,
+            organizationAndTeamData,
+            prNumber,
+            codeReviewConfig,
+            language,
+            platformType,
+        );
+
+        const processedBody = await this.messageProcessor.processTemplate(
+            template,
+            placeholderContext,
+        );
+
+        return this.sanitizeBitbucketMarkdown(processedBody, platformType);
+    }
+
     async updateOverallComment(
         organizationAndTeamData: OrganizationAndTeamData,
         prNumber: number,

--- a/src/core/infrastructure/adapters/services/codeBase/utils/services/messageTemplateProcessor.service.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/utils/services/messageTemplateProcessor.service.ts
@@ -222,13 +222,11 @@ ${reviewOptionsMarkdown}
         if (!translation) return '';
 
         const cadenceType = context.codeReviewConfig.reviewCadence.type;
-        let statusEmoji = '';
         let statusText = '';
         let description = '';
 
         switch (cadenceType) {
             case ReviewCadenceType.AUTOMATIC:
-                statusEmoji = '🤖';
                 statusText = translation.automaticTitle || 'Automatic Review';
                 description =
                     translation.automaticDesc ||
@@ -236,7 +234,6 @@ ${reviewOptionsMarkdown}
                 break;
 
             case ReviewCadenceType.AUTO_PAUSE:
-                statusEmoji = '⏸️';
                 statusText = translation.autoPauseTitle || 'Auto-Pause Mode';
                 const timeWindow =
                     context.codeReviewConfig.reviewCadence.timeWindow || 15;
@@ -248,7 +245,6 @@ ${reviewOptionsMarkdown}
                 break;
 
             case ReviewCadenceType.MANUAL:
-                statusEmoji = '✋';
                 statusText = translation.manualTitle || 'Manual Review';
                 description =
                     translation.manualDesc ||
@@ -259,7 +255,7 @@ ${reviewOptionsMarkdown}
                 return '';
         }
 
-        return `**${statusEmoji} ${statusText}**: ${description}`;
+        return `**${statusText}**: ${description}`;
     };
 
     private getTranslation(language?: string) {

--- a/src/shared/utils/translations/dictionaries/pt-BR.json
+++ b/src/shared/utils/translations/dictionaries/pt-BR.json
@@ -10,7 +10,7 @@
     "pullRequestSummaryMarkdown": {
         "title": "Resumo da PR (Comentário criado por [Kody](https://kodus.io) 🤖)",
         "codeReviewStarted": "Revisão de Código Iniciada! 🚀",
-        "description": "✋ Olá, equipe! Já estou analisando os arquivos alterados e iniciando a revisão para garantir que tudo esteja em ordem. Se precisarem de mais detalhes, estou aqui! [Kody](https://kodus.io)",
+        "description": "✋ Olá, time! Já estou analisando os arquivos alterados e iniciando a revisão para garantir que tudo esteja em ordem. Se precisarem de mais detalhes, estou aqui! [Kody](https://kodus.io)",
         "changedFiles": "📂 Arquivos Alterados",
         "filesTable": [
             "Arquivo",


### PR DESCRIPTION
- Implemented a new method in CommentManagerService to process end review message templates, enhancing the ability to generate customized comments based on the context of code changes and review configurations.
- Updated the finish-comments stage to utilize the new method for generating final comment bodies, improving the overall comment generation process in the code review pipeline.

---

<!-- kody-pr-summary:start -->
This pull request introduces a new capability to dynamically process and generate end-of-review messages using templates.

Key changes include:

*   **Dynamic End Review Message Processing**: A new method, `processEndReviewMessageTemplate`, has been added to the `CommentManagerService`. This method allows for the processing of a template string, incorporating pull request context such as changed files, organization data, and configuration, to generate a customized final review message.
*   **Integration into Review Pipeline**: The code review pipeline's `UpdateCommentsAndGenerateSummaryStage` now utilizes this new template processing method to construct the final overall comment for a pull request, replacing the previous static content assignment.
*   **Removal of Emojis from Review Cadence Status**: Emojis previously displayed alongside the review cadence status (e.g., Automatic Review, Auto-Pause Mode) have been removed from generated messages.
*   **Translation Correction**: A minor text correction was made in the Portuguese (Brazil) translation file for the pull request summary description.
<!-- kody-pr-summary:end -->