### PR TITLE
feat: add Vertex AI Service Account support for self-hosted mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -135,7 +135,10 @@ API_GOOGLE_CLIENT_ID=
 API_GOOGLE_CLIENT_SECRET=
 
 # VERTEX AI
+# Service Account JSON in base64: cat service-account.json | base64 -w 0
 API_VERTEX_AI_API_KEY=
+# Vertex AI location/region (default: us-central1)
+API_VERTEX_AI_LOCATION=us-central1
 
 # NOVITA AI
 API_NOVITA_AI_API_KEY=

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,17 @@ RUN corepack disable \
 
 FROM base AS deps
 COPY package.json yarn.lock .npmrc ./
+COPY packages/kodus-common ./packages/kodus-common
+COPY packages/kodus-flow ./packages/kodus-flow
+
+# Build local packages first
+RUN cd packages/kodus-common && yarn install && yarn prepack
+RUN cd packages/kodus-flow && yarn install && yarn build
+
+# Install dependencies and link local packages
 RUN yarn install --frozen-lockfile
+RUN rm -rf node_modules/@kodus/kodus-common && cp -r packages/kodus-common node_modules/@kodus/kodus-common
+RUN rm -rf node_modules/@kodus/flow && cp -r packages/kodus-flow node_modules/@kodus/flow
 
 FROM deps AS build
 ARG API_CLOUD_MODE=false
@@ -39,7 +49,17 @@ RUN yarn build:apps && yarn build:migrations
 # Install production dependencies only
 FROM base AS prod-deps
 COPY package.json yarn.lock .npmrc ./
+COPY packages/kodus-common ./packages/kodus-common
+COPY packages/kodus-flow ./packages/kodus-flow
+
+# Build local packages first
+RUN cd packages/kodus-common && yarn install && yarn prepack
+RUN cd packages/kodus-flow && yarn install && yarn build
+
+# Install dependencies and link local packages
 RUN yarn install --frozen-lockfile && yarn cache clean
+RUN rm -rf node_modules/@kodus/kodus-common && cp -r packages/kodus-common node_modules/@kodus/kodus-common
+RUN rm -rf node_modules/@kodus/flow && cp -r packages/kodus-flow node_modules/@kodus/flow
 
 FROM docker.io/library/node:22.22.0-slim AS runtime-common
 WORKDIR /usr/src/app

