### PR TITLE
Adding validation to save discarded suggestions

### DIFF
--- a/test/unit/code-review/pipeline/stages/create-file-comments.stage.spec.ts
+++ b/test/unit/code-review/pipeline/stages/create-file-comments.stage.spec.ts
@@ -584,4 +584,289 @@ describe('CreateFileCommentsStage', () => {
             expect(enrichedFiles[0].codeReviewModelUsed).toBe('gpt-4');
         });
     });
+
+    describe('saving discarded suggestions to database', () => {
+        it('should save all discarded suggestions to database when all suggestions are discarded by code-diff', async () => {
+            const discardedSuggestions = [
+                {
+                    id: 's1',
+                    relevantFile: 'test.ts',
+                    severity: 'high',
+                    suggestionContent: 'Use const instead of let',
+                    priorityStatus: 'discarded-by-code-diff',
+                },
+                {
+                    id: 's2',
+                    relevantFile: 'test.ts',
+                    severity: 'medium',
+                    suggestionContent: 'Add type annotation',
+                    priorityStatus: 'discarded-by-code-diff',
+                },
+            ];
+
+            const changedFiles = [{ filename: 'test.ts' } as any];
+
+            mockPullRequestService.findByNumberAndRepositoryName.mockResolvedValue(
+                null, // New PR, so no existing PR
+            );
+
+            mockCodeManagementService.getCommitsForPullRequestForCodeReview.mockResolvedValue([
+                { sha: 'abc123' },
+            ]);
+
+            mockSuggestionService.extractRepriorizedSuggestions.mockReturnValue({
+                repriorizedSuggestions: [],
+                filteredDiscardedSuggestions: discardedSuggestions,
+            });
+
+            const context = createBaseContext({
+                validSuggestions: [], // No valid suggestions
+                discardedSuggestions, // Only discarded suggestions
+                changedFiles,
+                prAllCommits: [{ sha: 'abc123' }] as any,
+            });
+
+            await (stage as any).executeStage(context);
+
+            // CRITICAL: aggregateAndSaveDataStructure MUST be called even when all suggestions are discarded
+            // This is the bug - it won't be called because of early return at line 113-137
+            expect(
+                mockPullRequestService.aggregateAndSaveDataStructure,
+            ).toHaveBeenCalled();
+
+            const callArgs =
+                mockPullRequestService.aggregateAndSaveDataStructure.mock
+                    .calls[0];
+            const unusedSuggestions = callArgs[4]; // 5th argument - unusedSuggestions
+            expect(unusedSuggestions).toHaveLength(2);
+            expect(unusedSuggestions[0].priorityStatus).toBe('discarded-by-code-diff');
+            expect(unusedSuggestions[1].priorityStatus).toBe('discarded-by-code-diff');
+        });
+
+        it('should save all discarded suggestions to database when all suggestions are discarded by severity', async () => {
+            const discardedSuggestions = [
+                {
+                    id: 's1',
+                    relevantFile: 'test.ts',
+                    severity: 'low',
+                    suggestionContent: 'Minor style improvement',
+                    priorityStatus: 'discarded-by-severity',
+                },
+                {
+                    id: 's2',
+                    relevantFile: 'test.ts',
+                    severity: 'info',
+                    suggestionContent: 'Consider refactoring',
+                    priorityStatus: 'discarded-by-severity',
+                },
+            ];
+
+            const changedFiles = [{ filename: 'test.ts' } as any];
+
+            mockPullRequestService.findByNumberAndRepositoryName.mockResolvedValue(
+                null,
+            );
+
+            mockCodeManagementService.getCommitsForPullRequestForCodeReview.mockResolvedValue([
+                { sha: 'abc123' },
+            ]);
+
+            mockSuggestionService.extractRepriorizedSuggestions.mockReturnValue({
+                repriorizedSuggestions: [],
+                filteredDiscardedSuggestions: discardedSuggestions,
+            });
+
+            const context = createBaseContext({
+                validSuggestions: [],
+                discardedSuggestions,
+                changedFiles,
+                prAllCommits: [{ sha: 'abc123' }] as any,
+            });
+
+            await (stage as any).executeStage(context);
+
+            expect(
+                mockPullRequestService.aggregateAndSaveDataStructure,
+            ).toHaveBeenCalled();
+
+            const callArgs =
+                mockPullRequestService.aggregateAndSaveDataStructure.mock
+                    .calls[0];
+            const unusedSuggestions = callArgs[4];
+            expect(unusedSuggestions).toHaveLength(2);
+            expect(unusedSuggestions.every(s => s.priorityStatus === 'discarded-by-severity')).toBe(true);
+        });
+
+        it('should save all discarded suggestions to database when all suggestions are discarded by safeguard', async () => {
+            const discardedSuggestions = [
+                {
+                    id: 's1',
+                    relevantFile: 'test.ts',
+                    severity: 'high',
+                    suggestionContent: 'Remove this code',
+                    priorityStatus: 'discarded-by-safeguard',
+                },
+            ];
+
+            const changedFiles = [{ filename: 'test.ts' } as any];
+
+            mockPullRequestService.findByNumberAndRepositoryName.mockResolvedValue(
+                null,
+            );
+
+            mockCodeManagementService.getCommitsForPullRequestForCodeReview.mockResolvedValue([
+                { sha: 'abc123' },
+            ]);
+
+            mockSuggestionService.extractRepriorizedSuggestions.mockReturnValue({
+                repriorizedSuggestions: [],
+                filteredDiscardedSuggestions: discardedSuggestions,
+            });
+
+            const context = createBaseContext({
+                validSuggestions: [],
+                discardedSuggestions,
+                changedFiles,
+                prAllCommits: [{ sha: 'abc123' }] as any,
+            });
+
+            await (stage as any).executeStage(context);
+
+            expect(
+                mockPullRequestService.aggregateAndSaveDataStructure,
+            ).toHaveBeenCalled();
+
+            const callArgs =
+                mockPullRequestService.aggregateAndSaveDataStructure.mock
+                    .calls[0];
+            const unusedSuggestions = callArgs[4];
+            expect(unusedSuggestions).toHaveLength(1);
+            expect(unusedSuggestions[0].priorityStatus).toBe('discarded-by-safeguard');
+        });
+
+        it('should save all discarded suggestions to database when all suggestions are discarded by kody-fine-tuning', async () => {
+            const discardedSuggestions = [
+                {
+                    id: 's1',
+                    relevantFile: 'test.ts',
+                    severity: 'medium',
+                    suggestionContent: 'Update this pattern',
+                    priorityStatus: 'discarded-by-kody-fine-tuning',
+                },
+                {
+                    id: 's2',
+                    relevantFile: 'test.ts',
+                    severity: 'high',
+                    suggestionContent: 'Fix this issue',
+                    priorityStatus: 'discarded-by-kody-fine-tuning',
+                },
+            ];
+
+            const changedFiles = [{ filename: 'test.ts' } as any];
+
+            mockPullRequestService.findByNumberAndRepositoryName.mockResolvedValue(
+                null,
+            );
+
+            mockCodeManagementService.getCommitsForPullRequestForCodeReview.mockResolvedValue([
+                { sha: 'abc123' },
+            ]);
+
+            mockSuggestionService.extractRepriorizedSuggestions.mockReturnValue({
+                repriorizedSuggestions: [],
+                filteredDiscardedSuggestions: discardedSuggestions,
+            });
+
+            const context = createBaseContext({
+                validSuggestions: [],
+                discardedSuggestions,
+                changedFiles,
+                prAllCommits: [{ sha: 'abc123' }] as any,
+            });
+
+            await (stage as any).executeStage(context);
+
+            expect(
+                mockPullRequestService.aggregateAndSaveDataStructure,
+            ).toHaveBeenCalled();
+
+            const callArgs =
+                mockPullRequestService.aggregateAndSaveDataStructure.mock
+                    .calls[0];
+            const unusedSuggestions = callArgs[4];
+            expect(unusedSuggestions).toHaveLength(2);
+            expect(unusedSuggestions.every(s => s.priorityStatus === 'discarded-by-kody-fine-tuning')).toBe(true);
+        });
+
+        it('should save mixed discarded suggestions to database when all are discarded by different reasons', async () => {
+            const discardedSuggestions = [
+                {
+                    id: 's1',
+                    relevantFile: 'test.ts',
+                    severity: 'high',
+                    suggestionContent: 'Fix 1',
+                    priorityStatus: 'discarded-by-code-diff',
+                },
+                {
+                    id: 's2',
+                    relevantFile: 'test.ts',
+                    severity: 'low',
+                    suggestionContent: 'Fix 2',
+                    priorityStatus: 'discarded-by-severity',
+                },
+                {
+                    id: 's3',
+                    relevantFile: 'test.ts',
+                    severity: 'medium',
+                    suggestionContent: 'Fix 3',
+                    priorityStatus: 'discarded-by-safeguard',
+                },
+                {
+                    id: 's4',
+                    relevantFile: 'test.ts',
+                    severity: 'high',
+                    suggestionContent: 'Fix 4',
+                    priorityStatus: 'discarded-by-kody-fine-tuning',
+                },
+            ];
+
+            const changedFiles = [{ filename: 'test.ts' } as any];
+
+            mockPullRequestService.findByNumberAndRepositoryName.mockResolvedValue(
+                null,
+            );
+
+            mockCodeManagementService.getCommitsForPullRequestForCodeReview.mockResolvedValue([
+                { sha: 'abc123' },
+            ]);
+
+            mockSuggestionService.extractRepriorizedSuggestions.mockReturnValue({
+                repriorizedSuggestions: [],
+                filteredDiscardedSuggestions: discardedSuggestions,
+            });
+
+            const context = createBaseContext({
+                validSuggestions: [],
+                discardedSuggestions,
+                changedFiles,
+                prAllCommits: [{ sha: 'abc123' }] as any,
+            });
+
+            await (stage as any).executeStage(context);
+
+            expect(
+                mockPullRequestService.aggregateAndSaveDataStructure,
+            ).toHaveBeenCalled();
+
+            const callArgs =
+                mockPullRequestService.aggregateAndSaveDataStructure.mock
+                    .calls[0];
+            const unusedSuggestions = callArgs[4];
+            expect(unusedSuggestions).toHaveLength(4);
+            expect(unusedSuggestions[0].priorityStatus).toBe('discarded-by-code-diff');
+            expect(unusedSuggestions[1].priorityStatus).toBe('discarded-by-severity');
+            expect(unusedSuggestions[2].priorityStatus).toBe('discarded-by-safeguard');
+            expect(unusedSuggestions[3].priorityStatus).toBe('discarded-by-kody-fine-tuning');
+        });
+    });
 });


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request addresses a bug where discarded code review suggestions were not being saved to the database if no "valid" (non-discarded) suggestions were generated for a pull request.

The changes ensure that:
- All discarded suggestions, regardless of the reason for discarding (e.g., by code diff, severity, safeguard rules, or Kody fine-tuning), are now explicitly saved to the database.
- A new code block has been added to the `CreateFileCommentsStage` to handle the saving of `discardedSuggestions` if any exist.
- Comprehensive unit tests have been added to verify that discarded suggestions are correctly saved for various discarding reasons and scenarios where only discarded suggestions are present.

This fix improves data completeness and traceability by ensuring that all generated suggestions, including those deemed irrelevant or low-priority by the system, are persistently stored.
<!-- kody-pr-summary:end -->