### PR TITLE
fixed cicd

### DIFF
--- a/.github/workflows/prod-build-push-and-pr-green.yml
+++ b/.github/workflows/prod-build-push-and-pr-green.yml
@@ -132,12 +132,11 @@ jobs:
             - name: Build, tag, and push (api/webhooks/worker)
               env:
                   ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+                  API_TAGS: ${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY_API }}:${{ env.IMAGE_TAG }}
+                  WEBHOOKS_TAGS: ${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY_WEBHOOKS }}:${{ env.IMAGE_TAG }}
+                  WORKER_TAGS: ${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY_WORKER }}:${{ env.IMAGE_TAG }}
               run: |
                   set -euo pipefail
-
-                  API_TAG="$ECR_REGISTRY/${{ env.ECR_REPOSITORY_API }}:${{ env.IMAGE_TAG }}"
-                  WEBHOOKS_TAG="$ECR_REGISTRY/${{ env.ECR_REPOSITORY_WEBHOOKS }}:${{ env.IMAGE_TAG }}"
-                  WORKER_TAG="$ECR_REGISTRY/${{ env.ECR_REPOSITORY_WORKER }}:${{ env.IMAGE_TAG }}"
 
                   docker buildx bake -f docker-bake.hcl \
                     --set base.args.RELEASE_VERSION=${{ env.IMAGE_TAG }} \
@@ -145,9 +144,6 @@ jobs:
                     --set base.cache-from=type=gha,scope=${{ env.BUILDX_CACHE_SCOPE }} \
                     --set base.cache-to=type=gha,scope=${{ env.BUILDX_CACHE_SCOPE }},mode=max \
                     --set *.platform=${{ env.BUILDX_PLATFORMS }} \
-                    --set API_TAGS="$API_TAG" \
-                    --set WEBHOOKS_TAGS="$WEBHOOKS_TAG" \
-                    --set WORKER_TAGS="$WORKER_TAG" \
                     --push
 
             - name: Checkout infra repo

--- a/.github/workflows/qa-build-push-and-pr-green.yml
+++ b/.github/workflows/qa-build-push-and-pr-green.yml
@@ -103,12 +103,11 @@ jobs:
             - name: Build, tag, and push (api/webhooks/worker)
               env:
                   ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+                  API_TAGS: ${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY_API }}:${{ env.IMAGE_TAG }}
+                  WEBHOOKS_TAGS: ${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY_WEBHOOKS }}:${{ env.IMAGE_TAG }}
+                  WORKER_TAGS: ${{ steps.login-ecr.outputs.registry }}/${{ vars.ECR_REPOSITORY_WORKER }}:${{ env.IMAGE_TAG }}
               run: |
                   set -euo pipefail
-
-                  API_TAG="$ECR_REGISTRY/${{ env.ECR_REPOSITORY_API }}:${{ env.IMAGE_TAG }}"
-                  WEBHOOKS_TAG="$ECR_REGISTRY/${{ env.ECR_REPOSITORY_WEBHOOKS }}:${{ env.IMAGE_TAG }}"
-                  WORKER_TAG="$ECR_REGISTRY/${{ env.ECR_REPOSITORY_WORKER }}:${{ env.IMAGE_TAG }}"
 
                           docker buildx bake -f docker-bake.hcl \
                             --set base.args.RELEASE_VERSION=${{ env.IMAGE_TAG }} \
@@ -116,9 +115,6 @@ jobs:
                             --set base.cache-from=type=gha,scope=${{ env.BUILDX_CACHE_SCOPE }} \
                     --set base.cache-to=type=gha,scope=${{ env.BUILDX_CACHE_SCOPE }},mode=max \
                     --set *.platform=${{ env.BUILDX_PLATFORMS }} \
-                    --set API_TAGS="$API_TAG" \
-                    --set WEBHOOKS_TAGS="$WEBHOOKS_TAG" \
-                    --set WORKER_TAGS="$WORKER_TAG" \
                     --push
 
                   docker buildx imagetools create \

--- a/.github/workflows/selfhosted-build-push.yml
+++ b/.github/workflows/selfhosted-build-push.yml
@@ -44,13 +44,11 @@ jobs:
               env:
                   REGISTRY: ghcr.io/${{ github.repository_owner }}
                   TAG: ${{ env.RELEASE_VERSION }}
+                  API_TAGS: ghcr.io/${{ github.repository_owner }}/kodus-ai-api:${{ env.RELEASE_VERSION }},ghcr.io/${{ github.repository_owner }}/kodus-ai-api:latest
+                  WEBHOOKS_TAGS: ghcr.io/${{ github.repository_owner }}/kodus-ai-webhook:${{ env.RELEASE_VERSION }},ghcr.io/${{ github.repository_owner }}/kodus-ai-webhook:latest
+                  WORKER_TAGS: ghcr.io/${{ github.repository_owner }}/kodus-ai-worker:${{ env.RELEASE_VERSION }},ghcr.io/${{ github.repository_owner }}/kodus-ai-worker:latest
               run: |
                   set -euo pipefail
-
-                  # Base image names
-                  API_BASE="${REGISTRY}/kodus-ai-api"
-                  WEBHOOK_BASE="${REGISTRY}/kodus-ai-webhook"
-                  WORKER_BASE="${REGISTRY}/kodus-ai-worker"
 
                   docker buildx bake -f docker-bake.hcl \
                     --set base.args.RELEASE_VERSION=${TAG} \
@@ -58,9 +56,6 @@ jobs:
                     --set base.cache-from=type=gha \
                     --set base.cache-to=type=gha,mode=max \
                     --set *.platform=linux/amd64,linux/arm64 \
-                    --set API_TAGS=${API_BASE}:${TAG},${API_BASE}:latest \
-                    --set WEBHOOKS_TAGS=${WEBHOOK_BASE}:${TAG},${WEBHOOK_BASE}:latest \
-                    --set WORKER_TAGS=${WORKER_BASE}:${TAG},${WORKER_BASE}:latest \
                     --push
 
             - name: Notify Discord on Success


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request refactors the CI/CD workflows for Production, QA, and Self-hosted builds to streamline how Docker image tags are handled.

**Changes:**
- Moved the definition of `API_TAGS`, `WEBHOOKS_TAGS`, and `WORKER_TAGS` from shell script calculations to the step's `env` configuration in GitHub Actions.
- Removed the explicit `--set` arguments for these tags from the `docker buildx bake` commands, relying instead on the environment variables.

**Impact:**
- Simplifies the build scripts by leveraging GitHub Actions environment variable substitution.
- Maintains the same tagging logic while cleaning up the command execution syntax.
<!-- kody-pr-summary:end -->