### PR TITLE
Update docker-compose.test.yml #315	

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -2,8 +2,6 @@ services:
     db_postgres:
         image: postgres:latest
         container_name: postgres
-        ports:
-            - '5432:5432'
         environment:
             POSTGRES_USER: ${API_PG_DB_USERNAME}
             POSTGRES_PASSWORD: ${API_PG_DB_PASSWORD}
@@ -14,8 +12,6 @@ services:
     db_mongodb:
         image: mongo:6
         container_name: mongodb
-        ports:
-            - '27017:27017'
         environment:
             MONGO_INITDB_ROOT_USERNAME: ${API_MG_DB_USERNAME}
             MONGO_INITDB_ROOT_PASSWORD: ${API_MG_DB_PASSWORD}
@@ -25,5 +21,5 @@ services:
 
 networks:
   kodus-backend-services-test:
-    external: true
+    external: false
 


### PR DESCRIPTION
Removed unnecessary exposed ports for db and network.



---

<!-- kody-pr-summary:start -->
This pull request updates the `docker-compose.test.yml` configuration to improve the isolation of the test environment. Specifically, it:

*   **Removes host port bindings**: The `ports` sections for both `db_postgres` (5432) and `db_mongodb` (27017) have been removed. This prevents the test databases from conflicting with services running on the host machine.
*   **Updates network configuration**: The `kodus-backend-services-test` network is changed from `external: true` to `external: false`, ensuring that Docker Compose creates and manages the network specifically for this stack rather than expecting a pre-existing external network.
<!-- kody-pr-summary:end -->