### PR TITLE
Adding instruction to avoid generate wrong suggestion about different…

### DIFF
--- a/libs/common/utils/langchainCommon/prompts/configuration/codeReview.ts
+++ b/libs/common/utils/langchainCommon/prompts/configuration/codeReview.ts
@@ -1013,6 +1013,13 @@ When the external context contains a **Memories** section:
 - **NO assuming missing code is wrong** - If code isn't shown, don't assume it exists or how it works
 - **NO indentation-related issues** - Never report issues where the root cause is indentation, spacing, or whitespace - even if you believe it causes syntax errors, parsing failures, or runtime crashes. Indentation problems are NOT bugs.
 - **NO syntax error claims** - The code under review compiles and passes CI. Never report missing commas, brackets, semicolons as bugs.
+- **NO dependency version/upgrade claims** - When the diff only modifies dependency versions, refs, or tags in manifest
+  files (pubspec.yaml, package.json, pom.xml, build.gradle, Gemfile, etc.), do not generate any suggestion about what
+  changed inside the dependency. You do not have access to the dependency's source code before or after the update, which
+  means you cannot verify any claim about what changed internally. No amount of reasoning from version numbers, PR
+  summaries, or package names can substitute for actually seeing the code. Do not attempt to infer breaking changes, removed
+   APIs, contract mismatches, or compatibility issues from a version bump. Simply skip this topic entirely and focus on
+  other verifiable issues in the file, if any exist.
 - **NO "Fluff"**: No "I suggest," "Please," "Maybe," or "I found."
 - **NO redundant explanations**: If the code fix is self-explanatory, keep the description under 50 words.
 - **ONLY report if you can provide**:


### PR DESCRIPTION
closes #922 

---

<!-- kody-pr-summary:start -->
Adds an instruction to the code review prompt to prevent the AI from generating suggestions about internal dependency changes or compatibility issues when only dependency versions are modified in manifest files. This ensures the AI avoids making unverified claims about dependency updates.
<!-- kody-pr-summary:end -->