### PR TITLE
Fix/code graph increment

### DIFF
--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/_utils/layout-dirty-state.spec.ts
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/_utils/layout-dirty-state.spec.ts
@@ -1,0 +1,60 @@
+import {
+    findFirstDirtyFieldOutsidePromptOverrides,
+    hasDirtyFieldsOutsidePromptOverrides,
+    shouldBlockCodeReviewLayoutNavigation,
+} from "./layout-dirty-state";
+
+describe("layout-dirty-state", () => {
+    it("does not treat prompt-only dirty fields as shared dirty fields", () => {
+        const dirtyFields = {
+            v2PromptOverrides: {
+                generation: {
+                    main: {
+                        value: true,
+                    },
+                },
+            },
+        };
+
+        expect(
+            hasDirtyFieldsOutsidePromptOverrides(dirtyFields, [
+                "v2PromptOverrides",
+            ]),
+        ).toBe(false);
+        expect(
+            findFirstDirtyFieldOutsidePromptOverrides(dirtyFields, "", [
+                "v2PromptOverrides",
+            ]),
+        ).toBeNull();
+        expect(
+            shouldBlockCodeReviewLayoutNavigation({
+                dirtyFields,
+                formIsSubmitting: false,
+            }),
+        ).toBe(false);
+    });
+
+    it("blocks navigation when a shared settings field is dirty", () => {
+        const dirtyFields = {
+            reviewOptions: {
+                security: true,
+            },
+        };
+
+        expect(
+            shouldBlockCodeReviewLayoutNavigation({
+                dirtyFields,
+                formIsSubmitting: false,
+            }),
+        ).toBe(true);
+    });
+
+    it("blocks navigation while the form is submitting", () => {
+        expect(
+            shouldBlockCodeReviewLayoutNavigation({
+                dirtyFields: {},
+                formIsSubmitting: true,
+            }),
+        ).toBe(true);
+    });
+});

--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/_utils/layout-dirty-state.ts
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/_utils/layout-dirty-state.ts
@@ -1,0 +1,86 @@
+type DirtyFieldTree = Record<string, unknown>;
+
+export function hasDirtyFieldsOutsidePromptOverrides(
+    value: DirtyFieldTree,
+    excludeKeys?: string[],
+): boolean {
+    for (const key of Object.keys(value)) {
+        if (excludeKeys?.includes(key)) {
+            continue;
+        }
+
+        const fieldValue = value[key];
+        if (
+            typeof fieldValue === "object" &&
+            fieldValue !== null &&
+            !Array.isArray(fieldValue)
+        ) {
+            if (
+                hasDirtyFieldsOutsidePromptOverrides(
+                    fieldValue as DirtyFieldTree,
+                    excludeKeys,
+                )
+            ) {
+                return true;
+            }
+            continue;
+        }
+
+        if (fieldValue === true) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+export function findFirstDirtyFieldOutsidePromptOverrides(
+    value: DirtyFieldTree,
+    prefix = "",
+    excludeKeys?: string[],
+): string | null {
+    for (const key of Object.keys(value)) {
+        if (excludeKeys?.includes(key)) {
+            continue;
+        }
+
+        const path = prefix ? `${prefix}.${key}` : key;
+        const fieldValue = value[key];
+
+        if (
+            typeof fieldValue === "object" &&
+            fieldValue !== null &&
+            !Array.isArray(fieldValue)
+        ) {
+            const found = findFirstDirtyFieldOutsidePromptOverrides(
+                fieldValue as DirtyFieldTree,
+                path,
+                excludeKeys,
+            );
+            if (found) {
+                return found;
+            }
+            continue;
+        }
+
+        if (fieldValue === true) {
+            return path;
+        }
+    }
+
+    return null;
+}
+
+export function shouldBlockCodeReviewLayoutNavigation({
+    dirtyFields,
+    formIsSubmitting,
+}: {
+    dirtyFields: DirtyFieldTree;
+    formIsSubmitting: boolean;
+}): boolean {
+    return (
+        hasDirtyFieldsOutsidePromptOverrides(dirtyFields, [
+            "v2PromptOverrides",
+        ]) || formIsSubmitting
+    );
+}

--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/layout.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/layout.tsx
@@ -17,6 +17,10 @@ import {
     shouldHydrateCodeReviewForm,
 } from "../_utils/settings-shell";
 import {
+    findFirstDirtyFieldOutsidePromptOverrides,
+    shouldBlockCodeReviewLayoutNavigation,
+} from "./_utils/layout-dirty-state";
+import {
     useCodeReviewConfig,
     useDefaultCodeReviewConfig,
 } from "../../_components/context";
@@ -77,7 +81,6 @@ export default function Layout(props: React.PropsWithChildren) {
         disabled: !canEdit,
     });
     const {
-        isDirty: formIsDirty,
         isSubmitting: formIsSubmitting,
         dirtyFields,
     } = form.formState;
@@ -96,79 +99,8 @@ export default function Layout(props: React.PropsWithChildren) {
         hydratedStateKeyRef.current = hydrationKey;
     }, [form, hydrationKey, initialFormValues]);
 
