### PR TITLE
Update self hosted installation guide link

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Get started in minutes with our fully-managed solution:
 
 Deploy Kodus on your own infrastructure with full control:
 
-- [Installation Guide using our CLI](https://docs.kodus.io/self-hosted/installation)
+- [Installation Guide using our CLI](https://docs.kodus.io/how_to_deploy/en/deploy_kodus/generic_vm)
 - [Installation Guide using our Docker file](https://docs.kodus.io/how_to_deploy/en/deploy_kodus/generic_vm)
 
 ## Open Source vs. Cloud vs. Enterprise


### PR DESCRIPTION
old  one is not working

---

<!-- kody-pr-summary:start -->
Updates the self-hosted installation guide link in the `README.md` file. The link for "Installation Guide using our CLI" has been changed from `https://docs.kodus.io/self-hosted/installation` to `https://docs.kodus.io/how_to_deploy/en/deploy_kodus/generic_vm` to point to the correct documentation.
<!-- kody-pr-summary:end -->