### PR TITLE
common 1.3.3

### DIFF
--- a/packages/kodus-common/package.json
+++ b/packages/kodus-common/package.json
@@ -7,7 +7,7 @@
         "type": "git",
         "url": "https://github.com/kodustech/kodus-common"
     },
-    "version": "1.3.2",
+    "version": "1.3.3",
     "publishConfig": {
         "access": "public",
         "registry": "https://us-central1-npm.pkg.dev/$GAR_PROJECT_ID/kodus-pkg/"

--- a/packages/kodus-common/src/llm/providerAdapters/capabilities.ts
+++ b/packages/kodus-common/src/llm/providerAdapters/capabilities.ts
@@ -41,6 +41,7 @@ export const MODELS_WITHOUT_TEMPERATURE = new Set([
 
     // OpenAI gpt-5 series
     'gpt-5',
+    'gpt-5.1-chat-2025-11-13',
 
     // OpenAI o3-pro
     'o3-pro',
@@ -118,14 +119,21 @@ const MODELS_WITHOUT_JSON_MODE = new Set([
     'gpt-3.5-turbo-0613',
     'gpt-3.5-turbo-16k',
     'gpt-3.5-turbo-16k-0613',
+    'hf:zai-org/GLM-4.7',
 ]);
+
+const MODELS_WITHOUT_JSON_MODE_PATTERNS: RegExp[] = [
+    /^gpt-5(\b|[-_@])/, // all gpt-5 models
+    /glm/i, // all GLM models
+    /(?:azure.*claude|claude.*azure)/i, // only Azure-hosted Claude models
+];
 
 const REASONING_PATTERN_RULES: Array<[RegExp, ReasoningConfig]> = [
     // OpenAI families (level)
     [/^o1(\b|[-_@])/, level()],
     [/^o3(\b|[-_@])/, level()],
     [/^o4(\b|[-_@])/, level()],
-    [/^gpt-5(\b|[-_@])/, level()],
+    [/^gpt-5(\b|[-_@])/, level(['medium', 'high'])],
     [/deep-research/i, level()],
 
     // Gemini 2.5 (budget)
@@ -227,6 +235,12 @@ export function supportsJsonMode(model: string | undefined | null): boolean {
 
     if (MODELS_WITHOUT_JSON_MODE.has(model)) {
         return false;
+    }
+
+    for (const re of MODELS_WITHOUT_JSON_MODE_PATTERNS) {
+        if (re.test(model)) {
+            return false;
+        }
     }
 
     return true;

--- a/packages/kodus-common/src/llm/providerAdapters/resolver.ts
+++ b/packages/kodus-common/src/llm/providerAdapters/resolver.ts
@@ -69,9 +69,15 @@ export function resolveModelOptions(
     } else if (rc?.type === 'level') {
         const allowedLevels = rc.options;
         const desiredLevel = user.reasoningLevel ?? FALLBACK_LEVEL;
-        resolvedReasoningLevel = allowedLevels.includes(desiredLevel)
-            ? desiredLevel
-            : (allowedLevels[0] ?? FALLBACK_LEVEL);
+
+        if (allowedLevels.includes(desiredLevel)) {
+            resolvedReasoningLevel = desiredLevel;
+        } else if (allowedLevels.length > 0) {
+            // If desired level isn't supported, use the first available one (e.g. 'medium' for GPT-5)
+            resolvedReasoningLevel = allowedLevels[0];
+        } else {
+            resolvedReasoningLevel = FALLBACK_LEVEL;
+        }
     }
 
     const temperature = caps.supportsTemperature ? user.temperature : undefined;


### PR DESCRIPTION
fix certain byok models

---

<!-- kody-pr-summary:start -->
Based on the provided code changes, here is a description of the pull request:

**Functional Changes**

*   **Enhanced JSON Mode Validation**: The `LLMProviderService` now explicitly checks if a model supports JSON mode via `supportsJsonMode` before attempting to configure it. This prevents errors when using models that do not support the `json_object` response format.
*   **Model Capability Definitions**:
    *   Added regex patterns to identify models that do not support JSON mode, specifically targeting GPT-5, GLM, and Azure-hosted Claude models.
    *   Registered `gpt-5.1-chat-2025-11-13` as a model that does not support temperature configuration.
    *   Updated the reasoning configuration for GPT-5 models to specifically allow only 'medium' and 'high' levels.
*   **Reasoning Level Fallback Logic**: Refined the resolution logic for reasoning levels. If a requested reasoning level is not supported by a model, the system now falls back to the first valid level defined for that model instead of a generic fallback, ensuring compatibility with models having restricted reasoning options.
<!-- kody-pr-summary:end -->