### PR TITLE
safely skip pr check creation if used token-auth

### DIFF
--- a/libs/platform/infrastructure/adapters/services/github/github.service.ts
+++ b/libs/platform/infrastructure/adapters/services/github/github.service.ts
@@ -124,15 +124,14 @@ interface GitHubInstallationData {
 @IntegrationServiceDecorator(PlatformType.GITHUB, 'codeManagement')
 export class GithubService
     implements
-        IGithubService,
-        Omit<
-            ICodeManagementService,
-            | 'getOrganizations'
-            | 'getUserById'
-            | 'getLanguageRepository'
-            | 'createSingleIssueComment'
-        >
-{
+    IGithubService,
+    Omit<
+        ICodeManagementService,
+        | 'getOrganizations'
+        | 'getUserById'
+        | 'getLanguageRepository'
+        | 'createSingleIssueComment'
+    > {
     private readonly MAX_RETRY_ATTEMPTS = 2;
     private readonly TTL = 50 * 60 * 1000; // 50 minutes
 
@@ -150,7 +149,7 @@ export class GithubService
         private readonly cacheService: CacheService,
         private readonly configService: ConfigService,
         private readonly mcpManagerService?: MCPManagerService,
-    ) {}
+    ) { }
 
     private async handleIntegration(
         integration: any,
@@ -435,9 +434,9 @@ export class GithubService
                 success: true,
                 status: CreateAuthIntegrationStatus.SUCCESS,
             };
-        } catch {
+        } catch (err) {
             throw new BadRequestException(
-                'Error authenticating with GITHUB PAT.',
+                err.message || 'Error authenticating with GITHUB PAT.',
             );
         }
     }
@@ -2511,11 +2510,11 @@ export class GithubService
                         const files = filters?.skipFiles
                             ? []
                             : await this.getPullRequestFiles(
-                                  octokit,
-                                  githubAuthDetail.org,
-                                  repo,
-                                  pullRequest?.number,
-                              );
+                                octokit,
+                                githubAuthDetail.org,
+                                repo,
+                                pullRequest?.number,
+                            );
                         return {
                             id: pullRequest.id,
                             pull_number: pullRequest?.number,
@@ -2818,7 +2817,7 @@ ${copyPrompt}
         const language = isCommittableSuggestion
             ? 'suggestion'
             : lineComment?.suggestion?.language?.toLowerCase() ||
-              repository?.language?.toLowerCase();
+            repository?.language?.toLowerCase();
 
         const severityShield = lineComment?.suggestion
             ? getSeverityLevelShield(lineComment.suggestion.severity)
@@ -2864,7 +2863,7 @@ This is an experimental feature that generates committable changes. Review the d
             copyPrompt,
             this.formatSub(translations.talkToKody),
             this.formatSub(translations.feedback) +
-                '<!-- kody-codereview -->&#8203;\n&#8203;',
+            '<!-- kody-codereview -->&#8203;\n&#8203;',
         ]
             .join('\n')
             .trim();
@@ -3094,13 +3093,13 @@ This is an experimental feature that generates committable changes. Review the d
                         // So we need one of them to actually mark the thread as resolved and the other to match the id we saved in the database.
                         return firstComment
                             ? {
-                                  id: firstComment.id, // Used to actually resolve the thread
-                                  threadId: reviewThread.id,
-                                  isResolved: reviewThread.isResolved,
-                                  isOutdated: reviewThread.isOutdated,
-                                  fullDatabaseId: firstComment.fullDatabaseId, // The REST API id, used to match comments saved in the database.
-                                  body: firstComment.body,
-                              }
+                                id: firstComment.id, // Used to actually resolve the thread
+                                threadId: reviewThread.id,
+                                isResolved: reviewThread.isResolved,
+                                isOutdated: reviewThread.isOutdated,
+                                fullDatabaseId: firstComment.fullDatabaseId, // The REST API id, used to match comments saved in the database.
+                                body: firstComment.body,
+                            }
                             : null;
                     })
                     .filter((comment) => comment !== null);
