### PR TITLE
feat: support PostgreSQL connection URI (DATABASE_URL)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -39,6 +39,9 @@ API_DOCS_SERVER_URLS=
 API_DOCS_BASE_URL=
 
 # Postgres
+# Option 1: Connection URI (takes precedence when set)
+# DATABASE_URL=postgres://kodusdev:123456@db_postgres:5432/kodus_db
+# Option 2: Individual variables (used as fallback)
 API_PG_DB_HOST=db_postgres
 API_PG_DB_PORT=5432
 API_PG_DB_USERNAME=kodusdev

--- a/libs/core/infrastructure/config/loaders/postgres.config.loader.ts
+++ b/libs/core/infrastructure/config/loaders/postgres.config.loader.ts
@@ -5,6 +5,13 @@ import { DatabaseConnection } from '@libs/core/infrastructure/config/types';
 export const postgresConfigLoader = registerAs(
     'postgresDatabase',
     (): DatabaseConnection => {
+        const connectionUrl =
+            process.env.DATABASE_URL ?? process.env.API_PG_DB_URL;
+
+        if (connectionUrl) {
+            return { url: connectionUrl };
+        }
+
         const env = process.env.API_DATABASE_ENV ?? process.env.API_NODE_ENV;
         return {
             host: ['homolog', 'production'].includes(env ?? '')

--- a/libs/core/infrastructure/config/types/database/database-connection.type.ts
+++ b/libs/core/infrastructure/config/types/database/database-connection.type.ts
@@ -1,5 +1,6 @@
 export type DatabaseConnection = {
-    host: string;
+    url?: string;
+    host?: string;
     port?: number;
     username?: string;
     password?: string;

--- a/libs/core/infrastructure/database/typeorm/ormconfig.ts
+++ b/libs/core/infrastructure/database/typeorm/ormconfig.ts
@@ -12,13 +12,21 @@ const isProduction = !['development', 'test'].includes(env);
 const disableSSL = process.env.API_DATABASE_DISABLE_SSL === 'true';
 const useSSL = isProduction && !disableSSL;
 
+const connectionUrl = process.env.DATABASE_URL ?? process.env.API_PG_DB_URL;
+
+const connectionConfig = connectionUrl
+    ? { url: connectionUrl }
+    : {
+          host: process.env.API_PG_DB_HOST,
+          port: parseInt(process.env.API_PG_DB_PORT!, 10),
+          username: process.env.API_PG_DB_USERNAME,
+          password: process.env.API_PG_DB_PASSWORD,
+          database: process.env.API_PG_DB_DATABASE,
+      };
+
 const optionsDataBase: DataSourceOptions = {
     type: 'postgres',
-    host: process.env.API_PG_DB_HOST,
-    port: parseInt(process.env.API_PG_DB_PORT!, 10),
-    username: process.env.API_PG_DB_USERNAME,
-    password: process.env.API_PG_DB_PASSWORD,
-    database: process.env.API_PG_DB_DATABASE,
+    ...connectionConfig,
     logging: false,
     logger: 'file',
     synchronize: false,

--- a/libs/core/infrastructure/database/typeorm/typeORM.factory.ts
+++ b/libs/core/infrastructure/database/typeorm/typeORM.factory.ts
@@ -49,13 +49,19 @@ export class TypeORMFactory implements TypeOrmOptionsFactory {
         };
         const poolConfig = poolConfigs[componentType] || poolConfigs.default;
 
+        const connectionConfig = this.config.url
+            ? { url: this.config.url }
+            : {
+                  host: this.config.host,
+                  port: this.config.port,
+                  username: this.config.username,
+                  password: this.config.password,
+                  database: this.config.database,
+              };
+
         const optionsTypeOrm: TypeOrmModuleOptions = {
             type: 'postgres',
-            host: this.config.host,
-            port: this.config.port,
-            username: this.config.username,
-            password: this.config.password,
-            database: this.config.database,
+            ...connectionConfig,
             entities: ENTITIES,
             autoLoadEntities: false,
             cache: false,


### PR DESCRIPTION
## Summary

Adds support for connecting to PostgreSQL via a single connection URI (`DATABASE_URL` or `API_PG_DB_URL`), with automatic fallback to the existing individual variables (`API_PG_DB_HOST`, `API_PG_DB_PORT`, etc.).

This is the standard approach used by managed database providers (Supabase, Railway, Render, Neon, etc.) and simplifies configuration for self-hosted and cloud deployments.

## Changes

- **`database-connection.type.ts`** — Added optional `url` field; made `host` optional since it's not needed when using a URI
- **`postgres.config.loader.ts`** — Config loader checks `DATABASE_URL` / `API_PG_DB_URL` first, falls back to individual vars
- **`typeORM.factory.ts`** — Runtime TypeORM options use `url` when available, individual fields otherwise
- **`ormconfig.ts`** — Same URI-first pattern for CLI migrations/seeding
- **`.env.example`** — Documented both connection options with examples

## How it works

```
# Option 1: Connection URI (takes precedence when set)
DATABASE_URL=postgres://user:pass@host:5432/mydb

# Option 2: Individual variables (used as fallback — existing behavior, unchanged)
API_PG_DB_HOST=db_postgres
API_PG_DB_PORT=5432
API_PG_DB_USERNAME=kodusdev
API_PG_DB_PASSWORD=123456
API_PG_DB_DATABASE=kodus_db
```

Precedence: `DATABASE_URL` > `API_PG_DB_URL` > individual variables.

## Test plan

- [x] Verified TypeScript compilation (`tsc --noEmit`) — no errors in changed files
- [x] Tested all 4 config paths with a live PostgreSQL instance:
  - Individual variables (existing behavior) ✅
  - `DATABASE_URL` connection URI ✅
  - `API_PG_DB_URL` connection URI ✅
  - Precedence order (URI overrides individual vars) ✅
- [x] Existing individual-variable config continues to work unchanged

Closes #870

---

<!-- kody-pr-summary:start -->
This pull request introduces support for configuring PostgreSQL database connections using a connection URI.

Key changes include:
*   **Prioritizing Connection URI**: The system will now first check for `DATABASE_URL` or `API_PG_DB_URL` environment variables. If a connection URI is provided, it will be used to establish the PostgreSQL connection.
*   **Fallback to Individual Parameters**: If no connection URI is found, the system will fall back to using individual environment variables for host, port, username, password, and database name, as was the previous behavior.
*   **Type Definition Update**: The `DatabaseConnection` type has been updated to include an optional `url` property and make the `host` property optional, accommodating the new connection method.
*   **Configuration Integration**: The PostgreSQL configuration loader, TypeORM `ormconfig.ts`, and TypeORM factory have all been updated to integrate and prioritize the connection URI.

This enhancement simplifies database configuration by allowing the use of a single connection string, which is a common practice in many deployment environments.
<!-- kody-pr-summary:end -->