### PR TITLE
Fix/byok bedrock list and save

### DIFF
--- a/apps/web/src/features/ee/byok/_components/page.client.tsx
+++ b/apps/web/src/features/ee/byok/_components/page.client.tsx
@@ -21,6 +21,7 @@ import {
     ShieldCheckIcon,
     TrashIcon,
 } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { ConfirmModal } from "src/core/components/ui/confirm-modal";
 import { revalidateServerSidePath } from "src/core/utils/revalidate-server-side";
 
@@ -29,6 +30,23 @@ import { CuratedCatalog } from "./catalog/catalog";
 import { ConfiguredSummary } from "./configured-summary";
 
 type SlotState = "idle" | "editing";
+
+/**
+ * Providers represented in the curated catalog at
+ * `_data/curated-models.json`. Configs created against any other provider
+ * (Bedrock, Vertex, Novita) can't be re-rendered through the catalog UI,
+ * so editing them has to skip straight to the manual wizard.
+ */
+const CURATED_PROVIDERS = new Set([
+    "anthropic",
+    "openai",
+    "openai_compatible",
+    "google_gemini",
+    "openrouter",
+]);
+
+const isEditableInCatalog = (config: BYOKConfig | undefined): boolean =>
+    !!config && CURATED_PROVIDERS.has(config.provider);
 
 const providerLabel = (providerId?: string) => {
     switch (providerId) {
@@ -143,12 +161,32 @@ export const ByokPageClient = ({
     config: { main: BYOKConfig; fallback: BYOKConfig } | null | undefined;
     llmConfigStatus: LLMConfigStatus | null;
 }) => {
+    const router = useRouter();
     const [mainState, setMainState] = useState<SlotState>(
         config?.main ? "idle" : "editing",
     );
     const [fallbackState, setFallbackState] = useState<SlotState>("idle");
     const [isDeletingMain, setIsDeletingMain] = useState(false);
     const [isDeletingFallback, setIsDeletingFallback] = useState(false);
+
+    /**
+     * The catalog UI only knows how to render configs whose provider is in
+     * CURATED_PROVIDERS. For Bedrock/Vertex/Novita configs, going through
+     * the catalog would force the user to hunt for the "Configure manually"
+     * link at the bottom every single edit — bypass it.
+     */
+    const handleEdit = (slot: "main" | "fallback") => {
+        const slotConfig = slot === "main" ? config?.main : config?.fallback;
+        if (slotConfig && !isEditableInCatalog(slotConfig)) {
+            router.push(`/organization/byok/manual?slot=${slot}`);
+            return;
+        }
+        if (slot === "main") {
+            setMainState("editing");
+        } else {
+            setFallbackState("editing");
+        }
+    };
 
     const envIsActiveSource = llmConfigStatus?.source === "env";
     const showEnvNotice =
@@ -311,7 +349,7 @@ export const ByokPageClient = ({
                         <ConfiguredSummary
                             config={config.main}
                             isDeleting={isDeletingMain}
-                            onChange={() => setMainState("editing")}
+                            onChange={() => handleEdit("main")}
                             onDelete={onDeleteMain}
                         />
                     ) : (
@@ -340,7 +378,7 @@ export const ByokPageClient = ({
                             <ConfiguredSummary
                                 config={config.fallback}
                                 isDeleting={isDeletingFallback}
-                                onChange={() => setFallbackState("editing")}
+                                onChange={() => handleEdit("fallback")}
                                 onDelete={onDeleteFallback}
                             />
                         ) : fallbackState === "idle" ? (

--- a/apps/web/src/features/ee/byok/manual/page.client.tsx
+++ b/apps/web/src/features/ee/byok/manual/page.client.tsx
@@ -119,11 +119,17 @@ export function ByokManualPageClient({
             openrouterAllowFallbacks:
                 existingConfig?.openrouterAllowFallbacks ?? null,
             vertexLocation: existingConfig?.vertexLocation ?? null,
-            awsBearerToken: existingConfig?.awsBearerToken ?? null,
-            awsAccessKeyId: existingConfig?.awsAccessKeyId ?? null,
-            awsSecretAccessKey: existingConfig?.awsSecretAccessKey ?? null,
+            // Sensitive Bedrock creds are stored encrypted server-side and
+            // returned masked, so we can't populate the inputs from
+            // existingConfig — that would re-submit the masked value and
+            // corrupt the stored secret. Leaving the fields empty mirrors
+            // the apiKey pattern (line 106): empty in the form means
+            // "keep existing", and the user only types when changing.
+            awsBearerToken: null,
+            awsAccessKeyId: null,
+            awsSecretAccessKey: null,
             awsRegion: existingConfig?.awsRegion ?? null,
-            awsSessionToken: existingConfig?.awsSessionToken ?? null,
+            awsSessionToken: null,
         },
     });
 
@@ -131,6 +137,21 @@ export function ByokManualPageClient({
     const provider = form.watch("provider");
     const model = form.watch("model");
     const apiKey = form.watch("apiKey");
+    const awsBearerToken = form.watch("awsBearerToken");
+    const awsAccessKeyId = form.watch("awsAccessKeyId");
+    const awsSecretAccessKey = form.watch("awsSecretAccessKey");
+
+    // Bedrock has no apiKey field; "creds entered" means either a bearer
+    // token or the IAM access key + secret pair. Used to gate the "Test"
+    // button — without this, the button stays disabled forever on Bedrock
+    // because apiKey is always empty for that provider.
+    const hasCredsForTest =
+        provider === "amazon_bedrock"
+            ? !!(
+                  awsBearerToken?.trim() ||
+                  (awsAccessKeyId?.trim() && awsSecretAccessKey?.trim())
+              )
+            : !!apiKey?.trim();
 
     const resetTestOnChange = () => {
         if (testState.status !== "idle") setTestState({ status: "idle" });
@@ -500,7 +521,7 @@ export function ByokManualPageClient({
                             loading={testing}
                             disabled={
                                 !isValid ||
-                                !apiKey?.trim() ||
+                                !hasCredsForTest ||
                                 isSaving ||
                                 !model?.trim()
                             }

--- a/apps/worker/src/worker.module.ts
+++ b/apps/worker/src/worker.module.ts
@@ -18,6 +18,7 @@ import { LangfuseShutdownProvider } from '@libs/core/log/langfuse-shutdown.provi
 import { LoggerWrapperService } from '@libs/core/log/loggerWrapper.service';
 import { OutboxRelayService } from '@libs/core/workflow/infrastructure/outbox-relay.service';
 import { WorkflowModule } from '@libs/core/workflow/modules/workflow.module';
+import { OrganizationModule } from '@libs/organization/modules/organization.module';
 import { PlatformModule } from '@libs/platform/modules/platform.module';
 import { SharedMongoModule } from '@libs/shared/database/shared-mongo.module';
 import { SharedPostgresModule } from '@libs/shared/database/shared-postgres.module';
@@ -92,9 +93,13 @@ export class WorkerModule {
                 // Postgres for cockpit warehouse queries used by the
                 // weekly-recap cron.
                 SharedPostgresModule.forRoot({ poolSize: 4 }),
-                // Cockpit pulls in EmailModule + UserModule + OrganizationModule
-                // (used by SendWeeklyRecapUseCase to render and dispatch emails).
+                // Cockpit pulls in EmailModule + UserModule for the
+                // SendWeeklyRecapUseCase email rendering. OrganizationModule
+                // is imported separately because the WeeklyRecapCron itself
+                // injects ORGANIZATION_SERVICE_TOKEN to fan out across orgs,
+                // and CockpitModule doesn't re-export that token.
                 CockpitModule,
+                OrganizationModule,
             ],
             providers: [
                 WorkerDrainService,

--- a/libs/organization/application/use-cases/organizationParameters/create-or-update.use-case.ts
+++ b/libs/organization/application/use-cases/organizationParameters/create-or-update.use-case.ts
@@ -1,4 +1,4 @@
-import { BYOKConfig } from '@kodus/kodus-common/llm';
+import { BYOKConfig, BYOKProvider } from '@kodus/kodus-common/llm';
 import { encrypt } from '@libs/common/utils/crypto';
 import { OrganizationParametersKey } from '@libs/core/domain/enums';
 import { IUseCase } from '@libs/core/domain/interfaces/use-case.interface';
@@ -166,38 +166,94 @@ export class CreateOrUpdateOrganizationParametersUseCase implements IUseCase {
             throw new Error('At least main or fallback config is required');
         }
 
-        let encryptedMain = null;
-        if (byokConfig.main) {
-            if (!byokConfig.main.apiKey && !existingConfig?.main?.apiKey) {
-                throw new Error('apiKey is required for main BYOK config');
-            }
-            encryptedMain = {
-                ...byokConfig.main,
-                apiKey: byokConfig.main.apiKey
-                    ? encrypt(byokConfig.main.apiKey)
-                    : existingConfig!.main.apiKey,
-            };
-        }
+        const encryptedMain = byokConfig.main
+            ? this.encryptSlot('main', byokConfig.main, existingConfig?.main)
+            : null;
 
-        let encryptedFallback = null;
-        if (byokConfig.fallback) {
-            if (
-                !byokConfig.fallback.apiKey &&
-                !existingConfig?.fallback?.apiKey
-            ) {
-                throw new Error('apiKey is required for fallback BYOK config');
-            }
-            encryptedFallback = {
-                ...byokConfig.fallback,
-                apiKey: byokConfig.fallback.apiKey
-                    ? encrypt(byokConfig.fallback.apiKey)
-                    : existingConfig!.fallback!.apiKey,
-            };
-        }
+        const encryptedFallback = byokConfig.fallback
+            ? this.encryptSlot(
+                  'fallback',
+                  byokConfig.fallback,
+                  existingConfig?.fallback,
+              )
+            : null;
 
         return {
             ...(encryptedMain && { main: encryptedMain }),
             ...(encryptedFallback && { fallback: encryptedFallback }),
         };
+    }
+
+    /**
+     * Encrypt the sensitive credential fields for a single BYOK slot
+     * (main or fallback). Bedrock uses AWS auth fields instead of a
+     * single apiKey; everything else uses apiKey. In both cases, an
+     * empty incoming field falls back to whatever is already persisted
+     * — so partial edits (e.g. changing only the model) don't require
+     * the user to re-enter their credentials.
+     */
+    private encryptSlot(
+        slot: 'main' | 'fallback',
+        next: BYOKConfig['main'],
+        existing?: BYOKConfig['main'],
+    ): BYOKConfig['main'] {
+        if (next.provider === BYOKProvider.AMAZON_BEDROCK) {
+            // Bedrock has two auth paths and the user only needs to
+            // satisfy one: bearer token (recommended) OR static IAM
+            // credentials (awsAccessKeyId + awsSecretAccessKey, with
+            // optional awsSessionToken). On edit we accept either path
+            // being satisfied by previously-persisted values.
+            const hasBearer =
+                !!next.awsBearerToken?.trim() || !!existing?.awsBearerToken;
+            const hasIam =
+                (!!next.awsAccessKeyId?.trim() ||
+                    !!existing?.awsAccessKeyId) &&
+                (!!next.awsSecretAccessKey?.trim() ||
+                    !!existing?.awsSecretAccessKey);
+
+            if (!hasBearer && !hasIam) {
+                throw new Error(
+                    `Bedrock ${slot} BYOK config requires either awsBearerToken or awsAccessKeyId + awsSecretAccessKey`,
+                );
+            }
+
+            return {
+                ...next,
+                awsBearerToken: this.encryptOrKeep(
+                    next.awsBearerToken,
+                    existing?.awsBearerToken,
+                ),
+                awsAccessKeyId: this.encryptOrKeep(
+                    next.awsAccessKeyId,
+                    existing?.awsAccessKeyId,
+                ),
+                awsSecretAccessKey: this.encryptOrKeep(
+                    next.awsSecretAccessKey,
+                    existing?.awsSecretAccessKey,
+                ),
+                awsSessionToken: this.encryptOrKeep(
+                    next.awsSessionToken,
+                    existing?.awsSessionToken,
+                ),
+            };
+        }
+
+        if (!next.apiKey && !existing?.apiKey) {
+            throw new Error(`apiKey is required for ${slot} BYOK config`);
+        }
+
+        return {
+            ...next,
+            apiKey: next.apiKey ? encrypt(next.apiKey) : existing!.apiKey,
+        };
+    }
+
+    private encryptOrKeep(
+        incoming: string | undefined,
+        existing: string | undefined,
+    ): string | undefined {
+        const trimmed = incoming?.trim();
+        if (trimmed) return encrypt(trimmed);
+        return existing;
     }
 }

--- a/libs/organization/application/use-cases/organizationParameters/find-by-key.use-case.ts
+++ b/libs/organization/application/use-cases/organizationParameters/find-by-key.use-case.ts
@@ -36,7 +36,11 @@ export class FindByKeyOrganizationParametersUseCase implements IUseCase {
                 return null;
             }
 
-            // Process BYOK configuration by masking API keys
+            // Process BYOK configuration by masking sensitive credential
+            // fields (apiKey for non-Bedrock providers, awsBearerToken /
+            // awsAccessKeyId / awsSecretAccessKey / awsSessionToken for
+            // Bedrock). Bedrock configs have no apiKey, so the gating
+            // check has to consider the AWS fields as well.
             if (
                 organizationParametersKey ===
                 OrganizationParametersKey.BYOK_CONFIG
@@ -46,39 +50,24 @@ export class FindByKeyOrganizationParametersUseCase implements IUseCase {
                 if (
                     configValue &&
                     typeof configValue === 'object' &&
-                    (configValue.main?.apiKey || configValue.fallback?.apiKey)
+                    (this.slotHasSecrets(configValue.main) ||
+                        this.slotHasSecrets(configValue.fallback))
                 ) {
                     try {
                         const processedConfig = { ...configValue };
 
-                        // Process main if it exists and has apiKey
-                        if (configValue.main?.apiKey) {
-                            const decryptedMainApiKey = decrypt(
-                                configValue.main.apiKey,
+                        if (configValue.main) {
+                            processedConfig.main = this.maskSlotSecrets(
+                                configValue.main,
                             );
-                            const maskedMainApiKey =
-                                this.maskApiKey(decryptedMainApiKey);
-
-                            processedConfig.main = {
-                                ...configValue.main,
-                                apiKey: maskedMainApiKey,
-                            };
                         } else {
                             processedConfig.main = null;
                         }
 
-                        if (configValue.fallback?.apiKey) {
-                            const decryptedFallbackApiKey = decrypt(
-                                configValue.fallback.apiKey,
+                        if (configValue.fallback) {
+                            processedConfig.fallback = this.maskSlotSecrets(
+                                configValue.fallback,
                             );
-                            const maskedFallbackApiKey = this.maskApiKey(
-                                decryptedFallbackApiKey,
-                            );
-
-                            processedConfig.fallback = {
-                                ...configValue.fallback,
-                                apiKey: maskedFallbackApiKey,
-                            };
                         } else {
                             processedConfig.fallback = null;
                         }
@@ -91,7 +80,7 @@ export class FindByKeyOrganizationParametersUseCase implements IUseCase {
                         };
                     } catch (error) {
                         this.logger.error({
-                            message: 'Error decrypting API key',
+                            message: 'Error decrypting BYOK credentials',
                             context:
                                 FindByKeyOrganizationParametersUseCase.name,
                             error: error,
@@ -136,5 +125,36 @@ export class FindByKeyOrganizationParametersUseCase implements IUseCase {
         const firstTwo = apiKey.substring(0, 2);
         const lastThree = apiKey.substring(apiKey.length - 3);
         return `${firstTwo}...${lastThree}`;
+    }
+
+    /**
+     * Names of the encrypted credential fields on a BYOK slot. apiKey
+     * covers OpenAI/Anthropic/Gemini/OpenRouter/Novita/Vertex (SA JSON);
+     * the aws* fields cover Amazon Bedrock's two auth paths.
+     */
+    private static readonly SECRET_FIELDS = [
+        'apiKey',
+        'awsBearerToken',
+        'awsAccessKeyId',
+        'awsSecretAccessKey',
+        'awsSessionToken',
+    ] as const;
+
+    private slotHasSecrets(slot: any): boolean {
+        if (!slot || typeof slot !== 'object') return false;
+        return FindByKeyOrganizationParametersUseCase.SECRET_FIELDS.some(
+            (field) => typeof slot[field] === 'string' && slot[field],
+        );
+    }
+
+    private maskSlotSecrets(slot: any): any {
+        const masked: Record<string, any> = { ...slot };
+        for (const field of FindByKeyOrganizationParametersUseCase.SECRET_FIELDS) {
+            const value = slot[field];
+            if (typeof value === 'string' && value) {
+                masked[field] = this.maskApiKey(decrypt(value));
+            }
+        }
+        return masked;
     }
 }

--- a/libs/organization/application/use-cases/organizationParameters/get-models-by-provider.use-case.ts
+++ b/libs/organization/application/use-cases/organizationParameters/get-models-by-provider.use-case.ts
@@ -99,11 +99,81 @@ export class GetModelsByProviderUseCase {
                         'https://api.openai.com',
                 );
 
+            case BYOKProvider.AMAZON_BEDROCK:
+                return this.getBedrockModels();
+
             default:
                 throw new BadRequestException(
                     `Unsupported provider: ${provider}`,
                 );
         }
+    }
+
+    /**
+     * Bedrock model IDs are region-scoped and cross-region inference
+     * profiles vary by AWS account. We can't list them generically without
+     * the user's AWS credentials (which are entered later in the wizard),
+     * so this returns a curated set of "us.*" cross-region inference
+     * profiles that cover the most common code-review use cases.
+     *
+     * Users on eu/apac regions or with custom inference profiles can still
+     * paste a model ID manually — the frontend allows free-form input on
+     * the Bedrock model field.
+     */
+    private getBedrockModels(): ModelResponse {
+        // Lookup by the Anthropic-style suffix (everything after
+        // "us.anthropic.") so we still pick up reasoning config from
+        // getModelCapabilities even though the catalog ID is prefixed.
+        const reasoningKeyOf = (id: string): string => {
+            const match = id.match(/^[a-z]{2,5}\.anthropic\.(.+?)-v\d+:\d+$/);
+            return match ? match[1] : id;
+        };
+
+        const catalog: Array<{ id: string; name: string }> = [
+            {
+                id: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+                name: 'Claude Sonnet 4.5 (us, cross-region)',
+            },
+            {
+                id: 'us.anthropic.claude-sonnet-4-20250514-v1:0',
+                name: 'Claude Sonnet 4 (us, cross-region)',
+            },
+            {
+                id: 'us.anthropic.claude-opus-4-1-20250805-v1:0',
+                name: 'Claude Opus 4.1 (us, cross-region)',
+            },
+            {
+                id: 'us.anthropic.claude-opus-4-20250514-v1:0',
+                name: 'Claude Opus 4 (us, cross-region)',
+            },
+            {
+                id: 'us.anthropic.claude-3-7-sonnet-20250219-v1:0',
+                name: 'Claude 3.7 Sonnet (us, cross-region)',
+            },
+            {
+                id: 'us.anthropic.claude-3-5-sonnet-20241022-v2:0',
+                name: 'Claude 3.5 Sonnet v2 (us, cross-region)',
+            },
+            {
+                id: 'us.anthropic.claude-3-5-haiku-20241022-v1:0',
+                name: 'Claude 3.5 Haiku (us, cross-region)',
+            },
+        ];
+
+        return {
+            provider: BYOKProvider.AMAZON_BEDROCK,
+            models: catalog.map(({ id, name }) => {
+                const capabilities = getModelCapabilities(reasoningKeyOf(id));
+                return {
+                    id,
+                    name,
+                    ...(capabilities.supportsReasoning && {
+                        supportsReasoning: true,
+                        reasoningConfig: capabilities.reasoningConfig,
+                    }),
+                };
+            }),
+        };
     }
 
     private async getOpenAIModels(apiKey?: string): Promise<ModelResponse> {

--- a/test/unit/byok/bedrock-byok-config.spec.ts
+++ b/test/unit/byok/bedrock-byok-config.spec.ts
@@ -1,0 +1,177 @@
+import { BYOKProvider } from '@kodus/kodus-common/llm';
+
+// Encryption is irrelevant to the validation/fallback logic we want to
+// pin down — we just need a deterministic, reversible stand-in so we can
+// assert that encrypted fields were actually transformed (and that the
+// fallback-to-existing path skipped encryption).
+jest.mock('@libs/common/utils/crypto', () => ({
+    encrypt: (value: string) => `enc(${value})`,
+    decrypt: (value: string) => value.replace(/^enc\(|\)$/g, ''),
+}));
+
+import { CreateOrUpdateOrganizationParametersUseCase } from '@libs/organization/application/use-cases/organizationParameters/create-or-update.use-case';
+
+/**
+ * Constructs the use case with no-op dependencies so we can exercise the
+ * pure encryption/validation logic on `encryptSlot`. We bypass the
+ * private modifier with `as any` — this is the project convention for
+ * testing private methods on services.
+ */
+function buildUseCase(): CreateOrUpdateOrganizationParametersUseCase {
+    return new CreateOrUpdateOrganizationParametersUseCase(
+        {} as any,
+        {} as any,
+        {} as any,
+    );
+}
+
+describe('CreateOrUpdateOrganizationParametersUseCase — BYOK encryption', () => {
+    const callSlot = (
+        slot: 'main' | 'fallback',
+        next: any,
+        existing?: any,
+    ) => (buildUseCase() as any).encryptSlot(slot, next, existing);
+
+    describe('Amazon Bedrock', () => {
+        it('encrypts the bearer token on first save', () => {
+            const result = callSlot('main', {
+                provider: BYOKProvider.AMAZON_BEDROCK,
+                model: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+                awsBearerToken: 'ABSK-real-token',
+                awsRegion: 'us-east-1',
+            });
+
+            expect(result.awsBearerToken).toBe('enc(ABSK-real-token)');
+            expect(result.awsRegion).toBe('us-east-1');
+            expect(result.awsAccessKeyId).toBeUndefined();
+            expect(result.awsSecretAccessKey).toBeUndefined();
+        });
+
+        it('encrypts IAM credentials when bearer token is absent', () => {
+            const result = callSlot('main', {
+                provider: BYOKProvider.AMAZON_BEDROCK,
+                model: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+                awsAccessKeyId: 'AKIA-id',
+                awsSecretAccessKey: 'aws-secret',
+                awsSessionToken: 'aws-session',
+                awsRegion: 'us-east-1',
+            });
+
+            expect(result.awsAccessKeyId).toBe('enc(AKIA-id)');
+            expect(result.awsSecretAccessKey).toBe('enc(aws-secret)');
+            expect(result.awsSessionToken).toBe('enc(aws-session)');
+            expect(result.awsBearerToken).toBeUndefined();
+        });
+
+        it('throws when no AWS auth path is provided on first save', () => {
+            expect(() =>
+                callSlot('main', {
+                    provider: BYOKProvider.AMAZON_BEDROCK,
+                    model: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+                    awsRegion: 'us-east-1',
+                }),
+            ).toThrow(
+                /Bedrock main BYOK config requires either awsBearerToken or awsAccessKeyId \+ awsSecretAccessKey/,
+            );
+        });
+
+        it('throws when only the access key id is provided (missing secret)', () => {
+            expect(() =>
+                callSlot('main', {
+                    provider: BYOKProvider.AMAZON_BEDROCK,
+                    model: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+                    awsAccessKeyId: 'AKIA-id',
+                    awsRegion: 'us-east-1',
+                }),
+            ).toThrow(
+                /Bedrock main BYOK config requires either awsBearerToken or awsAccessKeyId \+ awsSecretAccessKey/,
+            );
+        });
+
+        it('keeps existing credentials when the user only edits non-secret fields', () => {
+            const existing = {
+                provider: BYOKProvider.AMAZON_BEDROCK,
+                model: 'us.anthropic.claude-3-5-sonnet-20241022-v2:0',
+                awsBearerToken: 'enc(ABSK-stored)',
+                awsRegion: 'us-east-1',
+            };
+
+            const result = callSlot(
+                'main',
+                {
+                    provider: BYOKProvider.AMAZON_BEDROCK,
+                    model: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+                    awsRegion: 'us-east-1',
+                },
+                existing,
+            );
+
+            expect(result.awsBearerToken).toBe('enc(ABSK-stored)');
+            expect(result.model).toBe(
+                'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+            );
+        });
+
+        it('replaces only the field the user actually re-entered', () => {
+            const existing = {
+                provider: BYOKProvider.AMAZON_BEDROCK,
+                model: 'us.anthropic.claude-3-5-sonnet-20241022-v2:0',
+                awsAccessKeyId: 'enc(AKIA-old)',
+                awsSecretAccessKey: 'enc(secret-old)',
+                awsRegion: 'us-east-1',
+            };
+
+            const result = callSlot(
+                'main',
+                {
+                    provider: BYOKProvider.AMAZON_BEDROCK,
+                    model: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+                    awsAccessKeyId: 'AKIA-new',
+                    awsRegion: 'us-east-1',
+                },
+                existing,
+            );
+
+            expect(result.awsAccessKeyId).toBe('enc(AKIA-new)');
+            expect(result.awsSecretAccessKey).toBe('enc(secret-old)');
+        });
+    });
+
+    describe('non-Bedrock providers (regression)', () => {
+        it('still requires apiKey on first save', () => {
+            expect(() =>
+                callSlot('main', {
+                    provider: BYOKProvider.ANTHROPIC,
+                    model: 'claude-sonnet-4-5-20250929',
+                }),
+            ).toThrow(/apiKey is required for main BYOK config/);
+        });
+
+        it('encrypts the apiKey when provided', () => {
+            const result = callSlot('main', {
+                provider: BYOKProvider.ANTHROPIC,
+                model: 'claude-sonnet-4-5-20250929',
+                apiKey: 'sk-ant-real',
+            });
+
+            expect(result.apiKey).toBe('enc(sk-ant-real)');
+        });
+
+        it('keeps the existing apiKey on partial edit', () => {
+            const result = callSlot(
+                'main',
+                {
+                    provider: BYOKProvider.ANTHROPIC,
+                    model: 'claude-sonnet-4-5-20250929',
+                },
+                {
+                    provider: BYOKProvider.ANTHROPIC,
+                    model: 'claude-3-5-sonnet-20241022',
+                    apiKey: 'enc(sk-ant-stored)',
+                },
+            );
+
+            expect(result.apiKey).toBe('enc(sk-ant-stored)');
+        });
+    });
+});


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces comprehensive support for Amazon Bedrock as a Bring Your Own Key (BYOK) provider, enhancing both the user experience and the backend handling of sensitive credentials.

Key changes include:

*   **Improved BYOK Configuration Workflow**:
    *   When editing BYOK configurations for providers not supported by the curated catalog UI (e.g., Amazon Bedrock, Vertex AI, Novita), users are now directly navigated to the manual configuration wizard, streamlining the editing process.
    *   A curated list of common Amazon Bedrock models is now provided in the BYOK configuration UI, simplifying model selection while still allowing manual input for custom or region-specific models.

*   **Secure Handling of Bedrock Credentials**:
    *   Sensitive Amazon Bedrock credentials (bearer token, AWS access key ID, secret access key, session token) are no longer pre-filled in the manual configuration form when editing. This prevents accidental overwriting of encrypted credentials stored on the server.
    *   The "Test" button in the manual configuration wizard now correctly validates the presence of Bedrock-specific AWS credentials (bearer token or IAM keys) to enable testing.
    *   Backend logic has been updated to properly encrypt and validate Bedrock's multiple authentication methods. When editing, existing Bedrock credentials are preserved if not explicitly re-entered by the user.
    *   Credential masking has been extended to include Bedrock-specific fields, ensuring sensitive information is not exposed when BYOK configurations are retrieved.

*   **Dependency Resolution**:
    *   The `OrganizationModule` is now correctly imported in the worker context, ensuring necessary services are available for cron jobs like the weekly recap.

*   **Robust Testing**:
    *   New unit tests have been added to verify the correct encryption, validation, and preservation of Amazon Bedrock BYOK credentials, as well as to confirm that existing logic for other providers remains functional.
<!-- kody-pr-summary:end -->