### PR TITLE
add prnumber to getchanges azure

### DIFF
--- a/libs/code-review/domain/contracts/PullRequestManagerService.contract.ts
+++ b/libs/code-review/domain/contracts/PullRequestManagerService.contract.ts
@@ -16,7 +16,7 @@ export interface IPullRequestManagerService {
 
     getChangedFiles(
         organizationAndTeamData: OrganizationAndTeamData,
-        repository: { name: string; id: any },
+        repository: { name: string; id: any; project?: { id: any } },
         pullRequest: any,
         ignorePaths: string[],
         lastCommit?: string,

--- a/libs/code-review/workflow/implementation-verification.processor.ts
+++ b/libs/code-review/workflow/implementation-verification.processor.ts
@@ -119,6 +119,7 @@ export class ImplementationVerificationProcessor implements IJobProcessorService
             // 2. Fetch Pull Request Details from Platform (to get latest state)
             const platformPr =
                 payload.payload?.pull_request ||
+                payload.payload?.resource ||
                 (await this.pullRequestManagerService.getPullRequestDetails(
                     payload.organizationAndTeamData,
                     {
@@ -153,6 +154,8 @@ export class ImplementationVerificationProcessor implements IJobProcessorService
             const lastAnalyzedCommit =
                 lastExecution?.dataExecution?.lastAnalyzedCommit;
 
+            platformPr.number = payload.pullRequestNumber;
+
             // 3. Fetch Changed Files (Diff)
             const changedFiles =
                 await this.pullRequestManagerService.getChangedFiles(
@@ -160,6 +163,7 @@ export class ImplementationVerificationProcessor implements IJobProcessorService
                     {
                         name: payload.repository.name,
                         id: payload.repository.id,
+                        project: { id: platformPr.repository?.project?.id },
                     },
                     platformPr,
                     [],


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the implementation verification workflow to ensure changed files are fetched correctly, specifically improving compatibility with Azure DevOps integrations.

**Key Changes:**
*   **Payload Parsing**: Expanded the logic to retrieve pull request details from `payload.resource` in addition to `payload.pull_request`.
*   **PR Context**: Explicitly assigns the pull request number to the platform PR object before processing.
*   **Project ID Support**: Updated the `IPullRequestManagerService` interface and the verification processor to pass the `project` ID within the repository object when calling `getChangedFiles`.
<!-- kody-pr-summary:end -->