### PR TITLE
Kody language context

### DIFF
--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/general/_components/language-selector.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/general/_components/language-selector.tsx
@@ -172,8 +172,12 @@ export const LanguageSelector = () => {
             render={({ field }) => (
                 <FormControl.Root>
                     <FormControl.Label htmlFor={field.name}>
-                        Language
+                        Kody Language
                     </FormControl.Label>
+
+                    <FormControl.Description>
+                        The language Kody will use in code review responses
+                    </FormControl.Description>
 
                     <FormControl.Input>
                         <Popover


### PR DESCRIPTION
Update the language selector to provide more context for "Kody Language" in the UI.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-e4acd43c-52da-40f5-8081-8f620ab9789d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-e4acd43c-52da-40f5-8081-8f620ab9789d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>



---

<!-- kody-pr-summary:start -->
Updates the language selector in the code review settings to clarify its purpose. The label has been changed from "Language" to "Kody Language," and a description has been added to explain that this setting determines the language Kody will use in code review responses.
<!-- kody-pr-summary:end -->