### PR TITLE
emphasize brevity in responses

### DIFF
--- a/default-kodus-config.yml
+++ b/default-kodus-config.yml
@@ -192,4 +192,11 @@ v2PromptOverrides:
                 Edge-case issues
 
     generation:
-        main: 'Detailed and verifiable issue description'
+        main: |
+            Detailed and verifiable issue description
+            - **No conversational filler**: Avoid phrases like "I noticed that," "It seems like," or "You should consider."
+            - **Execute "Brevity First"**: Eliminate all introductory pleasantries. Start descriptions with the noun of the error (e.g., "Memory leak," "Null pointer dereference," "Timing attack").
+            - **Direct addressing**: State the problem immediately, followed by the technical cause.
+            - **Strictly technical**: Use only domain-specific terminology. If a bug is a race condition, start with "Race condition identified in..."
+            - **Use Active Voice**: "The function leaks memory" instead of "Memory is leaked by the function."
+            - **Sentence cap**: Limit the description to 1-2 high-impact sentences.

--- a/libs/common/utils/langchainCommon/prompts/configuration/codeReview.ts
+++ b/libs/common/utils/langchainCommon/prompts/configuration/codeReview.ts
@@ -902,6 +902,8 @@ ${lowText}
 13. **Reject insecure fallbacks for secrets** - When code uses \`|| 'fallback'\` with environment variables for encryption keys, secrets, or credentials, verify it fails-fast instead of using empty/default values
 14. **Validate user-controlled indices** - When user input (cursor offset, page number, array index) is used in slicing/indexing, verify bounds validation prevents negative values or out-of-range access
 15. **Detect SSRF in network calls** - When code calls network operations (open(), fetch(), HTTP.get(), requests.get()) with variables as URLs (not hardcoded strings), flag as SSRF vulnerability unless allowlist validation is present in same function
+16. **Execute "Brevity First"**: Eliminate all introductory pleasantries. Start descriptions with the noun of the error (e.g., "Memory leak," "Null pointer dereference," "Timing attack").
+17. **Use Active Voice**: "The function leaks memory" instead of "Memory is leaked by the function."
 
 ### MUST NOT DO:
 - **NO speculation whatsoever** - If you cannot trace the exact execution path that causes the issue, DO NOT report it
@@ -916,6 +918,8 @@ ${lowText}
 - **NO "in production this could..."** - Must be able to prove it WILL happen, not that it COULD happen
 - **NO assuming missing code is wrong** - If code isn't shown, don't assume it exists or how it works
 - **NO indentation-related issues** - Never report issues where the root cause is indentation, spacing, or whitespace - even if you believe it causes syntax errors, parsing failures, or runtime crashes. Indentation problems are NOT bugs.
+- **NO "Fluff"**: No "I suggest," "Please," "Maybe," or "I found."
+- **NO redundant explanations**: If the code fix is self-explanatory, keep the description under 50 words.
 - **ONLY report if you can provide**:
   1. Exact input values that trigger the issue
   2. Step-by-step execution trace showing the failure
@@ -950,7 +954,7 @@ ${lowText}
 - Report ONLY issues you can definitively prove will occur
 - Focus ONLY on bugs, performance, and security categories
 - Use PR summary as auxiliary context, not absolute truth
-- Be precise and concise in descriptions
+- Be surgically precise: Focus on the *mechanics* of the failure.
 - Always respond in ${languageNote} language
 - Return ONLY the JSON object, no additional text
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request updates the AI's prompt configurations to emphasize brevity, directness, and technical precision in its responses, particularly for issue descriptions and code reviews.

Key changes include:
- **Enhanced Brevity Instructions**: The main generation prompt now explicitly instructs the AI to avoid conversational filler, execute "Brevity First" by starting descriptions with the error's noun, use direct addressing, maintain a strictly technical tone, and limit descriptions to 1-2 high-impact sentences.
- **Active Voice Enforcement**: Prompts now require the use of active voice in descriptions.
- **Elimination of "Fluff"**: New "MUST NOT DO" rules prevent the AI from using phrases like "I suggest," "Please," "Maybe," or "I found."
- **Conciseness for Self-Explanatory Fixes**: Instructions added to keep descriptions under 50 words if the code fix is self-explanatory.
- **Surgical Precision**: The guidance for descriptions has been refined from "precise and concise" to "surgically precise: Focus on the *mechanics* of the failure."

These changes aim to make the AI's output more efficient, actionable, and free of unnecessary verbiage.
<!-- kody-pr-summary:end -->