### PR TITLE
Removing path

### DIFF
--- a/src/shared/utils/codeBase/ignorePaths/generated/paths.json
+++ b/src/shared/utils/codeBase/ignorePaths/generated/paths.json
@@ -997,7 +997,6 @@
         "**/rust-project.json",
         "**/pom.xml",
         "**/pom.xml.asc",
-        "**/classes/**",
         "**/checkouts/**",
         "**/.lein-deps-sum",
         "**/.lein-repl-history",


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request modifies the configuration for ignored paths in the codebase analysis tools. Specifically, it removes the `**/classes/**` pattern from `src/shared/utils/codeBase/ignorePaths/generated/paths.json`, ensuring that directories named `classes` are no longer excluded from processing.
<!-- kody-pr-summary:end -->