### PR TITLE
more fixes

### DIFF
--- a/libs/identity/infrastructure/adapters/services/auth/jwt-auth.guard.ts
+++ b/libs/identity/infrastructure/adapters/services/auth/jwt-auth.guard.ts
@@ -29,7 +29,9 @@ export class JwtAuthGuard extends AuthGuard('jwt') {
         // We can use this to allow public routes;
         const excludePaths = [
             '/health',
+            '/health/ready',
             '/health/simple',
+            '/health/live',
             '/auth/refresh',
             '/auth/login',
             '/auth/signup',


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the `JwtAuthGuard` configuration to exclude the `/health/ready` and `/health/live` endpoints from authentication requirements, allowing them to be accessed publicly.
<!-- kody-pr-summary:end -->