### PR TITLE
Language selection clarity

### DIFF
--- a/apps/api/src/controllers/organization.controller.ts
+++ b/apps/api/src/controllers/organization.controller.ts
@@ -101,8 +101,11 @@ export class OrganizationController {
 
     @Get('/language')
     @ApiOperation({
-        summary: 'Detect organization language',
-        description: 'Infer primary language based on repository or team data.',
+        summary: 'Detect programming language',
+        description: `Infer primary programming language (e.g., JavaScript, Python, Java) based on repository or team data.
+        
+Note: This is for programming language detection, NOT for Kody's response language. 
+To set the language for Kody's responses, use the 'language_config' parameter via /parameters endpoints.`,
     })
     @ApiQuery({ name: 'teamId', type: String, required: true })
     @ApiQuery({ name: 'repositoryId', type: String, required: false })

--- a/apps/api/src/controllers/parameters.controller.ts
+++ b/apps/api/src/controllers/parameters.controller.ts
@@ -91,7 +91,13 @@ export class ParametersController {
     @Post('/create-or-update')
     @ApiOperation({
         summary: 'Create or update parameter',
-        description: 'Create or update a parameter configuration by key.',
+        description: `Create or update a parameter configuration by key. 
+        
+Available parameter keys:
+- code_review_config: Code review settings
+- language_config: Language for Kody's responses (comments, summaries, UI text) - controls the human language Kody uses to communicate
+- platform_configs: Platform-specific configurations
+- issue_creation_config: Issue creation settings`,
     })
     @ApiCreatedResponse({ type: ParametersStoredResponseDto })
     @ApiBody({
@@ -102,9 +108,13 @@ export class ParametersController {
                 key: {
                     type: 'string',
                     enum: Object.values(ParametersKey),
+                    description:
+                        'Parameter key (e.g., language_config for Kody response language)',
                 },
                 configValue: {
                     type: 'object',
+                    description:
+                        'Configuration value (e.g., "en-US" for language_config)',
                 },
                 organizationAndTeamData: {
                     type: 'object',
@@ -114,14 +124,30 @@ export class ParametersController {
                     },
                 },
             },
-            example: {
-                key: ParametersKey.CODE_REVIEW_CONFIG,
-                configValue: {
-                    useLLM: true,
-                    reviewMode: 'comment',
+            examples: {
+                codeReview: {
+                    value: {
+                        key: ParametersKey.CODE_REVIEW_CONFIG,
+                        configValue: {
+                            useLLM: true,
+                            reviewMode: 'comment',
+                        },
+                        organizationAndTeamData: {
+                            teamId: 'c33ef663-70e7-4f43-9605-0bbef979b8e0',
+                        },
+                    },
+                    summary: 'Code review configuration example',
                 },
-                organizationAndTeamData: {
-                    teamId: 'c33ef663-70e7-4f43-9605-0bbef979b8e0',
+                language: {
+                    value: {
+                        key: ParametersKey.LANGUAGE_CONFIG,
+                        configValue: 'en-US',
+                        organizationAndTeamData: {
+                            teamId: 'c33ef663-70e7-4f43-9605-0bbef979b8e0',
+                        },
+                    },
+                    summary:
+                        'Language configuration example - sets language for Kody responses',
                 },
             },
         },
@@ -163,11 +189,15 @@ export class ParametersController {
         enum: ParametersKey,
         type: String,
         required: true,
+        description:
+            'Parameter key (e.g., language_config to get the language for Kody responses)',
     })
     @ApiQuery({ name: 'teamId', type: String, required: true })
     @ApiOperation({
         summary: 'Find parameter by key',
-        description: 'Return a parameter configuration by key for a team.',
+        description: `Return a parameter configuration by key for a team.
+        
+For language_config: Returns the language setting for Kody's responses (comments, summaries, UI text).`,
     })
     @ApiOkResponse({ type: ParametersStoredResponseDto })
     @UseGuards(PolicyGuard)

--- a/libs/core/domain/enums/language-parameter.enum.ts
+++ b/libs/core/domain/enums/language-parameter.enum.ts
@@ -1,3 +1,13 @@
+/**
+ * Language preference for Kody's responses and UI text.
+ * 
+ * This setting controls the human language that Kody uses to communicate with you:
+ * - Code review comments and suggestions
+ * - Pull request summaries and descriptions
+ * - Feedback messages and interactions
+ * 
+ * Note: This is NOT related to programming languages or code translation.
+ */
 export enum LanguageValue {
     ENGLISH = 'en-US',
     PORTUGUESE_BR = 'pt-BR',

--- a/libs/core/domain/enums/parameters-key.enum.ts
+++ b/libs/core/domain/enums/parameters-key.enum.ts
@@ -1,7 +1,13 @@
 export enum ParametersKey {
     CODE_REVIEW_CONFIG = 'code_review_config',
     PLATFORM_CONFIGS = 'platform_configs',
+    
+    /**
+     * Language for Kody's responses (comments, summaries, UI text).
+     * Controls the human language Kody uses to communicate, not programming languages.
+     */
     LANGUAGE_CONFIG = 'language_config',
+    
     ISSUE_CREATION_CONFIG = 'issue_creation_config',
 
     //DEPRECATED

--- a/libs/organization/domain/parameters/types/configValue.type.ts
+++ b/libs/organization/domain/parameters/types/configValue.type.ts
@@ -54,6 +54,14 @@ export enum KodyLearningStatus {
     GENERATING_CONFIG = 'generating_config',
 }
 
+/**
+ * Maps parameter keys to their value types.
+ * 
+ * @property CODE_REVIEW_CONFIG - Configuration for code review settings
+ * @property LANGUAGE_CONFIG - Language for Kody's responses (e.g., "en-US", "pt-BR"). 
+ *           Controls the human language used in comments, summaries, and UI text.
+ * @property PLATFORM_CONFIGS - Platform-specific configurations
+ */
 export type ConfigValueMap = {
     [ParametersKey.CODE_REVIEW_CONFIG]: CodeReviewParameter;
     [ParametersKey.LANGUAGE_CONFIG]: LanguageValue;


### PR DESCRIPTION
Clarify language selection parameters to distinguish between Kody's response language and programming language detection.

The existing language selection caused confusion as users were unsure if it controlled Kody's communication language or the programming language of the code. This PR adds comprehensive documentation to make it clear that `LANGUAGE_CONFIG` governs Kody's response language (e.g., PR comments, summaries) and not programming language detection.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-bce3e7c4-1c50-45c3-a213-d4312e7098ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-bce3e7c4-1c50-45c3-a213-d4312e7098ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



---

<!-- kody-pr-summary:start -->
This pull request enhances clarity regarding language selection within the API, specifically distinguishing between programming language detection and Kody's communication language.

Key changes include:
*   **API Documentation Updates**: The `/organization/language` endpoint's documentation has been updated to explicitly state it detects *programming languages* (e.g., JavaScript, Python) and is not for Kody's response language. It now directs users to the `/parameters` endpoints for configuring Kody's communication language.
*   **Kody's Response Language Configuration**: The `/parameters/create-or-update` and `/parameters/find-by-key` endpoints' documentation has been significantly improved to clearly define and provide examples for the `language_config` parameter. This parameter controls the human language Kody uses for responses, such as code review comments, PR summaries, and UI text.
*   **Codebase Clarity**: JSDoc comments have been added to the `LanguageValue` enum, `ParametersKey.LANGUAGE_CONFIG`, and `ConfigValueMap` type to explicitly define their purpose in managing Kody's communication language, further differentiating it from programming languages.

These changes aim to prevent user confusion and provide precise guidance on how to configure Kody's operational language versus its communication language.
<!-- kody-pr-summary:end -->