### PR TITLE
Update docker-compose.dev.small.yml #315	

### DIFF
--- a/docker-compose.dev.small.yml
+++ b/docker-compose.dev.small.yml
@@ -31,7 +31,6 @@ services:
     db_postgres:
         image: pgvector/pgvector:pg16
         container_name: db_postgres
-        ports: ['5432:5432']
         environment:
             POSTGRES_USER: ${API_PG_DB_USERNAME}
             POSTGRES_PASSWORD: ${API_PG_DB_PASSWORD}
@@ -55,7 +54,6 @@ services:
     db_mongodb:
         image: mongo:8
         container_name: mongodb
-        ports: ['27017:27017']
         environment:
             MONGO_INITDB_ROOT_USERNAME: ${API_MG_DB_USERNAME}
             MONGO_INITDB_ROOT_PASSWORD: ${API_MG_DB_PASSWORD}
@@ -83,7 +81,7 @@ volumes:
 networks:
     kodus-backend-services:
         driver: bridge
-        name: kodus-backend-services
-        external: true
+        name: kodus-backend-services-dev-small
+        external: false
     shared-network:
-        external: true
+        external: false


### PR DESCRIPTION
Removed  unnecessary exposed ports for db and network. 

---

<!-- kody-pr-summary:start -->
This pull request updates the `docker-compose.dev.small.yml` configuration to modify network isolation and management.

**Key Changes:**
*   **Service Isolation**: Removed port mappings for `db_postgres` (5432) and `db_mongodb` (27017), ensuring these services are not exposed to the host machine and are only accessible within the Docker network.
*   **Network Configuration**:
    *   Renamed the `kodus-backend-services` network to `kodus-backend-services-dev-small`.
    *   Changed both `kodus-backend-services` and `shared-network` from `external: true` to `external: false`, meaning these networks will now be managed directly by this Compose file rather than requiring pre-existing external networks.
<!-- kody-pr-summary:end -->