@@ -3706,12 +3705,12 @@ This is an experimental feature that generates committable changes. Review the d
         organizationAndTeamData: OrganizationAndTeamData;
         commentId: string;
         reason?:
-            | 'ABUSE'
-            | 'OFF_TOPIC'
-            | 'OUTDATED'
-            | 'RESOLVED'
-            | 'DUPLICATE'
-            | 'SPAM';
+        | 'ABUSE'
+        | 'OFF_TOPIC'
+        | 'OUTDATED'
+        | 'RESOLVED'
+        | 'DUPLICATE'
+        | 'SPAM';
     }): Promise<any | null> {
         try {
             const {
@@ -4096,15 +4095,15 @@ This is an experimental feature that generates committable changes. Review the d
                 reactions: {
                     thumbsUp: isOAuth
                         ? Math.max(
-                              0,
-                              comment.reactions[GitHubReaction.THUMBS_UP] - 1,
-                          )
+                            0,
+                            comment.reactions[GitHubReaction.THUMBS_UP] - 1,
+                        )
                         : comment.reactions[GitHubReaction.THUMBS_UP],
                     thumbsDown: isOAuth
                         ? Math.max(
-                              0,
-                              comment.reactions[GitHubReaction.THUMBS_DOWN] - 1,
-                          )
+                            0,
+                            comment.reactions[GitHubReaction.THUMBS_DOWN] - 1,
+                        )
                         : comment.reactions[GitHubReaction.THUMBS_DOWN],
                 },
                 comment: {
@@ -5049,13 +5048,13 @@ This is an experimental feature that generates committable changes. Review the d
                         // So we need one of them to actually mark the thread as resolved and the other to match the id we saved in the database.
                         return firstComment
                             ? {
-                                  id: firstComment.id, // Used to actually resolve the thread
-                                  threadId: reviewThread.id,
-                                  isResolved: reviewThread.isResolved,
-                                  isOutdated: reviewThread.isOutdated,
-                                  fullDatabaseId: firstComment.fullDatabaseId, // The REST API id, used to match comments saved in the database.
-                                  body: firstComment.body,
-                              }
+                                id: firstComment.id, // Used to actually resolve the thread
+                                threadId: reviewThread.id,
+                                isResolved: reviewThread.isResolved,
+                                isOutdated: reviewThread.isOutdated,
+                                fullDatabaseId: firstComment.fullDatabaseId, // The REST API id, used to match comments saved in the database.
+                                body: firstComment.body,
+                            }
                             : null;
                     })
                     .filter((comment) => comment !== null);
@@ -5082,11 +5081,11 @@ This is an experimental feature that generates committable changes. Review the d
                     // So we need one of them to actually mark the thread as resolved and the other to match the id we saved in the database.
                     return firstComment
                         ? {
-                              id: firstComment.id, // Used to actually resolve the thread
-                              reviewId: review.id,
-                              fullDatabaseId: firstComment.fullDatabaseId, // The REST API id, used to match comments saved in the database.
-                              body: firstComment.body,
-                          }
+                            id: firstComment.id, // Used to actually resolve the thread
+                            reviewId: review.id,
+                            fullDatabaseId: firstComment.fullDatabaseId, // The REST API id, used to match comments saved in the database.
+                            body: firstComment.body,
+                        }
                         : null;
                 })
                 .filter((comment) => comment !== null);


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request implements a mechanism to safely skip the creation and update of GitHub Check Runs when the GitHub integration is authenticated using a Personal Access Token (PAT).

Key changes include:
- Before attempting to create or update a GitHub Check Run, the system now verifies the authentication mode.
- If the authentication mode is identified as `TOKEN` (indicating PAT authentication), the Check Run operation is skipped, and a log message is recorded to indicate that Check Run management is not supported with PATs.
- This prevents potential errors or unsupported operations that may arise when using PATs for GitHub Check Run interactions.
- Minor improvements have also been made to the error handling when creating PAT-based GitHub authentications, allowing for more specific error messages.
<!-- kody-pr-summary:end -->