### PR TITLE
Implementing check permission for many workspaces

### DIFF
--- a/libs/platform/infrastructure/adapters/services/bitbucket.service.ts
+++ b/libs/platform/infrastructure/adapters/services/bitbucket.service.ts
@@ -3388,24 +3388,24 @@ export class BitbucketService implements Omit<
                 .getWorkspaces({})
                 .then((res) => res.data.values);
 
-            const workspace = workspaces[0];
+            for (const workspace of workspaces) {
+                const repositories = await bitbucketAPI.repositories
+                    .list({
+                        workspace: workspace.uuid,
+                    })
+                    .then((res) => res.data.values);
 
-            const repositories = await bitbucketAPI.repositories
-                .list({
-                    workspace: workspace.uuid,
-                })
-                .then((res) => res.data.values);
-
-            if (repositories.length === 0) {
-                return {
-                    success: false,
-                    status: CreateAuthIntegrationStatus.NO_REPOSITORIES,
-                };
+                if (repositories.length > 0) {
+                    return {
+                        success: true,
+                        status: CreateAuthIntegrationStatus.SUCCESS,
+                    };
+                }
             }
 
             return {
-                success: true,
-                status: CreateAuthIntegrationStatus.SUCCESS,
+                success: false,
+                status: CreateAuthIntegrationStatus.NO_REPOSITORIES,
             };
         } catch (error) {
             this.logger.error({


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Updated the Bitbucket service to check for the presence of repositories across all available workspaces when creating an authentication integration. Previously, the system only verified repositories within the first workspace found. This change ensures that if any workspace contains repositories, the integration is considered successful.
<!-- kody-pr-summary:end -->

Closes #498 