### PR TITLE
adjusted build docker

### DIFF
--- a/.github/workflows/prod-build-push-and-pr-green.yml
+++ b/.github/workflows/prod-build-push-and-pr-green.yml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   build_push_and_open_pr:
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-latest
     environment: production
     permissions:
       contents: read
@@ -120,6 +120,11 @@ jobs:
       - name: Mask ECR registry
         run: echo "::add-mask::${{ steps.login-ecr.outputs.registry }}"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.2.0
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.10.0
 
@@ -135,9 +140,9 @@ jobs:
 
           docker buildx bake -f docker-bake.hcl \
             --set base.args.RELEASE_VERSION=${{ env.IMAGE_TAG }} \
-            --set base.platforms=${{ env.BUILDX_PLATFORMS }} \
             --set base.cache-from=type=gha,scope=${{ env.BUILDX_CACHE_SCOPE }} \
             --set base.cache-to=type=gha,scope=${{ env.BUILDX_CACHE_SCOPE }},mode=max \
+            --set *.platform=${{ env.BUILDX_PLATFORMS }} \
             --set api.tags="$API_TAGS" \
             --set webhooks.tags="$WEBHOOKS_TAGS" \
             --set worker.tags="$WORKER_TAGS" \

--- a/.github/workflows/qa-build-push-and-pr-green.yml
+++ b/.github/workflows/qa-build-push-and-pr-green.yml
@@ -34,7 +34,7 @@ env:
 
 jobs:
   build_push_and_open_pr:
-    runs-on: ubuntu-22.04-arm
+    runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
     environment: qa
     permissions:
@@ -107,6 +107,11 @@ jobs:
       - name: Mask ECR registry
         run: echo "::add-mask::${{ steps.login-ecr.outputs.registry }}"
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3.2.0
+        with:
+          platforms: arm64
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3.10.0
 
@@ -122,9 +127,9 @@ jobs:
 
           docker buildx bake -f docker-bake.hcl \
             --set base.args.RELEASE_VERSION=${{ env.IMAGE_TAG }} \
-            --set base.platforms=${{ env.BUILDX_PLATFORMS }} \
             --set base.cache-from=type=gha,scope=${{ env.BUILDX_CACHE_SCOPE }} \
             --set base.cache-to=type=gha,scope=${{ env.BUILDX_CACHE_SCOPE }},mode=max \
+            --set *.platform=${{ env.BUILDX_PLATFORMS }} \
             --set api.tags="$API_TAGS" \
             --set webhooks.tags="$WEBHOOKS_TAGS" \
             --set worker.tags="$WORKER_TAGS" \

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -10,14 +10,9 @@ variable "CACHE_SCOPE" {
   default = "kodus-ai-arm64"
 }
 
-variable "PLATFORM" {
-  default = "linux/arm64"
-}
-
 target "base" {
   context = "."
   dockerfile = "${DOCKERFILE}"
-  platforms = ["${PLATFORM}"]
   args = {
     RELEASE_VERSION = "${RELEASE_VERSION}"
   }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request adjusts the Docker build configuration and CI/CD workflows for both QA and Production environments. The changes primarily focus on switching the runner environment and updating how build platforms are handled.

**Key Changes:**

*   **Workflow Runners**: Switched the GitHub Actions runner from `ubuntu-22.04-arm` to `ubuntu-latest` in both `prod-build-push-and-pr-green.yml` and `qa-build-push-and-pr-green.yml`.
*   **QEMU Integration**: Added the `docker/setup-qemu-action` step to enable `arm64` emulation, allowing the standard `ubuntu-latest` runners to build ARM64 images.
*   **Docker Bake Configuration**:
    *   Removed the hardcoded `PLATFORM` variable and platform assignment from `docker-bake.hcl`.
    *   Updated the `docker buildx bake` command in the workflows to apply the platform configuration to all targets (`--set *.platform=...`) instead of just the base target.
<!-- kody-pr-summary:end -->