### PR TITLE
fix: handle null automations in self-hosted onboarding

### DIFF
--- a/libs/automation/application/use-cases/teamAutomation/active-code-manegement-automations.use-case.ts
+++ b/libs/automation/application/use-cases/teamAutomation/active-code-manegement-automations.use-case.ts
@@ -49,7 +49,7 @@ export class ActiveCodeManagementTeamAutomationsUseCase implements IUseCase {
         const automations = await this.automationService.find({
             status: true,
             level: AutomationLevel.TEAM,
-        });
+        }) || [];
 
         const automationsFiltered = automations.filter((automation) =>
             codeManagementAutomations.includes(automation.automationType),


### PR DESCRIPTION
## Summary
- `automationService.find()` returns `null` when no automations are seeded (self-hosted), causing `.filter()` to crash during repository creation onboarding
- Added `|| []` fallback to prevent the TypeError

## Test plan
- [ ] Deploy to self-hosted environment
- [ ] Complete onboarding flow (select repos) without crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- kody-pr-summary:start -->
Ensures that the `ActiveCodeManagementTeamAutomationsUseCase` gracefully handles cases where `automationService.find()` might return `null` or `undefined` when fetching active team-level automations. The change defaults the `automations` variable to an empty array (`[]`) if no automations are found, preventing potential runtime errors when subsequently filtering these automations, particularly in scenarios like self-hosted onboarding.
<!-- kody-pr-summary:end -->