### PR TITLE
add time as context in prompts

### DIFF
--- a/libs/common/utils/langchainCommon/prompts/codeReviewCrossFileAnalysis.ts
+++ b/libs/common/utils/langchainCommon/prompts/codeReviewCrossFileAnalysis.ts
@@ -237,5 +237,6 @@ Generate suggestions in JSON format:
 - **Focus on actionable improvements**
 - **Prioritize high-impact consolidation opportunities**
 - **Language: All suggestions and feedback must be provided in ${payload?.language || 'en-US'} language**
+- **Current date: ${new Date().toLocaleDateString('en-GB')}**
 `;
 };

--- a/libs/common/utils/langchainCommon/prompts/codeReviewSafeguard.ts
+++ b/libs/common/utils/langchainCommon/prompts/codeReviewSafeguard.ts
@@ -24,23 +24,23 @@ export const prompt_codeReviewSafeguard_system = (params: {
    - **REASON**: "Syntax errors in config files are prevented by IDE validation before commit."
 
 2. **Undefined Symbols with Custom Imports - CHECKLIST**:
-   
+
    **Step 1**: Does suggestion say something is "undefined" or "not defined"?
    - If NO → Skip this rule
    - If YES → Go to Step 2
-   
+
    **Step 2**: Check file imports. Does the file import ANYTHING beyond these?
    - Go: \`fmt\`, \`os\`, \`strings\`, \`encoding/*\`, \`path/*\`, \`net/http\`
    - C#: Only \`System.*\` namespaces
    - Python: Only \`json\`, \`os\`, \`sys\`, \`re\`, \`datetime\`, \`math\`
    - JavaScript: No imports or only browser APIs
-   
+
    **Step 3**: If file has OTHER imports (custom packages, third-party libraries, domain-based imports):
    - Action: **DISCARD**
    - Reason: "Cannot verify symbol existence - file imports external dependencies not available in review context."
-   
+
    **Key principle**: If the import is NOT from the language's standard library → DISCARD undefined symbol claims
-   
+
    **Pattern recognition**:
    - Domain-based imports (github.com/*, gitlab.com/*, company.com/*)
    - Organization/company namespaces
@@ -48,22 +48,22 @@ export const prompt_codeReviewSafeguard_system = (params: {
    - Relative imports (./, ../)
 
 3. **Speculative Null/Undefined Checks**:
-   
+
    **Step 1**: Does suggestion add optional chaining (\`?.\`) or null checks without evidence?
    - Look for additions like: \`object?.method()\`, \`if (x)\`, \`x ?? fallback\`
-   
+
    **Step 2**: Check if the suggestion claims the variable "can be null/undefined/falsy"
    - If YES → Go to Step 3
-   
+
    **Step 3**: Verify the claim against FileContentContext:
    - Is there evidence the variable can actually be null/undefined?
    - Does the function/utility return type indicate nullable?
    - Is there existing null handling elsewhere in the code?
-   
+
    **Step 4**: If NO evidence found:
    - Action: **DISCARD**
    - Reason: "Speculative null check without evidence. No indication in code that variable can be null/undefined."
-   
+
    **Key principle**: Don't add defensive code based on "what if" scenarios without evidence in the actual codebase.
 
 4. **Database Schema Assumptions**:
@@ -207,7 +207,7 @@ For each suggestion, meticulously verify:
 - **discard**:
 Definition: The suggestion is flawed, irrelevant, assumes information we do not have access to, introduces problems that cannot be easily solved, or **its benefits cannot be reliably verified based on the given context.**
 
-**Use when**: 
+**Use when**:
 - The suggestion doesn't apply to the PR, introduces significant issues, offers no meaningful or verifiable benefit, or **requires assumptions beyond the provided \`FileContentContext\`, \`CodeDiffContext\`, and \`SuggestionsContext\` to be validated.**
   - Important: If the suggestion does not explain that something needs to be implemented, fixed, or improved in the code **in a way that can be verified against the provided context**, it should be discarded.
 
@@ -253,6 +253,7 @@ DISCUSSION
 - Explicit Role Flow (Alice → Bob → Charles → Diana): Forces a step-by-step check for compilation, logic, style, and final decision.
 - Syntax & Compilation Priority: Immediately flags removal or alteration of necessary code pieces.
 - Stylistic vs. Real Improvements: Clearly instructs to discard purely stylistic suggestions with no real benefits.
+- The current date is ${new Date().toLocaleDateString('en-GB')}.
 
 Start analysis`;
 };

--- a/libs/common/utils/langchainCommon/prompts/configuration/codeReview.ts
+++ b/libs/common/utils/langchainCommon/prompts/configuration/codeReview.ts
@@ -1,7 +1,7 @@
-import { LimitationType } from '@libs/core/infrastructure/config/types/general/codeReview.type';
-import { getTextOrDefault, sanitizePromptText } from '../prompt.helpers';
 import { ContextPack } from '@kodus/flow';
 import { getDefaultKodusConfigFile } from '@libs/common/utils/validateCodeReviewConfigFile';
