### PR TITLE
Update webpack configuration and VSCode launch settings for improved …

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,7 +12,13 @@
             "localRoot": "${workspaceFolder}",
             "remoteRoot": "/usr/src/app",
             "sourceMaps": true,
+            "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+            "resolveSourceMapLocations": [
+                "${workspaceFolder}/dist/**",
+                "!**/node_modules/**"
+            ],
             "sourceMapPathOverrides": {
+                "/usr/src/app/*": "${workspaceFolder}/*",
                 "webpack:///*": "${workspaceFolder}/*"
             },
             "skipFiles": ["<node_internals>/**"]
@@ -28,7 +34,13 @@
             "localRoot": "${workspaceFolder}",
             "remoteRoot": "/usr/src/app",
             "sourceMaps": true,
+            "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+            "resolveSourceMapLocations": [
+                "${workspaceFolder}/dist/**",
+                "!**/node_modules/**"
+            ],
             "sourceMapPathOverrides": {
+                "/usr/src/app/*": "${workspaceFolder}/*",
                 "webpack:///*": "${workspaceFolder}/*"
             },
             "skipFiles": ["<node_internals>/**"]
@@ -44,7 +56,13 @@
             "localRoot": "${workspaceFolder}",
             "remoteRoot": "/usr/src/app",
             "sourceMaps": true,
+            "outFiles": ["${workspaceFolder}/dist/**/*.js"],
+            "resolveSourceMapLocations": [
+                "${workspaceFolder}/dist/**",
+                "!**/node_modules/**"
+            ],
             "sourceMapPathOverrides": {
+                "/usr/src/app/*": "${workspaceFolder}/*",
                 "webpack:///*": "${workspaceFolder}/*"
             },
             "skipFiles": ["<node_internals>/**"]

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,8 +97,7 @@ module.exports = function (options, webpack) {
         output: {
             ...options.output,
             devtoolModuleFilenameTemplate: (info) => {
-                const rel = path.relative(__dirname, info.absoluteResourcePath);
-                return `webpack:///${rel.replace(/\\/g, '/')}`;
+                return info.absoluteResourcePath.replace(/\\/g, '/');
             },
         },
         resolve: {


### PR DESCRIPTION
…source map handling

---

<!-- kody-pr-summary:start -->
Updates the Webpack configuration to modify how module filenames are displayed in source maps. Previously, source map filenames were generated with a `webpack:///` prefix and a path relative to the project's root directory. This change now configures Webpack to use the absolute path of the resource directly in source maps, ensuring backslashes are replaced with forward slashes. This adjustment aims to improve source map resolution and debugging by providing more direct file paths.
<!-- kody-pr-summary:end -->