-    const sharedFormIsDirty = useCallback(() => {
-        const check = (
-            value: Record<string, unknown>,
-            excludeKeys?: string[],
-        ): boolean => {
-            for (const key of Object.keys(value)) {
-                if (excludeKeys?.includes(key)) {
-                    continue;
-                }
-
-                const fieldValue = value[key];
-                if (
-                    typeof fieldValue === "object" &&
-                    fieldValue !== null &&
-                    !Array.isArray(fieldValue)
-                ) {
-                    if (check(fieldValue as Record<string, unknown>)) {
-                        return true;
-                    }
-                    continue;
-                }
-
-                if (fieldValue === true) {
-                    return true;
-                }
-            }
-
-            return false;
-        };
-
-        return check(dirtyFields as Record<string, unknown>, [
-            "v2PromptOverrides",
-        ]);
-    }, [dirtyFields]);
-
     const scrollToDirtyField = useCallback(() => {
-        const findFirstDirtyKey = (
-            value: Record<string, unknown>,
-            prefix = "",
-            excludeKeys?: string[],
-        ): string | null => {
-            for (const key of Object.keys(value)) {
-                if (excludeKeys?.includes(key)) {
-                    continue;
-                }
-
-                const path = prefix ? `${prefix}.${key}` : key;
-                const fieldValue = value[key];
-
-                if (
-                    typeof fieldValue === "object" &&
-                    fieldValue !== null &&
-                    !Array.isArray(fieldValue)
-                ) {
-                    const found = findFirstDirtyKey(
-                        fieldValue as Record<string, unknown>,
-                        path,
-                    );
-                    if (found) {
-                        return found;
-                    }
-                    continue;
-                }
-
-                if (fieldValue === true) {
-                    return path;
-                }
-            }
-
-            return null;
-        };
-
-        const dirtyKey = findFirstDirtyKey(
+        const dirtyKey = findFirstDirtyFieldOutsidePromptOverrides(
             dirtyFields as Record<string, unknown>,
             "",
             ["v2PromptOverrides"],
@@ -232,7 +164,10 @@ export default function Layout(props: React.PropsWithChildren) {
 
     useUnsavedChangesGuard({
         id: "code-review-settings",
-        isDirty: sharedFormIsDirty() || formIsSubmitting || formIsDirty,
+        isDirty: shouldBlockCodeReviewLayoutNavigation({
+            dirtyFields: dirtyFields as Record<string, unknown>,
+            formIsSubmitting,
+        }),
         onBlock: scrollToDirtyField,
     });
 

--- a/libs/code-review/application/use-cases/enqueue-ast-graph-update-on-merged.use-case.ts
+++ b/libs/code-review/application/use-cases/enqueue-ast-graph-update-on-merged.use-case.ts
@@ -24,6 +24,12 @@ export interface EnqueueAstGraphUpdateInput {
     repoName: string;
     platform: PlatformType;
     baseBranch: string;
+    /**
+     * SHA representing the new state of the default branch after the merge.
+     * Used for tracking/auditing the graph version; the incremental
+     * processor tolerates missing values.
+     */
+    newSha?: string;
     organizationAndTeamData: OrganizationAndTeamData;
 }
 
@@ -75,6 +81,7 @@ export class EnqueueAstGraphUpdateOnMergedUseCase implements IUseCase {
             repoName,
             platform,
             baseBranch,
+            newSha,
             organizationAndTeamData,
         } = input;
 
@@ -112,7 +119,7 @@ export class EnqueueAstGraphUpdateOnMergedUseCase implements IUseCase {
             };
         }
 
-        let changedFiles: string[] = [];
+        let changedFiles: string[];
         try {
             const files =
                 (await this.codeManagementService.getFilesByPullRequestId(
@@ -171,7 +178,7 @@ export class EnqueueAstGraphUpdateOnMergedUseCase implements IUseCase {
                       payload: {
                           repositoryId: repo.uuid,
                           changedFiles,
-                          newSha: '',
+                          newSha,
                           cloneUrl: '',
                           defaultBranch: repo.defaultBranch,
                           fullName: repo.fullName,

--- a/libs/code-review/workflow/ast-graph-incremental-job.processor.ts
+++ b/libs/code-review/workflow/ast-graph-incremental-job.processor.ts
@@ -79,15 +79,15 @@ export class AstGraphIncrementalJobProcessor implements IJobProcessorService {
 
         await this.updateJobStage(jobId, 'VALIDATING');
 
-        if (
-            !payload?.repositoryId ||
-            !payload?.changedFiles?.length ||
-            !payload?.newSha
-        ) {
+        if (!payload?.repositoryId || !payload?.changedFiles?.length) {
             throw new Error(
-                'Invalid payload: missing required fields (repositoryId, changedFiles, newSha)',
+                'Invalid payload: missing required fields (repositoryId, changedFiles)',
             );
         }
+        // newSha is informational (logged + passed to graphIndexer for
+        // tracking) but not execution-critical — the sandbox clones by
+        // defaultBranch, not by sha. Keep it optional so incremental
+        // updates run even when the caller can't produce a merge sha.
 
         let sandbox: SandboxInstance | undefined;
         let sandboxId: string | undefined;
@@ -97,20 +97,35 @@ export class AstGraphIncrementalJobProcessor implements IJobProcessorService {
             await this.updateJobStage(jobId, 'RESOLVING_AUTH');
             const authStart = Date.now();
 
+            const repoRecord = await this.repositoryService.findById(
+                payload.repositoryId,
+            );
+            if (!repoRecord) {
+                throw new Error(
+                    `Repository ${payload.repositoryId} not found in DB — cannot resolve clone params`,
+                );
+            }
+
             const cloneParams = await this.codeManagementService.getCloneParams(
                 {
                     repository: {
-                        id: '0',
-                        defaultBranch: payload.defaultBranch,
-                        fullName: payload.fullName,
+                        id: repoRecord.externalId,
+                        defaultBranch: repoRecord.defaultBranch,
+                        fullName: repoRecord.fullName,
                         name:
-                            payload.fullName.split('/').pop() ||
-                            payload.fullName,
+                            repoRecord.fullName.split('/').pop() ||
+                            repoRecord.fullName,
                     },
                     organizationAndTeamData: payload.organizationAndTeamData,
                 },
                 payload.platform as PlatformType,
             );
+
+            if (!cloneParams) {
+                throw new Error(
+                    `Failed to resolve clone params for ${repoRecord.fullName} (platform=${payload.platform}) — provider returned null`,
+                );
+            }
 
             this.logger.log({
                 message: `[AST-GRAPH-INCR] Auth resolved for ${repoLabel} (${Date.now() - authStart}ms)`,
@@ -122,11 +137,14 @@ export class AstGraphIncrementalJobProcessor implements IJobProcessorService {
             await this.updateJobStage(jobId, 'CLONING');
             const cloneStart = Date.now();
 
+            const branchRaw = repoRecord.defaultBranch || payload.defaultBranch;
+            const branch = branchRaw.replace(/^refs\/heads\//, '');
+
             sandbox = await this.sandboxProvider.createSandboxWithRepo({
                 cloneUrl: cloneParams.url || payload.cloneUrl,
                 authToken: cloneParams.auth?.token || '',
                 authUsername: cloneParams.auth?.username,
-                branch: payload.defaultBranch,
+                branch,
                 platform: payload.platform as PlatformType,
                 sandboxMetadata: { stage: 'graph-incremental' },
             });

--- a/libs/core/workflow/domain/contracts/inbox-message.repository.contract.ts
+++ b/libs/core/workflow/domain/contracts/inbox-message.repository.contract.ts
@@ -18,6 +18,14 @@ export interface IInboxMessageRepository {
         consumerId: string,
         lockedBy: string,
         jobId?: string,
+        /**
+         * Minutes after which a message stuck in PROCESSING can be
+         * reclaimed by another worker. Defaults to 150 (2.5h) — appropriate
+         * for long-running workflows like code review (2h + margin).
+         * Pass a smaller value for short jobs (e.g. AST build at ~30min)
+         * so a hard worker crash doesn't block retries for hours.
+         */
+        claimTimeoutMinutes?: number,
     ): Promise<unknown | null>;
     findByConsumerAndMessageId(
         consumerId: string,

--- a/libs/core/workflow/infrastructure/repositories/inbox-message.repository.ts
+++ b/libs/core/workflow/infrastructure/repositories/inbox-message.repository.ts
@@ -45,14 +45,17 @@ export class InboxMessageRepository implements IInboxMessageRepository {
      * Claims a message for processing using an atomic UPSERT.
      * Returns the message model if successfully claimed, or null if it's already being processed or finished.
      *
-     * Uses 2.5-hour timeout for PROCESSING messages to avoid reclaiming long-running jobs
-     * (e.g., code reviews with 2h timeout + 30min margin). Only allows reclaiming messages that are truly stuck.
+     * `claimTimeoutMinutes` bounds how long a PROCESSING message stays locked before
+     * another worker can reclaim it after a hard crash (no releaseLock ran). Default
+     * 150min (2.5h) suits code review (2h timeout + margin); pass a smaller value for
+     * shorter workflows so retries aren't blocked for hours.
      */
     async claim(
         messageId: string,
         consumerId: string,
         lockedBy: string,
         jobId?: string,
+        claimTimeoutMinutes: number = 150,
     ): Promise<InboxMessageModel | null> {
         const query = `
             INSERT INTO "kodus_workflow"."inbox_messages"
@@ -67,7 +70,7 @@ export class InboxMessageRepository implements IInboxMessageRepository {
                 "attempts" = "inbox_messages"."attempts" + 1,
                 "updatedAt" = NOW()
             WHERE "inbox_messages"."status" NOT IN ($6, $7)
-               OR ("inbox_messages"."status" = $7 AND "inbox_messages"."lockedAt" < NOW() - INTERVAL '2.5 hours')
+               OR ("inbox_messages"."status" = $7 AND "inbox_messages"."lockedAt" < NOW() - make_interval(mins => $8))
             RETURNING *;
         `;
 
@@ -80,6 +83,7 @@ export class InboxMessageRepository implements IInboxMessageRepository {
                 lockedBy,
                 InboxStatus.PROCESSED,
                 InboxStatus.PROCESSING,
+                claimTimeoutMinutes,
             ]);
 
             if (results && results.length > 0) {

--- a/libs/core/workflow/infrastructure/workflow-job-consumer.service.ts
+++ b/libs/core/workflow/infrastructure/workflow-job-consumer.service.ts
@@ -164,6 +164,24 @@ export class WorkflowJobConsumer implements OnApplicationShutdown {
     /**
      * AST Graph Build jobs
      * Delayed exchange bindings are created by RabbitMQDLQInitializer.
+     *
+     * Uses Single Active Consumer so only ONE worker at a time pulls from
+     * this queue (up to prefetchCount in-flight). Combined with
+     * prefetchCount=5 on the channel, this caps global AST-build
+     * concurrency at 5 across the cluster and frees the other workers to
+     * serve other queues (code-review, webhook, etc). Failover is
+     * automatic: if the active consumer dies, RabbitMQ promotes another.
+     *
+     * `x-consumer-timeout` is set to 25min (20min job timeout + 5min
+     * overhead). If the active consumer holds a message unacked past
+     * this window, RabbitMQ cancels it and promotes another — this
+     * bounds the failover latency when a worker hangs (OOM, event-loop
+     * stall) rather than crashing cleanly.
+     *
+     * NOTE: queue arguments are fixed at creation. To apply SAC /
+     * consumer-timeout on an existing queue without recreating it, set a
+     * broker policy with `single-active-consumer: true` and
+     * `consumer-timeout: 1500000` matching this queue name.
      */
     @RabbitSubscribe({
         exchange: 'workflow.exchange',
@@ -175,6 +193,8 @@ export class WorkflowJobConsumer implements OnApplicationShutdown {
             channel: 'channel-ast-graph-build',
             arguments: {
                 'x-queue-type': 'quorum',
+                'x-single-active-consumer': true,
+                'x-consumer-timeout': 25 * 60 * 1000,
                 'x-dead-letter-exchange': 'workflow.exchange.dlx',
                 'x-dead-letter-routing-key': 'workflow.job.failed',
             },
@@ -195,6 +215,12 @@ export class WorkflowJobConsumer implements OnApplicationShutdown {
     /**
      * AST Graph Incremental Update jobs
      * Delayed exchange bindings are created by RabbitMQDLQInitializer.
+     *
+     * Single Active Consumer + prefetchCount=5 caps global concurrency
+     * at 5 — see handleAstGraphBuildJob for rationale.
+     *
+     * `x-consumer-timeout` set to 15min (10min job timeout + 5min
+     * overhead) for tighter failover when a worker hangs.
      */
     @RabbitSubscribe({
         exchange: 'workflow.exchange',
@@ -206,6 +232,8 @@ export class WorkflowJobConsumer implements OnApplicationShutdown {
             channel: 'channel-ast-graph-incremental',
             arguments: {
                 'x-queue-type': 'quorum',
+                'x-single-active-consumer': true,
+                'x-consumer-timeout': 15 * 60 * 1000,
                 'x-dead-letter-exchange': 'workflow.exchange.dlx',
                 'x-dead-letter-routing-key': 'workflow.job.failed',
             },
@@ -221,6 +249,19 @@ export class WorkflowJobConsumer implements OnApplicationShutdown {
             message,
             amqpMsg,
         );
+    }
+
+    /**
+     * Inbox claim timeout per queue, in minutes. Dimensioned as
+     * (workflow timeout + overhead) so a hard worker crash doesn't
+     * block retries for the default 2.5h while we wait for the reaper.
+     * Queues not listed fall back to 150 (2.5h).
+     */
+    private resolveClaimTimeoutMinutes(queueName: string): number {
+        if (queueName === 'workflow.jobs.ast_graph_build.queue') return 30;
+        if (queueName === 'workflow.jobs.ast_graph_incremental.queue') return 15;
+        if (queueName === 'workflow.jobs.webhook.queue') return 20;
+        return 150;
     }
 
     private async handleWorkflowJob(
@@ -289,6 +330,7 @@ export class WorkflowJobConsumer implements OnApplicationShutdown {
             consumerId,
             this.instanceId,
             unwrappedMessage.jobId,
+            this.resolveClaimTimeoutMinutes(queueName),
         );
 
         if (!claimed) {

--- a/libs/platform/infrastructure/webhooks/azure/azureReposPullRequest.handler.ts
+++ b/libs/platform/infrastructure/webhooks/azure/azureReposPullRequest.handler.ts
@@ -311,6 +311,10 @@ export class AzureReposPullRequestHandler implements IWebhookEventHandler {
                                             platform:
                                                 PlatformType.AZURE_REPOS,
                                             baseBranch: baseRefFull,
+                                            newSha:
+                                                params?.payload?.resource
+                                                    ?.lastMergeCommit
+                                                    ?.commitId,
                                             organizationAndTeamData:
                                                 context.organizationAndTeamData,
                                         })

--- a/libs/platform/infrastructure/webhooks/bitbucket/bitbucketPullRequest.handler.ts
+++ b/libs/platform/infrastructure/webhooks/bitbucket/bitbucketPullRequest.handler.ts
@@ -305,6 +305,9 @@ export class BitbucketPullRequestHandler implements IWebhookEventHandler {
                                             platform:
                                                 PlatformType.BITBUCKET,
                                             baseBranch: baseRef,
+                                            newSha:
+                                                payload?.pullrequest
+                                                    ?.merge_commit?.hash,
                                             organizationAndTeamData:
                                                 context.organizationAndTeamData,
                                         })

--- a/libs/platform/infrastructure/webhooks/forgejo/forgejoPullRequest.handler.ts
+++ b/libs/platform/infrastructure/webhooks/forgejo/forgejoPullRequest.handler.ts
@@ -262,6 +262,9 @@ export class ForgejoPullRequestHandler implements IWebhookEventHandler {
                                     repoName: repository.name,
                                     platform: PlatformType.FORGEJO,
                                     baseBranch: baseRef,
+                                    newSha:
+                                        payload?.pull_request
+                                            ?.merge_commit_sha,
                                     organizationAndTeamData:
                                         context.organizationAndTeamData,
                                 })

--- a/libs/platform/infrastructure/webhooks/github/githubPullRequest.handler.ts
+++ b/libs/platform/infrastructure/webhooks/github/githubPullRequest.handler.ts
@@ -262,6 +262,9 @@ export class GitHubPullRequestHandler implements IWebhookEventHandler {
                                     repoName: repository.name,
                                     platform: PlatformType.GITHUB,
                                     baseBranch: baseRef,
+                                    newSha:
+                                        payload?.pull_request
+                                            ?.merge_commit_sha,
                                     organizationAndTeamData:
                                         context.organizationAndTeamData,
                                 })

--- a/libs/platform/infrastructure/webhooks/gitlab/gitlabPullRequest.handler.ts
+++ b/libs/platform/infrastructure/webhooks/gitlab/gitlabPullRequest.handler.ts
@@ -281,6 +281,11 @@ export class GitLabMergeRequestHandler implements IWebhookEventHandler {
                                         repoName: repository.name,
                                         platform: PlatformType.GITLAB,
                                         baseBranch: baseRef,
+                                        newSha:
+                                            payload?.object_attributes
+                                                ?.merge_commit_sha ??
+                                            payload?.object_attributes
+                                                ?.last_commit?.id,
                                         organizationAndTeamData:
                                             context.organizationAndTeamData,
                                     })


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces several enhancements to code review settings and AST graph incremental updates.

**Code Review Settings UI Enhancements:**
*   Refactors the "unsaved changes" guard on the code review settings page.
*   Changes made *only* to prompt overrides (`v2PromptOverrides`) will no longer trigger unsaved changes warnings or block navigation. This allows users to adjust prompts without being constantly prompted to save, improving the user experience.
*   The logic for detecting dirty fields and blocking navigation has been extracted into new utility functions and includes dedicated unit tests.

**AST Graph Incremental Update Improvements:**
*   The `newSha` (merge commit SHA) is now an optional parameter when enqueuing AST graph incremental updates. This ensures the update process can proceed even if the merge commit SHA is not available from the source control provider's webhook.
*   Webhook handlers for Azure Repos, Bitbucket, Forgejo, GitHub, and GitLab have been updated to extract and pass the `merge_commit_sha` (or equivalent) to the AST graph update process when a pull request is merged. This `newSha` is used for tracking and auditing the graph version.
*   The AST graph incremental job processor has been made more robust by:
    *   No longer requiring `newSha` for job validation.
    *   Fetching repository details from the database to ensure accurate clone parameters.
    *   Adding improved error handling for missing clone parameters.
    *   Cleaning up branch names (removing `refs/heads/` prefix) before cloning.
<!-- kody-pr-summary:end -->

---

<!-- kody-pr-summary:start -->
This pull request introduces several enhancements across the application, focusing on improving the user experience in code review settings and bolstering the robustness and efficiency of the AST graph incremental update workflow.

Key changes include:

*   **Refined Code Review Settings Navigation Guard**: The code review settings page now intelligently distinguishes between changes to "shared" settings and "prompt override" settings. Only modifications to shared settings or an active form submission will trigger the unsaved changes navigation guard, preventing unnecessary interruptions when users only adjust prompt overrides. This is achieved by introducing new utility functions (`hasDirtyFieldsOutsidePromptOverrides`, `findFirstDirtyFieldOutsidePromptOverrides`, `shouldBlockCodeReviewLayoutNavigation`) to manage and evaluate dirty form states more precisely.
*   **Enhanced AST Graph Incremental Updates**:
    *   The `newSha` (merge commit SHA) is now an optional parameter for enqueuing AST graph incremental updates. This allows updates to proceed even if the SHA is not immediately available from the source, while still capturing it from various webhook providers (Azure Repos, Bitbucket, Forgejo, GitHub, GitLab) when present for improved tracking and auditing.
    *   The AST graph incremental job processor has been made more robust by fetching repository details from the database, ensuring correct branch handling (stripping `refs/heads/` prefixes), and adding comprehensive null checks for critical parameters during the cloning process.
*   **Improved Workflow Job Processing and Reliability**:
    *   **Dynamic Inbox Message Claim Timeouts**: The workflow system now supports dynamic claim timeouts for inbox messages. This allows different job types (e.g., AST graph build, AST graph incremental, webhooks) to have tailored timeouts for reclaiming messages stuck in a `PROCESSING` state. This significantly reduces the time it takes for jobs to be retried after a worker crash, preventing long delays.
    *   **Single Active Consumer (SAC) for Critical Queues**: RabbitMQ queues for AST graph build and incremental update jobs are configured with `x-single-active-consumer: true`. This ensures that only one worker actively consumes messages from these queues at a time, preventing redundant processing and managing concurrency more effectively across the cluster. Automatic failover is supported.
    *   **RabbitMQ Consumer Timeouts**: `x-consumer-timeout` is set for AST graph build (25 minutes) and incremental (15 minutes) queues. This bounds the failover latency by automatically canceling consumers that hold unacknowledged messages past the defined window, ensuring that hung workers do not indefinitely block message processing.
<!-- kody-pr-summary:end -->