--- a/libs/core/cache/cache.service.ts
+++ b/libs/core/cache/cache.service.ts
@@ -9,12 +9,13 @@ export class CacheService {
     constructor(@Inject(CACHE_MANAGER) private cacheManager: Cache) {}
 
     async addToCache<T>(
-        key: string,
+        key: string | number,
         item: T,
         ttl: number = 60000, // 1 minute
     ): Promise<void> {
+        const keyStr = String(key);
         try {
-            await this.cacheManager.set(key, JSON.stringify(item), ttl);
+            await this.cacheManager.set(keyStr, JSON.stringify(item), ttl);
         } catch (error) {
             this.logger.error({
                 message: 'Error adding item to cache with the key',
@@ -22,15 +23,16 @@ export class CacheService {
                 serviceName: 'CacheService',
                 error: error,
                 metadata: {
-                    key: key,
+                    key: keyStr,
                 },
             });
         }
     }
 
-    async getFromCache<T>(key: string): Promise<T | null> {
+    async getFromCache<T>(key: string | number): Promise<T | null> {
+        const keyStr = String(key);
         try {
-            const value = await this.cacheManager.get<string>(key);
+            const value = await this.cacheManager.get<string>(keyStr);
 
             if (!value) {
                 return null;
@@ -44,15 +46,16 @@ export class CacheService {
                 serviceName: 'CacheService',
                 error: error,
                 metadata: {
-                    key: key,
+                    key: keyStr,
                 },
             });
         }
     }
 
-    async removeFromCache(key: string) {
+    async removeFromCache(key: string | number) {
+        const keyStr = String(key);
         try {
-            await this.cacheManager.del(key);
+            await this.cacheManager.del(keyStr);
         } catch (error) {
             this.logger.error({
                 message: 'Error removing item from cache with the key',
@@ -60,7 +63,7 @@ export class CacheService {
                 serviceName: 'CacheService',
                 error: error,
                 metadata: {
-                    key: key,
+                    key: keyStr,
                 },
             });
         }
@@ -79,9 +82,10 @@ export class CacheService {
         }
     }
 
-    async cacheExists(key: string): Promise<boolean> {
+    async cacheExists(key: string | number): Promise<boolean> {
+        const keyStr = String(key);
         try {
-            const value = await this.cacheManager.get(key);
+            const value = await this.cacheManager.get(keyStr);
 
             return !!value;
         } catch (error) {
@@ -91,6 +95,9 @@ export class CacheService {
                 context: CacheService.name,
                 serviceName: 'CacheService',
                 error: error,
+                metadata: {
+                    key: keyStr,
+                },
             });
             return false;
         }

--- a/packages/kodus-common/src/llm/helper.ts
+++ b/packages/kodus-common/src/llm/helper.ts
@@ -119,7 +119,7 @@ const getChatGemini = (options?: Partial<FactoryArgs>) => {
     });
 };
 
-const getChatVertexAI = (options?: Partial<FactoryArgs>) => {
+export const getChatVertexAI = (options?: Partial<FactoryArgs>) => {
     const defaultOptions = {
         model: MODEL_STRATEGIES[LLMModelProvider.VERTEX_GEMINI_2_5_PRO]
             .modelName,
@@ -144,6 +144,9 @@ const getChatVertexAI = (options?: Partial<FactoryArgs>) => {
         'base64',
     ).toString('utf-8');
 
+    // Support configurable location via environment variable (default: us-central1)
+    const location = process.env.API_VERTEX_AI_LOCATION || 'us-central1';
+
     return new ChatVertexAI({
         model: finalOptions.model,
         authOptions: {
@@ -152,7 +155,7 @@ const getChatVertexAI = (options?: Partial<FactoryArgs>) => {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
             projectId: JSON.parse(credentials).project_id,
         },
-        location: 'us-east5',
+        location,
         temperature: finalOptions.temperature,
         maxOutputTokens: finalOptions.maxTokens,
         verbose: finalOptions.verbose,

--- a/packages/kodus-common/src/llm/llmModelProvider.service.ts
+++ b/packages/kodus-common/src/llm/llmModelProvider.service.ts
@@ -9,6 +9,7 @@ import {
     LLMModelProvider,
     MODEL_STRATEGIES,
     getChatGPT,
+    getChatVertexAI,
 } from './helper';
 import { supportsJsonMode } from './providerAdapters';
 
@@ -61,10 +62,23 @@ export class LLMProviderService {
             const envMode = process.env.API_LLM_PROVIDER_MODEL ?? 'auto';
 
             if (envMode !== 'auto') {
-                // for self-hosted: using openAI provider and changing baseURL
+                // Check if Vertex AI Service Account is configured
+                const useVertexAI = !!process.env.API_VERTEX_AI_API_KEY;
+
+                if (useVertexAI) {
+                    // Use Vertex AI with Service Account credentials
+                    const llm = getChatVertexAI({
+                        ...options,
+                        model: envMode,
+                    });
+
+                    return llm;
+                }
+
+                // Fallback to OpenAI-compatible provider
                 if (!process.env.API_OPEN_AI_API_KEY) {
                     throw new Error(
-                        'API_OPEN_AI_API_KEY not configured for self-hosted mode',
+                        'API_OPEN_AI_API_KEY or API_VERTEX_AI_API_KEY not configured for self-hosted mode',
                     );
                 }
 
@@ -98,6 +112,17 @@ export class LLMProviderService {
                     },
                     context: LLMProviderService.name,
                 });
+
+                // Use Vertex AI if configured, otherwise fallback to OpenAI
+                const useVertexAI = !!process.env.API_VERTEX_AI_API_KEY;
+                if (useVertexAI) {
+                    return getChatVertexAI({
+                        ...options,
+                        model: MODEL_STRATEGIES[
+                            LLMModelProvider.VERTEX_GEMINI_2_5_FLASH
+                        ].modelName,
+                    });
+                }
 
                 const llm = getChatGPT({
                     ...options,
@@ -169,6 +194,17 @@ export class LLMProviderService {
                 error:
                     error instanceof Error ? error : new Error(String(error)),
             });
+
+            // Use Vertex AI if configured, otherwise fallback to OpenAI
+            const useVertexAI = !!process.env.API_VERTEX_AI_API_KEY;
+            if (useVertexAI) {
+                return getChatVertexAI({
+                    ...options,
+                    model: MODEL_STRATEGIES[
+                        LLMModelProvider.VERTEX_GEMINI_2_5_FLASH
+                    ].modelName,
+                });
+            }
 
             const llm = getChatGPT({
                 ...options,


### PR DESCRIPTION
- Add support for API_VERTEX_AI_API_KEY with Service Account JSON in base64
- Add configurable region via API_VERTEX_AI_LOCATION (default: us-central1)
- Update Dockerfile to build local packages (kodus-common, kodus-flow)
- Fix CacheService to accept numeric keys (installationId bug)




---

<!-- kody-pr-summary:start -->
This pull request introduces support for Vertex AI as an alternative Large Language Model (LLM) provider for self-hosted deployments.

Key changes include:
*   **Vertex AI Integration:** The application can now utilize Vertex AI models by checking for the `API_VERTEX_AI_API_KEY` environment variable. If configured, the system will prioritize Vertex AI for LLM interactions, falling back to OpenAI-compatible providers if not present.
*   **Configurable Vertex AI Location:** Users can now specify the Vertex AI region using the `API_VERTEX_AI_LOCATION` environment variable, with `us-central1` as the default.
*   **Updated LLM Provider Logic:** The `LLMProviderService` has been modified to dynamically select between Vertex AI and OpenAI-compatible providers based on environment variable configuration, including in both explicit model selection and auto-detection modes.
*   **Enhanced Docker Build Process:** The Dockerfile has been updated to ensure local packages (`kodus-common` and `kodus-flow`) are correctly built and linked during the image creation, supporting the new LLM integration.
*   **Improved Error Messaging:** The error message for missing API keys in self-hosted mode now explicitly mentions both `API_OPEN_AI_API_KEY` and `API_VERTEX_AI_API_KEY`.
<!-- kody-pr-summary:end -->