### PR TITLE
update build bun

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,3 +1,7 @@
+# Global ARG — must be declared before the first FROM so it can be used in
+# the `oven/bun:${BUN_VERSION}-debian` stage below.
+ARG BUN_VERSION=1.2.12
+
 FROM docker.io/library/node:22.22.0-slim AS base
 WORKDIR /usr/src/app
 
@@ -63,6 +67,15 @@ RUN yarn install --frozen-lockfile && yarn cache clean
 RUN rm -rf node_modules/@kodus/kodus-common && cp -r packages/kodus-common node_modules/@kodus/kodus-common
 RUN rm -rf node_modules/@kodus/flow && cp -r packages/kodus-flow node_modules/@kodus/flow
 
+# Dedicated stage for the bun binary. Using the official oven/bun image
+# instead of `curl bun.sh/install | bash` because:
+#   - Docker Hub CDN is more reliable for tagged images than GitHub releases
+#     (the install script's internal curl hit 504s on GitHub during builds).
+#   - Buildx caches the pulled image; subsequent builds skip the download.
+#   - Eliminates `curl`/`unzip` installed just to delete them later.
+# BUN_VERSION is declared as a global ARG at the top of this file.
+FROM docker.io/oven/bun:${BUN_VERSION}-debian AS bun-source
+
 FROM docker.io/library/node:22.22.0-slim AS runtime-common
 WORKDIR /usr/src/app
 ENV NODE_ENV=production
@@ -81,16 +94,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates procps git ripgrep \
   && rm -rf /var/lib/apt/lists/*
 
-# Install bun (pinned) + kodus-graph CLI, then remove build-only deps (curl/unzip).
-# BUN_INSTALL is set inline (not ENV) so it doesn't persist at runtime —
-# prevents user 1000 from accidentally trying to write to /usr/local.
-ARG BUN_VERSION=1.2.12
-RUN apt-get update && apt-get install -y --no-install-recommends curl unzip \
-    && export BUN_INSTALL=/usr/local \
-    && curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" \
-    && bun install -g @kodus/kodus-graph \
-    && apt-get purge -y --auto-remove curl unzip \
-    && rm -rf /var/lib/apt/lists/*
+# Copy the bun binary from the official image and install kodus-graph with it.
+COPY --from=bun-source /usr/local/bin/bun /usr/local/bin/bun
+RUN bun install -g @kodus/kodus-graph
 
 COPY --chown=1000:1000 --from=prod-deps /usr/src/app/node_modules ./node_modules
 COPY --chown=1000:1000 --from=build /usr/src/app/dist ./dist

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -1,5 +1,10 @@
 ARG API_CLOUD_MODE=false
 ARG RELEASE_VERSION=local
+ARG BUN_VERSION=1.2.12
+
+# Dedicated stage for the bun binary — Docker Hub is more reliable than
+# GitHub releases for build-time downloads (prevents flaky 504s during CI).
+FROM docker.io/oven/bun:${BUN_VERSION}-debian AS bun-source
 
 FROM docker.io/library/node:22.22.0-slim
 
@@ -17,14 +22,12 @@ RUN corepack disable \
  && npm i -g yarn@1.22.22
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates python3 make g++ procps git ripgrep curl unzip \
+      ca-certificates python3 make g++ procps git ripgrep \
     && rm -rf /var/lib/apt/lists/*
 
-# Install bun (pinned) + kodus-graph CLI into /usr/local/bin
-ARG BUN_VERSION=1.2.12
-RUN export BUN_INSTALL=/usr/local \
-    && curl -fsSL https://bun.sh/install | bash -s "bun-v${BUN_VERSION}" \
-    && bun install -g @kodus/kodus-graph
+# Copy the bun binary from the official image and install kodus-graph globally.
+COPY --from=bun-source /usr/local/bin/bun /usr/local/bin/bun
+RUN bun install -g @kodus/kodus-graph
 
 RUN npm i -g yalc chokidar-cli nodemon @ast-grep/cli
 

--- a/packages/kodus-common/.npmrc
+++ b/packages/kodus-common/.npmrc
@@ -1,6 +1,10 @@
 # Google Artifact Registry Configuration
-# Público para uso, autenticação apenas para publicação
-@kodus:registry=https://us-central1-npm.pkg.dev/${GAR_PROJECT_ID}/kodus-pkg/
+# Público para uso, autenticação apenas para publicação.
+# A linha abaixo fica comentada porque yarn v1 quebra `yarn install` se
+# `GAR_PROJECT_ID` não estiver no ambiente (ver packages/kodus-flow/.npmrc,
+# que seguiu a mesma convenção). O registry é configurado só durante o
+# publish via CI, onde a env var está disponível.
+# @kodus:registry=https://us-central1-npm.pkg.dev/${GAR_PROJECT_ID}/kodus-pkg/
 
 # Fallback para npm público (para dependências)
 registry=https://registry.npmjs.org/


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Esta atualização refatora a forma como o Bun é instalado nos Dockerfiles de produção e desenvolvimento, e inclui uma correção para a configuração do registro npm privado.

**Principais Mudanças:**

*   **Instalação do Bun Refatorada**:
    *   A instalação do Bun agora utiliza uma abordagem de build multi-stage. Em vez de baixar e instalar o Bun via script (`curl bun.sh/install`), o binário do Bun é copiado diretamente da imagem oficial `oven/bun` (em um estágio dedicado `bun-source`).
    *   Esta mudança melhora a confiabilidade do processo de build (evitando erros 504 intermitentes de downloads do GitHub), otimiza o cache do Docker Buildx e elimina a necessidade de instalar `curl` e `unzip` como dependências temporárias de build.
    *   A versão do Bun é agora definida como um `ARG` global no topo dos Dockerfiles.
*   **Correção no `.npmrc` do `kodus-common`**:
    *   A configuração do registro npm privado (`@kodus:registry`) foi comentada por padrão no arquivo `packages/kodus-common/.npmrc`.
    *   Isso resolve um problema com o `yarn v1` que causava falhas no `yarn install` quando a variável de ambiente `GAR_PROJECT_ID` não estava definida. O registro será configurado apenas durante os passos de publicação na CI, onde a variável está garantida.
<!-- kody-pr-summary:end -->