### PR TITLE
add distributed locks for cron approval job

### DIFF
--- a/apps/api/src/cron/cron.module.ts
+++ b/apps/api/src/cron/cron.module.ts
@@ -1,16 +1,17 @@
-import { forwardRef, Module } from '@nestjs/common';
-import { ScheduleModule } from '@nestjs/schedule';
 import { AutomationModule } from '@libs/automation/modules/automation.module';
-import { IntegrationModule } from '@libs/integrations/modules/integrations.module';
+import { CodeReviewConfigurationModule } from '@libs/code-review/modules/code-review-configuration.module';
+import { CodebaseModule } from '@libs/code-review/modules/codebase.module';
+import { PullRequestsModule } from '@libs/code-review/modules/pull-requests.module';
+import { PullRequestMessagesModule } from '@libs/code-review/modules/pullRequestMessages.module';
+import { DistributedLockService } from '@libs/core/workflow/infrastructure/distributed-lock.service';
 import { IntegrationConfigModule } from '@libs/integrations/modules/config.module';
+import { IntegrationModule } from '@libs/integrations/modules/integrations.module';
 import { KodyRulesModule } from '@libs/kodyRules/modules/kodyRules.module';
 import { ParametersModule } from '@libs/organization/modules/parameters.module';
-import { PullRequestsModule } from '@libs/code-review/modules/pull-requests.module';
-import { CodeReviewConfigurationModule } from '@libs/code-review/modules/code-review-configuration.module';
-import { PlatformModule } from '@libs/platform/modules/platform.module';
 import { TeamModule } from '@libs/organization/modules/team.module';
-import { PullRequestMessagesModule } from '@libs/code-review/modules/pullRequestMessages.module';
-import { CodebaseModule } from '@libs/code-review/modules/codebase.module';
+import { PlatformModule } from '@libs/platform/modules/platform.module';
+import { forwardRef, Module } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
 
 import { CheckIfPRCanBeApprovedCronProvider } from './CheckIfPRCanBeApproved.cron';
 import { CodeReviewFeedbackCronProvider } from './codeReviewFeedback.cron';
@@ -35,6 +36,7 @@ import { KodyLearningCronProvider } from './kodyLearning.cron';
         CheckIfPRCanBeApprovedCronProvider,
         CodeReviewFeedbackCronProvider,
         KodyLearningCronProvider,
+        DistributedLockService,
     ],
 })
 export class CronModule {}


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request implements a distributed lock mechanism for the `CheckIfPRCanBeApprovedCronProvider` cron job.

The main goal of this change is to prevent concurrent executions of this cron job across multiple application instances. By using a distributed lock, only one instance of the cron job can process pull requests for approval at a time, which helps avoid race conditions and ensures data consistency.

Key changes include:
-   The `DistributedLockService` is now injected and used within the `CheckIfPRCanBeApprovedCronProvider`.
-   Before executing its logic, the cron job attempts to acquire a distributed lock with a 5-minute time-to-live (TTL).
-   If the lock is already held by another instance, the current cron execution is skipped to prevent duplicate processing.
-   The lock is guaranteed to be released in a `finally` block once the cron job completes or encounters an error.
-   The `@Cron` decorator is updated with `waitForCompletion: true` to ensure that the NestJS scheduler waits for the current job to finish before scheduling the next, complementing the distributed lock.
-   The `DistributedLockService` is added to the `CronModule` providers.
<!-- kody-pr-summary:end -->