### PR TITLE
Here's the commit message I'll use:

### DIFF
--- a/apps/web/src/core/utils/kody-rules/match-file-against-rules.ts
+++ b/apps/web/src/core/utils/kody-rules/match-file-against-rules.ts
@@ -1,4 +1,4 @@
-import { minimatch } from "minimatch";
+import minimatch from "minimatch";
 
 /**
  * Tests whether a rule's `path` glob (or comma-separated globs) matches

--- a/libs/code-review/pipeline/stages/validate-prerequisites.stage.spec.ts
+++ b/libs/code-review/pipeline/stages/validate-prerequisites.stage.spec.ts
@@ -384,4 +384,69 @@ describe('ValidatePrerequisitesStage', () => {
             expect(result.statusInfo?.status).not.toBe(AutomationStatus.SKIPPED);
         });
     });
+
+    describe('auto-assign license with automatedReviewActive disabled', () => {
+        beforeEach(() => {
+            jest.spyOn(stage as any, 'isAutomatedReviewActive').mockResolvedValue(false);
+            mockParametersService.findByKey.mockResolvedValue({
+                configValue: {
+                    configs: { showStatusFeedback: true },
+                    repositories: [],
+                },
+            });
+        });
+
+        it('should proceed with review when auto-assign succeeds even if automatedReviewActive is false', async () => {
+            const context = makeContext();
+            context.origin = 'opened';
+
+            mockPermissionValidationService.validateExecutionPermissions.mockResolvedValue({
+                allowed: false,
+                errorType: ValidationErrorType.USER_NOT_LICENSED,
+            });
+
+            mockAutoAssignLicenseUseCase.execute.mockResolvedValue({
+                shouldProceed: true,
+                reason: 'FREEBIE',
+            });
+
+            const result = await stage.execute(context);
+
+            expect(result.statusInfo?.status).not.toBe(AutomationStatus.SKIPPED);
+            expect(mockAutoAssignLicenseUseCase.execute).toHaveBeenCalled();
+        });
+
+        it('should skip review when auto-assign fails and automatedReviewActive is false', async () => {
+            const context = makeContext();
+            context.origin = 'opened';
+
+            mockPermissionValidationService.validateExecutionPermissions.mockResolvedValue({
+                allowed: false,
+                errorType: ValidationErrorType.USER_NOT_LICENSED,
+            });
+
+            mockAutoAssignLicenseUseCase.execute.mockResolvedValue({
+                shouldProceed: false,
+                reason: 'NOT_ELIGIBLE',
+            });
+
+            const result = await stage.execute(context);
+
+            expect(result.statusInfo?.status).toBe(AutomationStatus.SKIPPED);
+        });
+
+        it('should proceed with review when user has license even if automatedReviewActive is false', async () => {
+            const context = makeContext();
+            context.origin = 'opened';
+
+            mockPermissionValidationService.validateExecutionPermissions.mockResolvedValue({
+                allowed: true,
+                errorType: ValidationErrorType.NOT_ERROR,
+            });
+
+            const result = await stage.execute(context);
+
+            expect(result.statusInfo?.status).not.toBe(AutomationStatus.SKIPPED);
+        });
+    });
 });

--- a/libs/code-review/pipeline/stages/validate-prerequisites.stage.ts
+++ b/libs/code-review/pipeline/stages/validate-prerequisites.stage.ts
@@ -229,6 +229,19 @@ export class ValidatePrerequisitesStage extends BasePipelineStage<CodeReviewPipe
                         this.getLicenseSkipReason(validationResult.errorType),
                     ),
                 };
+
+                // handleValidationFailure already sent a license notification (for Azure/Bitbucket).
+                // Mark it so the handler doesn't send a generic "Skipped" message on top.
+                if (
+                    context.platformType === PlatformType.AZURE_REPOS ||
+                    context.platformType === PlatformType.BITBUCKET ||
+                    !showStatusFeedback
+                ) {
+                    if (!draft.pipelineMetadata) {
+                        draft.pipelineMetadata = {};
+                    }
+                    draft.pipelineMetadata.notificationHandled = true;
+                }
             });
         }
 

--- a/libs/code-review/pipeline/stages/validate-prerequisites.stage.ts
+++ b/libs/code-review/pipeline/stages/validate-prerequisites.stage.ts
@@ -203,6 +203,35 @@ export class ValidatePrerequisitesStage extends BasePipelineStage<CodeReviewPipe
             });
         }
 
+        // If validation failed due to USER_NOT_LICENSED, try auto-assign FIRST
+        // before checking autoReviewEnabled, so the "freebie" logic can work
+        // even when automatedReviewActive is false.
+        if (validationResult.errorType === ValidationErrorType.USER_NOT_LICENSED) {
+            const failureHandled = await this.handleValidationFailure(
+                context,
+                validationResult,
+                showStatusFeedback,
+            );
+
+            if (failureHandled === 'auto_assigned') {
+                return this.updateContext(context, (draft) => {
+                    applyShowStatusFeedbackMetadata(draft);
+                });
+            }
+
+            // Auto-assign didn't succeed (user not eligible), skip the autoReviewEnabled
+            // check and go straight to the final SKIP result below.
+            return this.updateContext(context, (draft) => {
+                applyShowStatusFeedbackMetadata(draft);
+                draft.statusInfo = {
+                    status: AutomationStatus.SKIPPED,
+                    message: StageMessageHelper.skippedWithReason(
+                        this.getLicenseSkipReason(validationResult.errorType),
+                    ),
+                };
+            });
+        }
+
         // If auto-review is disabled and this is not a command-triggered review,
         // skip silently without posting notifications (e.g. BYOK required).
         try {
@@ -228,18 +257,12 @@ export class ValidatePrerequisitesStage extends BasePipelineStage<CodeReviewPipe
             });
         }
 
-        // Validation failed
-        const failureHandled = await this.handleValidationFailure(
+        // Validation failed for other error types (non-USER_NOT_LICENSED)
+        await this.handleValidationFailure(
             context,
             validationResult,
             showStatusFeedback,
         );
-
-        if (failureHandled === 'auto_assigned') {
-            return this.updateContext(context, (draft) => {
-                applyShowStatusFeedbackMetadata(draft);
-            });
-        }
 
         return this.updateContext(context, (draft) => {
             applyShowStatusFeedbackMetadata(draft);


### PR DESCRIPTION
#970 

---

<!-- kody-pr-summary:start -->
This pull request modifies the `ValidatePrerequisitesStage` to ensure that license auto-assignment attempts are made even when the general automated review process is disabled.

Previously, if automated review was inactive, the system might skip a review for an unlicensed user without attempting to auto-assign a "freebie" license.

With this change:
*   When a user is identified as `USER_NOT_LICENSED`, the system will now first attempt to auto-assign a license.
*   If the auto-assignment is successful, the review will proceed.
*   If the auto-assignment fails, the review will be skipped.
*   This logic is executed before checking the `automatedReviewActive` flag, allowing the "freebie" license mechanism to function independently of the overall automated review status.
*   Reviews for users who already possess a license will continue to proceed as before, regardless of the `automatedReviewActive` setting.
<!-- kody-pr-summary:end -->