### PR TITLE
fix: show error message for invalid or expired invitations

### DIFF
--- a/apps/web/src/app/(auth)/invite/[id]/page.tsx
+++ b/apps/web/src/app/(auth)/invite/[id]/page.tsx
@@ -14,10 +14,13 @@ export const metadata: Metadata = {
 export default async function InvitePage({
     params,
 }: {
-    params: Promise<{ id: string }>;
+    params: { id: string };
 }) {
-    const { id } = await params;
-    const userData = await getInviteData(id);
+    const { id } = params;
+    const userData = await getInviteData(id).catch((error) => {
+    console.error(`Failed to get invite data for id ${id}:`, error);
+    return null;
+});
 
     if (!userData?.uuid || !userData?.email) {
         return (


### PR DESCRIPTION
#764 

---

<!-- kody-pr-summary:start -->
This pull request introduces an explicit error message for users attempting to access an invalid or expired invitation link.

Previously, if an invitation link's data was incomplete (missing user UUID or email), the application might not have handled it gracefully. With this change, if the retrieved invitation data lacks either the user's UUID or email, the page will now display a dedicated message stating "Invalid or expired invitation" and instruct the user to contact their organization administrator for a new link. This improves the user experience by providing clear feedback for invalid invitation attempts.
<!-- kody-pr-summary:end -->