### PR TITLE
fix: default feature flags to enabled for self-hosted without PostHog

### DIFF
--- a/apps/web/src/core/utils/posthog-server-side.ts
+++ b/apps/web/src/core/utils/posthog-server-side.ts
@@ -57,8 +57,8 @@ export const getFeatureFlagWithPayload = async ({
       }
     | undefined
 > => {
-    // if no environment key is provided, there's no way to create Posthog client
-    if (!process.env.WEB_POSTHOG_KEY) return undefined;
+    // if no environment key is provided, assume self-hosted with all features enabled
+    if (!process.env.WEB_POSTHOG_KEY) return { value: true, payload: undefined };
 
     const jwtPayload = await auth();
     const id =
@@ -112,7 +112,8 @@ export const isFeatureEnabled = async ({
     identifier?: "user" | "organization";
 }): Promise<boolean> => {
     try {
-        if (!process.env.WEB_POSTHOG_KEY) return false;
+        // if no environment key is provided, assume self-hosted with all features enabled
+        if (!process.env.WEB_POSTHOG_KEY) return true;
 
         const jwtPayload = await auth();
         const id =


### PR DESCRIPTION
When WEB_POSTHOG_KEY is not configured (self-hosted), isFeatureEnabled and getFeatureFlagWithPayload now return true instead of false/undefined, matching the backend behavior in libs/common/utils/posthog.

---

<!-- kody-pr-summary:start -->
Fixes an issue where features were disabled or unavailable by default for self-hosted instances without PostHog integration.

This change modifies the server-side feature flag utility to:
- Return `true` for `isFeatureEnabled` when the `WEB_POSTHOG_KEY` environment variable is not set.
- Return `{ value: true, payload: undefined }` for `getFeatureFlagWithPayload` when the `WEB_POSTHOG_KEY` environment variable is not set.

This ensures that all features are enabled by default for self-hosted deployments that do not configure PostHog.
<!-- kody-pr-summary:end -->