### PR TITLE
remove organization id from endpoints

### DIFF
--- a/src/core/application/use-cases/parameters/preview-pr-summary.use-case.ts
+++ b/src/core/application/use-cases/parameters/preview-pr-summary.use-case.ts
@@ -24,7 +24,7 @@ export class PreviewPrSummaryUseCase {
         private readonly codeManagementService: CodeManagementService,
     ) {}
 
-    async execute(body: PreviewPrSummaryDto) {
+    async execute(body: PreviewPrSummaryDto & { organizationId: string }) {
         const {
             prNumber,
             repository,

--- a/src/core/application/use-cases/platformIntegration/codeManagement/get-repository-tree-by-directory.use-case.ts
+++ b/src/core/application/use-cases/platformIntegration/codeManagement/get-repository-tree-by-directory.use-case.ts
@@ -1,14 +1,14 @@
+import { TreeItem } from '@/config/types/general/tree.type';
 import { PinoLoggerService } from '@/core/infrastructure/adapters/services/logger/pino.service';
 import { CodeManagementService } from '@/core/infrastructure/adapters/services/platformIntegration/codeManagement.service';
+import { GetRepositoryTreeByDirectoryDto } from '@/core/infrastructure/http/dtos/get-repository-tree-by-directory.dto';
+import {
+    GET_ADDITIONAL_INFO_HELPER_TOKEN,
+    IGetAdditionalInfoHelper,
+} from '@/shared/domain/contracts/getAdditionalInfo.helper.contract';
 import { IUseCase } from '@/shared/domain/interfaces/use-case.interface';
 import { CacheService } from '@/shared/utils/cache/cache.service';
-import {
-    IGetAdditionalInfoHelper,
-    GET_ADDITIONAL_INFO_HELPER_TOKEN,
-} from '@/shared/domain/contracts/getAdditionalInfo.helper.contract';
 import { Inject, Injectable } from '@nestjs/common';
-import { TreeItem } from '@/config/types/general/tree.type';
-import { GetRepositoryTreeByDirectoryDto } from '@/core/infrastructure/http/dtos/get-repository-tree-by-directory.dto';
 
 export interface DirectoryItem {
     name: string;
@@ -35,7 +35,7 @@ export class GetRepositoryTreeByDirectoryUseCase implements IUseCase {
     ) {}
 
     public async execute(
-        params: GetRepositoryTreeByDirectoryDto,
+        params: GetRepositoryTreeByDirectoryDto & { organizationId: string },
     ): Promise<RepositoryTreeByDirectoryResponse> {
         try {
             const cacheKey = this.buildCacheKey(

--- a/src/core/application/use-cases/user/update-another.use-case.ts
+++ b/src/core/application/use-cases/user/update-another.use-case.ts
@@ -1,18 +1,18 @@
 import {
-    ORGANIZATION_SERVICE_TOKEN,
     IOrganizationService,
+    ORGANIZATION_SERVICE_TOKEN,
 } from '@/core/domain/organization/contracts/organization.service.contract';
 import {
-    TEAM_SERVICE_TOKEN,
     ITeamService,
+    TEAM_SERVICE_TOKEN,
 } from '@/core/domain/team/contracts/team.service.contract';
 import {
-    TEAM_MEMBERS_SERVICE_TOKEN,
     ITeamMemberService,
+    TEAM_MEMBERS_SERVICE_TOKEN,
 } from '@/core/domain/teamMembers/contracts/teamMembers.service.contracts';
 import {
-    USER_SERVICE_TOKEN,
     IUsersService,
+    USER_SERVICE_TOKEN,
 } from '@/core/domain/user/contracts/user.service.contract';
 import { IUser } from '@/core/domain/user/interfaces/user.interface';
 import { PinoLoggerService } from '@/core/infrastructure/adapters/services/logger/pino.service';
@@ -42,6 +42,7 @@ export class UpdateAnotherUserUseCase implements IUseCase {
         userId: string,
         targetUserId: string,
         data: UpdateAnotherUserDto,
+        organizationId: string,
     ): Promise<IUser> {
         const { role, status } = data;
 
@@ -54,7 +55,7 @@ export class UpdateAnotherUserUseCase implements IUseCase {
             }
 
             const organization = await this.organizationService.findOne({
-                uuid: targetUser.organization?.uuid,
+                uuid: organizationId,
             });
             if (!organization) {
                 throw new Error('Organization not found');

--- a/src/core/infrastructure/http/controllers/agent.controller.ts
+++ b/src/core/infrastructure/http/controllers/agent.controller.ts
@@ -1,12 +1,17 @@
-import { Body, Controller, Post } from '@nestjs/common';
+import { UserRequest } from '@/config/types/http/user-request.type';
 import { ConversationAgentUseCase } from '@/core/application/use-cases/agent/conversation-agent.use-case';
-import { OrganizationAndTeamDataDto } from '../dtos/organizationAndTeamData.dto';
 import { createThreadId } from '@kodus/flow';
+import { Body, Controller, Inject, Post } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { OrganizationAndTeamDataDto } from '../dtos/organizationAndTeamData.dto';
 
 @Controller('agent')
 export class AgentController {
     constructor(
         private readonly conversationAgentUseCase: ConversationAgentUseCase,
+
+        @Inject(REQUEST)
+        private readonly request: UserRequest,
     ) {}
 
     @Post('/conversation')
@@ -17,15 +22,22 @@ export class AgentController {
             organizationAndTeamData: OrganizationAndTeamDataDto;
         },
     ) {
+        const organizationId = this.request?.user?.organization?.uuid;
+
+        if (!organizationId) {
+            throw new Error('Organization ID missing in user request');
+        }
+
         const thread = createThreadId(
             {
-                organizationId: body.organizationAndTeamData.organizationId,
+                organizationId,
                 teamId: body.organizationAndTeamData.teamId,
             },
             {
                 prefix: 'cmc', // Code Management Chat
             },
         );
+
         return this.conversationAgentUseCase.execute({ ...body, thread });
     }
 }

--- a/src/core/infrastructure/http/controllers/organizationParameters.controller.ts
+++ b/src/core/infrastructure/http/controllers/organizationParameters.controller.ts
@@ -58,7 +58,7 @@ export class OrgnizationParametersController {
     @CheckPolicies(
         checkPermissions({
             action: Action.Create,
-            resource: ResourceType.OrganizationSettings
+            resource: ResourceType.OrganizationSettings,
         }),
     )
     public async createOrUpdate(
@@ -66,13 +66,20 @@ export class OrgnizationParametersController {
         body: {
             key: OrganizationParametersKey;
             configValue: any;
-            organizationAndTeamData: { organizationId: string; teamId: string };
         },
     ) {
+        const organizationId = this.request?.user?.organization?.uuid;
+
+        if (!organizationId) {
+            throw new Error('Organization ID is missing from request');
+        }
+
         return await this.createOrUpdateOrganizationParametersUseCase.execute(
             body.key,
             body.configValue,
-            body.organizationAndTeamData,
+            {
+                organizationId,
+            },
         );
     }
 
@@ -81,13 +88,16 @@ export class OrgnizationParametersController {
     @CheckPolicies(
         checkPermissions({
             action: Action.Read,
-            resource: ResourceType.OrganizationSettings
+            resource: ResourceType.OrganizationSettings,
         }),
     )
-    public async findByKey(
-        @Query('key') key: OrganizationParametersKey,
-        @Query('organizationId') organizationId: string,
-    ) {
+    public async findByKey(@Query('key') key: OrganizationParametersKey) {
+        const organizationId = this.request?.user?.organization?.uuid;
+
+        if (!organizationId) {
+            throw new Error('Organization ID is missing from request');
+        }
+
         return await this.findByKeyOrganizationParametersUseCase.execute(key, {
             organizationId,
         });
@@ -116,9 +126,14 @@ export class OrgnizationParametersController {
 
     @Delete('/delete-byok-config')
     public async deleteByokConfig(
-        @Query('organizationId') organizationId: string,
         @Query('configType') configType: 'main' | 'fallback',
     ) {
+        const organizationId = this.request?.user?.organization?.uuid;
+
+        if (!organizationId) {
+            throw new Error('Organization ID is missing from request');
+        }
+
         return await this.deleteByokConfigUseCase.execute(
             organizationId,
             configType,
@@ -130,12 +145,16 @@ export class OrgnizationParametersController {
     @CheckPolicies(
         checkPermissions({
             action: Action.Read,
-            resource: ResourceType.OrganizationSettings
+            resource: ResourceType.OrganizationSettings,
         }),
     )
-    public async getCockpitMetricsVisibility(
-        @Query('organizationId') organizationId: string,
-    ): Promise<ICockpitMetricsVisibility> {
+    public async getCockpitMetricsVisibility(): Promise<ICockpitMetricsVisibility> {
+        const organizationId = this.request?.user?.organization?.uuid;
+
+        if (!organizationId) {
+            throw new Error('Organization ID is missing from request');
+        }
+
         return await this.getCockpitMetricsVisibilityUseCase.execute({
             organizationId,
         });
@@ -146,22 +165,27 @@ export class OrgnizationParametersController {
     @CheckPolicies(
         checkPermissions({
             action: Action.Update,
-            resource: ResourceType.OrganizationSettings
+            resource: ResourceType.OrganizationSettings,
         }),
     )
     public async updateCockpitMetricsVisibility(
         @Body()
         body: {
-            organizationId: string;
             teamId?: string;
             config: ICockpitMetricsVisibility;
         },
     ) {
+        const organizationId = this.request?.user?.organization?.uuid;
+
+        if (!organizationId) {
+            throw new Error('Organization ID is missing from request');
+        }
+
         return await this.createOrUpdateOrganizationParametersUseCase.execute(
             OrganizationParametersKey.COCKPIT_METRICS_VISIBILITY,
             body.config,
             {
-                organizationId: body.organizationId,
+                organizationId,
                 teamId: body.teamId,
             },
         );
@@ -172,7 +196,7 @@ export class OrgnizationParametersController {
     @CheckPolicies(
         checkPermissions({
             action: Action.Update,
-            resource: ResourceType.OrganizationSettings
+            resource: ResourceType.OrganizationSettings,
         }),
     )
     public async ignoreBots(

--- a/src/core/infrastructure/http/controllers/parameters.controller.ts
+++ b/src/core/infrastructure/http/controllers/parameters.controller.ts
@@ -73,13 +73,22 @@ export class ParametersController {
         body: {
             key: ParametersKey;
             configValue: any;
-            organizationAndTeamData: { organizationId: string; teamId: string };
+            organizationAndTeamData: { teamId: string };
         },
     ) {
+        const organizationId = this.request?.user?.organization?.uuid;
+
+        if (!organizationId) {
+            throw new Error('Organization ID is missing from request');
+        }
+
         return await this.createOrUpdateParametersUseCase.execute(
             body.key,
             body.configValue,
-            body.organizationAndTeamData,
+            {
+                organizationId,
+                teamId: body.organizationAndTeamData.teamId,
+            },
         );
     }
 
@@ -133,9 +142,19 @@ export class ParametersController {
         @Body()
         body: CreateOrUpdateCodeReviewParameterDto,
     ) {
-        return await this.updateOrCreateCodeReviewParameterUseCase.execute(
-            body,
-        );
+        const organizationId = this.request?.user?.organization?.uuid;
+
+        if (!organizationId) {
+            throw new Error('Organization ID is missing from request');
+        }
+
+        return await this.updateOrCreateCodeReviewParameterUseCase.execute({
+            ...body,
+            organizationAndTeamData: {
+                ...body.organizationAndTeamData,
+                organizationId,
+            },
+        });
     }
 
     @Post('/update-code-review-parameter-repositories')
@@ -149,12 +168,22 @@ export class ParametersController {
     public async UpdateCodeReviewParameterRepositories(
         @Body()
         body: {
-            organizationAndTeamData: { organizationId: string; teamId: string };
+            organizationAndTeamData: { teamId: string };
         },
     ) {
-        return await this.updateCodeReviewParameterRepositoriesUseCase.execute(
-            body,
-        );
+        const organizationId = this.request?.user?.organization?.uuid;
+
+        if (!organizationId) {
+            throw new Error('Organization ID is missing from request');
+        }
+
+        return await this.updateCodeReviewParameterRepositoriesUseCase.execute({
+            ...body,
+            organizationAndTeamData: {
+                ...body.organizationAndTeamData,
+                organizationId,
+            },
+        });
     }
 
     @Get('/code-review-parameter')
@@ -246,6 +275,15 @@ export class ParametersController {
         @Body()
         body: PreviewPrSummaryDto,
     ) {
-        return this.previewPrSummaryUseCase.execute(body);
+        const organizationId = this.request?.user?.organization?.uuid;
+
+        if (!organizationId) {
+            throw new Error('Organization ID is missing from request');
+        }
+
+        return this.previewPrSummaryUseCase.execute({
+            ...body,
+            organizationId,
+        });
     }
 }

--- a/src/core/infrastructure/http/controllers/pullRequestMessages.controller.ts
+++ b/src/core/infrastructure/http/controllers/pullRequestMessages.controller.ts
@@ -66,10 +66,15 @@ export class PullRequestMessagesController {
         }),
     )
     public async findByRepoOrDirectoryId(
-        @Query('organizationId') organizationId: string,
         @Query('repositoryId') repositoryId: string,
         @Query('directoryId') directoryId?: string,
     ) {
+        const organizationId = this.request?.user?.organization?.uuid;
+
+        if (!organizationId) {
+            throw new Error('Organization ID is missing from request');
+        }
+
         return await this.findByRepositoryOrDirectoryIdPullRequestMessagesUseCase.execute(
             organizationId,
             repositoryId,

--- a/src/core/infrastructure/http/controllers/ruleLike.controller.ts
+++ b/src/core/infrastructure/http/controllers/ruleLike.controller.ts
@@ -1,3 +1,4 @@
+import { UserRequest } from '@/config/types/http/user-request.type';
 import { RemoveRuleLikeUseCase } from '@/core/application/use-cases/rule-like/remove-rule-like.use-case';
 import { SetRuleLikeUseCase } from '@/core/application/use-cases/rule-like/set-rule-like.use-case';
 import { Body, Controller, Delete, Inject, Param, Post } from '@nestjs/common';
@@ -11,9 +12,7 @@ export class RuleLikeController {
         private readonly removeRuleLikeUseCase: RemoveRuleLikeUseCase,
 
         @Inject(REQUEST)
-        private readonly request: Request & {
-            user: { uuid: string; organization: { uuid: string } };
-        },
+        private readonly request: UserRequest,
     ) {}
 
     @Post(':ruleId/feedback')

--- a/src/core/infrastructure/http/controllers/tokenUsage.controller.ts
+++ b/src/core/infrastructure/http/controllers/tokenUsage.controller.ts
@@ -1,35 +1,35 @@
-import {
-    BadRequestException,
-    Inject,
-    UseInterceptors,
-    Scope,
-} from '@nestjs/common';
+import { UserRequest } from '@/config/types/http/user-request.type';
+import { CostEstimateUseCase } from '@/core/application/use-cases/usage/cost-estimate.use-case';
+import { TokenPricingUseCase } from '@/core/application/use-cases/usage/token-pricing.use-case';
+import { TokensByDeveloperUseCase } from '@/core/application/use-cases/usage/tokens-developer.use-case';
 import {
     ITokenUsageService,
     TOKEN_USAGE_SERVICE_TOKEN,
 } from '@/core/domain/tokenUsage/contracts/tokenUsage.service.contract';
 import {
+    CostEstimateContract,
+    DailyUsageByDeveloperResultContract,
+    DailyUsageByPrResultContract,
+    DailyUsageResultContract,
+    TokenUsageQueryContract,
+    UsageByDeveloperResultContract,
+    UsageByPrResultContract,
+    UsageSummaryContract,
+} from '@/core/domain/tokenUsage/types/tokenUsage.types';
+import {
     TokenPricingQueryDto,
     TokenUsageQueryDto,
 } from '@/core/infrastructure/http/dtos/token-usage.dto';
-import { Query, Controller, Get } from '@nestjs/common';
 import {
-    DailyUsageResultContract,
-    TokenUsageQueryContract,
-    UsageSummaryContract,
-    DailyUsageByPrResultContract,
-    UsageByPrResultContract,
-    DailyUsageByDeveloperResultContract,
-    UsageByDeveloperResultContract,
-    CostEstimateContract,
-} from '@/core/domain/tokenUsage/types/tokenUsage.types';
-import { TokensByDeveloperUseCase } from '@/core/application/use-cases/usage/tokens-developer.use-case';
-import { CacheInterceptor, CacheTTL } from '@nestjs/cache-manager';
-import { TokenPricingUseCase } from '@/core/application/use-cases/usage/token-pricing.use-case';
-import { CostEstimateUseCase } from '@/core/application/use-cases/usage/cost-estimate.use-case';
-import { PinoLoggerService } from '../../adapters/services/logger/pino.service';
+    BadRequestException,
+    Controller,
+    Get,
+    Inject,
+    Query,
+    Scope,
+} from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
-import { Request } from 'express';
+import { PinoLoggerService } from '../../adapters/services/logger/pino.service';
 
 @Controller({ path: 'usage', scope: Scope.REQUEST })
 export class TokenUsageController {
@@ -38,9 +38,7 @@ export class TokenUsageController {
         private readonly tokenUsageService: ITokenUsageService,
 
         @Inject(REQUEST)
-        private readonly request: Request & {
-            user: { organization: { uuid: string } };
-        },
+        private readonly request: UserRequest,
 
         private readonly tokensByDeveloperUseCase: TokensByDeveloperUseCase,
         private readonly tokenPricingUseCase: TokenPricingUseCase,
@@ -53,7 +51,15 @@ export class TokenUsageController {
         @Query() query: TokenUsageQueryDto,
     ): Promise<UsageSummaryContract> {
         try {
-            const mapped = this.mapDtoToContract(query);
+            const organizationId = this.request?.user?.organization?.uuid;
+
+            if (!organizationId) {
+                throw new BadRequestException(
+                    'organizationId not found in request',
+                );
+            }
+
+            const mapped = this.mapDtoToContract(query, organizationId);
             return this.tokenUsageService.getSummary(mapped);
         } catch (error) {
             this.logger.error({
@@ -71,7 +77,15 @@ export class TokenUsageController {
         @Query() query: TokenUsageQueryDto,
     ): Promise<DailyUsageResultContract[]> {
         try {
-            const mapped = this.mapDtoToContract(query);
+            const organizationId = this.request?.user?.organization?.uuid;
+
+            if (!organizationId) {
+                throw new BadRequestException(
+                    'organizationId not found in request',
+                );
+            }
+
+            const mapped = this.mapDtoToContract(query, organizationId);
             return this.tokenUsageService.getDailyUsage(mapped);
         } catch (error) {
             this.logger.error({
@@ -89,7 +103,15 @@ export class TokenUsageController {
         @Query() query: TokenUsageQueryDto,
     ): Promise<UsageByPrResultContract[]> {
         try {
-            const mapped = this.mapDtoToContract(query);
+            const organizationId = this.request?.user?.organization?.uuid;
+
+            if (!organizationId) {
+                throw new BadRequestException(
+                    'organizationId not found in request',
+                );
+            }
+
+            const mapped = this.mapDtoToContract(query, organizationId);
             return await this.tokenUsageService.getUsageByPr(mapped);
         } catch (error) {
             this.logger.error({
@@ -107,7 +129,15 @@ export class TokenUsageController {
         @Query() query: TokenUsageQueryDto,
     ): Promise<DailyUsageByPrResultContract[]> {
         try {
-            const mapped = this.mapDtoToContract(query);
+            const organizationId = this.request?.user?.organization?.uuid;
+
+            if (!organizationId) {
+                throw new BadRequestException(
+                    'organizationId not found in request',
+                );
+            }
+
+            const mapped = this.mapDtoToContract(query, organizationId);
             return await this.tokenUsageService.getDailyUsageByPr(mapped);
         } catch (error) {
             this.logger.error({
@@ -125,7 +155,15 @@ export class TokenUsageController {
         @Query() query: TokenUsageQueryDto,
     ): Promise<UsageByDeveloperResultContract[]> {
         try {
-            const mapped = this.mapDtoToContract(query);
+            const organizationId = this.request?.user?.organization?.uuid;
+
+            if (!organizationId) {
+                throw new BadRequestException(
+                    'organizationId not found in request',
+                );
+            }
+
+            const mapped = this.mapDtoToContract(query, organizationId);
             return await this.tokensByDeveloperUseCase.execute(mapped, false);
         } catch (error) {
             this.logger.error({
@@ -143,7 +181,15 @@ export class TokenUsageController {
         @Query() query: TokenUsageQueryDto,
     ): Promise<DailyUsageByDeveloperResultContract[]> {
         try {
-            const mapped = this.mapDtoToContract(query);
+            const organizationId = this.request?.user?.organization?.uuid;
+
+            if (!organizationId) {
+                throw new BadRequestException(
+                    'organizationId not found in request',
+                );
+            }
+
+            const mapped = this.mapDtoToContract(query, organizationId);
             return await this.tokensByDeveloperUseCase.execute(mapped, true);
         } catch (error) {
             this.logger.error({
@@ -158,6 +204,14 @@ export class TokenUsageController {
 
     @Get('tokens/pricing')
     async getPricing(@Query() query: TokenPricingQueryDto) {
+        const organizationId = this.request?.user?.organization?.uuid;
+
+        if (!organizationId) {
+            throw new BadRequestException(
+                'organizationId not found in request',
+            );
+        }
+
         return this.tokenPricingUseCase.execute(query.model, query.provider);
     }
 
@@ -198,6 +252,7 @@ export class TokenUsageController {
 
     private mapDtoToContract(
         query: TokenUsageQueryDto,
+        organizationId: string,
     ): TokenUsageQueryContract {
         const start = new Date(query.startDate);
         const end = new Date(query.endDate);
@@ -225,7 +280,7 @@ export class TokenUsageController {
         const byokBoolean = normalized === 'true';
 
         return {
-            organizationId: query.organizationId,
+            organizationId,
             prNumber: query.prNumber,
             start,
             end,

--- a/src/core/infrastructure/http/controllers/user.controller.ts
+++ b/src/core/infrastructure/http/controllers/user.controller.ts
@@ -11,6 +11,7 @@ import {
     UseGuards,
 } from '@nestjs/common';
 
+import { UserRequest } from '@/config/types/http/user-request.type';
 import { AcceptUserInvitationUseCase } from '@/core/application/use-cases/user/accept-user-invitation.use-case';
 import { CheckUserWithEmailUserUseCase } from '@/core/application/use-cases/user/check-user-email.use-case';
 import { JoinOrganizationUseCase } from '@/core/application/use-cases/user/join-organization.use-case';
@@ -40,9 +41,7 @@ export class UsersController {
         private readonly updateAnotherUserUseCase: UpdateAnotherUserUseCase,
 
         @Inject(REQUEST)
-        private readonly request: Request & {
-            user: { organization: { uuid: string }; uuid: string };
-        },
+        private readonly request: UserRequest,
     ) {}
 
     @Get('/email')
@@ -68,20 +67,24 @@ export class UsersController {
 
     @Post('/join-organization')
     @UseGuards(PolicyGuard)
-    @CheckPolicies(checkPermissions({
-        action: Action.Create,
-        resource: ResourceType.UserSettings
-    }))
+    @CheckPolicies(
+        checkPermissions({
+            action: Action.Create,
+            resource: ResourceType.UserSettings,
+        }),
+    )
     public async joinOrganization(@Body() body: JoinOrganizationDto) {
         return await this.joinOrganizationUseCase.execute(body);
     }
 
     @Patch('/:targetUserId')
     @UseGuards(PolicyGuard)
-    @CheckPolicies(checkPermissions({
-        action: Action.Update,
-        resource: ResourceType.UserSettings
-    }))
+    @CheckPolicies(
+        checkPermissions({
+            action: Action.Update,
+            resource: ResourceType.UserSettings,
+        }),
+    )
     public async updateAnother(
         @Body() body: UpdateAnotherUserDto,
         @Param('targetUserId') targetUserId: string,
@@ -91,15 +94,21 @@ export class UsersController {
         }
 
         const userId = this.request.user?.uuid;
+        const organizationId = this.request.user?.organization?.uuid;
 
         if (!userId) {
             throw new Error('User not found in request');
+        }
+
+        if (!organizationId) {
+            throw new Error('Organization not found in request');
         }
 
         return await this.updateAnotherUserUseCase.execute(
             userId,
             targetUserId,
             body,
+            organizationId,
         );
     }
 }

--- a/src/core/infrastructure/http/dtos/get-repository-tree-by-directory.dto.ts
+++ b/src/core/infrastructure/http/dtos/get-repository-tree-by-directory.dto.ts
@@ -1,10 +1,7 @@
-import { IsString, IsOptional, IsBoolean } from 'class-validator';
 import { Transform } from 'class-transformer';
+import { IsBoolean, IsOptional, IsString } from 'class-validator';
 
 export class GetRepositoryTreeByDirectoryDto {
-    @IsString()
-    organizationId: string;
-
     @IsString()
     teamId: string;
 

--- a/src/core/infrastructure/http/dtos/preview-pr-summary.dto.ts
+++ b/src/core/infrastructure/http/dtos/preview-pr-summary.dto.ts
@@ -1,5 +1,11 @@
-import { BehaviourForExistingDescription } from "@/config/types/general/codeReview.type";
-import { IsEnum, IsNotEmpty, IsObject, IsOptional, IsString } from "class-validator";
+import { BehaviourForExistingDescription } from '@/config/types/general/codeReview.type';
+import {
+    IsEnum,
+    IsNotEmpty,
+    IsObject,
+    IsOptional,
+    IsString,
+} from 'class-validator';
 
 export class PreviewPrSummaryDto {
     @IsNotEmpty()
@@ -12,10 +18,6 @@ export class PreviewPrSummaryDto {
         id: string;
         name: string;
     };
-
-    @IsNotEmpty()
-    @IsString()
-    organizationId: string;
 
     @IsNotEmpty()
     @IsString()

--- a/src/core/infrastructure/http/dtos/token-usage.dto.ts
+++ b/src/core/infrastructure/http/dtos/token-usage.dto.ts
@@ -1,17 +1,6 @@
-import { BadRequestException } from '@nestjs/common';
-import { Transform } from 'class-transformer';
-import {
-    IsBoolean,
-    IsISO8601,
-    IsNumber,
-    IsOptional,
-    IsString,
-} from 'class-validator';
+import { IsISO8601, IsNumber, IsOptional, IsString } from 'class-validator';
 
 export class TokenUsageQueryDto {
-    @IsString()
-    organizationId: string;
-
     @IsISO8601()
     startDate: string; // ISO date string
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request refactors multiple API endpoints to remove the explicit requirement for `organizationId` in request bodies or query parameters. Instead, the `organizationId` is now securely derived directly from the authenticated user's request context.

**Key Changes:**

*   **API Contract Updates**:
    *   Removed `organizationId` from the following DTOs and query parameters:
        *   `GetRepositoryTreeByDirectoryDto`
        *   `PreviewPrSummaryDto`
        *   `TokenUsageQueryDto`
        *   Various query parameters in `OrganizationParametersController`, `CodeManagementController`, and `PullRequestMessagesController`.
*   **Controller Logic**:
    *   Updated `AgentController`, `OrgnizationParametersController`, `ParametersController`, `CodeManagementController`, `PullRequestMessagesController`, `TokenUsageController`, and `UsersController`.
    *   These controllers now extract `organizationId` from `request.user.organization.uuid` and inject it into the respective use cases.
    *   Added validation to ensure `organizationId` exists in the user request context before proceeding.
*   **Use Case Updates**:
    *   Modified `PreviewPrSummaryUseCase`, `GetRepositoryTreeByDirectoryUseCase`, and `UpdateAnotherUserUseCase` to accept `organizationId` as a separate argument or part of an intersection type, rather than relying on it being present in the initial DTO.
<!-- kody-pr-summary:end -->