### PR TITLE
fix script blue/green cicd

### DIFF
--- a/.github/workflows/prod-build-push-and-pr-green.yml
+++ b/.github/workflows/prod-build-push-and-pr-green.yml
@@ -6,7 +6,7 @@ on:
     workflow_dispatch:
         inputs:
             image_tag:
-                description: "Tag das imagens no ECR (default: release tag)"
+                description: "ECR image tag (default: release tag)"
                 required: false
 
 concurrency:
@@ -154,7 +154,7 @@ jobs:
                   token: ${{ steps.infra_token.outputs.token }}
                   path: infra
 
-            - name: Update tfvars (green images + desired count)
+            - name: Update tfvars (green images)
               env:
                   ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
               run: |
@@ -192,7 +192,7 @@ jobs:
                   base: ${{ env.INFRA_BASE_BRANCH }}
                   title: "PROD: deploy green (${{ env.IMAGE_TAG }})"
                   body: |
-                      Atualiza as imagens green (api/webhook/worker) para a tag `${{ env.IMAGE_TAG }}` e escala green para 2 tasks.
+                      Update green images (api/webhook/worker) to tag `${{ env.IMAGE_TAG }}` and scale green to 2 tasks.
 
-                      Próximo passo (manual): rodar o workflow de promoção de tráfego (weights) no repo da aplicação.
+                      Next step (manual): run the traffic promotion workflow (weights) in the application repo.
                   commit-message: "prod: deploy green images (${{ env.IMAGE_TAG }})"

--- a/.github/workflows/prod-promote-traffic-pr.yml
+++ b/.github/workflows/prod-promote-traffic-pr.yml
@@ -4,10 +4,10 @@ on:
     workflow_dispatch:
         inputs:
             tag_name:
-                description: "Tag da versão para promover (ex: 2.0.1)"
+                description: "Tag version to promote (e.g., 2.0.1)"
                 required: true
             reason:
-                description: "Motivo/nota para promoção (opcional)"
+                description: "Reason/note for promotion (optional)"
                 required: false
 
 concurrency:
@@ -18,7 +18,7 @@ permissions:
     contents: read
 
 env:
-    # GitOps (infra repo + path do tfvars)
+    # GitOps (infra repo + tfvars path)
     INFRA_REPO: ${{ vars.INFRA_REPO }}
     INFRA_BASE_BRANCH: ${{ vars.INFRA_BASE_BRANCH }}
     INFRA_TFVARS_PATH: ${{ vars.INFRA_TFVARS_PATH }}
@@ -121,10 +121,10 @@ jobs:
                   base: ${{ env.INFRA_BASE_BRANCH }}
                   title: "PROD: promote traffic to 100% green (${{ github.event.inputs.tag_name }})"
                   body: |
-                      Ajusta pesos do ALB para 100% green (api/webhook).
+                      Adjust ALB weights to 100% green (api/webhook).
 
-                      Versão Promovida: ${{ github.event.inputs.tag_name }}
-                      Nota: ${{ github.event.inputs.reason || 'n/a' }}
+                      Promoted Version: ${{ github.event.inputs.tag_name }}
+                      Note: ${{ github.event.inputs.reason || 'n/a' }}
 
-                      Rollback: reverter este PR (volta pesos para blue).
+                      Rollback: revert this PR (switches weights back to blue).
                   commit-message: "prod: promote traffic weights to green (${{ github.event.inputs.tag_name }})"

--- a/.github/workflows/qa-build-push-and-pr-green.yml
+++ b/.github/workflows/qa-build-push-and-pr-green.yml
@@ -119,15 +119,15 @@ jobs:
 
                   docker buildx imagetools create \
                     -t "$ECR_REGISTRY/${{ env.ECR_REPOSITORY_API }}:qa-latest" \
-                    "$API_TAG"
+                    "$API_TAGS"
 
                   docker buildx imagetools create \
                     -t "$ECR_REGISTRY/${{ env.ECR_REPOSITORY_WEBHOOKS }}:qa-latest" \
-                    "$WEBHOOKS_TAG"
+                    "$WEBHOOKS_TAGS"
 
                   docker buildx imagetools create \
                     -t "$ECR_REGISTRY/${{ env.ECR_REPOSITORY_WORKER }}:qa-latest" \
-                    "$WORKER_TAG"
+                    "$WORKER_TAGS"
 
             - name: Checkout infra repo
               uses: actions/checkout@v4.2.2

--- a/.github/workflows/selfhosted-build-push.yml
+++ b/.github/workflows/selfhosted-build-push.yml
@@ -3,7 +3,7 @@ name: Build and Publish Docker Images for Self-Hosted
 on:
     release:
         types: [published]
-    workflow_dispatch: # Permite rodar manualmente
+    workflow_dispatch: # Allows manual run
 
 jobs:
     build-and-push:
@@ -19,7 +19,7 @@ jobs:
             - name: Capture release version
               run: |
                   TAG="${{ github.event.release.tag_name || github.ref_name }}"
-                  # Se a tag for algo como 'main', 'master' ou similar (não for tag real), usa 'manual'
+                  # If the tag is something like 'main', 'master' or similar (not a real tag), use 'manual'
                   if [[ "$TAG" == "main" || "$TAG" == "master" ]]; then
                     TAG="manual"
                   fi


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Based on the provided code changes, here is a description of the pull request:

**Functional Changes**

*   **Dynamic Blue/Green Deployment Logic**:
    *   Updated `scripts/gitops/update-tfvars-green.sh` to intelligently detect the currently active environment (Blue or Green) based on traffic weights. It now deploys the new version to the **idle** side (e.g., if Green is active, it updates Blue configuration) instead of always updating Green.
    *   Updated `scripts/gitops/update-tfvars-promote-weights.sh` to implement a toggle mechanism. Instead of hardcoding a switch to Green, it now inverts the current weights (swapping 100/0 to 0/100) to promote the idle environment to active, regardless of whether it is Blue or Green.

*   **QA Workflow Fixes**:
    *   Corrected variable references in `.github/workflows/qa-build-push-and-pr-green.yml` (changed `$API_TAG` to `$API_TAGS`, etc.) to ensure Docker image tools receive the correct tag arguments.

*   **Localization & Cleanup**:
    *   Translated workflow descriptions, inputs, PR body templates, and code comments from Portuguese to English across multiple workflow files (`prod-build-push-and-pr-green.yml`, `prod-promote-traffic-pr.yml`, `selfhosted-build-push.yml`).
<!-- kody-pr-summary:end -->