### PR TITLE
fix(queue): tighten rabbitmq timeouts and upgrade golevelup to v9

### DIFF
--- a/libs/common/utils/langchainCommon/prompts/configuration/codeReview.ts
+++ b/libs/common/utils/langchainCommon/prompts/configuration/codeReview.ts
@@ -1013,6 +1013,13 @@ When the external context contains a **Memories** section:
 - **NO assuming missing code is wrong** - If code isn't shown, don't assume it exists or how it works
 - **NO indentation-related issues** - Never report issues where the root cause is indentation, spacing, or whitespace - even if you believe it causes syntax errors, parsing failures, or runtime crashes. Indentation problems are NOT bugs.
 - **NO syntax error claims** - The code under review compiles and passes CI. Never report missing commas, brackets, semicolons as bugs.
+- **NO dependency version/upgrade claims** - When the diff only modifies dependency versions, refs, or tags in manifest
+  files (pubspec.yaml, package.json, pom.xml, build.gradle, Gemfile, etc.), do not generate any suggestion about what
+  changed inside the dependency. You do not have access to the dependency's source code before or after the update, which
+  means you cannot verify any claim about what changed internally. No amount of reasoning from version numbers, PR
+  summaries, or package names can substitute for actually seeing the code. Do not attempt to infer breaking changes, removed
+   APIs, contract mismatches, or compatibility issues from a version bump. Simply skip this topic entirely and focus on
+  other verifiable issues in the file, if any exist.
 - **NO "Fluff"**: No "I suggest," "Please," "Maybe," or "I found."
 - **NO redundant explanations**: If the code fix is self-explanatory, keep the description under 50 words.
 - **ONLY report if you can provide**:

--- a/libs/core/infrastructure/queue/rabbitmq.module.ts
+++ b/libs/core/infrastructure/queue/rabbitmq.module.ts
@@ -84,7 +84,7 @@ export class RabbitMQWrapperModule {
                         timeout: 5000,
                     },
                     connectionManagerOptions: {
-                        heartbeatIntervalInSeconds: 60,
+                        heartbeatIntervalInSeconds: 120,
                     },
                     reconnectTimeInSeconds: 10,
                     enableControllerDiscovery: options.enableConsumers,

--- a/libs/core/workflow/infrastructure/outbox-relay.service.ts
+++ b/libs/core/workflow/infrastructure/outbox-relay.service.ts
@@ -316,7 +316,7 @@ export class OutboxRelayService
                         'workflow-job-consumer.check_implementation':
                             20 * 60 * 1000, // 20 minutes
                         'workflow-job-consumer.code_review':
