### PR TITLE
fix: resolve LLM string line numbers causing null reference errors

### DIFF
--- a/libs/code-review/infrastructure/adapters/services/llmAnalysis.service.ts
+++ b/libs/code-review/infrastructure/adapters/services/llmAnalysis.service.ts
@@ -271,10 +271,10 @@ ${JSON.stringify(context?.suggestions) || 'No suggestions provided'}
                                 improvedCode: z.string(),
                                 oneSentenceSummary: z.string().optional(),
                                 relevantLinesStart: z
-                                    .number()
+                                    .coerce.number()
                                     .min(1)
                                     .optional(),
-                                relevantLinesEnd: z.number().min(1).optional(),
+                                relevantLinesEnd: z.coerce.number().min(1).optional(),
                                 label: z.string(),
                                 severity: z.string().optional(),
                                 rankScore: z.number().optional(),

--- a/libs/common/utils/langchainCommon/prompts/configuration/codeReview.ts
+++ b/libs/common/utils/langchainCommon/prompts/configuration/codeReview.ts
@@ -985,8 +985,8 @@ Return only valid JSON, nothing more. Under no circumstances should there be any
             "existingCode": "Problematic code from PR",
             "improvedCode": "Fixed code proposal",
             "oneSentenceSummary": "Concise issue description",
-            "relevantLinesStart": "starting_line",
-            "relevantLinesEnd": "ending_line",
+            "relevantLinesStart": 1,
+            "relevantLinesEnd": 10,
             "label": "bug|performance|security",
             "severity": "low|medium|high|critical",
             "llmPrompt": "Prompt for LLMs"
@@ -1102,8 +1102,8 @@ Your final output should be **only** a JSON object with the following structure:
             "existingCode": "Relevant new code from the PR",
             "improvedCode": "Improved proposal",
             "oneSentenceSummary": "Concise summary of the suggestion",
-            "relevantLinesStart": "starting_line",
-            "relevantLinesEnd": "ending_line",
+            "relevantLinesStart": 1,
+            "relevantLinesEnd": 10,
             "label": "selected_label",
             "llmPrompt": "Prompt for LLMs"
         }
@@ -1314,8 +1314,8 @@ Your final output should be **ONLY** a JSON object with the following structure:
             "existingCode": "Relevant new code from the PR",
             "improvedCode": "Improved proposal",
             "oneSentenceSummary": "Concise summary of the suggestion",
-            "relevantLinesStart": "starting_line",
-            "relevantLinesEnd": "ending_line",
+            "relevantLinesStart": 1,
+            "relevantLinesEnd": 10,
             "label": "selected_label",
             "llmPrompt": "Prompt for LLMs"
         }

--- a/libs/common/utils/langchainCommon/prompts/detectBreakingChanges.ts
+++ b/libs/common/utils/langchainCommon/prompts/detectBreakingChanges.ts
@@ -28,8 +28,8 @@ Your final response must be a JSON object in the following format:
             "existingCode": "Snippet of the problematic code or contract in the newFunction",
             "improvedCode": "Proposed correction to ensure compatibility with the callers",
             "oneSentenceSummary": "Concise summary of the suggestion",
-            "relevantLinesStart": "starting_line_number",
-            "relevantLinesEnd": "ending_line_number",
+            "relevantLinesStart": 1,
+            "relevantLinesEnd": 10,
         }
     ]
 }

--- a/libs/common/utils/langchainCommon/prompts/kodyRules.ts
+++ b/libs/common/utils/langchainCommon/prompts/kodyRules.ts
@@ -543,8 +543,8 @@ DISCUSSION HERE
             "existingCode": "Relevant code from the PR",
             "improvedCode": "Improved proposal",
             "oneSentenceSummary": "Concise summary",
-            "relevantLinesStart": "starting_line",
-            "relevantLinesEnd": "ending_line",
+            "relevantLinesStart": 1,
+            "relevantLinesEnd": 10,
             "label": "kody_rules",
             "llmPrompt": "Prompt for LLMs",
             "brokenKodyRulesIds": [

--- a/libs/common/utils/langchainCommon/prompts/repeatedCodeReviewSuggestionClustering.ts
+++ b/libs/common/utils/langchainCommon/prompts/repeatedCodeReviewSuggestionClustering.ts
@@ -28,8 +28,8 @@ You will receive an input in the following JSON format:
             "existingCode": "Relevant new code from the PR",
             "improvedCode": "Improved proposal",
             "oneSentenceSummary": "Concise summary of the suggestion",
-            "relevantLinesStart": "starting_line",
-            "relevantLinesEnd": "ending_line",
+            "relevantLinesStart": 1,
+            "relevantLinesEnd": 10,
             "label": "selected_label",
         }
     ]


### PR DESCRIPTION
I'm trying to setup kodus with GitLab self-hosted, everything seemed to work fine, except the comments were never added and suggestions yielded "All Good"

-----

<img width="580" height="252" alt="image" src="https://github.com/user-attachments/assets/76b73537-1841-41a3-adb7-6f02cba40263" />

