### PR TITLE
Update docker-compose.prod.yml #315	

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -28,4 +28,4 @@ volumes:
 
 networks:
     shared-network:
-        external: true
+        external: false


### PR DESCRIPTION
Removed  unnecessary exposed ports for external network.

---

<!-- kody-pr-summary:start -->
This pull request updates the `docker-compose.prod.yml` file to modify the network configuration. Specifically, it changes the `shared-network` setting `external` from `true` to `false`, ensuring that the network is created and managed by this Docker Compose stack rather than requiring a pre-existing external network.
<!-- kody-pr-summary:end -->