### PR TITLE
Fixing types

### DIFF
--- a/libs/code-review/infrastructure/adapters/services/collectCrossFileContexts.service.ts
+++ b/libs/code-review/infrastructure/adapters/services/collectCrossFileContexts.service.ts
@@ -366,7 +366,7 @@ export class CollectCrossFileContextsService {
 
         const builder = promptRunner
             .builder()
-            .setParser(ParserType.ZOD, CrossFileContextPlannerSchema)
+            .setParser(ParserType.ZOD, CrossFileContextPlannerSchema as any)
             .setLLMJsonMode(true)
             .setPayload(payload)
             .addPrompt({
@@ -395,7 +395,7 @@ export class CollectCrossFileContextsService {
                     builder.addCallbacks(callbacks).execute(),
             });
 
-        return result?.queries ?? [];
+        return (result as CrossFileContextPlannerSchemaType)?.queries ?? [];
     }
 
     private deduplicatePlannerQueries(


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request addresses type-related issues within the `CollectCrossFileContextsService`.

Specifically, it:
*   Casts `CrossFileContextPlannerSchema` to `any` when setting the ZOD parser for the prompt runner, resolving a type incompatibility.
*   Explicitly casts the `result` of the prompt execution to `CrossFileContextPlannerSchemaType` before accessing its `queries` property, ensuring correct type inference and preventing potential type errors.

These changes improve type safety and resolve compilation issues without altering the functional logic of collecting cross-file contexts.
<!-- kody-pr-summary:end -->