### PR TITLE
adjusted repository params to method getPullRequestReviewComment

### DIFF
--- a/libs/code-review/application/use-cases/codeReviewFeedback/get-reactions.use-case.ts
+++ b/libs/code-review/application/use-cases/codeReviewFeedback/get-reactions.use-case.ts
@@ -59,7 +59,7 @@ export class GetReactionsUseCase implements IUseCase {
                 await this.codeManagementService.getPullRequestReviewComment({
                     organizationAndTeamData,
                     filters: {
-                        repository: pr.repository.name,
+                        repository: pr.repository,
                         pullRequestNumber: pr.number,
                     },
                 });
@@ -81,7 +81,7 @@ export class GetReactionsUseCase implements IUseCase {
                     comments: commentsLinkedToSuggestions,
                     pr: {
                         pull_number: pr.number,
-                        repository: pr.repository.name,
+                        repository: pr.repository,
                     },
                 });
 
@@ -112,10 +112,10 @@ export class GetReactionsUseCase implements IUseCase {
                             repository: {
                                 id:
                                     reaction?.pullRequest?.repository?.id ||
-                                    pr.repository.id,
+                                    pr?.repository?.id,
                                 fullName:
                                     reaction?.pullRequest?.repository
-                                        ?.fullName || pr.repository.name,
+                                        ?.fullName || pr?.repository?.name,
                             },
                         },
                         organizationId: organizationAndTeamData.organizationId,
@@ -144,7 +144,7 @@ export class GetReactionsUseCase implements IUseCase {
                     prsWithoutReactionsDetails: prsWithoutReactions.map(
                         (pr) => ({
                             prNumber: pr.number,
-                            repository: pr.repository.name,
+                            repository: pr?.repository?.name,
                             suggestionsCount: pr.suggestions?.length || 0,
                         }),
                     ),


### PR DESCRIPTION
issue #700

---

<!-- kody-pr-summary:start -->
Adjusted the `repository` parameter passed to the `getPullRequestReviewComment` method and `getReactions` service call. Previously, only the repository name (`pr.repository.name`) was passed; now, the entire repository object (`pr.repository`) is provided.

Additionally, optional chaining (`?.`) was added when accessing `pr.repository.id` and `pr.repository.name` in various parts of the `GetReactionsUseCase` to enhance null safety and prevent potential runtime errors.
<!-- kody-pr-summary:end -->