### PR TITLE
Fixing azure urls in issues

### DIFF
--- a/src/core/application/use-cases/issues/get-issue-by-id.use-case.ts
+++ b/src/core/application/use-cases/issues/get-issue-by-id.use-case.ts
@@ -87,9 +87,11 @@ export class GetIssueByIdUseCase implements IUseCase {
                     configValue: [{ id: issue.repository.id }],
                 });
 
-            httpUrl = integrationConfig?.configValue
-                .filter((x) => x.id === issue.repository.id)
-                .map((y) => y.http_url)[0];
+            const repoConfig = integrationConfig?.configValue?.find(
+                (x) => x.id === issue.repository.id,
+            );
+            
+            httpUrl = repoConfig?.http_url ?? null;
         }
 
         const dataToBuildUrls = {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request fixes the generation of Azure DevOps URLs within issue details.

Previously, URLs for Azure Repos (files, pull requests, and the main repository link) were constructed using a hardcoded base URL. This change modifies the `GetIssueByIdUseCase` to:

*   Inject the `IIntegrationConfigService`.
*   For Azure Repositories, dynamically fetch the specific `http_url` from the `IntegrationConfigService` based on the repository's ID.
*   Utilize this fetched `http_url` as the base for constructing all Azure DevOps-related links, ensuring they accurately reflect the configured repository URL.
<!-- kody-pr-summary:end -->