### PR TITLE
fix webhook filters

### DIFF
--- a/apps/webhooks/src/controllers/azureRepos.controller.ts
+++ b/apps/webhooks/src/controllers/azureRepos.controller.ts
@@ -42,6 +42,19 @@ export class AzureReposController {
                 .send('Unrecognized event');
         }
 
+        // Filter unsupported events before enqueueing
+        const supportedEvents = [
+            'git.pullrequest.created',
+            'git.pullrequest.updated',
+            'git.pullrequest.merge.attempted',
+            'ms.vss-code.git-pullrequest-comment-event',
+        ];
+        if (!supportedEvents.includes(eventType)) {
+            return res
+                .status(HttpStatus.OK)
+                .send('Webhook ignored (event not supported)');
+        }
+
         res.status(HttpStatus.OK).send('Webhook received');
 
         setImmediate(() => {

--- a/apps/webhooks/src/controllers/bitbucket.controller.ts
+++ b/apps/webhooks/src/controllers/bitbucket.controller.ts
@@ -18,6 +18,20 @@ export class BitbucketController {
         const event = req.headers['x-event-key'] as string;
         const payload = req.body as any;
 
+        // Filter unsupported events before enqueueing
+        const supportedEvents = [
+            'pullrequest:created',
+            'pullrequest:updated',
+            'pullrequest:fulfilled',
+            'pullrequest:rejected',
+            'pullrequest:comment_created',
+        ];
+        if (!supportedEvents.includes(event)) {
+            return res
+                .status(HttpStatus.OK)
+                .send('Webhook ignored (event not supported)');
+        }
+
         res.status(HttpStatus.OK).send('Webhook received');
 
         setImmediate(() => {

--- a/apps/webhooks/src/controllers/github.controller.ts
+++ b/apps/webhooks/src/controllers/github.controller.ts
@@ -18,14 +18,28 @@ export class GithubController {
         const event = req.headers['x-github-event'] as string;
         const payload = req.body as any;
 
+        // Filter unsupported events before enqueueing
+        const supportedEvents = [
+            'pull_request',
+            'issue_comment',
+            'pull_request_review_comment',
+        ];
+        if (!supportedEvents.includes(event)) {
+            return res
+                .status(HttpStatus.OK)
+                .send('Webhook ignored (event not supported)');
+        }
+
+        // For pull_request events, filter unsupported actions
         if (event === 'pull_request') {
-            if (
-                payload?.action !== 'opened' &&
-                payload?.action !== 'synchronize' &&
-                payload?.action !== 'closed' &&
-                payload?.action !== 'reopened' &&
-                payload?.action !== 'ready_for_review'
-            ) {
+            const allowedActions = [
+                'opened',
+                'synchronize',
+                'closed',
+                'reopened',
+                'ready_for_review',
+            ];
+            if (!allowedActions.includes(payload?.action)) {
                 return res
                     .status(HttpStatus.OK)
                     .send('Webhook ignored (action not supported)');

--- a/apps/webhooks/src/controllers/gitlab.controller.ts
+++ b/apps/webhooks/src/controllers/gitlab.controller.ts
@@ -17,6 +17,14 @@ export class GitlabController {
         const event = req.headers['x-gitlab-event'] as string;
         const payload = req.body as any;
 
+        // Filter unsupported events before enqueueing
+        const supportedEvents = ['Merge Request Hook', 'Note Hook'];
+        if (!supportedEvents.includes(event)) {
+            return res
+                .status(HttpStatus.OK)
+                .send('Webhook ignored (event not supported)');
+        }
+
         res.status(HttpStatus.OK).send('Webhook received');
 
         setImmediate(() => {

--- a/test/unit/webhooks/controllers/azureRepos.controller.spec.ts
+++ b/test/unit/webhooks/controllers/azureRepos.controller.spec.ts
@@ -1,0 +1,272 @@
+import { AzureReposController } from '../../../../apps/webhooks/src/controllers/azureRepos.controller';
+import { EnqueueWebhookUseCase } from '@libs/platform/application/use-cases/webhook/enqueue-webhook.use-case';
+import { Request, Response } from 'express';
+import { HttpStatus } from '@nestjs/common';
+
+// Mock the validateWebhookToken function
+jest.mock('@libs/common/utils/webhooks/webhookTokenCrypto', () => ({
+    validateWebhookToken: jest.fn().mockReturnValue(true),
+}));
+
+import { validateWebhookToken } from '@libs/common/utils/webhooks/webhookTokenCrypto';
+
+describe('AzureReposController', () => {
+    let controller: AzureReposController;
+    let enqueueWebhookUseCase: jest.Mocked<EnqueueWebhookUseCase>;
+    let mockRequest: Partial<Request>;
+    let mockResponse: Partial<Response>;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        (validateWebhookToken as jest.Mock).mockReturnValue(true);
+
+        enqueueWebhookUseCase = {
+            execute: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        controller = new AzureReposController(enqueueWebhookUseCase);
+
+        mockResponse = {
+            status: jest.fn().mockReturnThis(),
+            send: jest.fn().mockReturnThis(),
+        };
+    });
+
+    describe('supported events', () => {
+        it('should enqueue "git.pullrequest.created" event', async () => {
+            mockRequest = {
+                query: { token: 'valid-token' },
+                body: {
+                    eventType: 'git.pullrequest.created',
+                    resource: { pullRequestId: 1 },
+                },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.OK);
+            expect(mockResponse.send).toHaveBeenCalledWith('Webhook received');
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).toHaveBeenCalledWith({
+                platformType: 'AZURE_REPOS',
+                event: 'git.pullrequest.created',
+                payload: {
+                    eventType: 'git.pullrequest.created',
+                    resource: { pullRequestId: 1 },
+                },
+            });
+        });
+
+        it('should enqueue "git.pullrequest.updated" event', async () => {
+            mockRequest = {
+                query: { token: 'valid-token' },
+                body: {
+                    eventType: 'git.pullrequest.updated',
+                    resource: { pullRequestId: 1 },
+                },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).toHaveBeenCalledWith({
+                platformType: 'AZURE_REPOS',
+                event: 'git.pullrequest.updated',
+                payload: {
+                    eventType: 'git.pullrequest.updated',
+                    resource: { pullRequestId: 1 },
+                },
+            });
+        });
+
+        it('should enqueue "git.pullrequest.merge.attempted" event', async () => {
+            mockRequest = {
+                query: { token: 'valid-token' },
+                body: {
+                    eventType: 'git.pullrequest.merge.attempted',
+                    resource: { pullRequestId: 1 },
+                },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).toHaveBeenCalled();
+        });
+
+        it('should enqueue "ms.vss-code.git-pullrequest-comment-event" event', async () => {
+            mockRequest = {
+                query: { token: 'valid-token' },
+                body: {
+                    eventType: 'ms.vss-code.git-pullrequest-comment-event',
+                    resource: { comment: { content: '@kody review' } },
+                },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).toHaveBeenCalledWith({
+                platformType: 'AZURE_REPOS',
+                event: 'ms.vss-code.git-pullrequest-comment-event',
+                payload: {
+                    eventType: 'ms.vss-code.git-pullrequest-comment-event',
+                    resource: { comment: { content: '@kody review' } },
+                },
+            });
+        });
+    });
+
+    describe('unsupported events - should NOT enqueue', () => {
+        it('should ignore "git.push" event', async () => {
+            mockRequest = {
+                query: { token: 'valid-token' },
+                body: {
+                    eventType: 'git.push',
+                    resource: { commits: [] },
+                },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.OK);
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (event not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+
+        it('should ignore "build.complete" event', async () => {
+            mockRequest = {
+                query: { token: 'valid-token' },
+                body: {
+                    eventType: 'build.complete',
+                    resource: {},
+                },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (event not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+
+        it('should ignore "workitem.created" event', async () => {
+            mockRequest = {
+                query: { token: 'valid-token' },
+                body: {
+                    eventType: 'workitem.created',
+                    resource: {},
+                },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (event not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+
+        it('should ignore "git.pullrequest.approved" event', async () => {
+            mockRequest = {
+                query: { token: 'valid-token' },
+                body: {
+                    eventType: 'git.pullrequest.approved',
+                    resource: { pullRequestId: 1 },
+                },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (event not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('validation', () => {
+        it('should return 403 for invalid token', () => {
+            (validateWebhookToken as jest.Mock).mockReturnValue(false);
+
+            mockRequest = {
+                query: { token: 'invalid-token' },
+                body: {
+                    eventType: 'git.pullrequest.created',
+                    resource: {},
+                },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.status).toHaveBeenCalledWith(403);
+            expect(mockResponse.send).toHaveBeenCalledWith('Unauthorized');
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+
+        it('should return 400 for missing eventType', () => {
+            mockRequest = {
+                query: { token: 'valid-token' },
+                body: { resource: {} },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.status).toHaveBeenCalledWith(
+                HttpStatus.BAD_REQUEST,
+            );
+            expect(mockResponse.send).toHaveBeenCalledWith('Unrecognized event');
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/test/unit/webhooks/controllers/bitbucket.controller.spec.ts
+++ b/test/unit/webhooks/controllers/bitbucket.controller.spec.ts
@@ -1,0 +1,244 @@
+import { BitbucketController } from '../../../../apps/webhooks/src/controllers/bitbucket.controller';
+import { EnqueueWebhookUseCase } from '@libs/platform/application/use-cases/webhook/enqueue-webhook.use-case';
+import { Request, Response } from 'express';
+import { HttpStatus } from '@nestjs/common';
+
+describe('BitbucketController', () => {
+    let controller: BitbucketController;
+    let enqueueWebhookUseCase: jest.Mocked<EnqueueWebhookUseCase>;
+    let mockRequest: Partial<Request>;
+    let mockResponse: Partial<Response>;
+
+    beforeEach(() => {
+        enqueueWebhookUseCase = {
+            execute: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        controller = new BitbucketController(enqueueWebhookUseCase);
+
+        mockResponse = {
+            status: jest.fn().mockReturnThis(),
+            send: jest.fn().mockReturnThis(),
+        };
+    });
+
+    describe('supported events', () => {
+        it('should enqueue "pullrequest:created" event', async () => {
+            mockRequest = {
+                headers: { 'x-event-key': 'pullrequest:created' },
+                body: { pullrequest: { id: 1 } },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.OK);
+            expect(mockResponse.send).toHaveBeenCalledWith('Webhook received');
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).toHaveBeenCalledWith({
+                platformType: 'BITBUCKET',
+                event: 'pullrequest:created',
+                payload: { pullrequest: { id: 1 } },
+            });
+        });
+
+        it('should enqueue "pullrequest:updated" event', async () => {
+            mockRequest = {
+                headers: { 'x-event-key': 'pullrequest:updated' },
+                body: { pullrequest: { id: 1 } },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).toHaveBeenCalledWith({
+                platformType: 'BITBUCKET',
+                event: 'pullrequest:updated',
+                payload: { pullrequest: { id: 1 } },
+            });
+        });
+
+        it('should enqueue "pullrequest:fulfilled" event', async () => {
+            mockRequest = {
+                headers: { 'x-event-key': 'pullrequest:fulfilled' },
+                body: { pullrequest: { id: 1 } },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).toHaveBeenCalled();
+        });
+
+        it('should enqueue "pullrequest:rejected" event', async () => {
+            mockRequest = {
+                headers: { 'x-event-key': 'pullrequest:rejected' },
+                body: { pullrequest: { id: 1 } },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).toHaveBeenCalled();
+        });
+
+        it('should enqueue "pullrequest:comment_created" event', async () => {
+            mockRequest = {
+                headers: { 'x-event-key': 'pullrequest:comment_created' },
+                body: { pullrequest: { id: 1 }, comment: { content: { raw: '@kody review' } } },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).toHaveBeenCalledWith({
+                platformType: 'BITBUCKET',
+                event: 'pullrequest:comment_created',
+                payload: { pullrequest: { id: 1 }, comment: { content: { raw: '@kody review' } } },
+            });
+        });
+    });
+
+    describe('unsupported events - should NOT enqueue', () => {
+        it('should ignore "repo:push" event', async () => {
+            mockRequest = {
+                headers: { 'x-event-key': 'repo:push' },
+                body: { push: { changes: [] } },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.OK);
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (event not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+
+        it('should ignore "repo:fork" event', async () => {
+            mockRequest = {
+                headers: { 'x-event-key': 'repo:fork' },
+                body: { fork: {} },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (event not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+
+        it('should ignore "issue:created" event', async () => {
+            mockRequest = {
+                headers: { 'x-event-key': 'issue:created' },
+                body: { issue: {} },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (event not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+
+        it('should ignore "pullrequest:approved" event', async () => {
+            mockRequest = {
+                headers: { 'x-event-key': 'pullrequest:approved' },
+                body: { pullrequest: { id: 1 } },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (event not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+
+        it('should ignore "pullrequest:unapproved" event', async () => {
+            mockRequest = {
+                headers: { 'x-event-key': 'pullrequest:unapproved' },
+                body: { pullrequest: { id: 1 } },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (event not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+
+        it('should ignore "pullrequest:changes_request_created" event', async () => {
+            mockRequest = {
+                headers: { 'x-event-key': 'pullrequest:changes_request_created' },
+                body: { pullrequest: { id: 1 } },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (event not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/test/unit/webhooks/controllers/github.controller.spec.ts
+++ b/test/unit/webhooks/controllers/github.controller.spec.ts
@@ -1,0 +1,322 @@
+import { GithubController } from '../../../../apps/webhooks/src/controllers/github.controller';
+import { EnqueueWebhookUseCase } from '@libs/platform/application/use-cases/webhook/enqueue-webhook.use-case';
+import { Request, Response } from 'express';
+import { HttpStatus } from '@nestjs/common';
+
+describe('GithubController', () => {
+    let controller: GithubController;
+    let enqueueWebhookUseCase: jest.Mocked<EnqueueWebhookUseCase>;
+    let mockRequest: Partial<Request>;
+    let mockResponse: Partial<Response>;
+
+    beforeEach(() => {
+        enqueueWebhookUseCase = {
+            execute: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        controller = new GithubController(enqueueWebhookUseCase);
+
+        mockResponse = {
+            status: jest.fn().mockReturnThis(),
+            send: jest.fn().mockReturnThis(),
+        };
+    });
+
+    describe('supported events', () => {
+        it('should enqueue pull_request event with "opened" action', async () => {
+            mockRequest = {
+                headers: { 'x-github-event': 'pull_request' },
+                body: { action: 'opened', pull_request: { number: 1 } },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.OK);
+            expect(mockResponse.send).toHaveBeenCalledWith('Webhook received');
+
+            // Wait for setImmediate
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).toHaveBeenCalledWith({
+                platformType: 'GITHUB',
+                event: 'pull_request',
+                payload: { action: 'opened', pull_request: { number: 1 } },
+            });
+        });
+
+        it('should enqueue pull_request event with "synchronize" action', async () => {
+            mockRequest = {
+                headers: { 'x-github-event': 'pull_request' },
+                body: { action: 'synchronize' },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).toHaveBeenCalled();
+        });
+
+        it('should enqueue pull_request event with "closed" action', async () => {
+            mockRequest = {
+                headers: { 'x-github-event': 'pull_request' },
+                body: { action: 'closed' },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).toHaveBeenCalled();
+        });
+
+        it('should enqueue pull_request event with "reopened" action', async () => {
+            mockRequest = {
+                headers: { 'x-github-event': 'pull_request' },
+                body: { action: 'reopened' },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).toHaveBeenCalled();
+        });
+
+        it('should enqueue pull_request event with "ready_for_review" action', async () => {
+            mockRequest = {
+                headers: { 'x-github-event': 'pull_request' },
+                body: { action: 'ready_for_review' },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).toHaveBeenCalled();
+        });
+
+        it('should enqueue issue_comment event', async () => {
+            mockRequest = {
+                headers: { 'x-github-event': 'issue_comment' },
+                body: { action: 'created', comment: { body: '@kody review' } },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).toHaveBeenCalledWith({
+                platformType: 'GITHUB',
+                event: 'issue_comment',
+                payload: {
+                    action: 'created',
+                    comment: { body: '@kody review' },
+                },
+            });
+        });
+
+        it('should enqueue pull_request_review_comment event', async () => {
+            mockRequest = {
+                headers: { 'x-github-event': 'pull_request_review_comment' },
+                body: { action: 'created', comment: { body: 'test' } },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).toHaveBeenCalledWith({
+                platformType: 'GITHUB',
+                event: 'pull_request_review_comment',
+                payload: { action: 'created', comment: { body: 'test' } },
+            });
+        });
+    });
+
+    describe('unsupported events - should NOT enqueue', () => {
+        it('should ignore push event', async () => {
+            mockRequest = {
+                headers: { 'x-github-event': 'push' },
+                body: { ref: 'refs/heads/main' },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.OK);
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (event not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+
+        it('should ignore workflow_run event', async () => {
+            mockRequest = {
+                headers: { 'x-github-event': 'workflow_run' },
+                body: { action: 'completed' },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (event not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+
+        it('should ignore issues event', async () => {
+            mockRequest = {
+                headers: { 'x-github-event': 'issues' },
+                body: { action: 'opened' },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (event not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+
+        it('should ignore release event', async () => {
+            mockRequest = {
+                headers: { 'x-github-event': 'release' },
+                body: { action: 'published' },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (event not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('unsupported pull_request actions - should NOT enqueue', () => {
+        it('should ignore pull_request with "labeled" action', async () => {
+            mockRequest = {
+                headers: { 'x-github-event': 'pull_request' },
+                body: { action: 'labeled' },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (action not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+
+        it('should ignore pull_request with "assigned" action', async () => {
+            mockRequest = {
+                headers: { 'x-github-event': 'pull_request' },
+                body: { action: 'assigned' },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (action not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+
+        it('should ignore pull_request with "converted_to_draft" action', async () => {
+            mockRequest = {
+                headers: { 'x-github-event': 'pull_request' },
+                body: { action: 'converted_to_draft' },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (action not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+
+        it('should ignore pull_request with "review_requested" action', async () => {
+            mockRequest = {
+                headers: { 'x-github-event': 'pull_request' },
+                body: { action: 'review_requested' },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (action not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/test/unit/webhooks/controllers/gitlab.controller.spec.ts
+++ b/test/unit/webhooks/controllers/gitlab.controller.spec.ts
@@ -1,0 +1,227 @@
+import { GitlabController } from '../../../../apps/webhooks/src/controllers/gitlab.controller';
+import { EnqueueWebhookUseCase } from '@libs/platform/application/use-cases/webhook/enqueue-webhook.use-case';
+import { Request, Response } from 'express';
+import { HttpStatus } from '@nestjs/common';
+
+describe('GitlabController', () => {
+    let controller: GitlabController;
+    let enqueueWebhookUseCase: jest.Mocked<EnqueueWebhookUseCase>;
+    let mockRequest: Partial<Request>;
+    let mockResponse: Partial<Response>;
+
+    beforeEach(() => {
+        enqueueWebhookUseCase = {
+            execute: jest.fn().mockResolvedValue(undefined),
+        } as any;
+
+        controller = new GitlabController(enqueueWebhookUseCase);
+
+        mockResponse = {
+            status: jest.fn().mockReturnThis(),
+            send: jest.fn().mockReturnThis(),
+        };
+    });
+
+    describe('supported events', () => {
+        it('should enqueue "Merge Request Hook" event', async () => {
+            mockRequest = {
+                headers: { 'x-gitlab-event': 'Merge Request Hook' },
+                body: {
+                    object_kind: 'merge_request',
+                    object_attributes: { iid: 1 },
+                },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.OK);
+            expect(mockResponse.send).toHaveBeenCalledWith('Webhook received');
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).toHaveBeenCalledWith({
+                platformType: 'GITLAB',
+                event: 'Merge Request Hook',
+                payload: {
+                    object_kind: 'merge_request',
+                    object_attributes: { iid: 1 },
+                },
+            });
+        });
+
+        it('should enqueue "Note Hook" event', async () => {
+            mockRequest = {
+                headers: { 'x-gitlab-event': 'Note Hook' },
+                body: {
+                    object_kind: 'note',
+                    object_attributes: { note: '@kody review' },
+                },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.OK);
+            expect(mockResponse.send).toHaveBeenCalledWith('Webhook received');
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).toHaveBeenCalledWith({
+                platformType: 'GITLAB',
+                event: 'Note Hook',
+                payload: {
+                    object_kind: 'note',
+                    object_attributes: { note: '@kody review' },
+                },
+            });
+        });
+    });
+
+    describe('unsupported events - should NOT enqueue', () => {
+        it('should ignore "Push Hook" event', async () => {
+            mockRequest = {
+                headers: { 'x-gitlab-event': 'Push Hook' },
+                body: { object_kind: 'push', ref: 'refs/heads/main' },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.OK);
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (event not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+
+        it('should ignore "Tag Push Hook" event', async () => {
+            mockRequest = {
+                headers: { 'x-gitlab-event': 'Tag Push Hook' },
+                body: { object_kind: 'tag_push' },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (event not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+
+        it('should ignore "Issue Hook" event', async () => {
+            mockRequest = {
+                headers: { 'x-gitlab-event': 'Issue Hook' },
+                body: { object_kind: 'issue' },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (event not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+
+        it('should ignore "Pipeline Hook" event', async () => {
+            mockRequest = {
+                headers: { 'x-gitlab-event': 'Pipeline Hook' },
+                body: { object_kind: 'pipeline' },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (event not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+
+        it('should ignore "Job Hook" event', async () => {
+            mockRequest = {
+                headers: { 'x-gitlab-event': 'Job Hook' },
+                body: { object_kind: 'build' },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (event not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+
+        it('should ignore "Wiki Page Hook" event', async () => {
+            mockRequest = {
+                headers: { 'x-gitlab-event': 'Wiki Page Hook' },
+                body: { object_kind: 'wiki_page' },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (event not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+
+        it('should ignore "Release Hook" event', async () => {
+            mockRequest = {
+                headers: { 'x-gitlab-event': 'Release Hook' },
+                body: { object_kind: 'release' },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.send).toHaveBeenCalledWith(
+                'Webhook ignored (event not supported)',
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).not.toHaveBeenCalled();
+        });
+    });
+});


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request implements explicit event filtering across all webhook controllers (Azure Repos, Bitbucket, GitHub, and GitLab).

The changes introduce a predefined list of supported webhook events for each platform. For GitHub, specific actions within `pull_request` events are also now explicitly filtered.

Any incoming webhook event that does not match the defined supported events or actions will be immediately ignored, and a `200 OK` response will be returned with a message indicating that the webhook was ignored. This prevents the system from processing irrelevant webhook payloads, thereby improving efficiency and reducing unnecessary resource consumption.

New unit tests have been added for each controller to validate the new filtering logic.
<!-- kody-pr-summary:end -->