### PR TITLE
Fixing name

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -226,7 +226,7 @@ WEBHOOK_FAILURE_THRESHOLD_PERCENT=10
 WEBHOOK_FAILURE_WINDOW_MINUTES=30
 
 # E2B
-E2B_API_KEY
+API_E2B_KEY=
 
 # ============================================================
 # Web Frontend

--- a/libs/code-review/infrastructure/adapters/services/e2bSandbox.service.ts
+++ b/libs/code-review/infrastructure/adapters/services/e2bSandbox.service.ts
@@ -29,17 +29,17 @@ export class E2BSandboxService {
     constructor(private readonly configService: ConfigService) {}
 
     isAvailable(): boolean {
-        return !!this.configService.get<string>('E2B_API_KEY');
+        return !!this.configService.get<string>('API_E2B_KEY');
     }
 
     async createSandboxWithRepo(
         params: CreateSandboxParams,
     ): Promise<SandboxWithCommands> {
         const { cloneUrl, authToken, branch, prNumber, platform } = params;
-        const apiKey = this.configService.get<string>('E2B_API_KEY');
+        const apiKey = this.configService.get<string>('API_E2B_KEY');
 
         if (!apiKey) {
-            throw new Error('E2B_API_KEY is not configured');
+            throw new Error('API_E2B_KEY is not configured');
         }
 
         const sandbox = await Sandbox.create({

--- a/libs/code-review/pipeline/stages/collect-cross-file-context.stage.ts
+++ b/libs/code-review/pipeline/stages/collect-cross-file-context.stage.ts
@@ -49,7 +49,7 @@ export class CollectCrossFileContextStage extends BasePipelineStage<CodeReviewPi
         // Guard: skip if E2B is not available
         if (!this.e2bSandboxService.isAvailable()) {
             this.logger.log({
-                message: `Skipping cross-file context collection: E2B_API_KEY not configured for PR#${context?.pullRequest?.number}`,
+                message: `Skipping cross-file context collection: API_E2B_KEY not configured for PR#${context?.pullRequest?.number}`,
                 context: this.stageName,
                 metadata: {
                     organizationAndTeamData: context?.organizationAndTeamData,

--- a/scripts/dev/fetch-env-prod.sh
+++ b/scripts/dev/fetch-env-prod.sh
@@ -160,6 +160,8 @@ KEYS=(
 
     "/prod/kodus-orchestrator/API_MORPHLLM_API_KEY"
 
+    "/prod/kodus-orchestrator/API_E2B_KEY"
+
     "/prod/kodus-orchestrator/API_BETTERSTACK_API_TOKEN"
     "/prod/kodus-orchestrator/API_BETTERSTACK_HEARTBEAT_ERROR_RATE_URL"
     "/prod/kodus-orchestrator/API_BETTERSTACK_HEARTBEAT_REVIEW_MONITOR_URL"

--- a/scripts/dev/fetch-env-qa.sh
+++ b/scripts/dev/fetch-env-qa.sh
@@ -120,6 +120,8 @@ KEYS=(
 
     "/qa/kodus-orchestrator/API_MORPHLLM_API_KEY"
 
+    "/qa/kodus-orchestrator/API_E2B_KEY"
+
     "/qa/kodus-orchestrator/API_BETTERSTACK_API_TOKEN"
     "/qa/kodus-orchestrator/API_BETTERSTACK_HEARTBEAT_ERROR_RATE_URL"
     "/qa/kodus-orchestrator/API_BETTERSTACK_HEARTBEAT_REVIEW_MONITOR_URL"

--- a/test/unit/code-review/services/e2bSandbox.service.spec.ts
+++ b/test/unit/code-review/services/e2bSandbox.service.spec.ts
@@ -49,14 +49,14 @@ describe('E2BSandboxService', () => {
     // ─── isAvailable ───────────────────────────────────────────────────────
 
     describe('isAvailable()', () => {
-        it('should return true when E2B_API_KEY is set', async () => {
+        it('should return true when API_E2B_KEY is set', async () => {
             service = await createService({
-                E2B_API_KEY: 'test-key-123',
+                API_E2B_KEY: 'test-key-123',
             });
             expect(service.isAvailable()).toBe(true);
         });
 
-        it('should return false when E2B_API_KEY is not set', async () => {
+        it('should return false when API_E2B_KEY is not set', async () => {
             service = await createService({});
             expect(service.isAvailable()).toBe(false);
         });
@@ -66,7 +66,7 @@ describe('E2BSandboxService', () => {
 
     describe('buildAuthHeader()', () => {
         beforeEach(async () => {
-            service = await createService({ E2B_API_KEY: 'key' });
+            service = await createService({ API_E2B_KEY: 'key' });
         });
 
         const buildAuthHeader = (platform: PlatformType, token: string) =>
@@ -94,7 +94,7 @@ describe('E2BSandboxService', () => {
 
     describe('getPrRefspec()', () => {
         beforeEach(async () => {
-            service = await createService({ E2B_API_KEY: 'key' });
+            service = await createService({ API_E2B_KEY: 'key' });
         });
 
         const getPrRefspec = (platform: PlatformType, prNumber: number) =>
@@ -139,16 +139,16 @@ describe('E2BSandboxService', () => {
             return { mockKill, mockRun, mockSandbox, Sandbox };
         };
 
-        it('should throw when E2B_API_KEY is not configured', async () => {
+        it('should throw when API_E2B_KEY is not configured', async () => {
             service = await createService({});
 
             await expect(
                 service.createSandboxWithRepo(defaultParams),
-            ).rejects.toThrow('E2B_API_KEY is not configured');
+            ).rejects.toThrow('API_E2B_KEY is not configured');
         });
 
         it('should kill sandbox on setup failure', async () => {
-            service = await createService({ E2B_API_KEY: 'test-key' });
+            service = await createService({ API_E2B_KEY: 'test-key' });
 
             const { Sandbox } = require('e2b');
             const mockKill = jest.fn().mockResolvedValue(undefined);
@@ -169,7 +169,7 @@ describe('E2BSandboxService', () => {
         });
 
         it('should create sandbox with correct apiKey and timeout', async () => {
-            service = await createService({ E2B_API_KEY: 'my-e2b-key' });
+            service = await createService({ API_E2B_KEY: 'my-e2b-key' });
             const { Sandbox } = setupSandboxMock();
 
             await service.createSandboxWithRepo(defaultParams);
@@ -181,7 +181,7 @@ describe('E2BSandboxService', () => {
         });
 
         it('should run apt-get install as first command', async () => {
-            service = await createService({ E2B_API_KEY: 'key' });
+            service = await createService({ API_E2B_KEY: 'key' });
             const { mockRun } = setupSandboxMock();
 
             await service.createSandboxWithRepo(defaultParams);
@@ -194,7 +194,7 @@ describe('E2BSandboxService', () => {
         });
 
         it('should run git commands with correct refspec and auth header', async () => {
-            service = await createService({ E2B_API_KEY: 'key' });
+            service = await createService({ API_E2B_KEY: 'key' });
             const { mockRun } = setupSandboxMock();
 
             await service.createSandboxWithRepo(defaultParams);
@@ -216,7 +216,7 @@ describe('E2BSandboxService', () => {
         });
 
         it('should return remoteCommands and cleanup function', async () => {
-            service = await createService({ E2B_API_KEY: 'key' });
+            service = await createService({ API_E2B_KEY: 'key' });
             setupSandboxMock();
 
             const result = await service.createSandboxWithRepo(defaultParams);
@@ -234,7 +234,7 @@ describe('E2BSandboxService', () => {
 
     describe('cleanup()', () => {
         it('should call sandbox.kill()', async () => {
-            service = await createService({ E2B_API_KEY: 'key' });
+            service = await createService({ API_E2B_KEY: 'key' });
 
             const mockKill = jest.fn().mockResolvedValue(undefined);
             const { Sandbox } = require('e2b');
@@ -257,7 +257,7 @@ describe('E2BSandboxService', () => {
         });
 
         it('should swallow sandbox.kill() errors (logged internally)', async () => {
-            service = await createService({ E2B_API_KEY: 'key' });
+            service = await createService({ API_E2B_KEY: 'key' });
 
             const mockKill = jest.fn().mockRejectedValue(new Error('kill failed'));
             const { Sandbox } = require('e2b');
@@ -286,7 +286,7 @@ describe('E2BSandboxService', () => {
         let remoteCommands: any;
 
         beforeEach(async () => {
-            service = await createService({ E2B_API_KEY: 'key' });
+            service = await createService({ API_E2B_KEY: 'key' });
 
             mockRun = jest.fn().mockResolvedValue({ stdout: 'output' });
             const { Sandbox } = require('e2b');
@@ -364,7 +364,7 @@ describe('E2BSandboxService', () => {
 
     describe('resolvePath()', () => {
         beforeEach(async () => {
-            service = await createService({ E2B_API_KEY: 'key' });
+            service = await createService({ API_E2B_KEY: 'key' });
         });
 
         const resolvePath = (path: string) =>


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request renames the environment variable used for the E2B API key from `E2B_API_KEY` to `API_E2B_KEY`.

The changes include:
*   Updating the `E2BSandboxService` to retrieve the E2B API key using the new `API_E2B_KEY` environment variable and updating associated error messages.
*   Adjusting log messages in the `CollectCrossFileContextStage` to reflect the updated variable name when E2B is not configured.
*   Modifying the `fetch-env-prod.sh` and `fetch-env-qa.sh` scripts to fetch the `API_E2B_KEY` from the AWS Systems Manager Parameter Store for production and QA environments, respectively.
*   Updating unit tests for `E2BSandboxService` to use the new `API_E2B_KEY` variable name in test cases and mock configurations.

This ensures consistency in naming conventions for the E2B API key across the application, deployment scripts, and tests.
<!-- kody-pr-summary:end -->