+import { LimitationType } from '@libs/core/infrastructure/config/types/general/codeReview.type';
+import { getTextOrDefault, sanitizePromptText } from '../prompt.helpers';
 
 export interface CodeReviewPayload {
     limitationType?: LimitationType;
@@ -812,6 +812,8 @@ function buildFinalPrompt(
 ): string {
     return `You are Kody Bug-Hunter, a senior engineer specialized in identifying verifiable issues through mental code execution. Your mission is to detect bugs, performance problems, and security vulnerabilities that will actually occur in production by mentally simulating code execution.
 
+The current date is ${new Date().toLocaleDateString('en-GB')}.
+
 ## Core Method: Mental Simulation
 
 Instead of pattern matching, you will mentally execute the code step-by-step focusing on critical points:
@@ -1340,6 +1342,7 @@ Your final output should be **ONLY** a JSON object with the following structure:
    - Your codeSuggestions array should include substantive recommendations when present, but can be empty if no meaningful improvements are identified.
    - Make sure that line numbers (relevantLinesStart and relevantLinesEnd) correspond exactly to the lines where the problematic code appears, not to the beginning of the file or other unrelated locations.
    - Note: No limit on number of suggestions.
+   - The current date is ${new Date().toLocaleDateString('en-GB')}
 `;
 };
 

--- a/libs/common/utils/langchainCommon/prompts/detectBreakingChanges.ts
+++ b/libs/common/utils/langchainCommon/prompts/detectBreakingChanges.ts
@@ -37,5 +37,6 @@ Your final response must be a JSON object in the following format:
 ### Important:
 - If no compatibility issues are found in the newFunction, the "codeSuggestions" array must be empty.
 - All the answers must be concise and direct language.
-- Responde ALWAYS only in ${payload?.languageResultPrompt}.`;
+- Responde ALWAYS only in ${payload?.languageResultPrompt}.
+- The current date is ${new Date().toLocaleDateString('en-GB')}.`;
 };

--- a/libs/common/utils/langchainCommon/prompts/kodyRules.ts
+++ b/libs/common/utils/langchainCommon/prompts/kodyRules.ts
@@ -214,6 +214,8 @@ export const prompt_kodyrules_updatestdsuggestions_system = () => {
     return `
 You are a senior engineer tasked with reviewing a list of code-review suggestions, ensuring that none of them violate the specific code rules (referred to as **Kody Rules**) and practices followed by your company.
 
+The current date is ${new Date().toLocaleDateString('en-GB')}.
+
 Your final output **must** be a single JSON object (see the exact schema below).
 
 Data you have access to
@@ -349,6 +351,8 @@ export type KodyRulesSuggestionGenerationSchema = z.infer<
 
 export const prompt_kodyrules_suggestiongeneration_system = () => {
     return `You are a senior engineer with expertise in code review and a deep understanding of coding standards and best practices. You received a list of standard suggestions that follow the specific code rules (referred to as Kody Rules) and practices followed by your company. Your task is to carefully analyze the file diff, the suggestions list, and try to identify any code that violates the Kody Rules, that isn't mentioned in the suggestion list, and provide suggestions in the specified format.
+
+The current date is ${new Date().toLocaleDateString('en-GB')}.
 
 Your final output should be a JSON object containing an array of new suggestions.
 

--- a/libs/common/utils/langchainCommon/prompts/kodyRulesPrLevel.ts
+++ b/libs/common/utils/langchainCommon/prompts/kodyRulesPrLevel.ts
@@ -239,6 +239,7 @@ Return a JSON array containing only rules that have violations:
 - **Always include rule reference** - end suggestionContent with "Kody Rule violation: [rule-id]"
 - **Base suggestions on actual context** - use the provided code diffs and file information to generate specific guidance
 - **Language: All suggestions and feedback must be provided in ${payload?.language || 'en-US'} language**
+- **Current date: ${new Date().toLocaleDateString('en-GB')}**
 ---
 
 **Now analyze the provided PR and rules to identify cross-file rule violations.**`;

--- a/libs/common/utils/langchainCommon/prompts/safeGuard.ts
+++ b/libs/common/utils/langchainCommon/prompts/safeGuard.ts
@@ -12,6 +12,7 @@ You are an AI specialist whose goal is to validate the quality and integrity of 
 - Do not hallucinate and never make up information.
 - You dont have skill to do math or calculations, so do not provide any response related to that. Alays trust in calculations made previous response.
 - Only confirm if there is data in input that validades generated response.
+- The current date is ${new Date().toLocaleDateString('en-GB')}.
 
 ### Instructions
 


### PR DESCRIPTION
closes #617

---

<!-- kody-pr-summary:start -->
This pull request integrates the current date into various AI prompts across different code review and analysis functionalities.

The change ensures that AI models receive the current date as part of their context, which can be crucial for tasks that require up-to-date information or time-sensitive analysis.

Specifically, the current date (formatted as `en-GB`) has been added to prompts related to:
- Cross-file code analysis
- Code review safeguards
- General code review configurations
- Detection of breaking changes
- Kody Rules updates and suggestion generation
- PR-level Kody Rules analysis
- General safeguard prompts
<!-- kody-pr-summary:end -->