### PR TITLE
ci: tell Trivy to scan the arm64 manifest on arm64-only release builds

### DIFF
--- a/.github/workflows/prod-build-push-and-pr-green.yml
+++ b/.github/workflows/prod-build-push-and-pr-green.yml
@@ -27,6 +27,12 @@ env:
         github.sha }}
     BUILDX_PLATFORMS: linux/arm64
     BUILDX_CACHE_SCOPE: kodus-ai-arm64
+    # The runner is linux/amd64 but our images are pushed arm64-only.
+    # Without this, Trivy tries to resolve a child manifest for its own
+    # platform inside the manifest list and fails with "no child with
+    # platform linux/amd64". Trivy CLI picks up `TRIVY_PLATFORM` env to
+    # mean `--platform`, so all three scan steps inherit it.
+    TRIVY_PLATFORM: linux/arm64
 
     # ECR repositories (required)
     ECR_REPOSITORY_API: ${{ vars.ECR_REPOSITORY_API }}

--- a/.github/workflows/qa-build-push-and-pr-green.yml
+++ b/.github/workflows/qa-build-push-and-pr-green.yml
@@ -34,6 +34,12 @@ env:
     IMAGE_TAG: ${{ github.event.inputs.image_tag || github.sha }}
     BUILDX_PLATFORMS: linux/arm64
     BUILDX_CACHE_SCOPE: kodus-ai-arm64
+    # The runner is linux/amd64 but our images are pushed arm64-only.
+    # Without this, Trivy tries to resolve a child manifest for its own
+    # platform inside the manifest list and fails with "no child with
+    # platform linux/amd64". Trivy CLI picks up `TRIVY_PLATFORM` env to
+    # mean `--platform`, so all three scan steps inherit it.
+    TRIVY_PLATFORM: linux/arm64
 
     # ECR repositories (required)
     ECR_REPOSITORY_API: ${{ vars.ECR_REPOSITORY_API }}


### PR DESCRIPTION
Backend prod and QA workflows publish arm64-only images (BUILDX_PLATFORMS: linux/arm64, since the workloads run on Graviton). The Trivy step runs on a linux/amd64 GHA runner, and by default it resolves the child manifest matching its own platform — which doesn't exist in our manifest list — and fails with:

    remote error: no child with platform linux/amd64 in index ...

Set `TRIVY_PLATFORM: linux/arm64` at the workflow env level so all three Trivy scans (api / webhooks / worker) explicitly request the arm64 child manifest. The Trivy CLI translates `TRIVY_PLATFORM` into `--platform` automatically.

Multi-arch workflows (selfhosted, rabbitmq) and web (built natively on the amd64 runner) don't need this — only the two ARM-only ones.

---

<!-- kody-pr-summary:start -->
Configures the CI/CD workflows for production and QA environments to explicitly instruct Trivy to scan `linux/arm64` manifests. This change addresses an issue where Trivy scans were failing because the `linux/amd64` GitHub Actions runners were attempting to resolve an `amd64` manifest, while the built container images are exclusively `linux/arm64`. By setting `TRIVY_PLATFORM: linux/arm64`, Trivy will now correctly target and scan the available `arm64` image manifests.
<!-- kody-pr-summary:end -->