### PR TITLE
Adding validation to show error in review

### DIFF
--- a/libs/code-review/infrastructure/observers/code-review-pipeline.observer.ts
+++ b/libs/code-review/infrastructure/observers/code-review-pipeline.observer.ts
@@ -166,7 +166,20 @@ export class CodeReviewPipelineObserver implements IPipelineObserver {
                     : `Posting File Comments (No suggestions)`;
         }
 
-        const message = errors.length > 0 ? 'Completed' : '';
+        let message = '';
+        if (errors.length > 0) {
+            const uniqueMessages = [
+                ...new Set(
+                    errors.map(
+                        (e) => e.error?.message || String(e.error),
+                    ),
+                ),
+            ];
+            const displayMessages = uniqueMessages.slice(0, 3);
+            const remaining = uniqueMessages.length - displayMessages.length;
+
+            message = `Error: ${displayMessages.join(' | ')}${remaining > 0 ? ` (+${remaining} more)` : ''}`;
+        }
 
         await this.logStage(stageName, status, message, context, {
             additionalMetadata,


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request significantly enhances the error reporting within the code review pipeline by providing more specific and informative messages when stages encounter issues.

Key changes include:
- **Detailed Error Propagation**: Instead of a generic "Completed" message for stages with errors, the system now captures and displays the actual error messages (e.g., LLM rate limits, timeouts, API errors) in the stage logs.
- **Error Deduplication**: Identical error messages occurring multiple times within a stage are now deduplicated to present a concise summary.
- **Summarized Error Display**: When a stage encounters more than three unique errors, the system will display the first three unique error messages, separated by a pipe (`|`), and indicate the count of additional unique errors (e.g., `Error: Error type A | Error type B | Error type C (+2 more)`).
- **Clear Success Indication**: Stages that complete successfully without any errors will continue to have an empty message, indicating a clean execution.

These improvements provide users with more actionable insights into code review failures, making it easier to diagnose and resolve underlying problems.
<!-- kody-pr-summary:end -->