### PR TITLE
Fix/ignore files field

### DIFF
--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/general/_components/ignore-paths.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/general/_components/ignore-paths.tsx
@@ -19,12 +19,13 @@ export const IgnorePaths = () => {
         [field.value],
     );
     const [draftValue, setDraftValue] = useState(fieldValue);
+    const [isEditing, setIsEditing] = useState(false);
 
     useEffect(() => {
-        if (draftValue !== fieldValue) {
+        if (!isEditing && draftValue !== fieldValue) {
             setDraftValue(fieldValue);
         }
-    }, [draftValue, fieldValue]);
+    }, [isEditing, draftValue, fieldValue]);
 
     return (
         <FormControl.Root>
@@ -41,6 +42,7 @@ export const IgnorePaths = () => {
                     id={field.name}
                     disabled={field.disabled}
                     value={draftValue}
+                    onFocus={() => setIsEditing(true)}
                     onChange={(ev) => {
                         const nextValue = ev.target.value;
                         setDraftValue(nextValue);
@@ -51,7 +53,10 @@ export const IgnorePaths = () => {
 
                         field.onChange(ignorePaths);
                     }}
-                    onBlur={field.onBlur}
+                    onBlur={() => {
+                        setIsEditing(false);
+                        field.onBlur();
+                    }}
                     placeholder={`List the files to be ignored here, one per line. Example:\n\nyarn.lock\npackage-lock.json\npackage.json\n.env`}
                     maxLength={1000}
                     className="min-h-40"

--- a/libs/code-review/application/use-cases/configuration/__tests__/update-or-create-code-review-parameter-use-case.spec.ts
+++ b/libs/code-review/application/use-cases/configuration/__tests__/update-or-create-code-review-parameter-use-case.spec.ts
@@ -3,6 +3,7 @@ import * as yaml from 'js-yaml';
 
 describe('UpdateOrCreateCodeReviewParameterUseCase', () => {
     const buildCentralizedConfigPrServiceMock = () => ({
+        getCentralizedRepositoryIfEnabled: jest.fn().mockResolvedValue(null),
         getScopedKodusConfigFileContent: jest.fn().mockResolvedValue(null),
         createMutationPullRequestIfEnabled: jest
             .fn()
@@ -414,6 +415,7 @@ describe('UpdateOrCreateCodeReviewParameterUseCase', () => {
         };
 
         const centralizedConfigPrService = {
+            getCentralizedRepositoryIfEnabled: jest.fn().mockResolvedValue({ id: 'central-repo-1', name: 'centralized-config' }),
             getScopedKodusConfigFileContent: jest.fn().mockResolvedValue({}),
             createMutationPullRequestIfEnabled: jest.fn().mockResolvedValue({
                 mode: 'centralized-pr',
@@ -568,6 +570,7 @@ describe('UpdateOrCreateCodeReviewParameterUseCase', () => {
         };
 
         const centralizedConfigPrService = {
+            getCentralizedRepositoryIfEnabled: jest.fn().mockResolvedValue({ id: 'central-repo-1', name: 'centralized-config' }),
             getScopedKodusConfigFileContent: jest.fn().mockResolvedValue({
                 customMessages: {
                     globalSettings: {
@@ -672,6 +675,7 @@ describe('UpdateOrCreateCodeReviewParameterUseCase', () => {
         };
 
         const centralizedConfigPrService = {
+            getCentralizedRepositoryIfEnabled: jest.fn().mockResolvedValue({ id: 'central-repo-1', name: 'centralized-config' }),
             getScopedKodusConfigFileContent: jest.fn().mockResolvedValue(null),
             createMutationPullRequestIfEnabled: jest.fn().mockResolvedValue({
                 mode: 'centralized-pr',
@@ -754,6 +758,7 @@ describe('UpdateOrCreateCodeReviewParameterUseCase', () => {
         };
 
         const centralizedConfigPrService = {
+            getCentralizedRepositoryIfEnabled: jest.fn().mockResolvedValue({ id: 'central-repo-1', name: 'centralized-config' }),
             getScopedKodusConfigFileContent: jest.fn().mockResolvedValue({
                 runOnDraft: true,
             }),
@@ -836,6 +841,7 @@ describe('UpdateOrCreateCodeReviewParameterUseCase', () => {
         };
 
         const centralizedConfigPrService = {
+            getCentralizedRepositoryIfEnabled: jest.fn().mockResolvedValue({ id: 'central-repo-1', name: 'centralized-config' }),
             getScopedKodusConfigFileContent: jest.fn().mockResolvedValue({
                 runOnDraft: true,
             }),
@@ -919,6 +925,7 @@ describe('UpdateOrCreateCodeReviewParameterUseCase', () => {
         };
 
         const centralizedConfigPrService = {
+            getCentralizedRepositoryIfEnabled: jest.fn().mockResolvedValue({ id: 'central-repo-1', name: 'centralized-config' }),
             getScopedKodusConfigFileContent: jest.fn().mockResolvedValue({
                 automatedReviewActive: false,
             }),
@@ -1101,6 +1108,7 @@ describe('UpdateOrCreateCodeReviewParameterUseCase', () => {
         };
 
         const centralizedConfigPrService = {
+            getCentralizedRepositoryIfEnabled: jest.fn().mockResolvedValue({ id: 'central-repo-1', name: 'centralized-config' }),
             getScopedKodusConfigFileContent: jest.fn().mockResolvedValue({
                 automatedReviewActive: false,
                 isRequestChangesActive: true,
@@ -1198,5 +1206,127 @@ describe('UpdateOrCreateCodeReviewParameterUseCase', () => {
                 prUrl: 'https://example.test/pr/5',
             }),
         );
+    });
+
+    it('saves config to database when centralized config is disabled (new company setup)', async () => {
+        const createOrUpdateParametersUseCase = {
+            execute: jest.fn().mockResolvedValue(true),
+        };
+
+        // Centralized disabled: getScopedKodusConfigFileContent returns null,
+        // createMutationPullRequestIfEnabled returns { mode: 'direct' }
+        const centralizedConfigPrServiceMock = {
+            getCentralizedRepositoryIfEnabled: jest.fn().mockResolvedValue(null),
+            getScopedKodusConfigFileContent: jest.fn().mockResolvedValue(null),
+            createMutationPullRequestIfEnabled: jest
+                .fn()
+                .mockResolvedValue({ mode: 'direct' }),
+        };
+
+        const useCase = new UpdateOrCreateCodeReviewParameterUseCase(
+            {
+                findByKey: jest.fn().mockResolvedValue(null),
+            } as any,
+            createOrUpdateParametersUseCase as any,
+            {
+                findIntegrationConfigFormatted: jest.fn().mockResolvedValue([
+                    { id: 'repo-1', name: 'my-app', directories: [] },
+                ]),
+            } as any,
+            { emit: jest.fn() } as any,
+            {} as any,
+            { ensure: jest.fn() } as any,
+            { detectAndSaveReferences: jest.fn() } as any,
+            { buildConfigKey: jest.fn().mockReturnValue('config-key') } as any,
+            centralizedConfigPrServiceMock as any,
+        );
+
+        await useCase.execute({
+            configValue: {},
+            organizationAndTeamData: {
+                organizationId: 'new-org-1',
+                teamId: 'new-team-1',
+            },
+            skipAuthorization: true,
+        } as any);
+
+        // Must persist to database, not short-circuit via centralized PR
+        expect(createOrUpdateParametersUseCase.execute).toHaveBeenCalledWith(
+            'code_review_config',
+            expect.objectContaining({
+                id: 'global',
+                name: 'Global',
+                isSelected: true,
+            }),
+            {
+                organizationId: 'new-org-1',
+                teamId: 'new-team-1',
+            },
+        );
+    });
+
+    it('saves updated config to database when centralized config is disabled (existing company)', async () => {
+        const createOrUpdateParametersUseCase = {
+            execute: jest.fn().mockResolvedValue(true),
+        };
+
+        const centralizedConfigPrServiceMock = {
+            getCentralizedRepositoryIfEnabled: jest.fn().mockResolvedValue(null),
+            getScopedKodusConfigFileContent: jest.fn().mockResolvedValue(null),
+            createMutationPullRequestIfEnabled: jest
+                .fn()
+                .mockResolvedValue({ mode: 'direct' }),
+        };
+
+        const useCase = new UpdateOrCreateCodeReviewParameterUseCase(
+            {
+                findByKey: jest.fn().mockResolvedValue({
+                    configValue: {
+                        id: 'global',
+                        name: 'Global',
+                        isSelected: true,
+                        configs: { automatedReviewActive: true },
+                        repositories: [
+                            {
+                                id: 'repo-1',
+                                name: 'my-app',
+                                isSelected: false,
+                                configs: {},
+                                directories: [],
+                            },
+                        ],
+                    },
+                }),
+            } as any,
+            createOrUpdateParametersUseCase as any,
+            {
+                findIntegrationConfigFormatted: jest.fn().mockResolvedValue([
+                    { id: 'repo-1', name: 'my-app', directories: [] },
+                ]),
+            } as any,
+            { emit: jest.fn() } as any,
+            {} as any,
+            { ensure: jest.fn() } as any,
+            { detectAndSaveReferences: jest.fn() } as any,
+            { buildConfigKey: jest.fn().mockReturnValue('config-key') } as any,
+            centralizedConfigPrServiceMock as any,
+        );
+
+        await useCase.execute({
+            configValue: { automatedReviewActive: false },
+            organizationAndTeamData: {
+                organizationId: 'org-1',
+                teamId: 'team-1',
+            },
+            skipAuthorization: true,
+        } as any);
+
+        // Must persist the update to database
+        expect(createOrUpdateParametersUseCase.execute).toHaveBeenCalled();
+
+        // Must NOT have gone through centralized PR flow
+        expect(
+            centralizedConfigPrServiceMock.createMutationPullRequestIfEnabled,
+        ).not.toHaveBeenCalled();
     });
 });

--- a/libs/code-review/application/use-cases/configuration/update-or-create-code-review-parameter-use-case.ts
+++ b/libs/code-review/application/use-cases/configuration/update-or-create-code-review-parameter-use-case.ts
@@ -460,6 +460,16 @@ export class UpdateOrCreateCodeReviewParameterUseCase {
             return null;
         }
 
+        // Check if centralized config is actually enabled before proceeding.
+        const centralizedRepository =
+            await this.centralizedConfigPrService?.getCentralizedRepositoryIfEnabled(
+                params.organizationAndTeamData,
+            );
+
+        if (!centralizedRepository) {
+            return null;
+        }
+
         const existingScopedConfigFileContent =
             await this.centralizedConfigPrService?.getScopedKodusConfigFileContent(
                 {
@@ -474,11 +484,6 @@ export class UpdateOrCreateCodeReviewParameterUseCase {
                             : undefined,
                 },
             );
-
-        // Centralized config is not enabled — fall through to direct persistence.
-        if (existingScopedConfigFileContent === null || existingScopedConfigFileContent === undefined) {
-            return null;
-        }
 
         const existingScopedConfigWithoutCustomMessages =
             this.stripCustomMessagesFromConfig(

--- a/libs/code-review/application/use-cases/configuration/update-or-create-code-review-parameter-use-case.ts
+++ b/libs/code-review/application/use-cases/configuration/update-or-create-code-review-parameter-use-case.ts
@@ -279,7 +279,7 @@ export class UpdateOrCreateCodeReviewParameterUseCase {
             newDelta: updatedConfigValue,
         });
 
-        if (centralizedPr) {
+        if (centralizedPr?.mode === 'centralized-pr') {
             return centralizedPr;
         }
 
@@ -399,7 +399,7 @@ export class UpdateOrCreateCodeReviewParameterUseCase {
                   newDelta,
               });
 
-        if (centralizedPr) {
+        if (centralizedPr?.mode === 'centralized-pr') {
             return centralizedPr;
         }
 
@@ -474,6 +474,11 @@ export class UpdateOrCreateCodeReviewParameterUseCase {
                             : undefined,
                 },
             );
+
+        // Centralized config is not enabled — fall through to direct persistence.
+        if (existingScopedConfigFileContent === null || existingScopedConfigFileContent === undefined) {
+            return null;
+        }
 
         const existingScopedConfigWithoutCustomMessages =
             this.stripCustomMessagesFromConfig(


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces the following changes:

*   **Improved User Experience for Ignore Paths Field**: Prevents the "ignore files" textarea in the code review settings from resetting its content while a user is actively typing. This is achieved by introducing an `isEditing` state that pauses external updates to the field's value when it is focused.
*   **Enhanced Configuration Persistence Logic**: Ensures that code review configuration changes are correctly saved directly to the database when centralized configuration is disabled. Previously, the system might have incorrectly attempted to create a pull request for centralized configuration even when it was not enabled.
    *   An explicit check has been added to verify if a centralized repository is enabled before attempting any centralized configuration operations, allowing the system to fall back to direct database storage if it's disabled.
    *   The logic for handling centralized pull requests has been refined to explicitly check for `mode === 'centralized-pr'` before short-circuiting the database save, ensuring that direct database saves are correctly processed when intended.
    *   New test cases have been added to validate the correct configuration saving behavior when centralized configuration is disabled.
<!-- kody-pr-summary:end -->