### PR TITLE
Removing patch from Kody Rules pr level validation

### DIFF
--- a/src/ee/codeBase/kodyRulesPrLevelAnalysis.service.ts
+++ b/src/ee/codeBase/kodyRulesPrLevelAnalysis.service.ts
@@ -1067,6 +1067,16 @@ export class KodyRulesPrLevelAnalysisService
         externalReferencesMap?: Map<string, any[]>,
         mcpResultsMap?: Map<string, Record<string, unknown>>,
     ): Promise<ExtendedKodyRule[] | null> {
+        const filesToAnalyze = filesChunk.map((file) => ({
+            filename: file?.filename,
+            sha: file?.sha,
+            patchWithLinesStr: file?.patchWithLinesStr,
+            additions: file?.additions,
+            changes: file?.changes,
+            deletions: file?.deletions,
+            status: file?.status,
+        }));
+
         // payload do chunk
         const analyzerPayload: KodyRulesPrLevelPayload = {
             pr_title: context.pullRequest.title,
@@ -1077,7 +1087,7 @@ export class KodyRulesPrLevelAnalysisService
                 total_files: 0,
                 total_lines_changed: 0,
             },
-            files: filesChunk,
+            files: filesToAnalyze,
             rules: kodyRulesPrLevel,
             language,
             externalReferencesMap,

--- a/src/shared/utils/langchainCommon/prompts/kodyRulesPrLevel.ts
+++ b/src/shared/utils/langchainCommon/prompts/kodyRulesPrLevel.ts
@@ -7,7 +7,7 @@ export type KodyRulesPrLevelPayload = {
     pr_title: string;
     pr_description: string;
     stats: AnalysisContext['pullRequest']['stats'];
-    files: FileChange[];
+    files: Partial<FileChange>[];
     rules?: any;
     rule?: any;
     language?: string;


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Based on the provided code changes, here is a description of the pull request:

**Functional Changes:**

*   **Optimized Analysis Payload:** Modified the `KodyRulesPrLevelAnalysisService` to filter the file objects sent to the analysis payload. Instead of sending the full file object, it now explicitly maps and sends only specific fields (`filename`, `sha`, `patchWithLinesStr`, `additions`, `changes`, `deletions`, and `status`).
*   **Removed Raw Patch:** By explicitly selecting fields, the raw `patch` property is excluded from the payload sent for Kody Rules PR-level analysis, relying instead on `patchWithLinesStr`.
*   **Type Definition Update:** Updated the `KodyRulesPrLevelPayload` type definition to accept `Partial<FileChange>[]` for the `files` property, aligning with the service changes.
<!-- kody-pr-summary:end -->