### PR TITLE
Fixing end message review

### DIFF
--- a/src/core/domain/codeBase/contracts/CommentManagerService.contract.ts
+++ b/src/core/domain/codeBase/contracts/CommentManagerService.contract.ts
@@ -143,5 +143,6 @@ export interface ICommentManagerService {
         endReviewMessage?: string,
         pullRequestMessagesConfig?: IPullRequestMessages,
         dryRun?: CodeReviewPipelineContext['dryRun'],
+        prLevelCommentResults?: Array<CommentResult>,
     ): Promise<void>;
 }

--- a/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/finish-comments.stage.ts
+++ b/src/core/infrastructure/adapters/services/codeBase/codeReviewPipeline/stages/finish-comments.stage.ts
@@ -197,6 +197,7 @@ export class UpdateCommentsAndGenerateSummaryStage extends BasePipelineStage<Cod
                 finalCommentBody,
                 context.pullRequestMessagesConfig,
                 context.dryRun,
+                context.prLevelCommentResults ?? [],
             );
         }
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Based on the provided code changes, here is a description of the pull request:

**Functional Changes:**
- **Improved Review Summary Accuracy**: The logic for generating the final pull request review message has been updated to accurately reflect whether comments were posted. It now considers both file-level comments and PR-level comments (previously, it appears PR-level comments might have been ignored in this check).
- **Delivery Status Verification**: The system now explicitly checks that comments have a `DeliveryStatus.SENT` status before counting them towards the summary. This ensures that failed comments do not trigger the "with comments" message.

**Technical Improvements:**
- **Refactoring**: Replaced hardcoded strings (`'sent'`, `'failed'`) with the `DeliveryStatus` enum throughout the `CommentManagerService` for better type safety and consistency.
- **Pipeline Data Flow**: Updated the `UpdateCommentsAndGenerateSummaryStage` and `CommentManagerService` contracts to pass `prLevelCommentResults` through to the summary generation logic.
<!-- kody-pr-summary:end -->