### PR TITLE
fix(queue): add worker health guard, channel logging, and fix reconne…

### DIFF
--- a/apps/worker/src/worker-health-guard.service.ts
+++ b/apps/worker/src/worker-health-guard.service.ts
@@ -1,0 +1,444 @@
+import * as os from 'os';
+import { AmqpConnection } from '@golevelup/nestjs-rabbitmq';
+import { createLogger } from '@kodus/flow';
+import {
+    Injectable,
+    OnApplicationBootstrap,
+    OnApplicationShutdown,
+    Optional,
+} from '@nestjs/common';
+
+/**
+ * Guarantees that a running worker always has active RabbitMQ consumers.
+ *
+ * ## Why this exists
+ *
+ * amqp-connection-manager has a critical gap: when the broker closes a
+ * **channel** (e.g. consumer_timeout → PRECONDITION_FAILED), the
+ * ChannelWrapper sets `_channel = undefined` and waits for the
+ * **connection** to reconnect. But the connection is still alive, so
+ * nothing ever triggers channel re-creation. The consumer silently
+ * disappears and the worker becomes a zombie.
+ *
+ * ## How it works
+ *
+ * 1. **Startup assertion** — waits for all managed channels to connect.
+ *    If any channel fails within BOOT_TIMEOUT_MS, exits.
+ *
+ * 2. **Event-driven channel monitoring** — listens for `close` and
+ *    `error` events on each managed channel. On close, attempts to
+ *    force reconnect. If channels stay dead after MAX_CHANNEL_DEAD_MS,
+ *    initiates graceful shutdown.
+ *
+ * 3. **Periodic health check** — safety net that polls channel state
+ *    in case events were missed.
+ */
+@Injectable()
+export class WorkerHealthGuardService
+    implements OnApplicationBootstrap, OnApplicationShutdown
+{
+    private readonly logger = createLogger(WorkerHealthGuardService.name);
+    private readonly instanceId = os.hostname();
+
+    private readonly BOOT_TIMEOUT_MS = 30_000;
+    private readonly CHECK_INTERVAL_MS = 30_000;
+    private readonly MAX_CHANNEL_DEAD_MS = 90_000;
+    private readonly MAX_DISCONNECT_MS = 120_000;
+
+    private checkTimer?: ReturnType<typeof setInterval>;
+    private disconnectedSince?: number;
+    private deadChannelsSince?: number;
+    private isShuttingDown = false;
+
+    constructor(
+        @Optional() private readonly amqpConnection?: AmqpConnection,
+    ) {}
+
+    // ───────────────────── Startup assertion ─────────────────────
+
+    async onApplicationBootstrap(): Promise<void> {
+        if (!this.amqpConnection) {
+            this.logger.warn({
+                message: 'No AmqpConnection — RabbitMQ disabled, skipping health guard.',
+                context: WorkerHealthGuardService.name,
+                metadata: { instanceId: this.instanceId },
+            });
+            return;
+        }
+
+        const expectedChannels = this.getExpectedChannelNames();
+
+        this.logger.log({
+            message: `Waiting up to ${this.BOOT_TIMEOUT_MS}ms for ${expectedChannels.length} channels...`,
+            context: WorkerHealthGuardService.name,
+            metadata: { instanceId: this.instanceId, expectedChannels },
+        });
+
+        const managedChannels = this.amqpConnection.managedChannels;
+        const missing = expectedChannels.filter((name) => !managedChannels[name]);
+
+        if (missing.length > 0) {
+            this.logger.error({
+                message: `Managed channels not registered: ${missing.join(', ')}. Exiting.`,
+                context: WorkerHealthGuardService.name,
+                metadata: {
+                    instanceId: this.instanceId,
+                    expected: expectedChannels,
+                    found: Object.keys(managedChannels),
+                    missing,
+                },
+            });
+            this.exitGracefully(1);
+            return;
+        }
+
+        // Wait for each channel to connect.
+        const timeout = new Promise<never>((_, reject) =>
+            setTimeout(
+                () => reject(new Error(`Boot timeout after ${this.BOOT_TIMEOUT_MS}ms`)),
+                this.BOOT_TIMEOUT_MS,
+            ),
+        );
+
+        try {
+            await Promise.race([
+                Promise.all(
+                    expectedChannels.map((name) =>
+                        managedChannels[name].waitForConnect(),
+                    ),
+                ),
+                timeout,
+            ]);
+        } catch (error) {
+            this.logger.error({
+                message: `Channels failed to connect on boot. Exiting.`,
+                context: WorkerHealthGuardService.name,
+                error: error instanceof Error ? error : undefined,
+                metadata: { instanceId: this.instanceId },
+            });
+            this.exitGracefully(1);
+            return;
+        }
+
+        this.logger.log({
+            message: `All ${expectedChannels.length} channels connected. Attaching listeners.`,
+            context: WorkerHealthGuardService.name,
+            metadata: { instanceId: this.instanceId },
+        });
+
+        // Attach event listeners on each channel for immediate detection.
+        this.attachChannelListeners(expectedChannels);
+
+        // Periodic safety net.
+        this.checkTimer = setInterval(
+            () => this.checkHealth(),
+            this.CHECK_INTERVAL_MS,
+        );
+    }
+
+    // ───────────────── Event-driven channel monitoring ─────────────────
+
+    private attachChannelListeners(channelNames: string[]): void {
+        const managedChannels = this.amqpConnection!.managedChannels;
+
+        for (const name of channelNames) {
+            const wrapper = managedChannels[name];
+            if (!wrapper) continue;
+
+            wrapper.on('close', () => {
+                if (this.isShuttingDown) return;
+
+                this.logger.error({
+                    message: `Channel "${name}" closed unexpectedly.`,
+                    context: WorkerHealthGuardService.name,
+                    metadata: {
+                        instanceId: this.instanceId,
+                        channel: name,
+                        connectionAlive: this.amqpConnection?.connected,
+                    },
+                });
+
+                this.handleChannelDeath(name);
+            });
+
+            wrapper.on('error', (err: Error, info?: { name?: string }) => {
+                this.logger.error({
+                    message: `Channel "${name}" error: ${err?.message}`,
+                    context: WorkerHealthGuardService.name,
+                    error: err,
+                    metadata: {
+                        instanceId: this.instanceId,
+                        channel: name,
+                        channelInfo: info,
+                        connectionAlive: this.amqpConnection?.connected,
+                    },
+                });
+            });
+
+            // Log connect events for visibility.
+            wrapper.on('connect', () => {
+                this.logger.log({
+                    message: `Channel "${name}" connected.`,
+                    context: WorkerHealthGuardService.name,
+                    metadata: {
+                        instanceId: this.instanceId,
+                        channel: name,
+                    },
+                });
+            });
+        }
+    }
+
+    private handleChannelDeath(channelName: string): void {
+        if (!this.amqpConnection?.connected) {
+            // Connection is down — amqp-connection-manager will handle
+            // reconnect and re-create channels. No action needed here.
+            this.logger.warn({
+                message: `Channel "${channelName}" died but connection is also down. Waiting for connection-level reconnect.`,
+                context: WorkerHealthGuardService.name,
+                metadata: { instanceId: this.instanceId },
+            });
+            return;
+        }
+
+        // Connection alive + channel dead = the zombie bug.
+        // Try to force reconnect so amqp-connection-manager re-creates channels.
+        this.logger.warn({
+            message: `Zombie state: connection alive but channel "${channelName}" dead. Forcing reconnect...`,
+            context: WorkerHealthGuardService.name,
+            metadata: { instanceId: this.instanceId, channel: channelName },
+        });
+
+        try {
+            const managedConnection = (this.amqpConnection as any).managedConnection;
+            if (managedConnection && typeof managedConnection.reconnect === 'function') {
+                managedConnection.reconnect();
+                this.logger.log({
+                    message: 'Forced reconnect triggered.',
+                    context: WorkerHealthGuardService.name,
+                    metadata: { instanceId: this.instanceId },
+                });
+            }
+        } catch (err) {
+            this.logger.error({
+                message: 'Failed to force reconnect.',
+                context: WorkerHealthGuardService.name,
+                error: err instanceof Error ? err : undefined,
+                metadata: { instanceId: this.instanceId },
+            });
+        }
+
+        // Start the dead-channel timer. If channels don't recover within
+        // MAX_CHANNEL_DEAD_MS, the periodic check will trigger exit.
+        if (!this.deadChannelsSince) {
+            this.deadChannelsSince = Date.now();
+        }
+    }
+
+    // ───────────────── Periodic health check (safety net) ─────────────────
+
+    private checkHealth(): void {
+        if (!this.amqpConnection || this.isShuttingDown) return;
+
+        const connectionAlive = this.amqpConnection.connected;
+
+        // ── Connection-level check ──
+        if (!connectionAlive) {
+            this.deadChannelsSince = undefined;
+
+            if (!this.disconnectedSince) {
+                this.disconnectedSince = Date.now();
+                this.logger.warn({
+                    message: 'AMQP connection lost.',
+                    context: WorkerHealthGuardService.name,
+                    metadata: {
+                        instanceId: this.instanceId,
+                        maxDisconnectMs: this.MAX_DISCONNECT_MS,
+                    },
+                });
+                return;
+            }
+
+            const downMs = Date.now() - this.disconnectedSince;
+            if (downMs >= this.MAX_DISCONNECT_MS) {
+                this.logger.error({
+                    message: `AMQP disconnected for ${Math.round(downMs / 1000)}s. Exiting.`,
+                    context: WorkerHealthGuardService.name,
+                    metadata: { instanceId: this.instanceId, downMs },
+                });
+                this.exitGracefully(1);
+                return;
+            }
+            return;
+        }
+
+        // Connection alive — reset.
+        if (this.disconnectedSince) {
+            const downMs = Date.now() - this.disconnectedSince;
+            this.logger.log({
+                message: `AMQP connection restored after ${Math.round(downMs / 1000)}s.`,
+                context: WorkerHealthGuardService.name,
+                metadata: { instanceId: this.instanceId },
+            });
+            this.disconnectedSince = undefined;
+        }
+
+        // ── Channel-level check (zombie detector) ──
+        const channelStatus = this.getChannelStatus();
+
+        if (channelStatus.dead.length === 0) {
+            if (this.deadChannelsSince) {
+                this.logger.log({
+                    message: 'All channels recovered.',
+                    context: WorkerHealthGuardService.name,
+                    metadata: {
+                        instanceId: this.instanceId,
+                        channels: channelStatus.alive,
+                        consumers: channelStatus.consumers,
+                    },
+                });
+                this.deadChannelsSince = undefined;
+            }
+            return;
+        }
+
+        // Dead channels detected.
+        if (!this.deadChannelsSince) {
+            this.deadChannelsSince = Date.now();
+            this.logger.warn({
+                message: `Dead channels while connection alive: ${channelStatus.dead.join(', ')}`,
+                context: WorkerHealthGuardService.name,
+                metadata: {
+                    instanceId: this.instanceId,
+                    deadChannels: channelStatus.dead,
+                    aliveChannels: channelStatus.alive,
+                    consumers: channelStatus.consumers,
+                    maxChannelDeadMs: this.MAX_CHANNEL_DEAD_MS,
+                },
+            });
+
+            // Try force reconnect on first detection.
+            this.handleChannelDeath(channelStatus.dead[0]);
+            return;
+        }
+
+        const deadMs = Date.now() - this.deadChannelsSince;
+        if (deadMs >= this.MAX_CHANNEL_DEAD_MS) {
+            this.logger.error({
+                message: `Channels dead for ${Math.round(deadMs / 1000)}s despite reconnect attempt. Exiting.`,
+                context: WorkerHealthGuardService.name,
+                metadata: {
+                    instanceId: this.instanceId,
+                    deadChannels: channelStatus.dead,
+                    deadMs,
+                },
+            });
+            this.exitGracefully(1);
+            return;
+        }
+
+        this.logger.warn({
+            message: `Channels still dead: ${channelStatus.dead.join(', ')} (${Math.round(deadMs / 1000)}s / ${this.MAX_CHANNEL_DEAD_MS / 1000}s)`,
+            context: WorkerHealthGuardService.name,
+            metadata: { instanceId: this.instanceId },
+        });
+    }
+
+    // ───────────────────── Helpers ─────────────────────
+
+    /**
+     * Derive expected channels from the AmqpConnection config instead
+     * of hardcoding. Falls back to known defaults.
+     */
+    private getExpectedChannelNames(): string[] {
+        try {
+            const config = (this.amqpConnection as any)?.config;
+            if (config?.channels && typeof config.channels === 'object') {
+                return Object.keys(config.channels);
+            }
+        } catch {
+            // Fallback below.
+        }
+
+        return [
+            'channel-webhook',
+            'channel-code-review',
+            'channel-check-implementation',
+            'channel-feedback',
+        ];
+    }
+
+    private getChannelStatus(): {
+        alive: string[];
+        dead: string[];
+        consumers: Record<string, number>;
+    } {
+        const managedChannels = this.amqpConnection!.managedChannels;
+        const expectedChannels = this.getExpectedChannelNames();
+        const alive: string[] = [];
+        const dead: string[] = [];
+        const consumers: Record<string, number> = {};
+
+        for (const name of expectedChannels) {
+            const wrapper = managedChannels[name] as any;
+            if (!wrapper || !wrapper._channel) {
+                dead.push(name);
+                consumers[name] = 0;
+            } else {
+                alive.push(name);
+                consumers[name] = Array.isArray(wrapper._consumers)
+                    ? wrapper._consumers.length
+                    : -1;
+            }
+        }
+
+        return { alive, dead, consumers };
+    }
+
+    /**
+     * Graceful exit: uses app.close() which triggers OnApplicationShutdown
+     * hooks (including releaseAllByInstance for inbox locks). Falls back
+     * to process.exit if close fails.
+     */
+    private exitGracefully(code: number): void {
+        if (this.isShuttingDown) return;
+        this.isShuttingDown = true;
+
+        this.logger.log({
+            message: 'Initiating graceful shutdown...',
+            context: WorkerHealthGuardService.name,
+            metadata: { instanceId: this.instanceId, exitCode: code },
+        });
+
+        // Give shutdown hooks 10s to run, then force exit.
+        const forceExitTimer = setTimeout(() => {
+            this.logger.error({
+                message: 'Graceful shutdown timed out. Force exiting.',
+                context: WorkerHealthGuardService.name,
+                metadata: { instanceId: this.instanceId },
+            });
+            process.exit(code);
+        }, 10_000);
+
+        // process.kill(process.pid, 'SIGTERM') triggers NestJS shutdown hooks
+        // (enableShutdownHooks is called in main.ts), which runs:
+        // - WorkerDrainService.onApplicationShutdown (close consumers)
+        // - WorkflowJobConsumer.onApplicationShutdown (release inbox locks)
+        // - This service's onApplicationShutdown (cleanup timer)
+        process.kill(process.pid, 'SIGTERM');
+
+        // Unref so the timer doesn't keep the process alive if shutdown completes.
+        forceExitTimer.unref();
+    }
+
+    // ───────────────────── Cleanup ─────────────────────
+
+    async onApplicationShutdown(): Promise<void> {
+        this.isShuttingDown = true;
+
+        if (this.checkTimer) {
+            clearInterval(this.checkTimer);
+            this.checkTimer = undefined;
+        }
+    }
+}

