### PR TITLE
Fix repository URL not being persisted in backfill and update paths

### DIFF
--- a/apps/api/src/controllers/pullRequest.controller.ts
+++ b/apps/api/src/controllers/pullRequest.controller.ts
@@ -462,6 +462,7 @@ ${'```'}`,
                             r.fullName ||
                             r.full_name ||
                             `${r.organizationName || ''}/${r.name}`,
+                        url: r.http_url || '',
                     })),
                     startDate,
                     endDate,

--- a/libs/platform/application/use-cases/codeManagement/create-repositories.ts
+++ b/libs/platform/application/use-cases/codeManagement/create-repositories.ts
@@ -116,6 +116,7 @@ export class CreateRepositoriesUseCase implements IUseCase {
                                         r.fullName ||
                                         r.full_name ||
                                         `${r.organizationName || ''}/${r.name}`,
+                                    url: r.http_url || '',
                                 }),
                             ),
                         })

--- a/libs/platformData/application/use-cases/pullRequests/backfill-historical-prs.use-case.ts
+++ b/libs/platformData/application/use-cases/pullRequests/backfill-historical-prs.use-case.ts
@@ -15,6 +15,7 @@ interface BackfillParams {
         id: string;
         name: string;
         fullName?: string;
+        url?: string;
     }>;
     startDate?: string;
     endDate?: string;
@@ -92,7 +93,7 @@ export class BackfillHistoricalPRsUseCase {
 
     private async backfillRepositoryPRs(
         organizationAndTeamData: OrganizationAndTeamData,
-        repository: { id: string; name: string; fullName?: string },
+        repository: { id: string; name: string; fullName?: string; url?: string },
         startDate: string,
         endDate: string,
     ): Promise<void> {
@@ -245,6 +246,7 @@ export class BackfillHistoricalPRsUseCase {
                     organizationAndTeamData.organizationId,
                     fileStats,
                     commits,
+                    repository,
                 );
 
                 await this.pullRequestsRepository.create(prDocument);
@@ -284,6 +286,7 @@ export class BackfillHistoricalPRsUseCase {
             totalChanges: number;
         },
         commits: any[],
+        repository: { id: string; name: string; fullName?: string; url?: string },
     ): Omit<IPullRequests, 'uuid'> {
         const isMerged = !!pr.merged_at;
         const repoData = pr.head?.repo || pr.base?.repo;
@@ -303,9 +306,9 @@ export class BackfillHistoricalPRsUseCase {
                     pr.repositoryId ||
                     '',
                 name: repoData?.name || pr.repositoryData?.name || '',
-                fullName: repoData?.fullName || '',
+                fullName: repoData?.fullName || repository.fullName || '',
                 language: '',
-                url: '',
+                url: repository.url || '',
                 createdAt: new Date().toISOString(),
                 updatedAt: new Date().toISOString(),
             },

--- a/libs/platformData/infrastructure/adapters/services/pullRequests.service.ts
+++ b/libs/platformData/infrastructure/adapters/services/pullRequests.service.ts
@@ -482,6 +482,15 @@ export class PullRequestsService implements IPullRequestsService {
                 ),
                 commits: enrichedPullRequest.commits,
                 isDraft: enrichedPullRequest.isDraft ?? false,
+                repository: {
+                    id: repository.id?.toString() || existingPR.repository?.id || '',
+                    name: repository.name || existingPR.repository?.name || '',
+                    fullName: this.extractRepoFullName(pullRequest) || existingPR.repository?.fullName || '',
+                    language: repository.language || existingPR.repository?.language || '',
+                    url: repository.url || existingPR.repository?.url || '',
+                    createdAt: existingPR.repository?.createdAt || new Date().toISOString(),
+                    updatedAt: new Date().toISOString(),
+                },
             });
 
             if (prLevelSuggestions && prLevelSuggestions.length > 0) {


### PR DESCRIPTION
The webhook mappers correctly extract the web URL (html_url, web_url, remoteUrl) but two code paths were not using it:

- Backfill created PRs with repository.url hardcoded to empty string
- PR update path did not include repository in the update object, so existing PRs never got their URL corrected

Now the backfill receives and persists the repository http_url, and the update path includes the full repository object with the mapped URL.

---

<!-- kody-pr-summary:start -->
This pull request resolves an issue where the repository URL was not consistently persisted across various operations.

Specifically, the changes ensure that:
- The `http_url` of a repository is now correctly captured and passed when creating new repositories.
- During the backfill process for historical pull requests, the repository URL is now properly received and stored in the pull request documents. Previously, this field was not populated.
- When updating existing pull requests, the repository URL is now correctly retained or updated, preventing its loss.
- The API controller and relevant application use cases have been updated to consistently pass the repository's `http_url`.

This fix ensures that repository URLs are reliably stored and available throughout the system, improving data integrity and completeness.
<!-- kody-pr-summary:end -->