### PR TITLE
Features enterprise

### DIFF
--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -8,6 +8,7 @@ import { TEAM_STATUS } from "src/core/types";
 import { BYOKMissingKeyTopbar } from "src/features/ee/byok/_components/missing-key-topbar";
 import {
     isBYOKSubscriptionPlan,
+    isEnterprisePlan,
     shouldShowBYOKMissingKeyTopbar,
 } from "src/features/ee/byok/_utils";
 import { FinishedTrialModal } from "src/features/ee/subscription/_components/finished-trial-modal";
@@ -85,6 +86,9 @@ export default async function Layout({ children }: React.PropsWithChildren) {
         ? isBYOKSubscriptionPlan(organizationLicense)
         : false;
     const isTrial = organizationLicense?.subscriptionStatus === "trial";
+    const isEnterprise = organizationLicense
+        ? isEnterprisePlan(organizationLicense)
+        : false;
     const showBYOKMissingKeyTopbar = shouldShowBYOKMissingKeyTopbar({
         license: organizationLicense,
         llmConfigStatus,
@@ -108,6 +112,7 @@ export default async function Layout({ children }: React.PropsWithChildren) {
             permissions={permissions}
             isBYOK={isBYOK}
             isTrial={isTrial}
+            isEnterprise={isEnterprise}
             featureFlags={featureFlags}>
             <SubscriptionProvider
                 license={

--- a/apps/web/src/app/(app)/organization/_components/sidebar.tsx
+++ b/apps/web/src/app/(app)/organization/_components/sidebar.tsx
@@ -21,7 +21,10 @@ import {
     LockKeyholeOpenIcon,
     ShieldIcon,
 } from "lucide-react";
-import { isBYOKSubscriptionPlan } from "src/features/ee/byok/_utils";
+import {
+    isBYOKSubscriptionPlan,
+    isEnterprisePlan,
+} from "src/features/ee/byok/_utils";
 import { useSubscriptionContext } from "src/features/ee/subscription/_providers/subscription-context";
 import { useOrganizationContext } from "src/features/organization/_providers/organization-context";
 
@@ -34,6 +37,7 @@ export const ConfigsSidebar = () => {
     const { license } = useSubscriptionContext();
     const isTrial = license.subscriptionStatus === "trial";
     const isBYOK = isBYOKSubscriptionPlan(license);
+    const isEnterprise = isEnterprisePlan(license);
 
     const topItems = [
         {
@@ -46,7 +50,7 @@ export const ConfigsSidebar = () => {
             icon: ShieldIcon,
             label: "SSO",
             href: `/organization/sso`,
-            visible: sso ?? false,
+            visible: (isEnterprise || isTrial) && (sso ?? false),
         },
         {
             icon: GaugeIcon,

--- a/apps/web/src/app/(app)/providers.tsx
+++ b/apps/web/src/app/(app)/providers.tsx
@@ -25,6 +25,7 @@ type ProvidersProps = PropsWithChildren<{
     permissions: PermissionsMap;
     isBYOK: boolean;
     isTrial: boolean;
+    isEnterprise: boolean;
     featureFlags: Partial<{
         [K in keyof typeof FEATURE_FLAGS]: boolean;
     }>;
@@ -38,6 +39,7 @@ export function Providers({
     permissions,
     isBYOK,
     isTrial,
+    isEnterprise,
     featureFlags,
 }: ProvidersProps) {
     return (
@@ -47,7 +49,8 @@ export function Providers({
                     <AllTeamsProvider teams={teams}>
                         <SubsciptionStatusProvider
                             isBYOK={isBYOK}
-                            isTrial={isTrial}>
+                            isTrial={isTrial}
+                            isEnterprise={isEnterprise}>
                             <SelectedTeamProvider>
                                 <FeatureFlagsProvider
                                     featureFlags={featureFlags}>

--- a/apps/web/src/core/layout/navbar/_components/user-nav.tsx
+++ b/apps/web/src/core/layout/navbar/_components/user-nav.tsx
@@ -11,7 +11,8 @@ import {
     SettingsIcon,
     UserIcon,
 } from "lucide-react";
-import { useFeatureFlags } from "src/app/(app)/settings/_components/context";
+import { useAllTeams } from "src/core/providers/all-teams-context";
+import { useAuth } from "src/core/providers/auth.provider";
 import { Avatar, AvatarFallback } from "src/core/components/ui/avatar";
 import { Button } from "src/core/components/ui/button";
 import {
@@ -24,8 +25,6 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from "src/core/components/ui/dropdown-menu";
-import { useAllTeams } from "src/core/providers/all-teams-context";
-import { useAuth } from "src/core/providers/auth.provider";
 import { useSubscriptionStatus } from "src/core/providers/byok.provider";
 import { useSelectedTeamId } from "src/core/providers/selected-team-context";
 import { TEAM_STATUS } from "src/core/types";
@@ -34,7 +33,6 @@ import { isSelfHosted } from "src/core/utils/self-hosted";
 import { VersionInfo } from "./version-info";
 
 export function UserNav() {
-    const { tokenUsagePage } = useFeatureFlags();
     const { email } = useAuth();
     const { teams } = useAllTeams();
     const { teamId, setTeamId } = useSelectedTeamId();
@@ -43,7 +41,7 @@ export function UserNav() {
         ResourceType.OrganizationSettings,
     );
     const canReadLogs = usePermission(Action.Read, ResourceType.Logs);
-    const { isBYOK, isTrial } = useSubscriptionStatus();
+    const { isBYOK, isTrial, isEnterprise } = useSubscriptionStatus();
 
     const handleChangeWorkspace = (teamId: string) => {
         setTeamId(teamId);
@@ -113,7 +111,7 @@ export function UserNav() {
                     </Link>
                 )}
 
-                {canReadLogs && (
+                {(isEnterprise || isTrial) && canReadLogs && (
                     <Link href="/user-logs">
                         <DropdownMenuItem leftIcon={<ActivityIcon />}>
                             Activity Logs
@@ -121,9 +119,7 @@ export function UserNav() {
                     </Link>
                 )}
 
-                {(isSelfHosted || isBYOK || isTrial) &&
-                    tokenUsagePage &&
-                    canReadLogs && (
+                {canReadLogs && (
                         <Link href="/token-usage">
                             <DropdownMenuItem leftIcon={<ChartColumn />}>
                                 Token Usage

--- a/apps/web/src/core/providers/byok.provider.tsx
+++ b/apps/web/src/core/providers/byok.provider.tsx
@@ -3,18 +3,22 @@ import { createContext, useContext } from "react";
 const subscriptionStatusContext = createContext({
     isBYOK: false,
     isTrial: false,
+    isEnterprise: false,
 });
 
 export const SubsciptionStatusProvider = ({
     children,
     isBYOK = false,
     isTrial = false,
+    isEnterprise = false,
 }: React.PropsWithChildren & {
     isBYOK: boolean;
     isTrial: boolean;
+    isEnterprise: boolean;
 }) => {
     return (
-        <subscriptionStatusContext.Provider value={{ isBYOK, isTrial }}>
+        <subscriptionStatusContext.Provider
+            value={{ isBYOK, isTrial, isEnterprise }}>
             {children}
         </subscriptionStatusContext.Provider>
     );

--- a/apps/web/src/features/ee/byok/_utils.ts
+++ b/apps/web/src/features/ee/byok/_utils.ts
@@ -30,6 +30,22 @@ export const isBYOKSubscriptionPlan = (license: OrganizationLicense) => {
     return license.planType.includes("byok");
 };
 
+export const isEnterprisePlan = (license: OrganizationLicense): boolean => {
+    if (
+        license.subscriptionStatus === "self-hosted" ||
+        license.subscriptionStatus === "licensed-self-hosted"
+    ) {
+        return true;
+    }
+    if (license.subscriptionStatus === "trial") {
+        return true;
+    }
+    if (license.subscriptionStatus !== "active") {
+        return false;
+    }
+    return license.planType?.startsWith("enterprise") ?? false;
+};
+
 export const shouldShowBYOKMissingKeyTopbar = (params: {
     license: OrganizationLicense | null;
     llmConfigStatus: LLMConfigStatus | null | undefined;

--- a/apps/web/src/features/ee/token-usage/page.tsx
+++ b/apps/web/src/features/ee/token-usage/page.tsx
@@ -77,14 +77,6 @@ export default async function TokenUsagePage({
 }: {
     searchParams: { [key: string]: string | string[] | undefined };
 }) {
-    const tokenUsagePageFeatureFlag = await isFeatureEnabled({
-        feature: FEATURE_FLAGS.tokenUsagePage,
-    });
-
-    if (!tokenUsagePageFeatureFlag) {
-        notFound();
-    }
-
     const params = await searchParams;
     const teamId = await getGlobalSelectedTeamId();
     const subscription = await validateOrganizationLicense({ teamId }).catch(

--- a/libs/identity/infrastructure/adapters/services/permissions/permissionsAbility.factory.ts
+++ b/libs/identity/infrastructure/adapters/services/permissions/permissionsAbility.factory.ts
@@ -97,7 +97,7 @@ export class PermissionsAbilityFactory {
                 canInRepo(Action.Create, ResourceType.KodyRules);
                 canInRepo(Action.Delete, ResourceType.KodyRules);
 
-                canInRepo(Action.Read, ResourceType.Cockpit);
+                canInRepo(Action.Read, ResourceType.Cockpit, {}, true);
 
                 canInOrg(Action.Read, ResourceType.Issues);
                 canInRepo(Action.Update, ResourceType.Issues);


### PR DESCRIPTION
#967 

---

<!-- kody-pr-summary:start -->
This pull request introduces and integrates an "Enterprise" plan status across the application to manage feature visibility and access.

Key changes include:

*   **Enterprise Plan Detection:** A new utility function, `isEnterprisePlan`, has been added to identify Enterprise subscriptions, including self-hosted and trial instances.
*   **Enterprise Status Propagation:** The `isEnterprise` status is now determined at the application's root layout and propagated through various providers, making it accessible via the `useSubscriptionStatus` context.
*   **Conditional Feature Visibility:**
    *   The SSO configuration option in the organization sidebar is now visible for both Enterprise and Trial plans.
    *   Activity Logs in the user navigation are now displayed exclusively for Enterprise and Trial plans, in addition to requiring read permissions.
*   **Token Usage Page Access:**
    *   The Token Usage page is no longer gated by a specific feature flag, simplifying its access control.
    *   Its visibility in the user navigation now solely depends on the user's permission to read logs.
*   **Permissions Update:** The "Cockpit" resource has been explicitly marked as an Enterprise feature within the permissions system.
<!-- kody-pr-summary:end -->