### PR TITLE
Fix/repeated kody rules

### DIFF
--- a/apps/webhooks/src/controllers/github.controller.ts
+++ b/apps/webhooks/src/controllers/github.controller.ts
@@ -64,6 +64,9 @@ export class GithubController {
                         context: GithubController.name,
                         metadata: {
                             event,
+                            action: payload?.action,
+                            commentId: payload?.comment?.id,
+                            deliveryId: req.headers['x-github-delivery'],
                             installationId: payload?.installation?.id,
                             repository: payload?.repository?.name,
                         },

--- a/libs/mcp-server/tools/kodyRules.tools.ts
+++ b/libs/mcp-server/tools/kodyRules.tools.ts
@@ -307,7 +307,7 @@ export class KodyRulesTools {
                         .string()
                         .optional()
                         .describe(
-                            'Repository unique identifier - can be used with both scopes to limit rule to specific repository',
+                            'Repository unique identifier to limit the rule to a specific repository. By default, when creating a rule from a PR suggestion, use the current repository ID. If the user explicitly asks for a global rule (e.g., "for all repositories", "organization-wide", "global", "for the entire organization"), omit this field or do not provide it so the rule defaults to global scope.',
                         ),
                     path: z
                         .string()
@@ -497,7 +497,7 @@ export class KodyRulesTools {
                         .string()
                         .optional()
                         .describe(
-                            'Updated repository unique identifier - can be used with both scopes to limit rule to specific repository',
+                            'Updated repository unique identifier. Set to a specific repository ID to limit the rule to that repository, or set to "global" to make the rule apply to all repositories in the organization. Use "global" when the user asks for organization-wide, global, or all-repositories scope.',
                         ),
                     path: z
                         .string()

--- a/libs/mcp-server/tools/kodyRules.tools.ts
+++ b/libs/mcp-server/tools/kodyRules.tools.ts
@@ -125,7 +125,7 @@ export class KodyRulesTools {
         return {
             name: 'KODUS_GET_KODY_RULES',
             description:
-                'Get all active Kody Rules at organization level. Use this to see organization-wide coding standards, global rules that apply across all repositories, or when you need a complete overview of all active rules. Returns only ACTIVE status rules.',
+                'Get all Kody Rules at organization level. Use this to see organization-wide coding standards, global rules that apply across all repositories, or when you need a complete overview of rules. Returns rules with ACTIVE and PENDING status.',
             inputSchema,
             outputSchema: z.object({
                 success: z.boolean(),
@@ -175,7 +175,8 @@ export class KodyRulesTools {
 
                     const rules: Partial<IKodyRule>[] = allRules.filter(
                         (rule: Partial<IKodyRule>) =>
-                            rule.status === KodyRulesStatus.ACTIVE,
+                            rule.status === KodyRulesStatus.ACTIVE ||
+                            rule.status === KodyRulesStatus.PENDING,
                     );
 
                     return {
@@ -207,7 +208,7 @@ export class KodyRulesTools {
         return {
             name: 'KODUS_GET_KODY_RULES_REPOSITORY',
             description:
-                'Get active Kody Rules specific to a particular repository. Use this to see repository-specific coding standards, rules that only apply to one codebase, or when analyzing rules for a specific project. More focused than get_kody_rules.',
+                'Get Kody Rules specific to a particular repository. Use this to see repository-specific coding standards, rules that only apply to one codebase, or when analyzing rules for a specific project. More focused than get_kody_rules. Returns rules with ACTIVE and PENDING status.',
             inputSchema,
             outputSchema: z.object({
                 success: z.boolean(),
@@ -261,7 +262,8 @@ export class KodyRulesTools {
                             (rule: Partial<IKodyRule>) =>
                                 rule.repositoryId &&
                                 rule.repositoryId === params.repositoryId &&
-                                rule.status === KodyRulesStatus.ACTIVE,
+                                (rule.status === KodyRulesStatus.ACTIVE ||
+                                    rule.status === KodyRulesStatus.PENDING),
                         );
 
                     return {

--- a/libs/mcp-server/tools/kodyRules.tools.ts
+++ b/libs/mcp-server/tools/kodyRules.tools.ts
@@ -443,7 +443,12 @@ export class KodyRulesTools {
                     return {
                         success: true,
                         count: 1,
-                        data: result,
+                        data: {
+                            uuid: result?.uuid,
+                            title: result?.title,
+                            rule: result?.rule,
+                            status: result?.status,
+                        },
                     };
                 },
             ),


### PR DESCRIPTION
Closes #885 

---

<!-- kody-pr-summary:start -->
This pull request introduces several enhancements and fixes related to Kody Rules management and GitHub webhook logging.

Key changes include:

*   **Expanded Kody Rule Retrieval:** The `KODUS_GET_KODY_RULES` and `KODUS_GET_KODY_RULES_REPOSITORY` tools now retrieve Kody Rules with both `ACTIVE` and `PENDING` statuses. Previously, these tools only returned `ACTIVE` rules, which could lead to an incomplete view of existing rules, potentially causing users to create duplicate rules or miss rules awaiting approval.
*   **Clarified Kody Rule Scope Management:** The descriptions for the `repositoryId` parameter in the `KODUS_CREATE_KODY_RULE` and `KODUS_UPDATE_KODY_RULE` tools have been updated. These descriptions now provide explicit guidance on how to define a rule's scope, differentiating between repository-specific and organization-wide (global) rules, especially when creating rules from PR suggestions or based on user requests.
*   **Refined Kody Rule Creation Output:** The `KODUS_CREATE_KODY_RULE` tool's output has been streamlined to return a more focused set of fields (`uuid`, `title`, `rule`, `status`) for the newly created rule.
*   **Enhanced GitHub Webhook Logging:** Additional metadata, including `action`, `commentId`, and `deliveryId`, has been added to the logs for GitHub webhook events. This provides more detailed context for debugging and monitoring webhook interactions.
<!-- kody-pr-summary:end -->