### PR TITLE
refresh token for custom mcps with oauth

### DIFF
--- a/src/core/infrastructure/adapters/mcp/services/mcp-manager.service.ts
+++ b/src/core/infrastructure/adapters/mcp/services/mcp-manager.service.ts
@@ -1,11 +1,11 @@
 import { AxiosMCPManagerService } from '@/config/axios/microservices/mcpManager.axios';
 import { OrganizationAndTeamData } from '@/config/types/general/organizationAndTeamData';
+import { PermissionValidationService } from '@/ee/shared/services/permissionValidation.service';
 import { MCPServerConfig } from '@kodus/flow';
+import { TransportType } from '@kodus/flow/dist/core/types/allTypes';
 import { Injectable } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { PinoLoggerService } from '../../services/logger/pino.service';
-import { PermissionValidationService } from '@/ee/shared/services/permissionValidation.service';
-import { TransportType } from '@kodus/flow/dist/core/types/allTypes';
 
 type MCPConnection = {
     id: string;
@@ -150,22 +150,11 @@ export class MCPManagerService {
 
     public async getConnections(
         organizationAndTeamData: OrganizationAndTeamData,
-        format?: true,
-    ): Promise<MCPServerConfig[]>;
-
-    public async getConnections(
-        organizationAndTeamData: OrganizationAndTeamData,
-        format?: false,
-    ): Promise<MCPItem[]>;
-
-    public async getConnections(
-        organizationAndTeamData: OrganizationAndTeamData,
-        format: boolean = true,
         filters?: {
             provider?: string;
             status?: string;
         },
-    ): Promise<MCPItem[] | MCPServerConfig[]> {
+    ): Promise<MCPServerConfig[]> {
         try {
             const limited =
                 await this.permissionValidationService.shouldLimitResources(
@@ -189,17 +178,13 @@ export class MCPManagerService {
 
             const limitedData = limited ? data.items.slice(0, 3) : data.items;
 
-            if (format) {
-                const formattedConnections: MCPServerConfig[] = [];
-                for (const connection of limitedData) {
-                    const formattedConnection =
-                        await this.formatConnection(connection);
-                    formattedConnections.push(formattedConnection);
-                }
-                return formattedConnections;
+            const formattedConnections: MCPServerConfig[] = [];
+            for (const connection of limitedData) {
+                const formattedConnection =
+                    await this.formatConnection(connection);
+                formattedConnections.push(formattedConnection);
             }
-
-            return limitedData;
+            return formattedConnections;
         } catch (error) {
             this.logger.error({
                 message: 'Error fetching MCP connections',
@@ -246,7 +231,7 @@ export class MCPManagerService {
         let headers: Record<string, string> = {};
         let type: string = 'http';
         if (connection.provider === 'custom') {
-            const integration: MCPIntegrationInterface =
+            let integration: MCPIntegrationInterface =
                 await this.axiosMCPManagerService.get(
                     `mcp/integration/custom/${connection.integrationId}`,
                     {
@@ -259,6 +244,17 @@ export class MCPManagerService {
             if (!integration) {
                 throw new Error(
                     `Integration not found: ${connection.integrationId}`,
+                );
+            }
+
+            if (integration.authType === MCPIntegrationAuthType.OAUTH2) {
+                integration = await this.axiosMCPManagerService.get(
+                    `mcp/integration/custom/oauth/${connection.integrationId}/refresh-token`,
+                    {
+                        headers: this.getAuthHeaders({
+                            organizationId: connection.organizationId,
+                        }),
+                    },
                 );
             }
 

--- a/src/core/infrastructure/adapters/mcp/services/mcp-tool-metadata.service.ts
+++ b/src/core/infrastructure/adapters/mcp/services/mcp-tool-metadata.service.ts
@@ -1,13 +1,13 @@
-import { Injectable } from '@nestjs/common';
-import { createMCPAdapter, type MCPServerConfig } from '@kodus/flow';
 import type { OrganizationAndTeamData } from '@/config/types/general/organizationAndTeamData';
-import { MCPManagerService } from './mcp-manager.service';
-import { PinoLoggerService } from '../../services/logger/pino.service';
 import {
     markProviderHasMetadata,
     normalizeProviderKey,
     normalizeToolKey,
 } from '@context-os-core/mcp/utils';
+import { createMCPAdapter, type MCPServerConfig } from '@kodus/flow';
+import { Injectable } from '@nestjs/common';
+import { PinoLoggerService } from '../../services/logger/pino.service';
+import { MCPManagerService } from './mcp-manager.service';
 
 export interface MCPToolMetadata {
     requiredArgs: string[];
@@ -33,10 +33,9 @@ export class MCPToolMetadataService {
             return this.buildEmptyResult();
         }
 
-        const rawConnections = (await this.mcpManagerService.getConnections(
+        const rawConnections = await this.mcpManagerService.getConnections(
             organizationAndTeamData,
-            true,
-        )) as MCPServerConfig[];
+        );
 
         if (!rawConnections?.length) {
             return this.buildEmptyResult();


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Based on the provided code changes, here is a description of the pull request:

**Functional Changes**
- **OAuth Token Refresh for Custom MCPs**: Implemented logic within the `MCPManagerService` to automatically trigger a token refresh for custom MCP integrations using OAuth2. When processing a custom provider connection, the system now calls a specific `refresh-token` endpoint to ensure the integration credentials are up to date before generating the configuration headers.

**Refactoring**
- **Streamlined Connection Retrieval**: Modified the `getConnections` method in `MCPManagerService` to remove the optional `format` parameter. The method now always returns formatted `MCPServerConfig` objects, eliminating the overload that returned raw `MCPItem` arrays.
- **Code Cleanup**: Updated `MCPToolMetadataService` to align with the simplified `getConnections` signature and reordered imports in affected files.
<!-- kody-pr-summary:end -->