-----

**Turns out the prompts asked for stringified numbers when the schema expected them to be js numbers.**

Anyway, the code also spewed this: Cannot read properties of null (reading 'codeSuggestions')

```
docker logs kodus-worker-prod --since 30m 2>&1 | grep -B 30 "Cannot read properties of null (reading 'codeSuggestions')" | head -100
ERROR [2026-02-05 20:09:34.705 +0000]: SYS:[ProcessFilesReview] error - ProcessFilesReview - Error analyzing file packages/backend/src/extensions/scaffolderCustomActions.ts
    serviceName: "ProcessFilesReview"
    context: "ProcessFilesReview"
    filename: "packages/backend/src/extensions/scaffolderCustomActions.ts"
    organizationId: "151cb377-8677-4eb8-9098-9cfef25194c0"
    teamId: "149600e5-a15e-475e-8090-557cb632a027"
    pullRequestNumber: 165
    error: {
      "type": "Object",
      "message": "Cannot read properties of null (reading 'codeSuggestions')",
      "stack":
          TypeError: Cannot read properties of null (reading 'codeSuggestions')
              at ProcessFilesReview.initialFilterSuggestions (/usr/src/app/libs/code-review/pipeline/stages/process-files-review.stage.ts:759:24)
              at ProcessFilesReview.processAnalysisResult (/usr/src/app/libs/code-review/pipeline/stages/process-files-review.stage.ts:558:48)
              at ProcessFilesReview.executeFileAnalysis (/usr/src/app/libs/code-review/pipeline/stages/process-files-review.stage.ts:511:44)
              at processTicksAndRejections (node:internal/process/task_queues:105:5)
              at async Promise.allSettled (index 1)
              at ProcessFilesReview.processSingleBatch (/usr/src/app/libs/code-review/pipeline/stages/process-files-review.stage.ts:367:25)
              at ProcessFilesReview.processBatchesSequentially (/usr/src/app/libs/code-review/pipeline/stages/process-files-review.stage.ts:317:17)
              at ProcessFilesReview.runBatches (/usr/src/app/libs/code-review/pipeline/stages/process-files-review.stage.ts:235:9)
              at ProcessFilesReview.analyzeChangedFilesInBatches (/usr/src/app/libs/code-review/pipeline/stages/process-files-review.stage.ts:151:31)
              at ProcessFilesReview.executeStage (/usr/src/app/libs/code-review/pipeline/stages/process-files-review.stage.ts:93:17)
              at ProcessFilesReview.execute (/usr/src/app/libs/core/infrastructure/pipeline/abstracts/base-stage.abstract.ts:12:16)
              at PipelineExecutor.execute (/usr/src/app/libs/core/infrastructure/pipeline/services/pipeline-executor.service.ts:63:27)
              at Object.execute (/usr/src/app/libs/core/providers/code-review-pipeline.provider.ee.ts:42:25)
              at CodeReviewHandlerService.handlePullRequest (/usr/src/app/libs/code-review/infrastructure/adapters/services/codeReviewHandlerService.service.ts:129:28)
              at AutomationCodeReviewService.run (/usr/src/app/libs/automation/infrastructure/adapters/services/processAutomation/strategies/automationCodeReview.ts:173:17)
              at ExecuteAutomationService.executeStrategy (/usr/src/app/libs/automation/infrastructure/adapters/services/processAutomation/config/execute.automation.ts:13:16)
    }
    err: {
      "type": "TypeError",
      "message": "Cannot read properties of null (reading 'codeSuggestions')",
      "stack":
          TypeError: Cannot read properties of null (reading 'codeSuggestions')
```

-----------------

- Update prompt templates to use numeric line numbers (1, 10) instead of strings ("starting_line", "ending_line") in JSON examples
- Add z.coerce.number() to Zod schema for relevantLinesStart/End as safety net
- Add regression test for string-to-number coercion in LLM responses

Fixes TypeError: Cannot read properties of null (reading 'codeSuggestions') caused by LLMs following string format in prompt examples and failing schema validation.

---

<!-- kody-pr-summary:start -->
This pull request resolves an issue where the LLM analysis service could encounter null reference errors or validation failures when line numbers (`relevantLinesStart`, `relevantLinesEnd`) were returned as strings by the Large Language Model (LLM) instead of numbers.

The changes implement the following:
-   **Schema Coercion:** The Zod schema for `relevantLinesStart` and `relevantLinesEnd` in the LLM analysis service has been updated to use `z.coerce.number()`. This ensures that if the LLM provides these values as strings, they are automatically converted to numbers, preventing type-related errors.
-   **Prompt Example Alignment:** The example outputs for `relevantLinesStart` and `relevantLinesEnd` in various LLM prompts have been updated to reflect numeric values, guiding the LLM to generate the correct data type.
-   **Unit Test Coverage:** A new unit test has been added to specifically verify that the system correctly handles and coerces string line numbers from LLM responses into numeric values without errors.
<!-- kody-pr-summary:end -->