### PR TITLE
Adding pagination at get

### DIFF
--- a/libs/platform/infrastructure/adapters/services/github/github.service.ts
+++ b/libs/platform/infrastructure/adapters/services/github/github.service.ts
@@ -4474,7 +4474,7 @@ This is an experimental feature that generates committable changes. Review the d
             viewer: { login: string; id: string };
         } = await graphQLWithAuth(query);
 
-        const { data: allReviews } = await octokit.rest.pulls.listReviews({
+        const allReviews = await octokit.paginate(octokit.rest.pulls.listReviews, {
             owner: githubAuth.org,
             repo: repository.name,
             pull_number: prNumber,
@@ -4501,7 +4501,7 @@ This is an experimental feature that generates committable changes. Review the d
             return null;
         }
 
-        const lastReview = myReviews.pop();
+        const lastReview = myReviews.at(-1);
 
         switch (lastReview?.state) {
             case 'APPROVED':


### PR DESCRIPTION
Closes #549 

---

<!-- kody-pr-summary:start -->
Based on the code changes, this pull request introduces the following modifications:

*   **Pagination for PR Reviews**: Updated the GitHub service to use `octokit.paginate` when fetching pull request reviews. This ensures that all reviews are retrieved rather than just the first page of results.
*   **Safe Array Access**: Changed the method for retrieving the last review from `myReviews.pop()` to `myReviews.at(-1)`, avoiding mutation of the array.
<!-- kody-pr-summary:end -->