### PR TITLE
let kody reply in pr reviews

### DIFF
--- a/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
+++ b/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
@@ -644,6 +644,10 @@ export class ChatWithKodyFromGitUseCase {
                 },
             });
 
+        const commentsMap = new Map<any, Comment>(
+            allComments?.map((c) => [c.id, c]) || [],
+        );
+
         const commentId = this.getCommentId(params);
         const comment =
             params.platformType !== PlatformType.AZURE_REPOS
@@ -659,11 +663,7 @@ export class ChatWithKodyFromGitUseCase {
         }
 
         if (
-            this.shouldIgnoreComment(
-                comment,
-                allComments || [],
-                params.platformType,
-            )
+            this.shouldIgnoreComment(comment, commentsMap, params.platformType)
         ) {
             this.logger.log({
                 message:
@@ -1318,7 +1318,7 @@ export class ChatWithKodyFromGitUseCase {
 
     private shouldIgnoreComment(
         comment: any,
-        allComments: any[],
+        commentsMap: Map<any, Comment>,
         platformType: PlatformType,
     ): boolean {
         if (this.isKodyComment(comment, platformType)) {
@@ -1331,7 +1331,7 @@ export class ChatWithKodyFromGitUseCase {
 
         const parentComment = this.getParentComment(
             comment,
-            allComments,
+            commentsMap,
             platformType,
         );
 
@@ -1344,7 +1344,7 @@ export class ChatWithKodyFromGitUseCase {
 
     private getParentComment(
         comment: Comment,
-        allComments: Comment[],
+        commentsMap: Map<any, Comment>,
         platformType: PlatformType,
     ): Comment | undefined {
         switch (platformType) {
@@ -1353,24 +1353,22 @@ export class ChatWithKodyFromGitUseCase {
                 if (!comment.in_reply_to_id) {
                     return undefined;
                 }
-                return allComments.find(
-                    (c) => c.id === comment.in_reply_to_id,
-                );
+                return commentsMap.get(comment.in_reply_to_id);
 
             case PlatformType.BITBUCKET:
                 if (!comment.parent?.id) {
                     return undefined;
                 }
-                return allComments.find((c) => c.id === comment.parent.id);
+                return commentsMap.get(comment.parent.id);
 
             case PlatformType.AZURE_REPOS:
                 if (
                     comment.thread &&
-                    Array.isArray(comment.thread.comments) &&
-                    comment.thread.comments.length > 0
+                    Array.isArray(comment.thread.replies) &&
+                    comment.thread.replies.length > 0
                 ) {
                     // For Azure, we treat the thread starter as the parent
-                    return comment.thread.comments[0];
+                    return comment.thread.replies[0];
                 }
                 return undefined;
 

--- a/libs/platform/infrastructure/webhooks/github/githubPullRequest.handler.ts
+++ b/libs/platform/infrastructure/webhooks/github/githubPullRequest.handler.ts
@@ -37,7 +37,7 @@ export class GitHubPullRequestHandler implements IWebhookEventHandler {
         private readonly eventEmitter: EventEmitter2,
         private readonly enqueueCodeReviewJobUseCase: EnqueueCodeReviewJobUseCase,
         private readonly enqueueImplementationCheckUseCase: EnqueueImplementationCheckUseCase,
-    ) { }
+    ) {}
 
     public canHandle(params: IWebhookEventParams): boolean {
         // Verify if the event is from GitHub
@@ -480,8 +480,7 @@ export class GitHubPullRequestHandler implements IWebhookEventHandler {
                     event === 'issue_comment') &&
                 !hasMarker &&
                 !isStartCommand &&
-                (isKodyMentionNonReview(comment.body) ||
-                    payload?.comment?.in_reply_to_id)
+                isKodyMentionNonReview(comment.body)
             ) {
                 this.chatWithKodyFromGitUseCase.execute(params);
                 return;


### PR DESCRIPTION
closes #631

<!-- kody-pr-summary:start -->
This pull request enhances Kody's ability to participate in pull request review conversations by allowing it to respond to comments that are replies to its own previous comments, even if Kody is not explicitly mentioned in the reply.

Key changes include:
*   **Improved Conversation Detection**: Kody now identifies comments as part of a `CONVERSATION` if they are replies to existing comments on GitHub, Bitbucket, or Azure Repos, even if no specific command is recognized.
*   **Contextual Reply Handling**: The logic for ignoring comments has been updated. Kody will no longer ignore a comment if it is a direct reply to a comment previously made by Kody, enabling it to follow up on its own feedback or questions.
*   **Cross-Platform Parent Comment Identification**: A new utility method was introduced to accurately determine the parent comment across different Git platforms (GitHub, GitLab, Bitbucket, Azure Repos), which is essential for the updated reply detection logic.
*   **Expanded Webhook Triggering**: GitHub webhooks will now trigger Kody's chat functionality for any comment that is a reply, ensuring these conversational interactions are processed.

These changes allow Kody to maintain context and engage in more natural, multi-turn conversations within pull request reviews.
<!-- kody-pr-summary:end -->