### PR TITLE
exisMerge branch 'main' into fix/github-check-finalize-for-skipped

### DIFF
--- a/libs/core/infrastructure/pipeline/services/pipeline-checks.service.spec.ts
+++ b/libs/core/infrastructure/pipeline/services/pipeline-checks.service.spec.ts
@@ -320,6 +320,45 @@ describe('PipelineChecksService', () => {
             );
         });
 
+        it('should replace generic failure reason with context-derived details', async () => {
+            const contextWithFailureDetails = {
+                ...mockContext,
+                statusInfo: {
+                    status: 'ERROR',
+                    message: 'Code review failed',
+                },
+                errors: [
+                    {
+                        stage: 'FileAnalysisStage',
+                        substage: 'src/app/service.ts',
+                        error: new Error('400 status code (no body)'),
+                    },
+                ],
+            };
+
+            await service.finalizeCheck(
+                mockObserverContext,
+                contextWithFailureDetails,
+                CheckConclusion.FAILURE,
+                '_pipelineEndFailure',
+                'An error occurred during the review. Please check the logs for details.',
+            );
+
+            expect(checksAdapter.updateCheckRun).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    checkRunId: '123',
+                    status: CheckStatus.COMPLETED,
+                    conclusion: CheckConclusion.FAILURE,
+                    output: expect.objectContaining({
+                        title: 'Code Review Failed',
+                        summary: expect.stringContaining(
+                            '400 status code (no body)',
+                        ),
+                    }),
+                }),
+            );
+        });
+
         it('should call updateCheckRun with COMPLETED status and clear checkRunId', async () => {
             await service.finalizeCheck(
                 mockObserverContext,

--- a/libs/core/infrastructure/pipeline/services/pipeline-checks.service.ts
+++ b/libs/core/infrastructure/pipeline/services/pipeline-checks.service.ts
@@ -396,8 +396,14 @@ export class PipelineChecksService implements IPipelineChecksService {
             }
         }
 
-        if (stageName === CheckStageNames._pipelineEndFailure && !reason) {
-            summary = this.buildFailureSummaryFromContext(context) || summary;
+        if (stageName === CheckStageNames._pipelineEndFailure) {
+            const shouldBuildFailureSummaryFromContext =
+                !summary || this.isGenericFailureMessage(summary);
+
+            if (shouldBuildFailureSummaryFromContext) {
+                summary =
+                    this.buildFailureSummaryFromContext(context) || summary;
+            }
         }
 
         try {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request enhances the detail provided in GitHub check run failure summaries.

Specifically, it modifies the `finalizeCheck` service to:
- **Generate detailed failure summaries:** When a pipeline check concludes with a failure, if the provided summary message is generic or empty, the system will now automatically construct a more specific and informative summary.
- **Utilize pipeline context for details:** This improved summary is derived from the pipeline's execution context, incorporating specific error messages and status information to provide clearer insights into the cause of the failure.

This change aims to improve the developer experience by offering more actionable and precise error messages directly within GitHub check runs, reducing the need to manually inspect logs for common pipeline failures.
<!-- kody-pr-summary:end -->