### PR TITLE
fix: accept JWT Bearer token authentication on /cli/review

### DIFF
--- a/apps/api/src/controllers/cli-review.controller.ts
+++ b/apps/api/src/controllers/cli-review.controller.ts
@@ -369,6 +369,13 @@ export class CliReviewController {
             }
 
             const { team, organization } = teamData;
+
+            if (!team?.uuid || !organization?.uuid) {
+                throw new UnauthorizedException(
+                    'Invalid or incomplete team API key',
+                );
+            }
+
             organizationAndTeamData = {
                 organizationId: organization.uuid,
                 teamId: team.uuid,


### PR DESCRIPTION
The CLI has two auth flows (team key and personal JWT login), but /cli/review only validated team CLI keys. When a JWT was sent via Authorization: Bearer, the controller stripped the prefix and passed the raw JWT to teamCliKeyService.validateKey(), which always failed with 401.

Now the controller detects the token type and routes accordingly:
- X-Team-Key or Bearer kodus_* → team CLI key validation (unchanged)
- Bearer <jwt> → JWT verification + user validation + team lookup via ?teamId query param with organization ownership check

---

<!-- kody-pr-summary:start -->
This pull request enhances the `/cli/review` and `/cli/validate-key` endpoints to support JWT Bearer token authentication.

Previously, these endpoints primarily relied on a dedicated Team CLI API key (provided via the `X-Team-Key` header or as a `Bearer kodus_...` token).

With this change:
- The endpoints now accept a standard JWT Bearer token in the `Authorization` header.
- When authenticating with a JWT, a `teamId` query parameter is required to specify the target team for the operation.
- The system validates the JWT, verifies the associated user's status and role, and ensures the provided `teamId` belongs to the organization authenticated by the JWT.
- Rate limiting and CLI-specific configurations (such as allowed domains) are correctly applied based on the identified team, irrespective of whether a CLI key or JWT was used for authentication.
<!-- kody-pr-summary:end -->