### PR TITLE
Updating pr description with the new files data

### DIFF
--- a/src/core/application/use-cases/parameters/preview-pr-summary.use-case.ts
+++ b/src/core/application/use-cases/parameters/preview-pr-summary.use-case.ts
@@ -82,7 +82,6 @@ export class PreviewPrSummaryUseCase {
             pullRequest,
             repository,
             files,
-            files,
             organizationAndTeamData,
             languageResultPrompt?.configValue ?? 'en-US',
             summaryConfig,

--- a/src/core/domain/codeBase/contracts/CommentManagerService.contract.ts
+++ b/src/core/domain/codeBase/contracts/CommentManagerService.contract.ts
@@ -45,7 +45,6 @@ export interface ICommentManagerService {
         pullRequest: any,
         repository: { name: string; id: string },
         changedFiles: Partial<FileChange>[],
-        allFilesFromPR: Partial<FileChange>[],
         organizationAndTeamData: OrganizationAndTeamData,
         languageResultPrompt: string,
         summaryConfig: SummaryConfig,

--- a/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/context/code-review-pipeline.context.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/context/code-review-pipeline.context.ts
@@ -56,7 +56,6 @@ export interface CodeReviewPipelineContext extends PipelineContext {
     automaticReviewStatus?: AutomaticReviewStatus;
 
     changedFiles?: FileChange[];
-    allFilesFromPR?: FileChange[];
     lastExecution?: {
         commentId?: any;
         noteId?: any;

--- a/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/fetch-changed-files.stage.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/fetch-changed-files.stage.ts
@@ -59,14 +59,6 @@ export class FetchChangedFilesStage extends BasePipelineStage<CodeReviewPipeline
             context?.lastExecution?.lastAnalyzedCommit,
         );
 
-        const allFilesFromPR = await this.pullRequestHandlerService.getChangedFiles(
-            context.organizationAndTeamData,
-            context.repository,
-            context.pullRequest,
-            context.codeReviewConfig.ignorePaths,
-            null,
-        );
-
         if (!files?.length || files.length > this.maxFilesToAnalyze) {
             const msg = !files?.length
                 ? AutomationMessage.NO_FILES_AFTER_IGNORE
@@ -102,12 +94,9 @@ export class FetchChangedFilesStage extends BasePipelineStage<CodeReviewPipeline
 
         const filesWithLineNumbers = this.prepareFilesWithLineNumbers(files);
 
-        const allFilesWithLineNumbers = this.prepareFilesWithLineNumbers(allFilesFromPR);
-
         const stats = this.getStatsForPR(filesWithLineNumbers);
 
         return this.updateContext(context, (draft) => {
-            draft.allFilesFromPR = allFilesWithLineNumbers;
             draft.changedFiles = filesWithLineNumbers;
             draft.pipelineMetadata = {
                 ...draft.pipelineMetadata,

--- a/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/finish-comments.stage.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/finish-comments.stage.ts
@@ -75,18 +75,11 @@ export class UpdateCommentsAndGenerateSummaryStage extends BasePipelineStage<Cod
                 status: file.status,
             }));
 
-            const allFilesFromPR = context.allFilesFromPR.map((file) => ({
-                filename: file.filename,
-                patch: file.patch,
-                status: file.status,
-            }));
-
             const summaryPR =
                 await this.commentManagerService.generateSummaryPR(
                     pullRequest,
                     repository,
                     changedFiles,
-                    allFilesFromPR,
                     organizationAndTeamData,
                     codeReviewConfig.languageResultPrompt,
                     codeReviewConfig.summary,

--- a/src/core/infrastructure/adapters/services/codeBase/commentManager.service.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/commentManager.service.ts
@@ -73,7 +73,6 @@ export class CommentManagerService implements ICommentManagerService {
         pullRequest: any,
         repository: { name: string; id: string },
         changedFiles: Partial<FileChange>[],
-        allFilesFromPR: Partial<FileChange>[],
         organizationAndTeamData: OrganizationAndTeamData,
         languageResultPrompt: string,
         summaryConfig: SummaryConfig,
@@ -193,17 +192,20 @@ export class CommentManagerService implements ICommentManagerService {
                     summaryConfig,
                     languageResultPrompt,
                     updatedPR,
-                    allFilesFromPR,
                 };
 
-                let changedFilesUpdated = baseContext?.changedFiles;
+                let userPrompt = '';
 
                 if (isCommitRun && summaryConfig?.behaviourForNewCommits === BehaviourForNewCommits.REPLACE) {
-                    changedFilesUpdated = baseContext?.allFilesFromPR;
+                    userPrompt =  `
+                    This is the updated pull request summary:
+                    <pullRequestSummaryContext>${updatedPR?.body || 'No pull request summary'}</pullRequestSummaryContext>
+                    Use this summary to concatenate the existing pull request summary with the new changed files context:`;
                 }
 
-                const fallbackProvider = LLMModelProvider.OPENAI_GPT_4O;
-                const userPrompt = `<changedFilesContext>${JSON.stringify(changedFilesUpdated, null, 2) || 'No files changed'}</changedFilesContext>`;
+                const fallbackProvider = LLMModelProvider.OPENAI_GPT_4O
+                ;
+                userPrompt += `<changedFilesContext>${JSON.stringify(baseContext?.changedFiles, null, 2) || 'No files changed'}</changedFilesContext>`;
 
                 const promptRunner = new BYOKPromptRunnerService(
                     this.promptRunnerService,


### PR DESCRIPTION
closes #379 

---

<!-- kody-pr-summary:start -->
This pull request simplifies and refines the pull request summarization process by removing the redundant concept of 'all files from PR'.

Key changes include:
*   Eliminating the `allFilesFromPR` property from the code review pipeline context and related service contracts.
*   Removing the fetching and processing of `allFilesFromPR` in the `FetchChangedFilesStage`.
*   Ensuring that the `CommentManagerService` and `PreviewPrSummaryUseCase` consistently use only the `changedFiles` context for generating and updating pull request summaries.
*   Adjusting the prompt generation for pull request summary updates (specifically for the 'REPLACE' behavior on new commits) to explicitly guide the LLM to concatenate the existing summary with the context of the new `changedFiles`.
<!-- kody-pr-summary:end -->