### PR TITLE
fix(web/proxy): pick internal-vs-public hop based on WEB_PORT_API

### DIFF
--- a/apps/web/src/core/utils/helpers.ts
+++ b/apps/web/src/core/utils/helpers.ts
@@ -41,9 +41,21 @@ export function pathToApiUrl(
     }
     const port = process.env.WEB_PORT_API;
 
-    // Web server talks to the API container over the internal Docker
-    // network — http + port, never https.
-    return createUrl(hostName, port, path, { internal: true });
+    // Two deployment shapes share this code path:
+    //   1. Docker compose / dev: WEB_HOSTNAME_API is an internal service
+    //      name (`kodus_api`) reached via http on WEB_PORT_API. Use the
+    //      explicit internal hop — no TLS, port required.
+    //   2. AWS QA/prod: WEB_HOSTNAME_API is a public domain (`qa.api.kodus.io`,
+    //      `app.api.kodus.io`) fronted by an ALB that only listens on 443
+    //      with TLS termination. WEB_PORT_API is not set in those envs.
+    //      Falling through to the heuristic path correctly produces an
+    //      `https://<host><path>` URL with no port.
+    //
+    // The presence/absence of WEB_PORT_API is the cleanest signal: a
+    // public ALB never has a port in the env, an internal compose service
+    // always does.
+    const isInternal = !!port;
+    return createUrl(hostName, port, path, { internal: isInternal });
 }
 
 /**


### PR DESCRIPTION
The runtime-config migration hard-coded \`internal: true\` on the server-side \`pathToApiUrl\`, assuming WEB_HOSTNAME_API was always an internal Docker service name. It is — in dev / docker-compose. But on AWS QA and prod it's a public domain (\`qa.api.kodus.io\`, \`app.api.kodus.io\`) fronted by an ALB that only listens on 443 with TLS termination.

Forcing \`internal\` produced \`http://qa.api.kodus.io/user/email\` (port 80, plain HTTP), which the ALB refuses → ECONNREFUSED on every /api/proxy/* call. With this fix:

  - WEB_PORT_API set (compose): internal hop, http + port, no heuristics.
  - WEB_PORT_API absent (QA/prod): heuristic path → https://host/path.

The signal — whether the env contains a port — is the cleanest discriminator we have without introducing a new variable. A public ALB never has a port; an internal compose service always does.

---

<!-- kody-pr-summary:start -->
Adjusts the logic for constructing API URLs to correctly differentiate between internal and public API endpoints based on the deployment environment.

Previously, the web server unconditionally treated API calls as internal. This update now uses the presence of the `WEB_PORT_API` environment variable as a signal:

*   If `WEB_PORT_API` is defined (e.g., in Docker Compose/development environments), API URLs are constructed for internal communication, typically using HTTP and the specified port.
*   If `WEB_PORT_API` is not defined (e.g., in AWS QA/production environments where an ALB fronts a public API domain), API URLs are constructed for public access, typically using HTTPS without an explicit port, allowing the system to correctly handle TLS termination and default ports.
<!-- kody-pr-summary:end -->