### PR TITLE
Add pricing markdown content

### DIFF
--- a/kodus.io/pricing.md
+++ b/kodus.io/pricing.md
@@ -1,0 +1,79 @@
+# Kodus Pricing
+
+Open source and model-agnostic. Use your own API keys (OpenAI, Anthropic, Gemini, etc.) and pay for model usage directly with your provider. Kodus does not add markup on AI costs.
+
+## Plans Overview
+
+| Plan       | Price                  | Deployment                  | Best for                                                          |
+| ---------- | ------------- ---------| --------------------------- | ----------------------------------------------------------------- |
+| Community  | Free                   | Self-hosted or Cloud        | Teams that want full flexibility with no platform cost            |
+| Teams      | $10/dev/month + (BYOK) | Cloud                       | Teams that need more control, visibility, and automation          |
+| Enterprise | Custom                 | Cloud or On-premise         | Organizations with security, compliance, and support requirements |
+
+## Example Pricing
+
+- **5 active developers on Teams**: $50/month to Kodus, plus model usage billed by your provider  
+- **20 active developers on Teams**: $200/month to Kodus, plus model usage billed by your provider  
+- **Enterprise**: custom pricing based on infrastructure, support, and security needs  
+  Contact sales at [kodus.io/pricing](https://kodus.io/pricing/).
+
+## How Billing Works
+
+Pricing is based on active developers who open pull requests.
+
+- You only pay for developers who actively create pull requests  
+- Update seats anytime  
+- Unlimited pull requests across all plans  
+- Pull requests with more than 200 files are not supported  
+
+## Bring Your Own API Keys
+
+Bring your own API keys and pay for model usage directly with your provider.
+
+- Use OpenAI, Anthropic, Gemini, or other supported providers  
+- Choose the model that fits your workflow  
+- See exactly what you spend on tokens  
+- No bundled costs or hidden markups  
+- Kodus runs the review workflow while you control model choice and spend  
+
+## Feature Comparison
+
+| Feature                                   | Community | Teams                       | Enterprise                              |
+| ----------------------------------------- | --------- | --------------------------- | --------------------------------------- |
+| Unlimited code reviews                    | Yes       | Yes                         | Yes                                     |
+| Unlimited users                           | Yes       | Billed by active developer  | Yes                                     |
+| Quality Radar issues                      | Unlimited | Unlimited                   | Unlimited                               |
+| Kody Learnings and Memory                 | Yes       | Yes                         | Yes                                     |
+| Kodus MCP                                 | Yes       | Yes                         | Yes                                     |
+| Kody Rules                                | Up to 10  | Unlimited                   | Unlimited                               |
+| Plugins / MCPs                            | Up to 3   | Unlimited                   | Unlimited                               |
+| Cockpit Analytics (Engineering Metrics)   | No        | Yes                         | Yes                                     |
+| 1-click Issues Autofix                    | No        | Yes                         | Yes                                     |
+| Unlimited PRs (Kodus-managed tokens)      | No        | No                          | Yes                                     |
+| Hosted by Kodus                           | No        | Yes                         | Yes                                     |
+| SSO / SAML                                | No        | No                          | Yes                                     |
+| RBAC / Audit logs                         | No        | No                          | Yes                                     |
+| Dedicated instance                        | No        | No                          | Yes                                     |
+| SOC 2 (in progress)                       | No        | No                          | Yes                                     |
+| Dedicated support & onboarding            | No        | Email                       | Up to 5h/month + onboarding             |
+| Priority queue for Kody Agents            | No        | No                          | Yes                                     |
+| Custom SLA                                | No        | No                          | Yes                                     |
+
+## Support for Non-Profits and Open Source
+
+Kodus is free for non-profit organizations and open-source projects.
+
+How to apply:
+
+1. Join our Discord community: https://discord.gg/TFZBRk9fT6  
+2. Share your organization name, website, and a brief description  
+3. For non-profits: include proof of status  
+4. For open-source: share links to public repositories  
+5. Applications are reviewed within 3 business days  
+
+## Payments and Billing
+
+- Payments are processed with Stripe  
+- Cancel anytime (changes apply at the end of the billing cycle)  
+- Invoices available  
+- Brazilian customers receive Nota Fiscal  


### PR DESCRIPTION
## Summary
- add the pricing markdown file under 
- include the pricing, plan comparison, billing, and support details provided by the user

## Testing
- not run (content-only change)