### PR TITLE
fix: apply severity level filter to cross-file suggestions

### DIFF
--- a/test/unit/code-review/pipeline/stages/process-files-review.stage.spec.ts
+++ b/test/unit/code-review/pipeline/stages/process-files-review.stage.spec.ts
@@ -1,0 +1,370 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ProcessFilesReview } from '@/code-review/pipeline/stages/process-files-review.stage';
+import { SUGGESTION_SERVICE_TOKEN } from '@/code-review/domain/contracts/SuggestionService.contract';
+import { PULL_REQUESTS_SERVICE_TOKEN } from '@/platformData/domain/pullRequests/contracts/pullRequests.service.contracts';
+import { FILE_REVIEW_CONTEXT_PREPARATION_TOKEN } from '@/core/domain/interfaces/file-review-context-preparation.interface';
+import { KODY_FINE_TUNING_CONTEXT_PREPARATION_TOKEN } from '@/core/domain/interfaces/kody-fine-tuning-context-preparation.interface';
+import { KODY_AST_ANALYZE_CONTEXT_PREPARATION_TOKEN } from '@/core/domain/interfaces/kody-ast-analyze-context-preparation.interface';
+import { CodeAnalysisOrchestrator } from '@/ee/codeBase/codeAnalysisOrchestrator.service';
+import { PriorityStatus } from '@/platformData/domain/pullRequests/enums/priorityStatus.enum';
+import { DeliveryStatus } from '@/platformData/domain/pullRequests/enums/deliveryStatus.enum';
+import {
+    AnalysisContext,
+    AIAnalysisResult,
+    CodeSuggestion,
+} from '@/core/infrastructure/config/types/general/codeReview.type';
+import { SeverityLevel } from '@/common/utils/enums/severityLevel.enum';
+
+jest.mock('@kodus/flow', () => ({
+    createLogger: () => ({
+        log: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+        debug: jest.fn(),
+        info: jest.fn(),
+    }),
+}));
+
+describe('ProcessFilesReview', () => {
+    let stage: ProcessFilesReview;
+
+    const mockSuggestionService = {
+        filterCodeSuggestionsByReviewOptions: jest.fn(),
+        filterSuggestionsCodeDiff: jest.fn(),
+        getDiscardedSuggestions: jest.fn(),
+        filterSuggestionsSafeGuard: jest.fn(),
+        analyzeSuggestionsSeverity: jest.fn(),
+        filterSuggestionsBySeverityLevel: jest.fn(),
+        calculateSuggestionRankScore: jest.fn(),
+        removeSuggestionsRelatedToSavedFiles: jest.fn(),
+    };
+
+    const mockPullRequestService = {
+        findSuggestionsByPRAndFilename: jest.fn(),
+    };
+
+    const mockFileReviewContextPreparation = {
+        prepareFileContext: jest.fn(),
+    };
+
+    const mockKodyFineTuningContextPreparation = {
+        prepareKodyFineTuningContext: jest.fn(),
+    };
+
+    const mockKodyAstAnalyzeContextPreparation = {
+        prepareKodyASTAnalyzeContext: jest.fn(),
+    };
+
+    const mockCodeAnalysisOrchestrator = {
+        executeStandardAnalysis: jest.fn(),
+        executeKodyRulesAnalysis: jest.fn(),
+    };
+
+    const mockOrganizationAndTeamData = {
+        organizationId: 'org-123',
+        teamId: 'team-456',
+    };
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                ProcessFilesReview,
+                { provide: SUGGESTION_SERVICE_TOKEN, useValue: mockSuggestionService },
+                { provide: PULL_REQUESTS_SERVICE_TOKEN, useValue: mockPullRequestService },
+                { provide: FILE_REVIEW_CONTEXT_PREPARATION_TOKEN, useValue: mockFileReviewContextPreparation },
+                { provide: KODY_FINE_TUNING_CONTEXT_PREPARATION_TOKEN, useValue: mockKodyFineTuningContextPreparation },
+                { provide: KODY_AST_ANALYZE_CONTEXT_PREPARATION_TOKEN, useValue: mockKodyAstAnalyzeContextPreparation },
+                { provide: CodeAnalysisOrchestrator, useValue: mockCodeAnalysisOrchestrator },
+            ],
+        }).compile();
+
+        stage = module.get<ProcessFilesReview>(ProcessFilesReview);
+        jest.clearAllMocks();
+    });
+
+    describe('processAnalysisResult - cross-file severity filtering', () => {
+        /**
+         * Helper to build a minimal AnalysisContext with cross-file suggestions
+         * and a configured severityLevelFilter.
+         */
+        function buildContext(overrides: {
+            severityLevelFilter?: string;
+            crossFileSuggestions?: CodeSuggestion[];
+        }): AnalysisContext {
+            return {
+                organizationAndTeamData: mockOrganizationAndTeamData as any,
+                pullRequest: {
+                    number: 42,
+                    base: { repo: { fullName: 'org/repo' } },
+                    repository: { id: 'repo-1', fullName: 'org/repo' },
+                },
+                platformType: 'github',
+                correlationId: 'test-corr',
+                reviewModeResponse: undefined,
+                codeReviewConfig: {
+                    reviewOptions: {},
+                    suggestionControl: {
+                        maxSuggestions: 10,
+                        severityLevelFilter: overrides.severityLevelFilter as any,
+                    },
+                } as any,
+                fileChangeContext: {
+                    file: { filename: 'src/app.ts' },
+                    relevantContent: '',
+                    patchWithLinesStr: '@@ -1,5 +1,5 @@\n1 +line1',
+                    hasRelevantContent: true,
+                },
+                validCrossFileSuggestions: overrides.crossFileSuggestions || [],
+                tasks: { astAnalysis: { taskId: 'task-1' } },
+            } as any;
+        }
+
+        /**
+         * Helper to build cross-file CodeSuggestions with specific severities.
+         */
+        function buildCrossFileSuggestion(
+            id: string,
+            severity: string,
+            filename = 'src/app.ts',
+        ): CodeSuggestion {
+            return {
+                id,
+                severity,
+                label: 'cross_file',
+                type: 'cross_file',
+                relevantFile: filename,
+                relevantLinesStart: 1,
+                relevantLinesEnd: 5,
+                suggestionContent: `Cross-file suggestion ${id}`,
+                existingCode: 'const a = 1;',
+                improvedCode: 'const a = 2;',
+                oneSentenceSummary: `Summary ${id}`,
+                language: 'typescript',
+            } as any;
+        }
+
+        /**
+         * Sets up all mocks so processAnalysisResult runs through cleanly.
+         * The key behavior: suggestions pass through filters unchanged,
+         * so we can verify the severity filter is the only gate.
+         */
+        function setupMocks(crossFileSuggestions: CodeSuggestion[]) {
+            // initialFilterSuggestions: return all suggestions as filtered (no discards)
+            mockSuggestionService.filterCodeSuggestionsByReviewOptions.mockReturnValue({
+                codeSuggestions: crossFileSuggestions,
+            });
+            mockSuggestionService.filterSuggestionsCodeDiff.mockReturnValue(crossFileSuggestions);
+            mockSuggestionService.getDiscardedSuggestions.mockReturnValue([]);
+
+            // kodyFineTuning: keep all suggestions
+            mockKodyFineTuningContextPreparation.prepareKodyFineTuningContext.mockResolvedValue({
+                keepedSuggestions: crossFileSuggestions,
+                discardedSuggestions: [],
+            });
+
+            // safeguard: return empty (only applied to non-cross-file)
+            mockSuggestionService.filterSuggestionsSafeGuard.mockResolvedValue({
+                suggestions: [],
+                codeReviewModelUsed: { safeguard: '' },
+            });
+
+            // analyzeSuggestionsSeverity: return suggestions as-is (severity already set)
+            mockSuggestionService.analyzeSuggestionsSeverity.mockImplementation(
+                (_org, _pr, suggestions) => Promise.resolve(suggestions),
+            );
+
+            // kodyRules: no suggestions
+            mockCodeAnalysisOrchestrator.executeKodyRulesAnalysis.mockResolvedValue({
+                codeSuggestions: [],
+            });
+
+            // kodyAST: no suggestions
+            mockKodyAstAnalyzeContextPreparation.prepareKodyASTAnalyzeContext.mockResolvedValue({
+                codeSuggestions: [],
+            });
+
+            // rankScore
+            mockSuggestionService.calculateSuggestionRankScore.mockResolvedValue(50);
+        }
+
+        it('should DISCARD cross-file suggestions with medium/low severity when severityLevelFilter is "high"', async () => {
+            const crossFileSuggestions = [
+                buildCrossFileSuggestion('cf-1', 'critical'),
+                buildCrossFileSuggestion('cf-2', 'high'),
+                buildCrossFileSuggestion('cf-3', 'medium'),
+                buildCrossFileSuggestion('cf-4', 'low'),
+            ];
+
+            setupMocks(crossFileSuggestions);
+
+            // filterSuggestionsBySeverityLevel: simulate real behavior for 'high' filter
+            mockSuggestionService.filterSuggestionsBySeverityLevel.mockImplementation(
+                (suggestions) => {
+                    const acceptedSeverities = ['critical', 'high'];
+                    return Promise.resolve(
+                        suggestions.map((s) => ({
+                            ...s,
+                            priorityStatus: acceptedSeverities.includes(s.severity?.toLowerCase())
+                                ? PriorityStatus.PRIORITIZED
+                                : PriorityStatus.DISCARDED_BY_SEVERITY,
+                            deliveryStatus: DeliveryStatus.NOT_SENT,
+                        })),
+                    );
+                },
+            );
+
+            const context = buildContext({
+                severityLevelFilter: 'high',
+                crossFileSuggestions,
+            });
+
+            const emptyAIResult: AIAnalysisResult = {
+                codeSuggestions: [],
+            };
+
+            // Call private method
+            const result = await (stage as any).processAnalysisResult(emptyAIResult, context);
+
+            // filterSuggestionsBySeverityLevel MUST have been called with cross-file suggestions
+            expect(mockSuggestionService.filterSuggestionsBySeverityLevel).toHaveBeenCalledWith(
+                crossFileSuggestions, // the cross-file suggestions
+                'high',              // the severity level filter
+                mockOrganizationAndTeamData,
+                42,                  // PR number
+            );
+
+            // Only critical and high should be in the valid output
+            const validIds = result.validSuggestionsToAnalyze.map((s) => s.id);
+            expect(validIds).toContain('cf-1'); // critical - INCLUDED
+            expect(validIds).toContain('cf-2'); // high - INCLUDED
+            expect(validIds).not.toContain('cf-3'); // medium - EXCLUDED
+            expect(validIds).not.toContain('cf-4'); // low - EXCLUDED
+
+            // Discarded should include the medium/low cross-file suggestions
+            const discardedIds = result.discardedSuggestionsBySafeGuard.map((s) => s.id);
+            expect(discardedIds).toContain('cf-3');
+            expect(discardedIds).toContain('cf-4');
+        });
+
+        it('should KEEP all cross-file suggestions when severityLevelFilter is not configured', async () => {
+            const crossFileSuggestions = [
+                buildCrossFileSuggestion('cf-1', 'critical'),
+                buildCrossFileSuggestion('cf-2', 'medium'),
+                buildCrossFileSuggestion('cf-3', 'low'),
+            ];
+
+            setupMocks(crossFileSuggestions);
+
+            const context = buildContext({
+                severityLevelFilter: undefined, // not configured
+                crossFileSuggestions,
+            });
+
+            const emptyAIResult: AIAnalysisResult = {
+                codeSuggestions: [],
+            };
+
+            const result = await (stage as any).processAnalysisResult(emptyAIResult, context);
+
+            // filterSuggestionsBySeverityLevel should NOT be called
+            expect(mockSuggestionService.filterSuggestionsBySeverityLevel).not.toHaveBeenCalled();
+
+            // All cross-file suggestions should be in valid output
+            const validIds = result.validSuggestionsToAnalyze.map((s) => s.id);
+            expect(validIds).toContain('cf-1');
+            expect(validIds).toContain('cf-2');
+            expect(validIds).toContain('cf-3');
+        });
+
+        it('should DISCARD only low cross-file suggestions when severityLevelFilter is "medium"', async () => {
+            const crossFileSuggestions = [
+                buildCrossFileSuggestion('cf-1', 'critical'),
+                buildCrossFileSuggestion('cf-2', 'high'),
+                buildCrossFileSuggestion('cf-3', 'medium'),
+                buildCrossFileSuggestion('cf-4', 'low'),
+            ];
+
+            setupMocks(crossFileSuggestions);
+
+            mockSuggestionService.filterSuggestionsBySeverityLevel.mockImplementation(
+                (suggestions) => {
+                    const acceptedSeverities = ['critical', 'high', 'medium'];
+                    return Promise.resolve(
+                        suggestions.map((s) => ({
+                            ...s,
+                            priorityStatus: acceptedSeverities.includes(s.severity?.toLowerCase())
+                                ? PriorityStatus.PRIORITIZED
+                                : PriorityStatus.DISCARDED_BY_SEVERITY,
+                            deliveryStatus: DeliveryStatus.NOT_SENT,
+                        })),
+                    );
+                },
+            );
+
+            const context = buildContext({
+                severityLevelFilter: 'medium',
+                crossFileSuggestions,
+            });
+
+            const result = await (stage as any).processAnalysisResult(
+                { codeSuggestions: [] } as AIAnalysisResult,
+                context,
+            );
+
+            const validIds = result.validSuggestionsToAnalyze.map((s) => s.id);
+            expect(validIds).toContain('cf-1'); // critical
+            expect(validIds).toContain('cf-2'); // high
+            expect(validIds).toContain('cf-3'); // medium
+            expect(validIds).not.toContain('cf-4'); // low - EXCLUDED
+
+            const discardedIds = result.discardedSuggestionsBySafeGuard.map((s) => s.id);
+            expect(discardedIds).toContain('cf-4');
+        });
+
+        it('should not filter cross-file suggestions that do not match the current file', async () => {
+            const crossFileSuggestions = [
+                buildCrossFileSuggestion('cf-1', 'medium', 'src/app.ts'),        // matches file
+                buildCrossFileSuggestion('cf-2', 'medium', 'src/other-file.ts'),  // different file
+            ];
+
+            // Only cf-1 matches the file being analyzed (src/app.ts).
+            // cf-2 should not appear at all since it's for a different file.
+            const matchingOnly = [crossFileSuggestions[0]];
+
+            setupMocks(matchingOnly);
+
+            mockSuggestionService.filterSuggestionsBySeverityLevel.mockImplementation(
+                (suggestions) => {
+                    return Promise.resolve(
+                        suggestions.map((s) => ({
+                            ...s,
+                            priorityStatus: PriorityStatus.DISCARDED_BY_SEVERITY,
+                            deliveryStatus: DeliveryStatus.NOT_SENT,
+                        })),
+                    );
+                },
+            );
+
+            const context = buildContext({
+                severityLevelFilter: 'high',
+                crossFileSuggestions,
+            });
+
+            const result = await (stage as any).processAnalysisResult(
+                { codeSuggestions: [] } as AIAnalysisResult,
+                context,
+            );
+
+            // filterSuggestionsBySeverityLevel should only receive the file-matching suggestion
+            expect(mockSuggestionService.filterSuggestionsBySeverityLevel).toHaveBeenCalledTimes(1);
+            const calledWith = mockSuggestionService.filterSuggestionsBySeverityLevel.mock.calls[0][0];
+            expect(calledWith).toHaveLength(1);
+            expect(calledWith[0].id).toBe('cf-1');
+
+            // No cross-file suggestions should be in the valid output (both excluded)
+            const validIds = result.validSuggestionsToAnalyze.map((s) => s.id);
+            expect(validIds).not.toContain('cf-1'); // discarded by severity
+            expect(validIds).not.toContain('cf-2'); // different file, never processed
+        });
+    });
+});


### PR DESCRIPTION
Cross-file suggestions were bypassing the severity filter because they skip applySafeguardFilter (which contains the severity pre-filter). When limitationType is SEVERITY, the downstream filter overrides severityLevelFilter to LOW, making cross-file suggestions pass through unfiltered.

Apply filterSuggestionsBySeverityLevel directly to cross-file suggestions in processAnalysisResult before merging them, using the actual severityLevelFilter from config.

Closes #576

---

<!-- kody-pr-summary:start -->
This pull request addresses an issue where cross-file suggestions were not being filtered by the configured severity level.

Previously, cross-file suggestions bypassed the `applySafeguardFilter` stage, which is responsible for applying the severity pre-filter for other suggestion types. This resulted in an inconsistency where cross-file suggestions with lower severities (e.g., 'medium' or 'low') could still be included in the review, even when the `severityLevelFilter` was set to a higher level (e.g., 'high').

This change introduces a dedicated filtering step within the `ProcessFilesReview` pipeline stage to explicitly apply the `suggestionControl.severityLevelFilter` to cross-file suggestions. Suggestions that do not meet the minimum severity threshold are now correctly discarded and tracked, ensuring that all suggestion types adhere to the user's configured severity preferences.
<!-- kody-pr-summary:end -->