### PR TITLE
fix: replace `*Reaction` with union type called `Reaction`

### DIFF
--- a/libs/code-review/domain/codeReviewFeedback/enums/codeReviewCommentReaction.enum.ts
+++ b/libs/code-review/domain/codeReviewFeedback/enums/codeReviewCommentReaction.enum.ts
@@ -17,6 +17,8 @@ export enum GitlabReaction {
     LOCK = 'lock',
 }
 
+export type Reaction = GitHubReaction | GitlabReaction;
+
 export enum CountingType {
     CREATE = 'create',
     REVOKE = 'revoke',

--- a/libs/code-review/infrastructure/adapters/services/codeReviewHandlerService.service.ts
+++ b/libs/code-review/infrastructure/adapters/services/codeReviewHandlerService.service.ts
@@ -10,6 +10,7 @@ import { AutomationStatus } from '@libs/automation/domain/automation/enum/automa
 import {
     GitHubReaction,
     GitlabReaction,
+    Reaction,
     ReviewStatusReaction,
 } from '@libs/code-review/domain/codeReviewFeedback/enums/codeReviewCommentReaction.enum';
 import { CodeReviewPipelineContext } from '@libs/code-review/pipeline/context/code-review-pipeline.context';
@@ -361,10 +362,7 @@ export class CodeReviewHandlerService {
                 return;
             }
 
-            const reactionsToRemove = Object.values(platformReactions) as (
-                | GitHubReaction
-                | GitlabReaction
-            )[];
+            const reactionsToRemove = Object.values(platformReactions) as Reaction[];
 
             if (triggerCommentId) {
                 await this.codeManagement.removeReactionsFromComment({

--- a/libs/platform/domain/platformIntegrations/interfaces/code-management.interface.ts
+++ b/libs/platform/domain/platformIntegrations/interfaces/code-management.interface.ts
@@ -1,7 +1,4 @@
-import {
-    GitHubReaction,
-    GitlabReaction,
-} from '@libs/code-review/domain/codeReviewFeedback/enums/codeReviewCommentReaction.enum';
+import { Reaction } from '@libs/code-review/domain/codeReviewFeedback/enums/codeReviewCommentReaction.enum';
 import { PullRequestState } from '@libs/core/domain/enums/pullRequestState.enum';
 import { Repository } from '@libs/core/infrastructure/config/types/general/codeReview.type';
 import { Commit } from '@libs/core/infrastructure/config/types/general/commit.type';
@@ -256,7 +253,7 @@ export interface ICodeManagementService extends ICommonPlatformIntegrationServic
         organizationAndTeamData: OrganizationAndTeamData;
         repository: { id?: string; name?: string };
         prNumber: number;
-        reaction: GitHubReaction | GitlabReaction;
+        reaction: Reaction;
     }): Promise<void>;
 
     addReactionToComment?(params: {
@@ -264,14 +261,14 @@ export interface ICodeManagementService extends ICommonPlatformIntegrationServic
         repository: { id?: string; name?: string };
         prNumber: number;
         commentId: number;
-        reaction: GitHubReaction | GitlabReaction;
+        reaction: Reaction;
     }): Promise<void>;
 
     removeReactionsFromPR?(params: {
         organizationAndTeamData: OrganizationAndTeamData;
         repository: { id?: string; name?: string };
         prNumber: number;
-        reactions: (GitHubReaction | GitlabReaction)[];
+        reactions: Reaction[];
     }): Promise<void>;
 
     removeReactionsFromComment?(params: {
@@ -279,6 +276,6 @@ export interface ICodeManagementService extends ICommonPlatformIntegrationServic
         repository: { id?: string; name?: string };
         prNumber: number;
         commentId: number;
-        reactions: (GitHubReaction | GitlabReaction)[];
+        reactions: Reaction[];
     }): Promise<void>;
 }

--- a/libs/platform/infrastructure/adapters/services/bitbucket.service.ts
+++ b/libs/platform/infrastructure/adapters/services/bitbucket.service.ts
@@ -1,9 +1,6 @@
 import { createLogger } from '@kodus/flow';
 
-import {
-    GitHubReaction,
-    GitlabReaction,
-} from '@libs/code-review/domain/codeReviewFeedback/enums/codeReviewCommentReaction.enum';
+import { Reaction } from '@libs/code-review/domain/codeReviewFeedback/enums/codeReviewCommentReaction.enum';
 import { hasKodyMarker } from '@libs/common/utils/codeManagement/codeCommentMarkers';
 import { decrypt, encrypt } from '@libs/common/utils/crypto';
 import { IntegrationServiceDecorator } from '@libs/common/utils/decorators/integration-service.decorator';
@@ -109,7 +106,7 @@ export class BitbucketService implements Omit<
         organizationAndTeamData: OrganizationAndTeamData;
         repository: { id?: string; name?: string };
         prNumber: number;
-        reaction: GitHubReaction | GitlabReaction;
+        reaction: Reaction;
     }): Promise<void> {
         throw new Error('Method not implemented.');
     }
