### PR TITLE
feat: support MongoDB connection URI (MONGODB_URI)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,6 +46,9 @@ API_PG_DB_PASSWORD=123456
 API_PG_DB_DATABASE=kodus_db
 
 # MongoDB
+# Option 1: Connection URI (takes precedence when set)
+# MONGODB_URI=mongodb://kodusdev:123456@db_mongodb:27017/kodus_db?authSource=admin
+# Option 2: Individual variables (used as fallback)
 API_MG_DB_HOST=db_mongodb
 API_MG_DB_PORT=27017
 API_MG_DB_USERNAME=kodusdev

--- a/libs/core/infrastructure/config/loaders/mongodb.config.loader.ts
+++ b/libs/core/infrastructure/config/loaders/mongodb.config.loader.ts
@@ -5,6 +5,13 @@ import { DatabaseConnection } from '@libs/core/infrastructure/config/types';
 export const mongoDBConfigLoader = registerAs(
     'mongoDatabase',
     (): DatabaseConnection => {
+        const connectionUrl =
+            process.env.MONGODB_URI ?? process.env.API_MG_DB_URI;
+
+        if (connectionUrl) {
+            return { url: connectionUrl, database: process.env.API_MG_DB_DATABASE };
+        }
+
         const env = process.env.API_DATABASE_ENV ?? process.env.API_NODE_ENV;
         return {
             host: ['homolog', 'production'].includes(env ?? '')

--- a/libs/core/infrastructure/config/types/database/database-connection.type.ts
+++ b/libs/core/infrastructure/config/types/database/database-connection.type.ts
@@ -1,5 +1,6 @@
 export type DatabaseConnection = {
-    host: string;
+    url?: string;
+    host?: string;
     port?: number;
     username?: string;
     password?: string;

--- a/libs/core/infrastructure/database/mongodb/mongoose.factory.ts
+++ b/libs/core/infrastructure/database/mongodb/mongoose.factory.ts
@@ -27,21 +27,27 @@ export class MongooseFactory implements MongooseOptionsFactory {
             mongoose.set('debug', true);
         }
 
-        let uri = new ConnectionString('', {
-            user: this.config.username,
-            password: this.config.password,
-            protocol: this.config.port ? 'mongodb' : 'mongodb+srv',
-            hosts: [{ name: this.config.host, port: this.config.port }],
-        }).toString();
+        let uri: string;
+
+        if (this.config.url) {
+            uri = this.config.url;
+        } else {
+            uri = new ConnectionString('', {
+                user: this.config.username,
+                password: this.config.password,
+                protocol: this.config.port ? 'mongodb' : 'mongodb+srv',
+                hosts: [{ name: this.config.host, port: this.config.port }],
+            }).toString();
+
+            const shouldAppendClusterConfig =
+                isProduction && !!process.env.API_MG_DB_PRODUCTION_CONFIG;
+
+            if (shouldAppendClusterConfig) {
+                uri = `${uri}/${process.env.API_MG_DB_PRODUCTION_CONFIG}`;
+            }
+        }
 
         const { createForInstance } = MongooseConnectionFactory;
-
-        const shouldAppendClusterConfig =
-            isProduction && !!process.env.API_MG_DB_PRODUCTION_CONFIG;
-
-        if (shouldAppendClusterConfig) {
-            uri = `${uri}/${process.env.API_MG_DB_PRODUCTION_CONFIG}`;
-        }
 
         // Detect component type to adjust connection pool
         const componentType = process.env.COMPONENT_TYPE || 'default';


### PR DESCRIPTION
## Summary

Adds support for connecting to MongoDB via a single connection URI (`MONGODB_URI` or `API_MG_DB_URI`), with automatic fallback to the existing individual variables (`API_MG_DB_HOST`, `API_MG_DB_PORT`, etc.).

This is the MongoDB counterpart to #874 (PostgreSQL URI support), and together they close the parent tracking issue #868.

Connection URIs are the standard for managed MongoDB providers (Atlas, Kubernetes MongoDB Operator) and are essential for replica set connections where multiple hosts and query parameters (`?replicaSet=rs0&authSource=admin`) don't map to a single `API_MG_DB_HOST`.

## Changes

- **`database-connection.type.ts`** — Added optional `url` field; made `host` optional since it's not needed when using a URI
- **`mongodb.config.loader.ts`** — Config loader checks `MONGODB_URI` / `API_MG_DB_URI` first, falls back to individual vars
- **`mongoose.factory.ts`** — When a URI is provided, uses it directly instead of building one via `ConnectionString`; skips `API_MG_DB_PRODUCTION_CONFIG` suffix (those params can be included in the URI itself)
- **`.env.example`** — Documented both connection options with examples

## How it works

```
# Option 1: Connection URI (takes precedence when set)
MONGODB_URI=mongodb://user:pass@host:27017/mydb?authSource=admin

# Option 2: Individual variables (used as fallback — existing behavior, unchanged)
API_MG_DB_HOST=db_mongodb
API_MG_DB_PORT=27017
API_MG_DB_USERNAME=kodusdev
API_MG_DB_PASSWORD=123456
API_MG_DB_DATABASE=kodus_db
```

Precedence: `MONGODB_URI` > `API_MG_DB_URI` > individual variables.

## Existing precedent

The CLI scripts already implement this exact pattern (e.g., [`scripts/analyze-pr-performance.cli.ts`](https://github.com/kodustech/kodus-ai/blob/main/scripts/analyze-pr-performance.cli.ts#L61-L63), [`scripts/check-pr-errors.cli.ts`](https://github.com/kodustech/kodus-ai/blob/main/scripts/check-pr-errors.cli.ts#L96-L98)). This PR brings the main NestJS app in line with that convention.

## Test plan

- [x] Verified TypeScript compilation (`tsc --noEmit`) — no errors in changed files
- [x] Tested all 4 config paths with a live MongoDB instance:
  - Individual variables (existing behavior) ✅
  - `MONGODB_URI` connection URI ✅
  - `API_MG_DB_URI` connection URI ✅
  - Precedence order (URI overrides individual vars) ✅
- [x] Existing individual-variable config continues to work unchanged

**Note:** `database-connection.type.ts` is also modified in #874 (same change). The merge conflict will be trivial — identical addition of `url?: string`.

Closes #869

---

<!-- kody-pr-summary:start -->
This pull request enhances MongoDB connection configuration by introducing support for a full connection URI.

Key changes include:
-   **Connection URI Prioritization:** The system now checks for `MONGODB_URI` or `API_MG_DB_URI` environment variables. If a connection URI is provided, it will be used directly to establish the MongoDB connection.
-   **Flexible Configuration Fallback:** If no connection URI is specified, the system reverts to its previous behavior of constructing the connection string from individual parameters such as host, port, username, and password.
-   **Updated Database Connection Type:** The `DatabaseConnection` type has been modified to include an optional `url` property and make the `host` property optional, accommodating the new URI-based configuration.
-   **Mongoose Factory Adaptation:** The Mongoose connection factory has been updated to intelligently utilize the provided connection URI when available, or construct the URI from individual components otherwise.
<!-- kody-pr-summary:end -->