### PR TITLE
Update docker-compose.qa.yml  #315

### DIFF
--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -25,4 +25,4 @@ volumes:
 
 networks:
     shared-network:
-        external: true
+        external: false


### PR DESCRIPTION
Removed unnecessary exposed ports for network.



---

<!-- kody-pr-summary:start -->
This pull request updates the `docker-compose.qa.yml` file to modify the network configuration. Specifically, it changes the `shared-network` setting from `external: true` to `external: false`. This ensures that Docker Compose creates and manages the network within the stack, rather than expecting a pre-existing external network to be present.
<!-- kody-pr-summary:end -->