--- a/apps/worker/src/worker-health-guard.service.ts
+++ b/apps/worker/src/worker-health-guard.service.ts
@@ -410,7 +410,8 @@ export class WorkerHealthGuardService
             metadata: { instanceId: this.instanceId, exitCode: code },
         });
 
-        // Give shutdown hooks 10s to run, then force exit.
+        // Give shutdown hooks 30s to run, then force exit.
+        // This must be longer than the WorkerDrainService timeout (default 25s).
         const forceExitTimer = setTimeout(() => {
             this.logger.error({
                 message: 'Graceful shutdown timed out. Force exiting.',
@@ -418,7 +419,7 @@ export class WorkerHealthGuardService
                 metadata: { instanceId: this.instanceId },
             });
             process.exit(code);
-        }, 10_000);
+        }, 30_000);
 
         // process.kill(process.pid, 'SIGTERM') triggers NestJS shutdown hooks
         // (enableShutdownHooks is called in main.ts), which runs:

--- a/apps/worker/src/worker.module.ts
+++ b/apps/worker/src/worker.module.ts
@@ -21,6 +21,7 @@ import { WorkflowModule } from '@libs/core/workflow/modules/workflow.module';
 import { OutboxRelayService } from '@libs/core/workflow/infrastructure/outbox-relay.service';
 import { ScheduleModule } from '@nestjs/schedule';
 import { WorkerDrainService } from './worker-drain.service';
