### PR TITLE
change commitable suggestions default to true

### DIFF
--- a/default-kodus-config.yml
+++ b/default-kodus-config.yml
@@ -18,7 +18,7 @@ ignorePaths:
     - '**/*.json'
 ignoredTitleKeywords: []
 baseBranches: []
-enableCommittableSuggestions: false
+enableCommittableSuggestions: true
 
 # review categories
 codeReviewVersion: 'v2' # legacy | v2


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Changes the default value of `enableCommittableSuggestions` in `default-kodus-config.yml` from `false` to `true`. This update ensures that committable suggestions are enabled by default.
<!-- kody-pr-summary:end -->