### PR TITLE
fix: preserve PR author when updating existing pull requests

### DIFF
--- a/libs/platformData/infrastructure/adapters/services/pullRequests.service.ts
+++ b/libs/platformData/infrastructure/adapters/services/pullRequests.service.ts
@@ -531,12 +531,7 @@ export class PullRequestsService implements IPullRequestsService {
             merged: this.extractMergedStatus(pullRequest),
             updatedAt: new Date().toISOString(),
             closedAt: this.extractClosedAt(pullRequest),
-            user: await this.extractUser(
-                pullRequest.user,
-                organizationAndTeamData,
-                platformType,
-                pullRequest?.number,
-            ),
+            user: existingPR.user,
             reviewers: await this.extractUsers(
                 (pullRequest.reviewers || pullRequest?.requested_reviewers) ??
                     enrichedPullRequest.reviewers,


### PR DESCRIPTION
#958 

---

<!-- kody-pr-summary:start -->
Preserves the author of a pull request when updating an existing pull request. Instead of re-extracting the author from the incoming pull request data, the author information from the `existingPR` object is now used, ensuring the original author is consistently maintained during updates.
<!-- kody-pr-summary:end -->