### PR TITLE
fix(web/cockpit): drop duplicate \`params\` declaration in analyticsF…

### DIFF
--- a/apps/web/src/features/ee/cockpit/_services/analytics/utils.ts
+++ b/apps/web/src/features/ee/cockpit/_services/analytics/utils.ts
@@ -113,12 +113,6 @@ export const analyticsFetch = async <Data>(
             'kodus-analytics-service';
     }
 
-    const params = {
-        ...options.params,
-        organizationId,
-        ...(selectedRepository && { repository: selectedRepository }),
-    };
-
     // Analytics service is intra-network — http + port, no heuristics.
     const finalUrl = createUrl(`${hostName}`, port, `/api${url}`, {
         internal: true,


### PR DESCRIPTION
…etch

After the cockpit-source resolver was added, \`params\` was hoisted above the \`if (source === 'internal')\` branch so both paths could reuse it, but the original declaration inside the legacy branch was left behind. SWC's strict-mode parser correctly flagged "Identifier 'params' has already been declared" and webpack failed the production build.

The two declarations were identical, so the legacy-branch one is just dead duplication. Removed.

---

<!-- kody-pr-summary:start -->
Removed a duplicate `params` declaration within the `analyticsFetch` utility function in the web cockpit's analytics services. This change cleans up the code by eliminating redundant parameter construction.
<!-- kody-pr-summary:end -->