### PR TITLE
fix: grant repo admin global access to cockpit dashboard

### DIFF
--- a/libs/identity/infrastructure/adapters/services/permissions/permissionsAbility.factory.ts
+++ b/libs/identity/infrastructure/adapters/services/permissions/permissionsAbility.factory.ts
@@ -97,7 +97,7 @@ export class PermissionsAbilityFactory {
                 canInRepo(Action.Create, ResourceType.KodyRules);
                 canInRepo(Action.Delete, ResourceType.KodyRules);
 
-                canInRepo(Action.Read, ResourceType.Cockpit);
+                canInRepo(Action.Read, ResourceType.Cockpit, {}, true);
 
                 canInOrg(Action.Read, ResourceType.Issues);
                 canInRepo(Action.Update, ResourceType.Issues);


### PR DESCRIPTION
#964

---

<!-- kody-pr-summary:start -->
Grants repository administrators global read access to the Cockpit dashboard. Previously, access to the Cockpit dashboard was restricted to a specific repository context for this role. This change ensures that repository administrators can view the Cockpit dashboard without repository-specific limitations.
<!-- kody-pr-summary:end -->