-                            12 * 60 * 60 * 1000, // 12 hours (very conservative to avoid reprocessing without checkpoints)
+                            2.5 * 60 * 60 * 1000, // 2.5 hours (1.25x the 2h job timeout — 12h was too conservative and caused stuck messages after worker crashes)
                     };
 
                     const reclaimResults = await Promise.allSettled(

--- a/libs/core/workflow/infrastructure/repositories/inbox-message.repository.ts
+++ b/libs/core/workflow/infrastructure/repositories/inbox-message.repository.ts
@@ -45,7 +45,7 @@ export class InboxMessageRepository implements IInboxMessageRepository {
      * Claims a message for processing using an atomic UPSERT.
      * Returns the message model if successfully claimed, or null if it's already being processed or finished.
      *
-     * Uses 3-hour timeout for PROCESSING messages to avoid reclaiming long-running jobs
+     * Uses 2.5-hour timeout for PROCESSING messages to avoid reclaiming long-running jobs
      * (e.g., code reviews with 2h timeout). Only allows reclaiming messages that are truly stuck.
      */
     async claim(
@@ -67,7 +67,7 @@ export class InboxMessageRepository implements IInboxMessageRepository {
                 "attempts" = "inbox_messages"."attempts" + 1,
                 "updatedAt" = NOW()
             WHERE "inbox_messages"."status" NOT IN ($6, $7)
-               OR ("inbox_messages"."status" = $7 AND "inbox_messages"."lockedAt" < NOW() - INTERVAL '3 hours')
+               OR ("inbox_messages"."status" = $7 AND "inbox_messages"."lockedAt" < NOW() - INTERVAL '2.5 hours')
             RETURNING *;
         `;
 

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
         "@casl/ability": "^6.8.0",
         "@faker-js/faker": "^10.3.0",
         "@gitbeaker/rest": "^43.8.0",
-        "@golevelup/nestjs-rabbitmq": "^7.1.2",
+        "@golevelup/nestjs-rabbitmq": "^9.0.0",
         "@google/generative-ai": "^0.24.1",
         "@kodus/flow": "0.1.46",
         "@kodus/kodus-common": "1.3.15",

--- a/yarn.lock
+++ b/yarn.lock
@@ -687,22 +687,22 @@
     "@gitbeaker/core" "^43.8.0"
     "@gitbeaker/requester-utils" "^43.8.0"
 
-"@golevelup/nestjs-discovery@^6.1.2":
-  version "6.1.2"
-  resolved "https://registry.npmjs.org/@golevelup/nestjs-discovery/-/nestjs-discovery-6.1.2.tgz#10ee27d7bbb58ad319bd7b99ce41638fd4ff42c2"
-  integrity sha512-jP2jFpWycx2vtJQOXGAPHJLVfltYMvV6in7AY/jQA5DAXQRLEzi1HQUi0QVyyF/PwkL/k5ch+svHA1QA+KbLJA==
+"@golevelup/nestjs-discovery@^7.0.0":
+  version "7.0.0"
+  resolved "https://registry.npmjs.org/@golevelup/nestjs-discovery/-/nestjs-discovery-7.0.0.tgz#4ef8fbb0695b0f093bd9ae9251a9b16735d344f1"
+  integrity sha512-l2O4qokytyBwTqNKNOv3OITdJtYfV0f6eLqR5c0brS1Hy4MV4h9YXy+o534yczOcxWnDfeATArDpLxz88wonSQ==
   dependencies:
-    lodash "^4.17.21"
+    lodash "^4.17.23"
 
-"@golevelup/nestjs-rabbitmq@^7.1.2":
-  version "7.1.2"
-  resolved "https://registry.npmjs.org/@golevelup/nestjs-rabbitmq/-/nestjs-rabbitmq-7.1.2.tgz#6a14a322cf5fd697decc562214e91ad59ce6ba81"
-  integrity sha512-q2Xn9V+/Y4lq7Ik+LmLYC2PFwHiZrrez8EjaNodC2QG6CP7GROybclWf//PVzyTIKqq44B0dEh2+amrXFyN4zA==
+"@golevelup/nestjs-rabbitmq@^9.0.0":
+  version "9.0.0"
+  resolved "https://registry.npmjs.org/@golevelup/nestjs-rabbitmq/-/nestjs-rabbitmq-9.0.0.tgz#6e8a20ace44b134506d4d508e7c24a5b043fb1b4"
+  integrity sha512-sPQuLk73ZqHSO9fs9+WvYRYh56cQZWNsnIhGcthVgADCb2gzzflVYFqMgOyP+ZbUDvdrahw6RXeC0Vn9nTLtNw==
   dependencies:
-    "@golevelup/nestjs-discovery" "^6.1.2"
+    "@golevelup/nestjs-discovery" "^7.0.0"
     amqp-connection-manager "^5.0.0"
     amqplib "^0.10.9"
-    lodash "^4.17.21"
+    lodash "^4.17.23"
 
 "@google/generative-ai@^0.24.1":
   version "0.24.1"
@@ -8668,6 +8668,11 @@ lodash@4.17.23, lodash@^4.17.15, lodash@^4.17.21, lodash@~4.17.21, lodash@~4.17.
   version "4.17.23"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz#f113b0378386103be4f6893388c73d0bde7f2c5a"
   integrity sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==
+
+lodash@^4.17.23:
+  version "4.18.1"
+  resolved "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 log-symbols@^4.1.0:
   version "4.1.0"


### PR DESCRIPTION
Reduces recovery windows so stuck inbox messages are reclaimed quickly after worker crashes, and raises heartbeat to survive event-loop stalls during heavy code-review bursts.

- rabbitmq: heartbeat 60s -> 120s (more tolerance for event-loop saturation)
- outbox reaper: code_review timeout 12h -> 2.5h (faster stuck-message recovery)
- inbox claim: stale PROCESSING reclaim 3h -> 2.5h (consistent with reaper)
- upgrade @golevelup/nestjs-rabbitmq 7.1.2 -> 9.0.0
- codeReview prompt hotfix

---

<!-- kody-pr-summary:start -->
This pull request introduces several adjustments to queue management and AI prompt configuration:

*   **Adjusted RabbitMQ Heartbeat Interval**: The RabbitMQ connection heartbeat interval has been increased from 60 seconds to 120 seconds, potentially improving connection stability.
*   **Reduced Workflow Job Reclaim Timeout**: The reclaim timeout for `code_review` workflow jobs has been significantly reduced from 12 hours to 2.5 hours. This change aims to prevent messages from getting stuck for extended periods after worker crashes, allowing for quicker reprocessing.
*   **Tightened Inbox Message Claim Timeout**: The timeout for claiming `PROCESSING` inbox messages has been reduced from 3 hours to 2.5 hours, aligning with the new `code_review` job timeout to ensure stuck messages are reprocessed more promptly.
*   **Enhanced Code Review AI Prompt**: A new rule has been added to the `codeReview` prompt configuration, instructing the AI to avoid generating suggestions or claims about changes within dependencies when only manifest files (e.g., `package.json`, `pubspec.yaml`) are modified. This prevents the AI from making unverified inferences about internal dependency changes.
<!-- kody-pr-summary:end -->