### PR TITLE
fix: pass packages as array to aptInstall in E2B template

### DIFF
--- a/e2b-sandbox/template.ts
+++ b/e2b-sandbox/template.ts
@@ -7,7 +7,7 @@ const downloadUrl = `https://github.com/shadowsocks/shadowsocks-rust/releases/do
 // so git fetch, curl, etc. automatically use the proxy without any extra configuration.
 export const kodusTemplate = Template()
     .fromBaseImage()
-    .aptInstall('iptables', 'git', 'ripgrep')
+    .aptInstall(['iptables', 'git', 'ripgrep'])
     .runCmd([
         `wget ${downloadUrl}`,
         'tar -xf shadowsocks-*.tar.xz',


### PR DESCRIPTION
aptInstall() accepts a single string or an array — passing multiple arguments only installed the first package (iptables). git and ripgrep were silently missing from the template, causing all cross-file context searches and safeguard agent verifications to return empty results.

---

<!-- kody-pr-summary:start -->
Updated the E2B template to correctly pass the list of packages to the `aptInstall` method. The packages (`iptables`, `git`, `ripgrep`) are now provided as a single array argument, aligning with the expected input format for the `aptInstall` function.
<!-- kody-pr-summary:end -->