### PR TITLE
Fixing

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -61,6 +61,10 @@ services:
     worker:
         <<: *app-service-defaults
         container_name: kodus_worker
+        volumes:
+            - .:/usr/src/app:delegated
+            - node_modules_cache:/usr/src/app/node_modules:nocopy
+            - yalc_store:/root/.yalc
         ports:
             - '9231:9231'
             - '8001:8001'
@@ -89,6 +93,10 @@ services:
     webhooks:
         <<: *app-service-defaults
         container_name: kodus_webhooks
+        volumes:
+            - .:/usr/src/app:delegated
+            - node_modules_cache:/usr/src/app/node_modules:nocopy
+            - yalc_store:/root/.yalc
         ports:
             - '${API_WEBHOOKS_PORT:-3332}:${API_WEBHOOKS_PORT:-3332}'
             - '9232:9232'

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -21,6 +21,18 @@ RUN npm i -g yalc chokidar-cli nodemon
 COPY package.json yarn.lock ./
 COPY nest-cli.json tsconfig*.json ./
 
+COPY packages/kodus-common ./packages/kodus-common
+COPY packages/kodus-flow ./packages/kodus-flow
+
+# Build local packages first
+RUN cd packages/kodus-common && yarn install && yarn prepack
+RUN cd packages/kodus-flow && yarn install && yarn build
+
+# Install dependencies and link local packages
+RUN yarn install --frozen-lockfile
+RUN rm -rf node_modules/@kodus/kodus-common && cp -r packages/kodus-common node_modules/@kodus/kodus-common
+RUN rm -rf node_modules/@kodus/flow && cp -r packages/kodus-flow node_modules/@kodus/flow
+
 COPY --chmod=0755 docker/dev-entrypoint.sh /usr/local/bin/dev-entrypoint
 
 ENTRYPOINT ["/usr/local/bin/dev-entrypoint"]

--- a/package.json
+++ b/package.json
@@ -150,7 +150,6 @@
         "@langchain/google-gauth": "^2.1.18",
         "@langchain/google-vertexai": "^2.1.18",
         "@langchain/openai": "1.2.7",
-        "@llamaduck/forgejo-ts": "14.0.2-4",
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@morphllm/morphsdk": "^0.2.114",
         "@nestjs/axios": "^4.0.1",

--- a/packages/kodus-common/package.json
+++ b/packages/kodus-common/package.json
@@ -75,7 +75,7 @@
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.55.0",
         "zod": "^4.2.1",
-        "zod-to-json-schema": "^3.24.6"
+        "zod-to-json-schema": "^3.25.0"
     },
     "peerDependencies": {
         "@langchain/anthropic": "^1.3.17",

--- a/packages/kodus-common/yarn.lock
+++ b/packages/kodus-common/yarn.lock
@@ -3851,10 +3851,10 @@ yocto-queue@^0.1.0:
   resolved "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zod-to-json-schema@^3.24.6:
-  version "3.25.0"
-  resolved "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.0.tgz#df504c957c4fb0feff467c74d03e6aab0b013e1c"
-  integrity sha512-HvWtU2UG41LALjajJrML6uQejQhNJx+JBO9IflpSja4R03iNWfKXrj6W2h7ljuLyc1nKS+9yDyL/9tD1U/yBnQ==
+zod-to-json-schema@^3.25.0:
+  version "3.25.1"
+  resolved "https://registry.yarnpkg.com/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz#7f24962101a439ddade2bf1aeab3c3bfec7d84ba"
+  integrity sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==
 
 "zod@^3.25.76 || ^4", zod@^4.2.1:
   version "4.2.1"


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request enhances the Docker development environment by improving how local monorepo packages are handled.

Key changes include:
*   **Dockerfile.dev Updates**: The development Dockerfile now explicitly copies, installs dependencies for, and builds local packages (`kodus-common` and `kodus-flow`). It then manually links these built local packages into the main project's `node_modules` directory within the Docker image.
*   **Docker Compose Volume Mounts**: The `docker-compose.dev.yml` file has been updated for the `worker` and `webhooks` services to include additional volume mounts:
    *   Mounts the project root (`.`) into the container (`/usr/src/app`) with `delegated` synchronization for efficient live code reloading during development.
    *   Utilizes a named volume (`node_modules_cache`) for `node_modules` with `nocopy` to manage dependencies more effectively within the container.
    *   Mounts a named volume (`yalc_store`) for the `yalc` store, supporting local package linking.

These changes ensure that the Docker development environment correctly builds, resolves, and utilizes local packages, facilitating a smoother development workflow.
<!-- kody-pr-summary:end -->