### PR TITLE
adjusted build docker

### DIFF
--- a/.github/workflows/prod-build-push-and-pr-green.yml
+++ b/.github/workflows/prod-build-push-and-pr-green.yml
@@ -134,22 +134,18 @@ jobs:
         run: |
           set -euo pipefail
 
-          API_TAG_1="$ECR_REGISTRY/${{ env.ECR_REPOSITORY_API }}:${{ env.IMAGE_TAG }}"
-          WEBHOOKS_TAG_1="$ECR_REGISTRY/${{ env.ECR_REPOSITORY_WEBHOOKS }}:${{ env.IMAGE_TAG }}"
-          WORKER_TAG_1="$ECR_REGISTRY/${{ env.ECR_REPOSITORY_WORKER }}:${{ env.IMAGE_TAG }}"
-
-          API_TAGS=$(printf '[\"%s\"]' "$API_TAG_1")
-          WEBHOOKS_TAGS=$(printf '[\"%s\"]' "$WEBHOOKS_TAG_1")
-          WORKER_TAGS=$(printf '[\"%s\"]' "$WORKER_TAG_1")
+          API_TAG="$ECR_REGISTRY/${{ env.ECR_REPOSITORY_API }}:${{ env.IMAGE_TAG }}"
+          WEBHOOKS_TAG="$ECR_REGISTRY/${{ env.ECR_REPOSITORY_WEBHOOKS }}:${{ env.IMAGE_TAG }}"
+          WORKER_TAG="$ECR_REGISTRY/${{ env.ECR_REPOSITORY_WORKER }}:${{ env.IMAGE_TAG }}"
 
           docker buildx bake -f docker-bake.hcl \
             --set base.args.RELEASE_VERSION=${{ env.IMAGE_TAG }} \
             --set base.cache-from=type=gha,scope=${{ env.BUILDX_CACHE_SCOPE }} \
             --set base.cache-to=type=gha,scope=${{ env.BUILDX_CACHE_SCOPE }},mode=max \
             --set *.platform=${{ env.BUILDX_PLATFORMS }} \
-            --set api.tags="$API_TAGS" \
-            --set webhooks.tags="$WEBHOOKS_TAGS" \
-            --set worker.tags="$WORKER_TAGS" \
+            --set api.tags="$API_TAG" \
+            --set webhooks.tags="$WEBHOOKS_TAG" \
+            --set worker.tags="$WORKER_TAG" \
             --push
 
       - name: Checkout infra repo

--- a/.github/workflows/qa-build-push-and-pr-green.yml
+++ b/.github/workflows/qa-build-push-and-pr-green.yml
@@ -121,26 +121,31 @@ jobs:
         run: |
           set -euo pipefail
 
-          API_TAG_1="$ECR_REGISTRY/${{ env.ECR_REPOSITORY_API }}:${{ env.IMAGE_TAG }}"
-          API_TAG_2="$ECR_REGISTRY/${{ env.ECR_REPOSITORY_API }}:qa-latest"
-          WEBHOOKS_TAG_1="$ECR_REGISTRY/${{ env.ECR_REPOSITORY_WEBHOOKS }}:${{ env.IMAGE_TAG }}"
-          WEBHOOKS_TAG_2="$ECR_REGISTRY/${{ env.ECR_REPOSITORY_WEBHOOKS }}:qa-latest"
-          WORKER_TAG_1="$ECR_REGISTRY/${{ env.ECR_REPOSITORY_WORKER }}:${{ env.IMAGE_TAG }}"
-          WORKER_TAG_2="$ECR_REGISTRY/${{ env.ECR_REPOSITORY_WORKER }}:qa-latest"
-
-          API_TAGS=$(printf '[\"%s\",\"%s\"]' "$API_TAG_1" "$API_TAG_2")
-          WEBHOOKS_TAGS=$(printf '[\"%s\",\"%s\"]' "$WEBHOOKS_TAG_1" "$WEBHOOKS_TAG_2")
-          WORKER_TAGS=$(printf '[\"%s\",\"%s\"]' "$WORKER_TAG_1" "$WORKER_TAG_2")
+          API_TAG="$ECR_REGISTRY/${{ env.ECR_REPOSITORY_API }}:${{ env.IMAGE_TAG }}"
+          WEBHOOKS_TAG="$ECR_REGISTRY/${{ env.ECR_REPOSITORY_WEBHOOKS }}:${{ env.IMAGE_TAG }}"
+          WORKER_TAG="$ECR_REGISTRY/${{ env.ECR_REPOSITORY_WORKER }}:${{ env.IMAGE_TAG }}"
 
           docker buildx bake -f docker-bake.hcl \
             --set base.args.RELEASE_VERSION=${{ env.IMAGE_TAG }} \
             --set base.cache-from=type=gha,scope=${{ env.BUILDX_CACHE_SCOPE }} \
             --set base.cache-to=type=gha,scope=${{ env.BUILDX_CACHE_SCOPE }},mode=max \
             --set *.platform=${{ env.BUILDX_PLATFORMS }} \
-            --set api.tags="$API_TAGS" \
-            --set webhooks.tags="$WEBHOOKS_TAGS" \
-            --set worker.tags="$WORKER_TAGS" \
+            --set api.tags="$API_TAG" \
+            --set webhooks.tags="$WEBHOOKS_TAG" \
+            --set worker.tags="$WORKER_TAG" \
             --push
+
+          docker buildx imagetools create \
+            -t "$ECR_REGISTRY/${{ env.ECR_REPOSITORY_API }}:qa-latest" \
+            "$API_TAG"
+
+          docker buildx imagetools create \
+            -t "$ECR_REGISTRY/${{ env.ECR_REPOSITORY_WEBHOOKS }}:qa-latest" \
+            "$WEBHOOKS_TAG"
+
+          docker buildx imagetools create \
+            -t "$ECR_REGISTRY/${{ env.ECR_REPOSITORY_WORKER }}:qa-latest" \
+            "$WORKER_TAG"
 
       - name: Checkout infra repo
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Based on the provided code changes, here is a description of the pull request:

**Modifications to CI/CD Docker Build Workflows**

*   **QA Workflow (`qa-build-push-and-pr-green.yml`):**
    *   Changed the tagging strategy for Docker images. Instead of passing multiple tags (versioned and `qa-latest`) directly to `docker buildx bake`, the workflow now pushes the versioned tag first.
    *   Added explicit `docker buildx imagetools create` steps to apply the `qa-latest` tag to the pushed images, separating the aliasing process from the build step.

*   **Prod Workflow (`prod-build-push-and-pr-green.yml`):**
    *   Simplified the tag arguments passed to `docker buildx bake` by removing the JSON array formatting and passing the single image tag string directly.
<!-- kody-pr-summary:end -->