### PR TITLE
update kody suggestion

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -88,6 +88,9 @@ COPY --chown=1000:1000 --from=build /usr/src/app/tsconfig-paths-bootstrap.js ./t
 
 COPY --chmod=0755 docker/prod-entrypoint.sh /usr/local/bin/prod-entrypoint
 
+# Give ownership of working directory to user 1000 so they can create files (like ormlogs.log)
+RUN chown 1000:1000 /usr/src/app
+
 USER 1000
 
 ENTRYPOINT ["/usr/local/bin/prod-entrypoint"]


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Ensures the application running within the Docker container has write permissions in its working directory (`/usr/src/app`). This is achieved by changing the ownership of `/usr/src/app` to user ID 1000 before the container switches to run as that user, preventing permission errors when creating files like `ormlogs.log`.
<!-- kody-pr-summary:end -->