### PR TITLE
fix ci/cd

### DIFF
--- a/.github/workflows/prod-build-push-and-pr-green.yml
+++ b/.github/workflows/prod-build-push-and-pr-green.yml
@@ -113,44 +113,50 @@ jobs:
       - name: Mask ECR registry
         run: echo "::add-mask::${{ steps.login-ecr.outputs.registry }}"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.10.0
+
       - name: Build, tag, and push (api)
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
-          docker build \
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
             --build-arg RELEASE_VERSION=${{ env.IMAGE_TAG }} \
             -f docker/Dockerfile \
             --target api \
             -t $ECR_REGISTRY/${{ env.ECR_REPOSITORY_API }}:${{ env.IMAGE_TAG }} \
+            --push \
             .
-
-          docker push $ECR_REGISTRY/${{ env.ECR_REPOSITORY_API }}:${{ env.IMAGE_TAG }}
 
       - name: Build, tag, and push (webhooks)
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
-          docker build \
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
             --build-arg RELEASE_VERSION=${{ env.IMAGE_TAG }} \
             -f docker/Dockerfile \
             --target webhooks \
             -t $ECR_REGISTRY/${{ env.ECR_REPOSITORY_WEBHOOKS }}:${{ env.IMAGE_TAG }} \
+            --push \
             .
-
-          docker push $ECR_REGISTRY/${{ env.ECR_REPOSITORY_WEBHOOKS }}:${{ env.IMAGE_TAG }}
 
       - name: Build, tag, and push (worker)
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
-          docker build \
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
             --build-arg RELEASE_VERSION=${{ env.IMAGE_TAG }} \
             -f docker/Dockerfile \
             --target worker \
             -t $ECR_REGISTRY/${{ env.ECR_REPOSITORY_WORKER }}:${{ env.IMAGE_TAG }} \
+            --push \
             .
-
-          docker push $ECR_REGISTRY/${{ env.ECR_REPOSITORY_WORKER }}:${{ env.IMAGE_TAG }}
 
       - name: Checkout infra repo
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/qa-build-push-and-pr-green.yml
+++ b/.github/workflows/qa-build-push-and-pr-green.yml
@@ -105,50 +105,53 @@ jobs:
       - name: Mask ECR registry
         run: echo "::add-mask::${{ steps.login-ecr.outputs.registry }}"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.2.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3.10.0
+
       - name: Build, tag, and push (api)
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
-          docker build \
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
             --build-arg RELEASE_VERSION=${{ env.IMAGE_TAG }} \
             -f docker/Dockerfile \
             --target api \
             -t $ECR_REGISTRY/${{ env.ECR_REPOSITORY_API }}:${{ env.IMAGE_TAG }} \
             -t $ECR_REGISTRY/${{ env.ECR_REPOSITORY_API }}:qa-latest \
+            --push \
             .
-
-          docker push $ECR_REGISTRY/${{ env.ECR_REPOSITORY_API }}:${{ env.IMAGE_TAG }}
-          docker push $ECR_REGISTRY/${{ env.ECR_REPOSITORY_API }}:qa-latest
 
       - name: Build, tag, and push (webhooks)
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
-          docker build \
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
             --build-arg RELEASE_VERSION=${{ env.IMAGE_TAG }} \
             -f docker/Dockerfile \
             --target webhooks \
             -t $ECR_REGISTRY/${{ env.ECR_REPOSITORY_WEBHOOKS }}:${{ env.IMAGE_TAG }} \
             -t $ECR_REGISTRY/${{ env.ECR_REPOSITORY_WEBHOOKS }}:qa-latest \
+            --push \
             .
-
-          docker push $ECR_REGISTRY/${{ env.ECR_REPOSITORY_WEBHOOKS }}:${{ env.IMAGE_TAG }}
-          docker push $ECR_REGISTRY/${{ env.ECR_REPOSITORY_WEBHOOKS }}:qa-latest
 
       - name: Build, tag, and push (worker)
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
-          docker build \
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
             --build-arg RELEASE_VERSION=${{ env.IMAGE_TAG }} \
             -f docker/Dockerfile \
             --target worker \
             -t $ECR_REGISTRY/${{ env.ECR_REPOSITORY_WORKER }}:${{ env.IMAGE_TAG }} \
             -t $ECR_REGISTRY/${{ env.ECR_REPOSITORY_WORKER }}:qa-latest \
+            --push \
             .
-
-          docker push $ECR_REGISTRY/${{ env.ECR_REPOSITORY_WORKER }}:${{ env.IMAGE_TAG }}
-          docker push $ECR_REGISTRY/${{ env.ECR_REPOSITORY_WORKER }}:qa-latest
 
       - name: Checkout infra repo
         uses: actions/checkout@v4.2.2

--- a/README_DEPLOY.md
+++ b/README_DEPLOY.md
@@ -33,6 +33,8 @@ export ECR_REPOSITORY_WORKER="kodus-orchestrator-worker-qa"
 
 ## CI/CD (GitHub Actions) — QA (GitOps)
 
+As imagens publicadas no ECR são multi-arch (linux/amd64 + linux/arm64).
+
 ### Workflows (repo do código)
 
 - Deploy green (build/push + PR no repo infra): `.github/workflows/qa-build-push-and-pr-green.yml`
@@ -83,6 +85,8 @@ Implementado em `apps/worker/src/worker-drain.service.ts:1`.
 - Webhooks usa `WEBHOOKS_PORT` (obrigatório).
 
 ## CI/CD (GitHub Actions) — PROD (GitOps)
+
+As imagens publicadas no ECR são multi-arch (linux/amd64 + linux/arm64).
 
 PROD roda **somente por release** (tag `x.y.z`, ex.: `1.0.92`) e usa o environment `production` com aprovação.
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the CI/CD pipelines to enable multi-architecture Docker image builds for both QA and Production environments.

**Key Changes:**

*   **Multi-Architecture Support**: Updated the GitHub Actions workflows (`prod-build-push-and-pr-green.yml` and `qa-build-push-and-pr-green.yml`) to build images for both `linux/amd64` and `linux/arm64` platforms.
*   **Docker Buildx**: Switched the build process from standard `docker build` to `docker buildx`, including steps to set up QEMU and Docker Buildx.
*   **Documentation**: Updated `README_DEPLOY.md` to reflect that images published to ECR are now multi-architecture.
<!-- kody-pr-summary:end -->