### PR TITLE
add invalid cache

### DIFF
--- a/apps/api/src/controllers/parameters.controller.ts
+++ b/apps/api/src/controllers/parameters.controller.ts
@@ -107,7 +107,12 @@ export class ParametersController {
         @Query('key') key: ParametersKey,
         @Query('teamId') teamId: string,
     ) {
-        return await this.findByKeyParametersUseCase.execute(key, { teamId });
+        const organizationId = this.request?.user?.organization?.uuid;
+
+        return await this.findByKeyParametersUseCase.execute(key, {
+            teamId,
+            organizationId,
+        });
     }
 
     //endregion

--- a/apps/api/src/controllers/pullRequest.controller.ts
+++ b/apps/api/src/controllers/pullRequest.controller.ts
@@ -384,6 +384,7 @@ ${'```'}`,
         @Query() query: OnboardingReviewModeSignalsQueryDto,
     ) {
         const organizationId = this.request.user?.organization?.uuid;
+
         if (!organizationId) {
             throw new Error('No organization found in request');
         }

--- a/libs/automation/application/use-cases/teamAutomation/active-code-review-automation.use-case.ts
+++ b/libs/automation/application/use-cases/teamAutomation/active-code-review-automation.use-case.ts
@@ -45,9 +45,11 @@ export class ActiveCodeReviewAutomationUseCase implements IUseCase {
             automation: { uuid: codeReviewAutomation.automationUuid },
         });
 
-        await this.updateTeamAutomationStatusUseCase.execute(
-            teamAutomation.uuid,
-            true,
-        );
+        if (teamAutomation) {
+            await this.updateTeamAutomationStatusUseCase.execute(
+                teamAutomation.uuid,
+                true,
+            );
+        }
     }
 }

--- a/libs/code-review/application/use-cases/configuration/apply-code-review-preset.use-case.ts
+++ b/libs/code-review/application/use-cases/configuration/apply-code-review-preset.use-case.ts
@@ -23,6 +23,7 @@ import {
     IParametersService,
     PARAMETERS_SERVICE_TOKEN,
 } from '@libs/organization/domain/parameters/contracts/parameters.service.contract';
+import { CreateOrUpdateParametersUseCase } from '@libs/organization/application/use-cases/parameters/create-or-update-use-case';
 import { Inject, Injectable } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
 
@@ -33,6 +34,8 @@ export class ApplyCodeReviewPresetUseCase implements IUseCase {
     constructor(
         @Inject(PARAMETERS_SERVICE_TOKEN)
         private readonly parametersService: IParametersService,
+
+        private readonly createOrUpdateParametersUseCase: CreateOrUpdateParametersUseCase,
 
         @Inject(ORGANIZATION_PARAMETERS_SERVICE_TOKEN)
         private readonly organizationParametersService: IOrganizationParametersService,
@@ -79,7 +82,7 @@ export class ApplyCodeReviewPresetUseCase implements IUseCase {
 
             const updatedConfig = this.applyPreset(baseConfig, params.preset);
 
-            await this.parametersService.createOrUpdateConfig(
+            await this.createOrUpdateParametersUseCase.execute(
                 ParametersKey.CODE_REVIEW_CONFIG,
                 updatedConfig,
                 organizationAndTeamData,

--- a/libs/code-review/application/use-cases/configuration/delete-repository-code-review-parameter.use-case.ts
+++ b/libs/code-review/application/use-cases/configuration/delete-repository-code-review-parameter.use-case.ts
@@ -1,3 +1,4 @@
+import { CreateOrUpdateParametersUseCase } from '@libs/organization/application/use-cases/parameters/create-or-update-use-case';
 import { Inject, Injectable } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
 import { produce } from 'immer';
@@ -34,6 +35,8 @@ export class DeleteRepositoryCodeReviewParameterUseCase {
     constructor(
         @Inject(PARAMETERS_SERVICE_TOKEN)
         private readonly parametersService: IParametersService,
+
+        private readonly createOrUpdateParametersUseCase: CreateOrUpdateParametersUseCase,
 
         @Inject(CODE_REVIEW_SETTINGS_LOG_SERVICE_TOKEN)
         private readonly codeReviewSettingsLogService: ICodeReviewSettingsLogService,
@@ -132,7 +135,7 @@ export class DeleteRepositoryCodeReviewParameterUseCase {
             repo.isSelected = false;
         });
 
-        const updated = await this.parametersService.createOrUpdateConfig(
+        const updated = await this.createOrUpdateParametersUseCase.execute(
             ParametersKey.CODE_REVIEW_CONFIG,
             updatedConfig,
             organizationAndTeamData,
@@ -188,7 +191,7 @@ export class DeleteRepositoryCodeReviewParameterUseCase {
             }
         });
 
-        const updated = await this.parametersService.createOrUpdateConfig(
+        const updated = await this.createOrUpdateParametersUseCase.execute(
             ParametersKey.CODE_REVIEW_CONFIG,
             updatedConfig,
             organizationAndTeamData,

--- a/libs/code-review/application/use-cases/configuration/update-code-review-parameter-repositories-use-case.ts
+++ b/libs/code-review/application/use-cases/configuration/update-code-review-parameter-repositories-use-case.ts
@@ -1,3 +1,4 @@
+import { CreateOrUpdateParametersUseCase } from '@libs/organization/application/use-cases/parameters/create-or-update-use-case';
 import { Inject, Injectable } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
 
@@ -44,6 +45,8 @@ export class UpdateCodeReviewParameterRepositoriesUseCase {
     constructor(
         @Inject(PARAMETERS_SERVICE_TOKEN)
         private readonly parametersService: IParametersService,
+
+        private readonly createOrUpdateParametersUseCase: CreateOrUpdateParametersUseCase,
 
         @Inject(INTEGRATION_CONFIG_SERVICE_TOKEN)
         private readonly integrationConfigService: IIntegrationConfigService,
@@ -120,7 +123,7 @@ export class UpdateCodeReviewParameterRepositoriesUseCase {
                 repositories: updatedRepositories,
             } as CodeReviewParameter;
 
-            const result = await this.parametersService.createOrUpdateConfig(
+            const result = await this.createOrUpdateParametersUseCase.execute(
                 ParametersKey.CODE_REVIEW_CONFIG,
                 updatedCodeReviewConfigValue,
                 organizationAndTeamData,

--- a/libs/code-review/application/use-cases/configuration/update-or-create-code-review-parameter-use-case.ts
+++ b/libs/code-review/application/use-cases/configuration/update-or-create-code-review-parameter-use-case.ts
@@ -1,3 +1,4 @@
+import { CreateOrUpdateParametersUseCase } from '@libs/organization/application/use-cases/parameters/create-or-update-use-case';
 import { Inject, Injectable } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
 
@@ -66,6 +67,8 @@ export class UpdateOrCreateCodeReviewParameterUseCase {
     constructor(
         @Inject(PARAMETERS_SERVICE_TOKEN)
         private readonly parametersService: IParametersService,
+
+        private readonly createOrUpdateParametersUseCase: CreateOrUpdateParametersUseCase,
 
         @Inject(INTEGRATION_CONFIG_SERVICE_TOKEN)
         private readonly integrationConfigService: IIntegrationConfigService,
@@ -247,7 +250,7 @@ export class UpdateOrCreateCodeReviewParameterUseCase {
             repositories: filteredRepositoryInfo,
         } as CodeReviewParameter;
 
-        return await this.parametersService.createOrUpdateConfig(
+        return await this.createOrUpdateParametersUseCase.execute(
             ParametersKey.CODE_REVIEW_CONFIG,
             updatedConfig,
             organizationAndTeamData,
@@ -332,7 +335,7 @@ export class UpdateOrCreateCodeReviewParameterUseCase {
             updater,
         );
 
-        await this.parametersService.createOrUpdateConfig(
+        await this.createOrUpdateParametersUseCase.execute(
             ParametersKey.CODE_REVIEW_CONFIG,
             updatedCodeReviewConfigValue,
             organizationAndTeamData,

--- a/libs/code-review/pipeline/stages/create-file-comments.stage.ts
+++ b/libs/code-review/pipeline/stages/create-file-comments.stage.ts
@@ -22,15 +22,11 @@ import {
     DRY_RUN_SERVICE_TOKEN,
     IDryRunService,
 } from '@libs/dryRun/domain/contracts/dryRun.service.contract';
-import { PullRequestReviewComment } from '@libs/platform/domain/platformIntegrations/types/codeManagement/pullRequests.type';
 import { CodeManagementService } from '@libs/platform/infrastructure/adapters/services/codeManagement.service';
 import {
     IPullRequestsService,
     PULL_REQUESTS_SERVICE_TOKEN,
 } from '@libs/platformData/domain/pullRequests/contracts/pullRequests.service.contracts';
-import { PullRequestsEntity } from '@libs/platformData/domain/pullRequests/entities/pullRequests.entity';
-import { DeliveryStatus } from '@libs/platformData/domain/pullRequests/enums/deliveryStatus.enum';
-import { ImplementationStatus } from '@libs/platformData/domain/pullRequests/enums/implementationStatus.enum';
 import { Inject, Injectable } from '@nestjs/common';
 import { CodeReviewPipelineContext } from '../context/code-review-pipeline.context';
 

--- a/libs/core/domain/enums/parameters-key.enum.ts
+++ b/libs/core/domain/enums/parameters-key.enum.ts
@@ -1,12 +1,14 @@
 export enum ParametersKey {
-    BOARD_PRIORITY_TYPE = 'board_priority_type',
-    CHECKIN_CONFIG = 'checkin_config',
     CODE_REVIEW_CONFIG = 'code_review_config',
-    COMMUNICATION_STYLE = 'communication_style',
-    DEPLOYMENT_TYPE = 'deployment_type',
-    ORGANIZATION_ARTIFACTS_CONFIG = 'organization_artifacts_config',
-    TEAM_ARTIFACTS_CONFIG = 'team_artifacts_config',
     PLATFORM_CONFIGS = 'platform_configs',
     LANGUAGE_CONFIG = 'language_config',
     ISSUE_CREATION_CONFIG = 'issue_creation_config',
+
+    //DEPRECATED
+    TEAM_ARTIFACTS_CONFIG = 'team_artifacts_config',
+    ORGANIZATION_ARTIFACTS_CONFIG = 'organization_artifacts_config',
+    COMMUNICATION_STYLE = 'communication_style',
+    CHECKIN_CONFIG = 'checkin_config',
+    BOARD_PRIORITY_TYPE = 'board_priority_type',
+    DEPLOYMENT_TYPE = 'deployment_type',
 }

--- a/libs/kodyRules/application/use-cases/generate-kody-rules.use-case.ts
+++ b/libs/kodyRules/application/use-cases/generate-kody-rules.use-case.ts
@@ -32,6 +32,7 @@ import { ModuleRef } from '@nestjs/core';
 import { CreateOrUpdateKodyRulesUseCase } from './create-or-update.use-case';
 import { FindRulesInOrganizationByRuleFilterKodyRulesUseCase } from './find-rules-in-organization-by-filter.use-case';
 import { SendRulesNotificationUseCase } from './send-rules-notification.use-case';
+import { CreateOrUpdateParametersUseCase } from '@libs/organization/application/use-cases/parameters/create-or-update-use-case';
 
 @Injectable()
 export class GenerateKodyRulesUseCase {
@@ -43,6 +44,7 @@ export class GenerateKodyRulesUseCase {
         private readonly integrationConfigService: IIntegrationConfigService,
         @Inject(PARAMETERS_SERVICE_TOKEN)
         private readonly parametersService: IParametersService,
+        private readonly createOrUpdateParametersUseCase: CreateOrUpdateParametersUseCase,
         private readonly codeManagementService: CodeManagementService,
         private readonly commentAnalysisService: CommentAnalysisService,
         private readonly moduleRef: ModuleRef,
@@ -112,7 +114,7 @@ export class GenerateKodyRulesUseCase {
                 throw new Error('Platform config not found');
             }
 
-            await this.parametersService.createOrUpdateConfig(
+            await this.createOrUpdateParametersUseCase.execute(
                 ParametersKey.PLATFORM_CONFIGS,
                 {
                     ...platformConfig.configValue,
@@ -283,7 +285,7 @@ export class GenerateKodyRulesUseCase {
                     metadata: { body, organizationAndTeamData },
                 });
 
-                await this.parametersService.createOrUpdateConfig(
+                await this.createOrUpdateParametersUseCase.execute(
                     ParametersKey.PLATFORM_CONFIGS,
                     {
                         ...platformConfig.configValue,
@@ -295,7 +297,7 @@ export class GenerateKodyRulesUseCase {
                 return [];
             }
 
-            await this.parametersService.createOrUpdateConfig(
+            await this.createOrUpdateParametersUseCase.execute(
                 ParametersKey.PLATFORM_CONFIGS,
                 {
                     ...platformConfig.configValue,
@@ -348,7 +350,7 @@ export class GenerateKodyRulesUseCase {
             });
 
             if (platformConfig) {
-                await this.parametersService.createOrUpdateConfig(
+                await this.createOrUpdateParametersUseCase.execute(
                     ParametersKey.PLATFORM_CONFIGS,
                     {
                         ...platformConfig.configValue,

--- a/libs/platform/application/use-cases/codeManagement/delete-integration-and-repositories.use-case.ts
+++ b/libs/platform/application/use-cases/codeManagement/delete-integration-and-repositories.use-case.ts
@@ -14,6 +14,7 @@ import {
     KODY_RULES_SERVICE_TOKEN,
 } from '@libs/kodyRules/domain/contracts/kodyRules.service.contract';
 import { KodyRulesStatus } from '@libs/kodyRules/domain/interfaces/kodyRules.interface';
+import { CreateOrUpdateParametersUseCase } from '@libs/organization/application/use-cases/parameters/create-or-update-use-case';
 
 @Injectable()
 export class DeleteIntegrationAndRepositoriesUseCase {
@@ -24,6 +25,7 @@ export class DeleteIntegrationAndRepositoriesUseCase {
         private readonly deleteIntegrationUseCase: DeleteIntegrationUseCase,
         @Inject(PARAMETERS_SERVICE_TOKEN)
         private readonly parametersService: IParametersService,
+        private readonly createOrUpdateParametersUseCase: CreateOrUpdateParametersUseCase,
         @Inject(PULL_REQUEST_MESSAGES_SERVICE_TOKEN)
         private readonly pullRequestMessagesService: IPullRequestMessagesService,
         @Inject(KODY_RULES_SERVICE_TOKEN)
@@ -194,7 +196,7 @@ export class DeleteIntegrationAndRepositoriesUseCase {
                 repositories: [],
             };
 
-            await this.parametersService.createOrUpdateConfig(
+            await this.createOrUpdateParametersUseCase.execute(
                 ParametersKey.CODE_REVIEW_CONFIG,
                 updatedConfigValue,
                 {

--- a/libs/platform/application/use-cases/codeManagement/finish-onboarding.use-case.ts
+++ b/libs/platform/application/use-cases/codeManagement/finish-onboarding.use-case.ts
@@ -15,6 +15,7 @@ import { FindRulesInOrganizationByRuleFilterKodyRulesUseCase } from '@libs/kodyR
 import { ChangeStatusKodyRulesUseCase } from '@libs/kodyRules/application/use-cases/change-status-kody-rules.use-case';
 import { SyncSelectedRepositoriesKodyRulesUseCase } from '@libs/kodyRules/application/use-cases/sync-selected-repositories.use-case';
 import { KodyRulesStatus } from '@libs/kodyRules/domain/interfaces/kodyRules.interface';
+import { CreateOrUpdateParametersUseCase } from '@libs/organization/application/use-cases/parameters/create-or-update-use-case';
 
 @Injectable()
 export class FinishOnboardingUseCase {
@@ -31,6 +32,7 @@ export class FinishOnboardingUseCase {
             user: { organization: { uuid: string } };
         },
         private readonly syncSelectedReposKodyRulesUseCase: SyncSelectedRepositoriesKodyRulesUseCase,
+        private readonly createOrUpdateParametersUseCase: CreateOrUpdateParametersUseCase,
     ) {}
 
     async execute(params: FinishOnboardingDTO) {
@@ -60,7 +62,7 @@ export class FinishOnboardingUseCase {
                 throw new Error('Platform config not found');
             }
 
-            await this.parametersService.createOrUpdateConfig(
+            await this.createOrUpdateParametersUseCase.execute(
                 ParametersKey.PLATFORM_CONFIGS,
                 {
                     ...platformConfig.configValue,

--- a/libs/platform/infrastructure/adapters/services/bitbucket.service.ts
+++ b/libs/platform/infrastructure/adapters/services/bitbucket.service.ts
@@ -1187,7 +1187,7 @@ export class BitbucketService implements Omit<
             const { organizationAndTeamData } = params;
 
             const filters = params?.filters ?? {};
-            const { prStatus } = filters ?? 'OPEN';
+            const { prStatus = 'OPEN' } = filters;
             const perRepoLimit = Math.min(Math.max(filters?.limit || 5, 1), 10);
             const repoFilter = filters?.repositoryId
                 ? new Set([String(filters.repositoryId)])


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Based on the provided code changes, here is a description of the pull request:

**Summary**
This pull request introduces cache invalidation logic for organization parameters, refactors parameter update flows to ensure consistency, and optimizes the implementation verification process. It also includes various bug fixes and code cleanup.

**Key Changes**

*   **Parameter Cache Invalidation**:
    *   Updated `CreateOrUpdateParametersUseCase` to invalidate the cache after a parameter is successfully created or updated.
    *   Refactored multiple use cases (including Code Review configuration, Kody Rules generation, and Onboarding) to use `CreateOrUpdateParametersUseCase` instead of calling the service directly, ensuring the invalidation logic is always triggered.
    *   Updated `ParametersController` to pass the `organizationId` when fetching parameters, likely to support scoped caching.

*   **Implementation Verification Optimization**:
    *   Modified `ImplementationVerificationProcessor` to filter suggestions based on the files actually changed in the pull request.
    *   Added logic to skip verification and mark the job as completed with `NO_RELEVANT_CHANGES` if none of the suggestions apply to the modified files.

*   **Bug Fixes & Improvements**:
    *   **Bitbucket Service**: Fixed the default value assignment for `prStatus` in the `BitbucketService` filter logic.
    *   **Team Automation**: Added a safety check to ensure `teamAutomation` exists before attempting to update its status in `ActiveCodeReviewAutomationUseCase`.
    *   **API**: Added a check to ensure `organizationId` is present in the `PullRequestController`.
    *   **Cleanup**: Marked several `ParametersKey` values as deprecated and removed unused imports in the file comments stage.
<!-- kody-pr-summary:end -->