### PR TITLE
Fix/deploy improviment

### DIFF
--- a/apps/web/src/app/api/proxy/_lib/create-proxy-handler.ts
+++ b/apps/web/src/app/api/proxy/_lib/create-proxy-handler.ts
@@ -126,6 +126,25 @@ async function forward(
     const headers = new Headers(req.headers);
     headers.delete("host");
 
+    // Hop-by-hop headers (RFC 7230 §6.1) must not be forwarded by a
+    // proxy. The AWS ALB adds `Connection: upgrade` to every request,
+    // and forwarding it makes undici (Node's fetch) blow up with
+    // `UND_ERR_INVALID_ARG: invalid connection header`, killing every
+    // /api/proxy/* call with a TypeError. Stripping the full RFC list
+    // also covers any future hop-by-hop quirk an upstream LB might add.
+    for (const h of [
+        "connection",
+        "keep-alive",
+        "proxy-authenticate",
+        "proxy-authorization",
+        "te",
+        "trailer",
+        "transfer-encoding",
+        "upgrade",
+    ]) {
+        headers.delete(h);
+    }
+
     if (options.resolveBearerToken) {
         const token = await options.resolveBearerToken(req);
         if (token) headers.set("Authorization", `Bearer ${token}`);

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,12 +17,13 @@ ENV API_DEVELOPMENT_MODE=false
 ENV RELEASE_VERSION=${RELEASE_VERSION}
 ENV SENTRY_RELEASE=${RELEASE_VERSION}
 
-# Yarn1's default HTTP timeout is 30s, which is too tight for slow paths to
+# Yarn1's default HTTP timeout is 30s, too tight for slow paths to
 # registry.npmjs.org from the GitHub Actions runners — a single laggy
-# tarball (e.g. date-fns) can blow the whole `yarn install` after 4 retries
-# and abort the bake. 10 minutes covers realistic transient slowness; if
-# the registry is genuinely down we want to fail fast on a re-run anyway.
-ENV YARN_HTTP_TIMEOUT=600000
+# tarball (e.g. date-fns) blows the whole `yarn install` after 4 retries
+# and aborts the bake. Yarn1 honours `network-timeout` from `.yarnrc`
+# (NOT the env var; YARN_HTTP_TIMEOUT does nothing on yarn1), so set it
+# globally here. Inherited by `deps` and `prod-deps` since they FROM base.
+RUN echo 'network-timeout 600000' > /root/.yarnrc
 
 # apt cache mounts persist /var/cache/apt and /var/lib/apt across builds so
 # repeated apt-get runs don't re-download the same .deb packages. The

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -10,9 +10,9 @@ ARG RELEASE_VERSION=local
 ENV RELEASE_VERSION=${RELEASE_VERSION}
 
 # Yarn1's default 30s tarball timeout is too tight for slow paths to
-# registry.npmjs.org from the GHA runners — see docker/Dockerfile for the
-# full rationale. Same fix applies here.
-ENV YARN_HTTP_TIMEOUT=600000
+# registry.npmjs.org from the GHA runners. yarn1 reads `network-timeout`
+# from `.yarnrc` (the YARN_HTTP_TIMEOUT env var does NOT exist on yarn1).
+RUN echo 'network-timeout 600000' > /root/.yarnrc
 
 COPY package.json yarn.lock ./
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces improvements to deployment and proxy handling:

*   **Enhance API Proxy Stability**: Hop-by-hop headers (e.g., `Connection: upgrade` from AWS ALB) are now explicitly removed from forwarded requests in the API proxy handler. This prevents `undici` (Node's fetch) from encountering `UND_ERR_INVALID_ARG` errors, ensuring `/api/proxy/*` calls function correctly.
*   **Improve Docker Build Reliability**: The Yarn 1 network timeout is now correctly configured in the Dockerfiles by writing `network-timeout 600000` to `/root/.yarnrc`. This addresses an issue where the `YARN_HTTP_TIMEOUT` environment variable was not honored by Yarn 1, preventing `yarn install` failures due to slow package downloads during builds.
<!-- kody-pr-summary:end -->