### PR TITLE
chore: improve changelog tag-range resolution and guardrails

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -35,14 +35,14 @@ jobs:
                       if echo "$current_tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
                         tag_regex='^v[0-9]+\.[0-9]+\.[0-9]+$'
                       else
-                        tag_regex='.*'
+                        tag_regex='^$'
                       fi
                       ;;
                     *)
                       if echo "$current_tag" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
                         tag_regex='^[0-9]+\.[0-9]+\.[0-9]+$'
                       else
-                        tag_regex='.*'
+                        tag_regex='^$'
                       fi
                       ;;
                   esac

--- a/.github/workflows/prod-build-push-and-pr-green.yml
+++ b/.github/workflows/prod-build-push-and-pr-green.yml
@@ -299,14 +299,14 @@ jobs:
                       if echo "$current_tag" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
                         tag_regex='^v[0-9]+\.[0-9]+\.[0-9]+$'
                       else
-                        tag_regex='.*'
+                        tag_regex='^$'
                       fi
                       ;;
                     *)
                       if echo "$current_tag" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
                         tag_regex='^[0-9]+\.[0-9]+\.[0-9]+$'
                       else
-                        tag_regex='.*'
+                        tag_regex='^$'
                       fi
                       ;;
                   esac


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request significantly enhances the changelog generation process by improving how tag ranges are resolved and by adding more robust guardrails.

Key changes include:

*   **Precise Tag Range Resolution:** The workflow now dynamically determines the previous release tag based on the current tag's naming convention (e.g., `web-`, `selfhosted-`, `v-`, or generic `X.Y.Z` versions). This allows for more accurate identification of the commit range for a given release, replacing the previous date-based approach.
*   **Commit-Based Changelog Window:** The `start_date` and `end_date` for the changelog are now derived directly from the commit timestamps of the resolved previous and current tags, ensuring the changelog accurately reflects changes between specific release points. If no previous tag is found, it defaults to a 30-day window.
*   **Improved Empty Changelog Handling:**
    *   The workflow now explicitly checks if the current tag exists locally.
    *   If the changelog API returns an empty changelog but commits are detected within the resolved tag range, the workflow will now fail and log the relevant commits, preventing silent omissions of changes.
    *   If no commits are detected in the resolved range and the API returns an empty changelog, a default "No changes in this release" message is generated for clarity.
*   **Full Git History Fetch:** The `actions/checkout` step now fetches the complete git history (`fetch-depth: 0`), which is crucial for accurate tag and commit range calculations.

These improvements are applied to both the dedicated `changelog.yml` workflow and the `prod-build-push-and-pr-green.yml` workflow, ensuring consistent and reliable changelog generation for all releases.
<!-- kody-pr-summary:end -->