### PR TITLE
fix(cli-review): deep-merge config defaults

### DIFF
--- a/libs/cli-review/application/use-cases/execute-cli-review.use-case.ts
+++ b/libs/cli-review/application/use-cases/execute-cli-review.use-case.ts
@@ -34,6 +34,7 @@ import {
     TEAM_AUTOMATION_SERVICE_TOKEN,
 } from '@libs/automation/domain/teamAutomation/contracts/team-automation.service';
 import { PlatformType } from '@libs/core/domain/enums/platform-type.enum';
+import { deepMerge } from '@libs/common/utils/deep';
 
 interface GitContext {
     remote?: string;
@@ -315,14 +316,7 @@ export class ExecuteCliReviewUseCase implements IUseCase {
         defaults: CodeReviewConfig,
     ): DeepPartial<CodeReviewConfig> {
         const base = defaults as DeepPartial<CodeReviewConfig>;
-        const merged = {
-            ...base,
-            ...config,
-            reviewOptions: {
-                ...(base.reviewOptions || {}),
-                ...(config.reviewOptions || {}),
-            },
-        } as DeepPartial<CodeReviewConfig>;
+        const merged = deepMerge(base, config || {}) as DeepPartial<CodeReviewConfig>;
 
         merged.codeReviewVersion = CodeReviewVersion.v2;
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Refactors the configuration merging logic within the CLI review process to use a deep merge strategy. Previously, configuration defaults were merged with user-provided configurations using a shallow merge, with a specific shallow merge applied to `reviewOptions`. This update replaces that logic with a `deepMerge` utility, ensuring that all nested configuration objects are merged comprehensively rather than being entirely overwritten. This change improves the robustness and predictability of how CLI review configurations are applied, allowing for more granular overrides of default settings.
<!-- kody-pr-summary:end -->