@@ -118,7 +115,7 @@ export class BitbucketService implements Omit<
         repository: { id?: string; name?: string };
         prNumber: number;
         commentId: number;
-        reaction: GitHubReaction | GitlabReaction;
+        reaction: Reaction;
     }): Promise<void> {
         throw new Error('Method not implemented.');
     }
@@ -126,7 +123,7 @@ export class BitbucketService implements Omit<
         organizationAndTeamData: OrganizationAndTeamData;
         repository: { id?: string; name?: string };
         prNumber: number;
-        reactions: (GitHubReaction | GitlabReaction)[];
+        reactions: Reaction[];
     }): Promise<void> {
         throw new Error('Method not implemented.');
     }
@@ -135,7 +132,7 @@ export class BitbucketService implements Omit<
         repository: { id?: string; name?: string };
         prNumber: number;
         commentId: number;
-        reactions: (GitHubReaction | GitlabReaction)[];
+        reactions: Reaction[];
     }): Promise<void> {
         throw new Error('Method not implemented.');
     }

--- a/libs/platform/infrastructure/adapters/services/codeManagement.service.ts
+++ b/libs/platform/infrastructure/adapters/services/codeManagement.service.ts
@@ -1,9 +1,6 @@
 import { Inject, Injectable, forwardRef } from '@nestjs/common';
 
-import {
-    GitHubReaction,
-    GitlabReaction,
-} from '@libs/code-review/domain/codeReviewFeedback/enums/codeReviewCommentReaction.enum';
+import { Reaction } from '@libs/code-review/domain/codeReviewFeedback/enums/codeReviewCommentReaction.enum';
 import { ISuggestionByPR } from '@libs/platformData/domain/pullRequests/interfaces/pullRequests.interface';
 import { IntegrationCategory } from '@libs/core/domain/enums/integration-category.enum';
 import { PlatformType } from '@libs/core/domain/enums/platform-type.enum';
