### PR TITLE
Update docker-compose.dev.yml #315	

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -35,8 +35,6 @@ services:
             context: ./docker/postgres
         image: pgvector/pgvector:pg16
         container_name: db_postgres
-        ports:
-            - '5432:5432'
         environment:
             POSTGRES_USER: ${API_PG_DB_USERNAME}
             POSTGRES_PASSWORD: ${API_PG_DB_PASSWORD}
@@ -63,8 +61,6 @@ services:
             - local-db
         image: mongo:8
         container_name: mongodb
-        ports:
-            - '27017:27017'
         volumes:
             - mongodbdata:/data/db
         environment:
@@ -92,7 +88,7 @@ volumes:
 networks:
     kodus-backend-services:
         driver: bridge
-        name: kodus-backend-services
-        external: true
+        name: kodus-backend-services-dev
+        external: false
     shared-network:
-        external: true
+        external: false


### PR DESCRIPTION
Removed unnecessary exposed ports for db and network.



---

<!-- kody-pr-summary:start -->
This pull request updates the `docker-compose.dev.yml` configuration with the following changes:

*   **Database Security**: Removes the host port bindings (`5432` for Postgres and `27017` for MongoDB), restricting database access to within the Docker network.
*   **Network Configuration**:
    *   Renames the backend network to `kodus-backend-services-dev`.
    *   Changes both `kodus-backend-services` and `shared-network` from `external: true` to `external: false`, ensuring these networks are created and managed by Docker Compose rather than requiring pre-existing external networks.
<!-- kody-pr-summary:end -->