### PR TITLE
fix saml callback

### DIFF
--- a/src/core/infrastructure/adapters/services/auth/saml-auth.strategy.ts
+++ b/src/core/infrastructure/adapters/services/auth/saml-auth.strategy.ts
@@ -55,7 +55,7 @@ export class SamlStrategy extends PassportStrategy(MultiSamlStrategy, 'saml') {
     }
 
     async validate(req: Request, profile: any) {
-        const email: string = profile.email || profile.nameId;
+        const email: string = profile.email || profile.nameId || profile.nameID;
 
         if (!email || !/[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,3}/.test(email)) {
             throw new UnauthorizedException('Invalid email in SAML assertion');


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the SAML authentication strategy to include `profile.nameID` as a fallback when extracting the user's email address. This change ensures the application can correctly identify users from SAML providers that return the identifier using the `nameID` property, in addition to the previously supported `email` and `nameId` properties.
<!-- kody-pr-summary:end -->