+import { WorkerHealthGuardService } from './worker-health-guard.service';
 
 @Module({
     imports: [
@@ -47,6 +48,7 @@ import { WorkerDrainService } from './worker-drain.service';
     providers: [
         OutboxRelayService,
         WorkerDrainService,
+        WorkerHealthGuardService,
         ErrorRateMonitorService,
         ReviewResponseMonitorService,
         WebhookFailureMonitorService,

--- a/libs/core/infrastructure/queue/rabbitmq-connection-logger.service.ts
+++ b/libs/core/infrastructure/queue/rabbitmq-connection-logger.service.ts
@@ -1,3 +1,4 @@
+import * as os from 'os';
 import { AmqpConnection } from '@golevelup/nestjs-rabbitmq';
 import { createLogger } from '@kodus/flow';
 import {
@@ -7,6 +8,7 @@ import {
     Optional,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { ChannelWrapper } from 'amqp-connection-manager';
 
 type ManagedConnection = {
     on: (event: string, handler: (...args: any[]) => void) => void;
@@ -22,7 +24,9 @@ export class RabbitMQConnectionLoggerService
         RabbitMQConnectionLoggerService.name,
     );
     private readonly componentType: string;
+    private readonly instanceId = os.hostname();
     private managedConnection?: ManagedConnection;
+    private readonly channelCleanups: Array<() => void> = [];
     private connectHandler?: (args: { connection?: unknown }) => void;
     private disconnectHandler?: (args: { err?: Error }) => void;
     private connectFailedHandler?: (args: { err?: Error }) => void;
@@ -43,11 +47,21 @@ export class RabbitMQConnectionLoggerService
                 message:
                     'RabbitMQ connection not available; skipping listeners',
                 context: RabbitMQConnectionLoggerService.name,
-                metadata: { component: this.componentType },
+                metadata: {
+                    component: this.componentType,
+                    instanceId: this.instanceId,
+                },
             });
             return;
         }
 
+        this.attachConnectionListeners();
+        this.attachChannelListeners();
+    }
+
+    // ───────────────── Connection-level listeners ─────────────────
+
+    private attachConnectionListeners(): void {
         const managedConnection = (this.amqpConnection as any)
             .managedConnection as ManagedConnection | undefined;
 
@@ -56,7 +70,10 @@ export class RabbitMQConnectionLoggerService
                 message:
                     'RabbitMQ managedConnection not available; skipping listeners',
                 context: RabbitMQConnectionLoggerService.name,
-                metadata: { component: this.componentType },
+                metadata: {
+                    component: this.componentType,
+                    instanceId: this.instanceId,
+                },
             });
             return;
         }
