### PR TITLE
fix: docker images to use full names

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -117,7 +117,7 @@ services:
         profiles:
             - profiling
             - infra
-        image: grafana/pyroscope:latest
+        image: docker.io/grafana/pyroscope:latest
         container_name: pyroscope
         ports:
             - '4040:4040'
@@ -134,7 +134,7 @@ services:
         profiles:
             - local-db
             - infra
-        image: pgvector/pgvector:pg16
+        image: docker.io/pgvector/pgvector:pg16
         container_name: db_postgres
         ports:
             - '5432:5432'
@@ -163,7 +163,7 @@ services:
         profiles:
             - local-db
             - infra
-        image: mongo:8
+        image: docker.io/mongo:8
         container_name: mongodb
         ports:
             - '27017:27017'

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -76,7 +76,7 @@ services:
   # Databases & Infrastructure
   #----------------------------------------------------------------
   db_postgres:
-    image: pgvector/pgvector:pg16
+    image: docker.io/pgvector/pgvector:pg16
     container_name: kodus_postgres_prod
     restart: unless-stopped
     env_file:
@@ -93,7 +93,7 @@ services:
       start_period: 10s
 
   db_mongodb:
-    image: mongo:8
+    image: docker.io/mongo:8
     container_name: kodus_mongodb_prod
     restart: unless-stopped
     env_file:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,6 +1,6 @@
 services:
     db_postgres:
-        image: pgvector/pgvector:pg16
+        image: docker.io/pgvector/pgvector:pg16
         container_name: postgres
         ports:
             - '5432:5432'
@@ -12,7 +12,7 @@ services:
             - kodus-backend-services-test
 
     db_mongodb:
-        image: mongo:8
+        image: docker.io/mongo:8
         container_name: mongodb
         ports:
             - '27017:27017'

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:22.22.0-slim AS base
+FROM docker.io/library/node:22.22.0-slim AS base
 WORKDIR /usr/src/app
 
 ARG API_CLOUD_MODE=false
@@ -41,7 +41,7 @@ FROM base AS prod-deps
 COPY package.json yarn.lock .npmrc ./
 RUN yarn install --frozen-lockfile && yarn cache clean
 
-FROM node:22.22.0-slim AS runtime-common
+FROM docker.io/library/node:22.22.0-slim AS runtime-common
 WORKDIR /usr/src/app
 ENV NODE_ENV=production
 

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,6 +1,6 @@
 ARG API_CLOUD_MODE=false
 
-FROM node:22.22.0-slim
+FROM docker.io/library/node:22.22.0-slim
 
 ARG API_CLOUD_MODE
 ENV API_CLOUD_MODE=${API_CLOUD_MODE}


### PR DESCRIPTION
Hey! I normally like to use podman instead of docker for security reasons, and be default this doesn't have anything in the registries. can we update the docker files to use the full registry name?

e.g
```
Error: short-name "pgvector/pgvector:pg16" did not resolve to an alias and no containers-registries.conf(5) was found
Error: short-name "mongo:8" did not resolve to an alias and no containers-registries.conf(5) was found
```

but using `docker.io/mongo:8` doesn't cause issues since it has a the full registry name.