### PR TITLE
fixed get info

### DIFF
--- a/src/core/infrastructure/adapters/services/context/file-context-augmentation.service.ts
+++ b/src/core/infrastructure/adapters/services/context/file-context-augmentation.service.ts
@@ -190,6 +190,13 @@ export class FileContextAugmentationService {
         }
 
         for (const evidence of result.sandboxEvidences) {
+            if (
+                (evidence.metadata as Record<string, unknown>)
+                    ?.executionStatus !== 'success'
+            ) {
+                continue;
+            }
+
             if (evidence.metadata?.hidden || evidence.metadata?.internal) {
                 continue;
             }
@@ -219,22 +226,25 @@ export class FileContextAugmentationService {
                 provider: evidence.provider ?? 'unknown',
                 toolName: resolvedToolName ?? 'unknown',
                 success: true,
-                output: this.serializeEvidence(evidence),
+                output: this.serializeEvidencePayload(evidence.payload),
             });
         }
 
         return map;
     }
 
-    private serializeEvidence(evidence: ContextEvidence): string {
-        if (typeof evidence.payload === 'string') {
-            return evidence.payload;
+    private serializeEvidencePayload(payload: unknown): string {
+        if (payload === null || payload === undefined) {
+            return 'No output returned.';
+        }
+        if (typeof payload === 'string') {
+            return payload;
         }
 
         try {
-            return JSON.stringify(evidence.payload ?? evidence, null, 2);
+            return JSON.stringify(payload, null, 2);
         } catch {
-            return String(evidence.payload ?? '[unserializable payload]');
+            return String(payload ?? '[unserializable payload]');
         }
     }
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Based on the code changes provided, here is a description of the pull request:

**Functional Changes:**

*   **Filter Unsuccessful Evidences:** The `FileContextAugmentationService` now filters out sandbox evidences where the `executionStatus` in metadata is not `'success'`, preventing failed executions from being included in the context.
*   **Refined Payload Serialization:** Refactored the evidence serialization logic (renaming `serializeEvidence` to `serializeEvidencePayload`) to specifically handle the payload data. It now explicitly handles `null` or `undefined` payloads by returning "No output returned." and ensures consistent stringification of the payload content.
<!-- kody-pr-summary:end -->