@@ -69,6 +86,7 @@ export class RabbitMQConnectionLoggerService
                 context: RabbitMQConnectionLoggerService.name,
                 metadata: {
                     component: this.componentType,
+                    instanceId: this.instanceId,
                     connectionName: this.amqpConnection?.configuration?.name,
                 },
             });
@@ -81,6 +99,7 @@ export class RabbitMQConnectionLoggerService
                 error: err,
                 metadata: {
                     component: this.componentType,
+                    instanceId: this.instanceId,
                     connectionName: this.amqpConnection?.configuration?.name,
                     errorMessage: err?.message,
                 },
@@ -94,6 +113,7 @@ export class RabbitMQConnectionLoggerService
                 error: err,
                 metadata: {
                     component: this.componentType,
+                    instanceId: this.instanceId,
                     connectionName: this.amqpConnection?.configuration?.name,
                     errorMessage: err?.message,
                 },
@@ -105,27 +125,118 @@ export class RabbitMQConnectionLoggerService
         managedConnection.on('connectFailed', this.connectFailedHandler);
     }
 
+    // ───────────────── Channel-level listeners ─────────────────
+
+    private attachChannelListeners(): void {
+        const managedChannels = this.amqpConnection?.managedChannels;
+        if (!managedChannels) return;
+
+        for (const [name, wrapper] of Object.entries(managedChannels)) {
+            const cw: ChannelWrapper = wrapper;
+            if (!cw || typeof cw.on !== 'function') continue;
+
+            const onConnect = () => {
+                const consumerCount = Array.isArray((cw as any)._consumers)
+                    ? (cw as any)._consumers.length
+                    : 'unknown';
+                this.logger.log({
+                    message: `RabbitMQ channel "${name}" connected`,
+                    context: RabbitMQConnectionLoggerService.name,
+                    metadata: {
+                        component: this.componentType,
+                        instanceId: this.instanceId,
+                        channel: name,
+                        consumers: consumerCount,
+                    },
+                });
+            };
+
+            const onClose = () => {
+                this.logger.error({
+                    message: `RabbitMQ channel "${name}" closed`,
+                    context: RabbitMQConnectionLoggerService.name,
+                    metadata: {
+                        component: this.componentType,
+                        instanceId: this.instanceId,
+                        channel: name,
+                        connectionAlive:
+                            this.amqpConnection?.connected ?? false,
+                        zombieRisk:
+                            (this.amqpConnection?.connected ?? false) === true,
+                    },
+                });
+            };
+
+            const onError = (err: Error, info?: { name?: string }) => {
+                this.logger.error({
+                    message: `RabbitMQ channel "${name}" error: ${err?.message}`,
+                    context: RabbitMQConnectionLoggerService.name,
+                    error: err,
+                    metadata: {
+                        component: this.componentType,
+                        instanceId: this.instanceId,
+                        channel: name,
+                        channelInfo: info,
+                        errorName: err?.name,
+                        errorMessage: err?.message,
+                        connectionAlive:
+                            this.amqpConnection?.connected ?? false,
+                    },
+                });
+            };
+
+            cw.on('connect', onConnect);
+            cw.on('close', onClose);
+            cw.on('error', onError);
+
+            // Store cleanup functions for onModuleDestroy.
+            this.channelCleanups.push(() => {
+                cw.removeListener('connect', onConnect);
+                cw.removeListener('close', onClose);
+                cw.removeListener('error', onError);
+            });
+        }
+
+        const channelNames = Object.keys(managedChannels);
+        this.logger.log({
+            message: `Attached listeners to ${channelNames.length} managed channels`,
+            context: RabbitMQConnectionLoggerService.name,
+            metadata: {
+                component: this.componentType,
+                instanceId: this.instanceId,
+                channels: channelNames,
+            },
+        });
+    }
+
+    // ───────────────── Cleanup ─────────────────
+
     onModuleDestroy(): void {
-        if (!this.managedConnection) {
-            return;
+        // Connection listeners.
+        if (this.managedConnection) {
+            const off =
+                this.managedConnection.off?.bind(this.managedConnection) ||
+                this.managedConnection.removeListener?.bind(
+                    this.managedConnection,
+                );
+
+            if (off) {
+                if (this.connectHandler) off('connect', this.connectHandler);
+                if (this.disconnectHandler)
+                    off('disconnect', this.disconnectHandler);
+                if (this.connectFailedHandler)
+                    off('connectFailed', this.connectFailedHandler);
+            }
         }
 
-        const off =
-            this.managedConnection.off?.bind(this.managedConnection) ||
-            this.managedConnection.removeListener?.bind(this.managedConnection);
-
-        if (!off) {
-            return;
+        // Channel listeners.
+        for (const cleanup of this.channelCleanups) {
+            try {
+                cleanup();
+            } catch {
+                // Best-effort cleanup.
+            }
         }
-
-        if (this.connectHandler) {
-            off('connect', this.connectHandler);
-        }
-        if (this.disconnectHandler) {
-            off('disconnect', this.disconnectHandler);
-        }
-        if (this.connectFailedHandler) {
-            off('connectFailed', this.connectFailedHandler);
-        }
+        this.channelCleanups.length = 0;
     }
 }

--- a/libs/core/infrastructure/queue/rabbitmq.module.ts
+++ b/libs/core/infrastructure/queue/rabbitmq.module.ts
@@ -83,10 +83,16 @@ export class RabbitMQWrapperModule {
                         wait: false,
                         timeout: 5000,
                     },
+                    // Both options live under connectionManagerOptions in
+                    // @golevelup/nestjs-rabbitmq v9. Before this PR the
+                    // `reconnectTimeInSeconds` sat at the top level where it
+                    // was silently ignored, causing the library to fall back
+                    // to amqp-connection-manager's 5s default instead of the
+                    // 10s we intended.
                     connectionManagerOptions: {
-                        heartbeatIntervalInSeconds: 120,
+                        heartbeatIntervalInSeconds: 60,
+                        reconnectTimeInSeconds: 10,
                     },
-                    reconnectTimeInSeconds: 10,
                     enableControllerDiscovery: options.enableConsumers,
                     prefetchCount:
                         configService.get<number>(
@@ -123,6 +129,14 @@ export class RabbitMQWrapperModule {
                                 configService.get<number>(
                                     'workflowQueue.WORKFLOW_QUEUE_FEEDBACK_PREFETCH',
                                 ) ?? 20,
+                            default: false,
+                        },
+                        'channel-ast-graph-build': {
+                            prefetchCount: 2,
+                            default: false,
+                        },
+                        'channel-ast-graph-incremental': {
+                            prefetchCount: 5,
                             default: false,
                         },
                     },


### PR DESCRIPTION
…ct config

Root cause: consumer_timeout (2h) closes the AMQP channel but amqp-connection-manager only watches the connection — so the channel stays dead and the worker becomes a zombie with no consumers.

Changes:

1. WorkerHealthGuardService (new)
   - Startup assertion: waits for all managed channels to connect, exits if any fail within 30s so ECS can replace.
   - Channel-level zombie detector: listens for channel close/error events. When a channel dies while the connection is alive, forces reconnect. If channels stay dead for 90s, triggers graceful shutdown via SIGTERM (preserves shutdown hooks like releaseAllByInstance).

2. RabbitMQConnectionLoggerService (improved)
   - Adds close/error/connect listeners on every managed channel.
   - Logs instanceId, consumer count, and zombieRisk flag on every channel event for production observability.

3. rabbitmq.module.ts (config fix)
   - Moves reconnectTimeInSeconds inside connectionManagerOptions where amqp-connection-manager actually reads it (was silently ignored at top level since golevelup v9 upgrade).
   - Aligns client heartbeat to 60s to match the server config.

---

<!-- kody-pr-summary:start -->
This pull request introduces significant improvements to RabbitMQ worker reliability, observability, and configuration.

Key changes include:

1.  **RabbitMQ Worker Health Guard**: Implements a new `WorkerHealthGuardService` to prevent "zombie worker" scenarios where RabbitMQ channels silently die while the connection remains active, causing workers to stop processing messages. This service:
    *   **Asserts channel connectivity on startup**: Ensures all configured channels connect successfully within a timeout, exiting if not.
    *   **Monitors channel events**: Listens for unexpected channel `close` and `error` events, attempting to force a connection reconnect when a channel dies but the main connection is still alive.
    *   **Performs periodic health checks**: Regularly verifies the state of the RabbitMQ connection and channels, initiating a graceful shutdown if the connection is lost for too long or if channels remain dead despite reconnect attempts.
    *   Includes a graceful shutdown mechanism to ensure proper resource release (e.g., inbox locks) before the worker exits.

2.  **Enhanced RabbitMQ Channel Logging**: Extends the `RabbitMQConnectionLoggerService` to provide more detailed insights into channel lifecycle events.
    *   Adds logging for channel `connect`, `close`, and `error` events.
    *   Includes the number of active consumers on channel connect and a `zombieRisk` flag on channel close events to highlight potential issues.

3.  **Refined RabbitMQ Connection Configuration**:
    *   **Corrects reconnect timing**: Moves `reconnectTimeInSeconds` to the `connectionManagerOptions` to ensure the intended 10-second reconnect interval is correctly applied, fixing a previous misconfiguration that caused it to default to 5 seconds.
    *   **Adjusts heartbeat interval**: Changes `heartbeatIntervalInSeconds` from 120 to 60 seconds for potentially faster detection of connection issues.
    *   **Adds new channels**: Introduces new RabbitMQ channel configurations (`channel-ast-graph-build` and `channel-ast-graph-incremental`) with specific prefetch counts, indicating new or optimized message processing capabilities.
<!-- kody-pr-summary:end -->