### PR TITLE
fix(ci): route preview API between Railway and QA

### DIFF
--- a/.github/workflows/preview-deploy.yml
+++ b/.github/workflows/preview-deploy.yml
@@ -139,18 +139,50 @@ jobs:
             - name: Determine API URL
               id: api-url
               run: |
+                  BACKEND_CHANGED="${{ needs.detect-changes.outputs.backend }}"
                   RAILWAY_URL="${{ needs.resolve-backend-url.outputs.api_url }}"
-                  if [ -n "$RAILWAY_URL" ]; then
-                    echo "url=$RAILWAY_URL" >> $GITHUB_OUTPUT
-                    echo "Using Railway backend: $RAILWAY_URL"
+
+                  if [ "$BACKEND_CHANGED" = "true" ]; then
+                    if [ -z "$RAILWAY_URL" ]; then
+                      echo "::error::Backend changed, but Railway preview URL could not be resolved."
+                      exit 1
+                    fi
+
+                    API_HOST="$RAILWAY_URL"
+                    API_HOST="${API_HOST#https://}"
+                    API_HOST="${API_HOST#http://}"
+                    API_HOST="${API_HOST%/}"
+                    echo "url=$API_HOST" >> $GITHUB_OUTPUT
+                    echo "Using Railway backend: https://$API_HOST"
                   else
-                    echo "url=${{ vars.QA_API_URL }}" >> $GITHUB_OUTPUT
-                    echo "Using QA backend: ${{ vars.QA_API_URL }}"
+                    API_HOST="${{ vars.QA_API_URL }}"
+                    API_HOST="${API_HOST#https://}"
+                    API_HOST="${API_HOST#http://}"
+                    API_HOST="${API_HOST%/}"
+                    echo "url=$API_HOST" >> $GITHUB_OUTPUT
+                    echo "Using QA backend: https://$API_HOST"
                   fi
 
             - name: Pull Vercel environment
               working-directory: apps/web
               run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+            - name: Override API host in pulled Vercel env
+              working-directory: apps/web
+              run: |
+                  ENV_FILE=".vercel/.env.preview.local"
+
+                  if [ ! -f "$ENV_FILE" ]; then
+                    echo "::error::Expected $ENV_FILE after 'vercel pull'."
+                    exit 1
+                  fi
+
+                  cp "$ENV_FILE" "$ENV_FILE.bak"
+                  grep -v '^WEB_HOSTNAME_API=' "$ENV_FILE.bak" > "$ENV_FILE" || true
+                  echo "WEB_HOSTNAME_API=${{ steps.api-url.outputs.url }}" >> "$ENV_FILE"
+
+                  echo "Injected WEB_HOSTNAME_API in $ENV_FILE"
+                  grep '^WEB_HOSTNAME_API=' "$ENV_FILE"
 
             - name: Build project
               working-directory: apps/web


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request enhances the CI/CD workflow for Vercel preview deployments by implementing dynamic API routing for the frontend.

Key changes include:

*   **Conditional API Backend Selection:** The workflow now intelligently determines the API backend for preview deployments. If backend code changes are detected in the pull request, the frontend preview will be configured to use the API URL of the corresponding Railway backend preview deployment. If no backend changes are detected, the frontend preview will default to using the stable QA API URL.
*   **Dynamic API Host Injection:** The selected API host (either Railway preview or QA) is now dynamically injected into the Vercel preview environment file (`.vercel/.env.preview.local`) as `WEB_HOSTNAME_API`. This ensures the frontend application correctly points to the appropriate backend for each preview.
*   **Consistent URL Formatting:** API host URLs are consistently processed to remove protocol prefixes (e.g., `https://`) and trailing slashes, ensuring a clean hostname is used.

This change improves the reliability and relevance of preview deployments by ensuring the frontend always connects to the correct and compatible backend API.
<!-- kody-pr-summary:end -->