### PR TITLE
Fix/repo admin access

### DIFF
--- a/apps/web/src/features/ee/subscription/@admins/_components/assign-repos.modal.tsx
+++ b/apps/web/src/features/ee/subscription/@admins/_components/assign-repos.modal.tsx
@@ -209,10 +209,7 @@ export default function AssignReposModal({ userId }: { userId: string }) {
                             variant="primary"
                             loading={isSaving}
                             onClick={saveSelectionAction}
-                            disabled={
-                                isInitializing ||
-                                selectedRepositories.length === 0
-                            }>
+                            disabled={isInitializing}>
                             Save changes
                         </Button>
                     </DialogFooter>

--- a/apps/web/src/features/ee/subscription/@admins/_components/assign-repos.modal.tsx
+++ b/apps/web/src/features/ee/subscription/@admins/_components/assign-repos.modal.tsx
@@ -34,7 +34,13 @@ import { Check } from "lucide-react";
 import { useSelectedTeamId } from "src/core/providers/selected-team-context";
 import { safeArray } from "src/core/utils/safe-array";
 
-export default function AssignReposModal({ userId }: { userId: string }) {
+export default function AssignReposModal({
+    userId,
+    onSave,
+}: {
+    userId: string;
+    onSave?: () => void;
+}) {
     const { teamId } = useSelectedTeamId();
 
     const [isPopoverOpen, setIsPopoverOpen] = useState(false);
@@ -108,6 +114,7 @@ export default function AssignReposModal({ userId }: { userId: string }) {
             // The selectedRepoIds Set can be used directly here
             const selectedIds = Array.from(selectedRepoIds);
             await assignRepos(selectedIds, userId, teamId);
+            onSave?.();
             magicModal.hide();
         },
     );

--- a/apps/web/src/features/ee/subscription/@admins/_components/columns.tsx
+++ b/apps/web/src/features/ee/subscription/@admins/_components/columns.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useContext, useState } from "react";
+import { useContext, useEffect, useState } from "react";
 import { Badge } from "@components/ui/badge";
 import { Button } from "@components/ui/button";
 import { DataTableColumnHeader } from "@components/ui/data-table";
@@ -21,6 +21,8 @@ import {
 } from "@components/ui/select";
 import { toast } from "@components/ui/toaster/use-toast";
 import { UserRole, UserStatus } from "@enums";
+import { useGetSelectedRepositories } from "@services/codeManagement/hooks";
+import { getAssignedRepos } from "@services/permissions/fetch";
 import { usePermission } from "@services/permissions/hooks";
 import {
     Action,
@@ -36,14 +38,120 @@ import {
     CopyIcon,
     EllipsisVertical,
     Pencil,
+    Plus,
     TrashIcon,
 } from "lucide-react";
 import { useAuth } from "src/core/providers/auth.provider";
+import { useSelectedTeamId } from "src/core/providers/selected-team-context";
 import { ClipboardHelpers } from "src/core/utils/clipboard";
+import { safeArray } from "src/core/utils/safe-array";
 import { revalidateServerSidePath } from "src/core/utils/revalidate-server-side";
+
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from "@components/ui/tooltip";
 
 import AssignReposModal from "./assign-repos.modal";
 import { DeleteModal } from "./delete-modal";
+
+function AssignedReposLink({
+    userId,
+    canEdit,
+}: {
+    userId: string;
+    canEdit: boolean;
+}) {
+    const { teamId } = useSelectedTeamId();
+    const { data: allRepositories = [] } = useGetSelectedRepositories(teamId);
+    const [repoNames, setRepoNames] = useState<string[]>([]);
+    const [isLoading, setIsLoading] = useState(true);
+
+    const fetchRepoNames = async () => {
+        setIsLoading(true);
+        try {
+            const assignedIds = await getAssignedRepos(userId);
+            const assignedSet = new Set(assignedIds);
+            const names = safeArray(allRepositories)
+                .filter((repo) => assignedSet.has(repo.id))
+                .map((repo) => repo.name);
+            setRepoNames(names);
+        } catch {
+            setRepoNames([]);
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    useEffect(() => {
+        if (allRepositories.length > 0) {
+            fetchRepoNames();
+        }
+    }, [userId, allRepositories]);
+
+    const openModal = () => {
+        magicModal.show(() => (
+            <AssignReposModal userId={userId} onSave={fetchRepoNames} />
+        ));
+    };
+
+    if (isLoading) {
+        return (
+            <span className="text-text-secondary text-xs">Loading...</span>
+        );
+    }
+
+    return (
+        <div className="flex w-full items-center gap-1.5">
+            {repoNames.length > 0 ? (
+                <TooltipProvider>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <div className="text-text-secondary flex flex-col text-xs">
+                                <span className="truncate">
+                                    {repoNames[0]}
+                                </span>
+                                {repoNames.length === 2 && (
+                                    <span className="truncate">
+                                        {repoNames[1]}
+                                    </span>
+                                )}
+                                {repoNames.length >= 3 && (
+                                    <span className="text-text-secondary/70 cursor-default">
+                                        +{repoNames.length - 1} more...
+                                    </span>
+                                )}
+                            </div>
+                        </TooltipTrigger>
+                        {repoNames.length >= 3 && (
+                            <TooltipContent side="bottom">
+                                <div className="flex flex-col gap-0.5">
+                                    {repoNames.map((name) => (
+                                        <span key={name}>{name}</span>
+                                    ))}
+                                </div>
+                            </TooltipContent>
+                        )}
+                    </Tooltip>
+                </TooltipProvider>
+            ) : (
+                <span className="text-text-secondary text-xs">
+                    No repositories
+                </span>
+            )}
+            {canEdit && (
+                <button
+                    type="button"
+                    onClick={openModal}
+                    className="bg-primary-light/10 text-primary-light hover:bg-primary-light/20 flex shrink-0 cursor-pointer items-center rounded-full p-0.5">
+                    <Plus className="size-3.5" />
+                </button>
+            )}
+        </div>
+    );
+}
 
 export const columns: ColumnDef<MembersSetup>[] = [
     {
@@ -181,21 +289,10 @@ export const columns: ColumnDef<MembersSetup>[] = [
                     </div>
                     {shouldShowButton && (
                         <div className="w-full">
-                            <Button
-                                variant="helper"
-                                size="sm"
-                                className="w-full gap-2 py-4"
-                                disabled={!canEdit}
-                                onClick={() =>
-                                    magicModal.show(() => (
-                                        <AssignReposModal
-                                            userId={row.original.userId!}
-                                        />
-                                    ))
-                                }>
-                                <Pencil />
-                                Repository access
-                            </Button>
+                            <AssignedReposLink
+                                userId={row.original.userId!}
+                                canEdit={canEdit}
+                            />
                         </div>
                     )}
                 </div>

--- a/apps/web/src/features/ee/subscription/@admins/_components/columns.tsx
+++ b/apps/web/src/features/ee/subscription/@admins/_components/columns.tsx
@@ -88,6 +88,9 @@ function AssignedReposLink({
     useEffect(() => {
         if (allRepositories.length > 0) {
             fetchRepoNames();
+        } else {
+            setRepoNames([]);
+            setIsLoading(false);
         }
     }, [userId, allRepositories]);
 

--- a/libs/identity/application/use-cases/permissions/assign-repos.use-case.ts
+++ b/libs/identity/application/use-cases/permissions/assign-repos.use-case.ts
@@ -74,10 +74,13 @@ export class AssignReposUseCase implements IUseCase {
                 (integrationConfigs.configValue as Repositories[]) || [];
             const configuredRepoIds = configuredRepos.map((repo) => repo.id);
 
-            const validRepoIds = repoIds.filter((id) =>
-                configuredRepoIds.includes(id),
-            );
-            if (validRepoIds.length === 0) {
+            const validRepoIds =
+                repoIds.length === 0
+                    ? []
+                    : repoIds.filter((id) =>
+                          configuredRepoIds.includes(id),
+                      );
+            if (repoIds.length > 0 && validRepoIds.length === 0) {
                 throw new Error(
                     'None of the provided repository IDs are valid',
                 );

--- a/libs/identity/application/use-cases/permissions/assign-repos.use-case.ts
+++ b/libs/identity/application/use-cases/permissions/assign-repos.use-case.ts
@@ -72,14 +72,14 @@ export class AssignReposUseCase implements IUseCase {
 
             const configuredRepos =
                 (integrationConfigs.configValue as Repositories[]) || [];
-            const configuredRepoIds = configuredRepos.map((repo) => repo.id);
+            const configuredRepoIdSet = new Set(
+                configuredRepos.map((repo) => repo.id),
+            );
 
             const validRepoIds =
                 repoIds.length === 0
                     ? []
-                    : repoIds.filter((id) =>
-                          configuredRepoIds.includes(id),
-                      );
+                    : repoIds.filter((id) => configuredRepoIdSet.has(id));
             if (repoIds.length > 0 && validRepoIds.length === 0) {
                 throw new Error(
                     'None of the provided repository IDs are valid',


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces significant improvements to the repository access management for team members in the admin section, alongside a critical bug fix.

Key changes include:

*   **Enhanced Repository Access Display**: The team members table now directly displays the names of repositories assigned to each user. This includes showing up to two repository names, with a "+X more..." indicator and a tooltip for three or more, providing a quick overview. It also handles loading states and displays "No repositories" when applicable.
*   **Streamlined Assignment Workflow**: A "Plus" button is integrated with the displayed repository list, allowing administrators to quickly open the "Assign Repositories" modal to modify a user's access.
*   **Dynamic UI Updates**: After saving changes in the "Assign Repositories" modal, the displayed list of assigned repositories in the table automatically refreshes to reflect the updates.
*   **Fixed Unassignment Logic**: Resolved a backend issue that previously prevented administrators from completely unassigning all repositories from a user. It is now possible to save an empty selection in the "Assign Repositories" modal, effectively removing all repository access without encountering an error. The "Save changes" button in the modal is now only disabled during initialization, allowing an empty selection to be saved.
<!-- kody-pr-summary:end -->