### PR TITLE
Adding metadata

### DIFF
--- a/libs/code-review/infrastructure/adapters/services/safeguardPipeline.service.ts
+++ b/libs/code-review/infrastructure/adapters/services/safeguardPipeline.service.ts
@@ -683,6 +683,13 @@ Evidence field in ${params.languageResultPrompt}.`;
                     return await builder
                         .setTemperature(0)
                         .addCallbacks(callbacks)
+                        .addMetadata({
+                            organizationId:
+                                organizationAndTeamData?.organizationId,
+                            teamId: organizationAndTeamData?.teamId,
+                            pullRequestId: prNumber,
+                            runName,
+                        })
                         .setRunName(`${runName}_turn${turn}`)
                         .execute();
                 },


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Adds `organizationId`, `teamId`, `pullRequestId`, and `runName` as metadata to the builder execution within the `safeguardPipeline.service.ts`. This change enhances the traceability and observability of pipeline runs by associating them with relevant organizational and request-specific identifiers.
<!-- kody-pr-summary:end -->