### PR TITLE
fixed method create initial comment message or

### DIFF
--- a/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/initial-comment.stage.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/initial-comment.stage.ts
@@ -79,17 +79,17 @@ export class InitialCommentStage extends BasePipelineStage<CodeReviewPipelineCon
             pullRequestMessagesConfig?.startReviewMessage;
 
         if (
-            !startReviewMessage ||
-            startReviewMessage.status === PullRequestMessageStatus.OFF ||
-            startReviewMessage.status === PullRequestMessageStatus.INACTIVE
+            startReviewMessage?.status === PullRequestMessageStatus.OFF ||
+            startReviewMessage?.status === PullRequestMessageStatus.INACTIVE
         ) {
             this.logger.log({
-                message: `Skipping initial comment for PR#${context.pullRequest.number} because start review message is off`,
+                message: `Skipping initial comment for PR#${context.pullRequest.number} because start review message is off or inactive`,
                 context: this.stageName,
                 metadata: {
                     organizationAndTeamData: context.organizationAndTeamData,
                     prNumber: context.pullRequest.number,
                     repository: context.repository.name,
+                    status: startReviewMessage.status,
                 },
             });
 
@@ -99,7 +99,8 @@ export class InitialCommentStage extends BasePipelineStage<CodeReviewPipelineCon
         }
 
         if (
-            startReviewMessage.status === PullRequestMessageStatus.ONLY_WHEN_OPENED &&
+            startReviewMessage?.status ===
+                PullRequestMessageStatus.ONLY_WHEN_OPENED &&
             context.lastExecution
         ) {
             this.logger.log({

--- a/src/core/infrastructure/http/controllers/platformIntegration/codeManagement.controller.ts
+++ b/src/core/infrastructure/http/controllers/platformIntegration/codeManagement.controller.ts
@@ -27,7 +27,6 @@ import { FinishOnboardingUseCase } from '@/core/application/use-cases/platformIn
 import { DeleteIntegrationUseCase } from '@/core/application/use-cases/platformIntegration/codeManagement/delete-integration.use-case';
 import { DeleteIntegrationAndRepositoriesUseCase } from '@/core/application/use-cases/platformIntegration/codeManagement/delete-integration-and-repositories.use-case';
 import { GetRepositoryTreeUseCase } from '@/core/application/use-cases/platformIntegration/codeManagement/get-repository-tree.use-case';
-import { GetRepositoryTreeDto } from '../../dtos/get-repository-tree.dto';
 import { GetWebhookStatusUseCase } from '@/core/application/use-cases/platformIntegration/codeManagement/get-webhook-status.use-case';
 import { WebhookStatusQueryDto } from '../../dtos/webhook-status-query.dto';
 import {
@@ -64,7 +63,6 @@ export class CodeManagementController {
         private readonly finishOnboardingUseCase: FinishOnboardingUseCase,
         private readonly deleteIntegrationUseCase: DeleteIntegrationUseCase,
         private readonly deleteIntegrationAndRepositoriesUseCase: DeleteIntegrationAndRepositoriesUseCase,
-        private readonly getRepositoryTreeUseCase: GetRepositoryTreeUseCase,
         private readonly getRepositoryTreeByDirectoryUseCase: GetRepositoryTreeByDirectoryUseCase,
         private readonly getWebhookStatusUseCase: GetWebhookStatusUseCase,
     ) {}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces several changes across different parts of the application:

1.  **Refined Initial Comment Creation Logic**: The logic for determining whether to skip the creation of an initial comment in the code review pipeline has been updated. Previously, the initial comment stage would skip if the `startReviewMessage` configuration was entirely absent (`null` or `undefined`), or if its status was `OFF` or `INACTIVE`. With this change, the stage will now only skip if the `startReviewMessage` configuration exists and its status is explicitly set to `OFF` or `INACTIVE`. If the `startReviewMessage` configuration is absent, the system will no longer skip the stage, implying that an initial comment should be created by default in such cases. Logging has also been improved to reflect these updated conditions and include the specific status.

2.  **ETag Caching Mechanism Improvement**: The ETag caching implementation for Octokit requests has been refactored. The internal `__etag_cache_key` property, previously stored directly on the request `options` object, has been replaced with a `WeakMap` for better encapsulation and memory management. Additionally, the handling of 304 (Not Modified) responses has been made more robust to ensure cached payloads are correctly returned and response objects are properly constructed.

3.  **Removed Repository Tree Functionality from Controller**: The `GetRepositoryTreeUseCase` and its associated DTO have been removed from the `CodeManagementController`. This indicates that the functionality to retrieve a full repository tree (without specifying a directory) is no longer directly exposed or managed by this controller, potentially shifting its responsibility or removing it entirely from this specific API endpoint.
<!-- kody-pr-summary:end -->