### PR TITLE
Enhance Kody command detection by introducing new patterns for review…

### DIFF
--- a/libs/common/utils/codeManagement/codeCommentMarkers.ts
+++ b/libs/common/utils/codeManagement/codeCommentMarkers.ts
@@ -20,7 +20,9 @@ const EXACT_MARKERS = [
  * Pattern-based markers to exclude (supports variations)
  * Each pattern can match multiple variations of the same command
  */
-const PATTERN_MARKERS = [/@?kody\s+start(-review)?|start-review/i] as const;
+const PATTERN_MARKERS = [
+    /@?kody\s+(start(-review)?|review)\b|start-review/i,
+] as const;
 
 /**
  * Check if a comment contains any Kody marker (exact match or pattern)
@@ -36,4 +38,41 @@ export const hasKodyMarker = (text: string | undefined | null): boolean => {
     );
 
     return hasPatternMatch;
+};
+
+/**
+ * Patterns for webhook comment command detection
+ * Uses (?=\s|$) lookahead to ensure command ends with whitespace or end of string
+ * This prevents matching "review-code" as a review command
+ */
+export const KODY_REVIEW_COMMAND_PATTERN =
+    /^\s*@kody\s+(start-review|review)(?=\s|$)/i;
+export const KODY_REVIEW_MARKER_PATTERN = /<!--\s*kody-codereview\s*-->/i;
+export const KODY_MENTION_NON_REVIEW_PATTERN =
+    /^\s*@kody\b(?!\s+(start-review|review)(?=\s|$))/i;
+
+/**
+ * Check if comment is a review command (@kody start-review or @kody review)
+ */
+export const isReviewCommand = (text: string | undefined | null): boolean => {
+    if (!text) return false;
+    return KODY_REVIEW_COMMAND_PATTERN.test(text);
+};
+
+/**
+ * Check if comment has the kody-codereview HTML marker
+ */
+export const hasReviewMarker = (text: string | undefined | null): boolean => {
+    if (!text) return false;
+    return KODY_REVIEW_MARKER_PATTERN.test(text);
+};
+
+/**
+ * Check if comment mentions @kody but is NOT a review command
+ */
+export const isKodyMentionNonReview = (
+    text: string | undefined | null,
+): boolean => {
+    if (!text) return false;
+    return KODY_MENTION_NON_REVIEW_PATTERN.test(text);
 };

--- a/test/unit/common/utils/codeManagement/codeCommentMarkers.spec.ts
+++ b/test/unit/common/utils/codeManagement/codeCommentMarkers.spec.ts
@@ -1,0 +1,210 @@
+import {
+    hasKodyMarker,
+    hasReviewMarker,
+    isKodyMentionNonReview,
+    isReviewCommand,
+} from '@libs/common/utils/codeManagement/codeCommentMarkers';
+
+describe('codeCommentMarkers', () => {
+    describe('isReviewCommand', () => {
+        it('should return true for "@kody review"', () => {
+            expect(isReviewCommand('@kody review')).toBe(true);
+        });
+
+        it('should return true for "@kody start-review"', () => {
+            expect(isReviewCommand('@kody start-review')).toBe(true);
+        });
+
+        it('should return true with leading whitespace', () => {
+            expect(isReviewCommand('  @kody review')).toBe(true);
+            expect(isReviewCommand('\t@kody start-review')).toBe(true);
+        });
+
+        it('should return true case-insensitive', () => {
+            expect(isReviewCommand('@KODY REVIEW')).toBe(true);
+            expect(isReviewCommand('@Kody Start-Review')).toBe(true);
+        });
+
+        it('should return true with text after command', () => {
+            expect(isReviewCommand('@kody review please')).toBe(true);
+            expect(isReviewCommand('@kody start-review now')).toBe(true);
+        });
+
+        it('should return false for partial matches like "reviewing"', () => {
+            expect(isReviewCommand('@kody reviewing')).toBe(false);
+        });
+
+        it('should return false for other @kody commands', () => {
+            expect(isReviewCommand('@kody help')).toBe(false);
+            expect(isReviewCommand('@kody explain')).toBe(false);
+            expect(isReviewCommand('@kody what is this?')).toBe(false);
+        });
+
+        it('should return false when @kody is not at the start', () => {
+            expect(isReviewCommand('hey @kody review')).toBe(false);
+            expect(isReviewCommand('please @kody start-review')).toBe(false);
+        });
+
+        it('should return false for null/undefined', () => {
+            expect(isReviewCommand(null)).toBe(false);
+            expect(isReviewCommand(undefined)).toBe(false);
+        });
+
+        it('should return false for empty string', () => {
+            expect(isReviewCommand('')).toBe(false);
+        });
+    });
+
+    describe('hasReviewMarker', () => {
+        it('should return true for standard kody-codereview marker', () => {
+            expect(hasReviewMarker('<!-- kody-codereview -->')).toBe(true);
+        });
+
+        it('should return true with varying whitespace', () => {
+            expect(hasReviewMarker('<!--kody-codereview-->')).toBe(true);
+            expect(hasReviewMarker('<!--  kody-codereview  -->')).toBe(true);
+        });
+
+        it('should return true when marker is embedded in text', () => {
+            expect(
+                hasReviewMarker('Some text <!-- kody-codereview --> more text'),
+            ).toBe(true);
+        });
+
+        it('should return true case-insensitive', () => {
+            expect(hasReviewMarker('<!-- KODY-CODEREVIEW -->')).toBe(true);
+            expect(hasReviewMarker('<!-- Kody-CodeReview -->')).toBe(true);
+        });
+
+        it('should return false when marker is not present', () => {
+            expect(hasReviewMarker('no marker here')).toBe(false);
+            expect(hasReviewMarker('<!-- other-marker -->')).toBe(false);
+        });
+
+        it('should return false for null/undefined', () => {
+            expect(hasReviewMarker(null)).toBe(false);
+            expect(hasReviewMarker(undefined)).toBe(false);
+        });
+
+        it('should return false for empty string', () => {
+            expect(hasReviewMarker('')).toBe(false);
+        });
+    });
+
+    describe('isKodyMentionNonReview', () => {
+        it('should return true for @kody with other commands', () => {
+            expect(isKodyMentionNonReview('@kody help')).toBe(true);
+            expect(isKodyMentionNonReview('@kody explain this')).toBe(true);
+            expect(isKodyMentionNonReview('@kody what is this?')).toBe(true);
+        });
+
+        it('should return true with leading whitespace', () => {
+            expect(isKodyMentionNonReview('  @kody help')).toBe(true);
+        });
+
+        it('should return false for review commands', () => {
+            expect(isKodyMentionNonReview('@kody review')).toBe(false);
+            expect(isKodyMentionNonReview('@kody start-review')).toBe(false);
+        });
+
+        it('should return false for review commands case-insensitive', () => {
+            expect(isKodyMentionNonReview('@kody REVIEW')).toBe(false);
+            expect(isKodyMentionNonReview('@KODY start-review')).toBe(false);
+        });
+
+        it('should return false when @kody is not at the start', () => {
+            expect(isKodyMentionNonReview('hey @kody help')).toBe(false);
+        });
+
+        it('should return false for null/undefined', () => {
+            expect(isKodyMentionNonReview(null)).toBe(false);
+            expect(isKodyMentionNonReview(undefined)).toBe(false);
+        });
+
+        it('should return false for empty string', () => {
+            expect(isKodyMentionNonReview('')).toBe(false);
+        });
+
+        it('should return true for @kody alone (just mention)', () => {
+            expect(isKodyMentionNonReview('@kody')).toBe(true);
+        });
+    });
+
+    describe('hasKodyMarker', () => {
+        it('should return true for Code Review Completed marker', () => {
+            expect(hasKodyMarker('## Code Review Completed! 🔥')).toBe(true);
+        });
+
+        it('should return true for critical issue marker', () => {
+            expect(
+                hasKodyMarker('# Found critical issues please fix them'),
+            ).toBe(true);
+        });
+
+        it('should return true for @kody start patterns', () => {
+            expect(hasKodyMarker('@kody start')).toBe(true);
+            expect(hasKodyMarker('@kody start-review')).toBe(true);
+        });
+
+        it('should return true for @kody review pattern', () => {
+            expect(hasKodyMarker('@kody review')).toBe(true);
+        });
+
+        it('should return true for kody without @ prefix', () => {
+            expect(hasKodyMarker('kody start')).toBe(true);
+            expect(hasKodyMarker('kody review')).toBe(true);
+        });
+
+        it('should return true for start-review alone', () => {
+            expect(hasKodyMarker('start-review')).toBe(true);
+        });
+
+        it('should return false for regular comments', () => {
+            expect(hasKodyMarker('This is a regular comment')).toBe(false);
+            expect(hasKodyMarker('Please fix this bug')).toBe(false);
+        });
+
+        it('should return false for null/undefined', () => {
+            expect(hasKodyMarker(null)).toBe(false);
+            expect(hasKodyMarker(undefined)).toBe(false);
+        });
+    });
+
+    describe('integration: command detection consistency', () => {
+        it('should correctly identify review commands vs mentions', () => {
+            const reviewCommands = [
+                '@kody review',
+                '@kody start-review',
+                '  @kody review',
+                '@KODY REVIEW',
+            ];
+
+            const nonReviewMentions = [
+                '@kody help',
+                '@kody explain',
+                '@kody what is this code doing?',
+                '@kody',
+            ];
+
+            reviewCommands.forEach((cmd) => {
+                expect(isReviewCommand(cmd)).toBe(true);
+                expect(isKodyMentionNonReview(cmd)).toBe(false);
+            });
+
+            nonReviewMentions.forEach((mention) => {
+                expect(isReviewCommand(mention)).toBe(false);
+                expect(isKodyMentionNonReview(mention)).toBe(true);
+            });
+        });
+
+        it('should handle edge cases consistently', () => {
+            // "reviewing" should not match as review command
+            expect(isReviewCommand('@kody reviewing')).toBe(false);
+            expect(isKodyMentionNonReview('@kody reviewing')).toBe(true);
+
+            // "review-something" should not match as review command
+            expect(isReviewCommand('@kody review-code')).toBe(false);
+            expect(isKodyMentionNonReview('@kody review-code')).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
… commands and markers. Refactor Azure, Bitbucket, GitHub, and GitLab webhook handlers to utilize these patterns, improving command recognition and reducing code duplication. Add unit tests for new functionalities in codeCommentMarkers.

closes #454 

---

<!-- kody-pr-summary:start -->
This pull request enhances the Kody bot's command detection capabilities and refactors how comment interactions are processed across supported platforms.

**Key Changes:**

*   **New Command Alias**: Added support for `@kody review` as a valid command to trigger code reviews, serving as an alias for the existing `@kody start-review` command.
*   **Centralized Detection Logic**: Extracted command parsing and marker validation into reusable utility functions (`isReviewCommand`, `hasReviewMarker`, `isKodyMentionNonReview`) within `codeCommentMarkers.ts`.
*   **Refactored Webhook Handlers**: Updated Azure, Bitbucket, GitHub, and GitLab handlers to use the shared utility functions instead of duplicated inline regex, ensuring consistent behavior across platforms.
*   **Improved Pattern Matching**: Refined regex patterns to use word boundaries and lookaheads, preventing false positives (e.g., ensuring `@kody reviewing` is treated as a chat mention rather than a review command).
*   **Unit Tests**: Added a comprehensive test suite (`codeCommentMarkers.spec.ts`) to validate command detection logic and edge cases.
<!-- kody-pr-summary:end -->