### PR TITLE
Refactor GitHub service to use extractRepoName for repository name ha…

### DIFF
--- a/libs/platform/infrastructure/adapters/services/github/github.service.ts
+++ b/libs/platform/infrastructure/adapters/services/github/github.service.ts
@@ -68,7 +68,7 @@ import {
 } from '@libs/platform/domain/platformIntegrations/types/codeManagement/pullRequests.type';
 import { IntegrationEntity } from '@libs/integrations/domain/integrations/entities/integration.entity';
 import { CodeManagementConnectionStatus } from '@libs/platform/domain/platformIntegrations/interfaces/code-management.interface';
-import { extractRepoData, extractRepoNames } from '@libs/common/utils/helpers';
+import { extractRepoData, extractRepoName, extractRepoNames } from '@libs/common/utils/helpers';
 import {
     RepositoryFile,
     RepositoryFileWithContent,
@@ -3579,9 +3579,12 @@ ${copyPrompt}
 
             const octokit = await this.instanceOctokit(organizationAndTeamData);
 
+            // Defensive: extract repo name in case fullName (owner/name) is passed
+            const repoName = extractRepoName(repository.name);
+
             const response = await octokit.issues.createComment({
                 owner: githubAuthDetail?.org,
-                repo: repository.name,
+                repo: repoName,
                 issue_number: prNumber,
                 body,
             });
@@ -3613,9 +3616,12 @@ ${copyPrompt}
 
             const owner = await this.getCorrectOwner(githubAuthDetail, octokit);
 
+            // Defensive: extract repo name in case fullName (owner/name) is passed
+            const repoName = extractRepoName(repository?.name);
+
             await octokit.issues.updateComment({
                 owner,
-                repo: repository?.name,
+                repo: repoName,
                 comment_id: commentId,
                 body,
             });


### PR DESCRIPTION
…ndling

---

<!-- kody-pr-summary:start -->
This Pull Request refactors the GitHub service to improve the handling of repository names when creating or updating issue comments. It introduces the use of the `extractRepoName` utility to ensure that only the repository name is passed to the GitHub API, defensively handling cases where the full repository string (owner/name) might be provided.

**Key Changes:**
*   **GitHub Service:** Updated the logic for creating and updating comments to sanitize the repository name using `extractRepoName` before making API calls.
<!-- kody-pr-summary:end -->