@@ -1242,7 +1239,7 @@ export class CodeManagementService implements ICodeManagementService {
         organizationAndTeamData: OrganizationAndTeamData;
         repository: { id?: string; name?: string };
         prNumber: number;
-        reaction: GitHubReaction | GitlabReaction;
+        reaction: Reaction;
     }): Promise<void> {
         const type = await this.getTypeIntegration(
             params.organizationAndTeamData,
@@ -1263,7 +1260,7 @@ export class CodeManagementService implements ICodeManagementService {
         repository: { id?: string; name?: string };
         prNumber: number;
         commentId: number;
-        reaction: GitHubReaction | GitlabReaction;
+        reaction: Reaction;
     }): Promise<void> {
         const type = await this.getTypeIntegration(
             params.organizationAndTeamData,
@@ -1283,7 +1280,7 @@ export class CodeManagementService implements ICodeManagementService {
         organizationAndTeamData: OrganizationAndTeamData;
         repository: { id?: string; name?: string };
         prNumber: number;
-        reactions: (GitHubReaction | GitlabReaction)[];
+        reactions: Reaction[];
     }): Promise<void> {
         const type = await this.getTypeIntegration(
             params.organizationAndTeamData,
@@ -1304,7 +1301,7 @@ export class CodeManagementService implements ICodeManagementService {
         repository: { id?: string; name?: string };
         prNumber: number;
         commentId: number;
-        reactions: (GitHubReaction | GitlabReaction)[];
+        reactions: Reaction[];
     }): Promise<void> {
         const type = await this.getTypeIntegration(
             params.organizationAndTeamData,

--- a/libs/platform/infrastructure/adapters/services/github/github.service.ts
+++ b/libs/platform/infrastructure/adapters/services/github/github.service.ts
@@ -15,7 +15,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { createLogger } from '@kodus/flow';
 import {
     GitHubReaction,
-    GitlabReaction,
+    Reaction,
 } from '@libs/code-review/domain/codeReviewFeedback/enums/codeReviewCommentReaction.enum';
 import { getCodeReviewBadge } from '@libs/common/utils/codeManagement/codeReviewBadge';
 import { getLabelShield } from '@libs/common/utils/codeManagement/labels';
@@ -3232,7 +3232,7 @@ This is an experimental feature that generates committable changes. Review the d
         organizationAndTeamData: OrganizationAndTeamData;
         repository: { id?: string; name?: string };
         prNumber: number;
-        reaction: GitHubReaction | GitlabReaction;
+        reaction: Reaction;
     }): Promise<void> {
         try {
             if (!params.repository.name) {
@@ -3277,7 +3277,7 @@ This is an experimental feature that generates committable changes. Review the d
         repository: { id?: string; name?: string };
         prNumber: number;
         commentId: number;
-        reaction: GitHubReaction | GitlabReaction;
+        reaction: Reaction;
     }): Promise<void> {
         try {
             if (!params.repository.name) {
@@ -3342,7 +3342,7 @@ This is an experimental feature that generates committable changes. Review the d
         organizationAndTeamData: OrganizationAndTeamData;
         repository: { id?: string; name?: string };
         prNumber: number;
-        reactions: (GitHubReaction | GitlabReaction)[];
+        reactions: Reaction[];
     }): Promise<void> {
         try {
             if (!params.repository.name) {
@@ -3404,7 +3404,7 @@ This is an experimental feature that generates committable changes. Review the d
         repository: { id?: string; name?: string };
         prNumber: number;
         commentId: number;
-        reactions: (GitHubReaction | GitlabReaction)[];
+        reactions: Reaction[];
     }): Promise<void> {
         try {
             if (!params.repository.name) {

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -10,10 +10,7 @@ import { ConfigService } from '@nestjs/config';
 import axios from 'axios';
 import { v4 as uuidv4 } from 'uuid';
 
-import {
-    GitHubReaction,
-    GitlabReaction,
-} from '@libs/code-review/domain/codeReviewFeedback/enums/codeReviewCommentReaction.enum';
+import { Reaction } from '@libs/code-review/domain/codeReviewFeedback/enums/codeReviewCommentReaction.enum';
 import { CacheService } from '@libs/core/cache/cache.service';
 import {
     CreateAuthIntegrationStatus,
@@ -2398,7 +2395,7 @@ export class GitlabService implements Omit<
         organizationAndTeamData: OrganizationAndTeamData;
         repository: { id?: string; name?: string };
         prNumber: number;
-        reaction: GitHubReaction | GitlabReaction;
+        reaction: Reaction;
     }): Promise<void> {
         try {
             if (!params.repository.id) {
@@ -2440,7 +2437,7 @@ export class GitlabService implements Omit<
         repository: { id?: string; name?: string };
         prNumber: number;
         commentId: number;
-        reaction: GitHubReaction | GitlabReaction;
+        reaction: Reaction;
     }): Promise<void> {
         try {
             if (!params.repository.id) {
@@ -2482,7 +2479,7 @@ export class GitlabService implements Omit<
         organizationAndTeamData: OrganizationAndTeamData;
         repository: { id?: string; name?: string };
         prNumber: number;
-        reactions: (GitHubReaction | GitlabReaction)[];
+        reactions: Reaction[];
     }): Promise<void> {
         try {
             if (!params.repository.id) {
@@ -2538,7 +2535,7 @@ export class GitlabService implements Omit<
         repository: { id?: string; name?: string };
         prNumber: number;
         commentId: number;
-        reactions: (GitHubReaction | GitlabReaction)[];
+        reactions: Reaction[];
     }): Promise<void> {
         try {
             if (!params.repository.id) {


### PR DESCRIPTION
Hey!

I noticed it was a bit of a pain to find all the places that needed to have this type added for a new provider so I created a union type of it

---

<!-- kody-pr-summary:start -->
Refactored reaction type definitions by introducing a new union type named `Reaction`. This `Reaction` type combines `GitHubReaction` and `GitlabReaction`, standardizing how reactions are represented across the application.

This change updates the `ICodeManagementService` interface and its implementations (Bitbucket, CodeManagement, GitHub, and GitLab services) to consistently use the `Reaction` union type for parameters related to adding or removing reactions from pull requests and comments.

The primary benefits of this refactoring are:
*   **Improved Type Consistency**: Ensures a unified type for reactions across different code management platforms.
*   **Enhanced Readability**: Simplifies type declarations in method signatures.
*   **Increased Maintainability**: Centralizes the definition of platform-agnostic reactions, making future updates easier.
<!-- kody-pr-summary:end -->