### PR TITLE
PR 618

### DIFF
--- a/libs/common/utils/langchainCommon/prompts/configuration/codeReview.ts
+++ b/libs/common/utils/langchainCommon/prompts/configuration/codeReview.ts
@@ -991,8 +991,8 @@ Return only valid JSON, nothing more. Under no circumstances should there be any
             "existingCode": "Problematic code from PR",
             "improvedCode": "Fixed code proposal",
             "oneSentenceSummary": "Concise issue description",
-            "relevantLinesStart": 1, // Line number (integer)
-            "relevantLinesEnd": 10, // Line number (integer)
+            "relevantLinesStart": 1,
+            "relevantLinesEnd": 10,
             "label": "bug|performance|security",
             "severity": "low|medium|high|critical",
             "llmPrompt": "Prompt for LLMs"
@@ -1108,8 +1108,8 @@ Your final output should be **only** a JSON object with the following structure:
             "existingCode": "Relevant new code from the PR",
             "improvedCode": "Improved proposal",
             "oneSentenceSummary": "Concise summary of the suggestion",
-            "relevantLinesStart": 1, // Line number (integer)
-            "relevantLinesEnd": 10, // Line number (integer)
+            "relevantLinesStart": 1,
+            "relevantLinesEnd": 10,
             "label": "selected_label",
             "llmPrompt": "Prompt for LLMs"
         }
@@ -1320,8 +1320,8 @@ Your final output should be **ONLY** a JSON object with the following structure:
             "existingCode": "Relevant new code from the PR",
             "improvedCode": "Improved proposal",
             "oneSentenceSummary": "Concise summary of the suggestion",
-            "relevantLinesStart": 1, // Line number (integer)   
-            "relevantLinesEnd": 10, // Line number (integer)
+            "relevantLinesStart": 1,
+            "relevantLinesEnd": 10,
             "label": "selected_label",
             "llmPrompt": "Prompt for LLMs"
         }

--- a/libs/common/utils/langchainCommon/prompts/detectBreakingChanges.ts
+++ b/libs/common/utils/langchainCommon/prompts/detectBreakingChanges.ts
@@ -28,8 +28,8 @@ Your final response must be a JSON object in the following format:
             "existingCode": "Snippet of the problematic code or contract in the newFunction",
             "improvedCode": "Proposed correction to ensure compatibility with the callers",
             "oneSentenceSummary": "Concise summary of the suggestion",
-            "relevantLinesStart": 1, // Line number (integer)
-            "relevantLinesEnd": 10, // Line number (integer)
+            "relevantLinesStart": 1,
+            "relevantLinesEnd": 10,
         }
     ]
 }

--- a/libs/common/utils/langchainCommon/prompts/kodyRules.ts
+++ b/libs/common/utils/langchainCommon/prompts/kodyRules.ts
@@ -268,8 +268,8 @@ DO NOT under any circumstances provide any sort of code block in this field, lik
       "existingCode": "Snippet from the PR",
       "improvedCode": "Refactored code (if changed)",
       "oneSentenceSummary": "Concise summary of the suggestion",
-      "relevantLinesStart": 1, // Line number (integer)
-      "relevantLinesEnd": 10, // Line number (integer)
+      "relevantLinesStart": 1,
+      "relevantLinesEnd": 10,
       "label": "string",
       "severity": "string",
       "llmPrompt": "Prompt for LLMs",
@@ -547,8 +547,8 @@ DISCUSSION HERE
             "existingCode": "Relevant code from the PR",
             "improvedCode": "Improved proposal",
             "oneSentenceSummary": "Concise summary",
-            "relevantLinesStart": 1, // Line number (integer)
-            "relevantLinesEnd": 10, // Line number (integer)
+            "relevantLinesStart": 1,
+            "relevantLinesEnd": 10,
             "label": "kody_rules",
             "llmPrompt": "Prompt for LLMs",
             "brokenKodyRulesIds": [

--- a/libs/common/utils/langchainCommon/prompts/repeatedCodeReviewSuggestionClustering.ts
+++ b/libs/common/utils/langchainCommon/prompts/repeatedCodeReviewSuggestionClustering.ts
@@ -28,8 +28,8 @@ You will receive an input in the following JSON format:
             "existingCode": "Relevant new code from the PR",
             "improvedCode": "Improved proposal",
             "oneSentenceSummary": "Concise summary of the suggestion",
-            "relevantLinesStart": 1, // Line number (integer)
-            "relevantLinesEnd": 10, // Line number (integer)
+            "relevantLinesStart": 1,
+            "relevantLinesEnd": 10,
             "label": "selected_label"
         }
     ]


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request refines the validation and clarity of line number fields (`relevantLinesStart` and `relevantLinesEnd`) across various LLM-related schemas and prompts.

Specifically:
*   **Improved Schema Validation:** The `relevantLinesStart` and `relevantLinesEnd` fields in several Zod schemas (e.g., within `llmAnalysis.service.ts` and `kodyRules.ts`) are now strictly enforced to be positive integers. This ensures that line numbers are always valid and correctly formatted.
*   **Enhanced Optionality:** In some schemas, `relevantLinesStart` and `relevantLinesEnd` have been updated to be optional, allowing them to be omitted when not applicable.
*   **Clearer Prompt Instructions:** Examples and comments within LLM prompt definitions have been updated to explicitly indicate that `relevantLinesStart` and `relevantLinesEnd` should be integer line numbers, improving the clarity of instructions for the language models.
<!-- kody-pr-summary:end -->