### PR TITLE
remove global from rule filters

### DIFF
--- a/libs/kodyRules/application/use-cases/find-rules-in-organization-by-filter.use-case.ts
+++ b/libs/kodyRules/application/use-cases/find-rules-in-organization-by-filter.use-case.ts
@@ -20,9 +20,9 @@ import {
     KodyRulesStatus,
 } from '@libs/kodyRules/domain/interfaces/kodyRules.interface';
 
-import { enrichRulesWithContextReferences } from './utils/enrich-rules-with-context-references.util';
 import { createLogger } from '@kodus/flow';
 import { IUseCase } from '@libs/core/domain/interfaces/use-case.interface';
+import { enrichRulesWithContextReferences } from './utils/enrich-rules-with-context-references.util';
 
 @Injectable()
 export class FindRulesInOrganizationByRuleFilterKodyRulesUseCase implements IUseCase {
@@ -64,10 +64,8 @@ export class FindRulesInOrganizationByRuleFilterKodyRulesUseCase implements IUse
 
             if (repositoryId && directoryId) {
                 ruleFilters.push({ repositoryId, directoryId });
-                ruleFilters.push({ repositoryId: 'global' });
             } else if (repositoryId) {
                 ruleFilters.push({ repositoryId });
-                ruleFilters.push({ repositoryId: 'global' });
             } else if (directoryId) {
                 ruleFilters.push({ directoryId });
             }


### PR DESCRIPTION
closes #625

---

<!-- kody-pr-summary:start -->
Removes the automatic inclusion of 'global' repository rules when filtering rules by a specific `repositoryId` or a combination of `repositoryId` and `directoryId`. This change ensures that rule searches are more precise, returning only rules explicitly associated with the specified repository and/or directory, without implicitly adding global rules to the filter criteria.
<!-- kody-pr-summary:end -->