### PR TITLE
fix(web/proxy): make \`internal: true\` fall through when no port is set

### DIFF
--- a/apps/web/src/core/utils/helpers.spec.ts
+++ b/apps/web/src/core/utils/helpers.spec.ts
@@ -85,6 +85,31 @@ describe("createUrl", () => {
                 }),
             ).toBe("https://api.internal:8443/x");
         });
+
+        // Regression repro for the QA/prod AWS outage on 2026-04-28: every
+        // /api/proxy/* route hardcodes `internal: true`, but when the env
+        // points at a public ALB-fronted domain there's no WEB_PORT_*. We
+        // must NOT produce `http://<host>/path` (port 80, plain HTTP) —
+        // the ALB only listens on 443 with TLS termination, so the
+        // upstream rejects with ECONNREFUSED. With no port, the call has
+        // to fall through to the public-URL heuristic (https + no port).
+        it("production with internal flag and NO port → https, no port (AWS ALB)", () => {
+            const createUrl = loadCreateUrl({ nodeEnv: "production" });
+            expect(
+                createUrl("qa.api.kodus.io", undefined, "/user/email", {
+                    internal: true,
+                }),
+            ).toBe("https://qa.api.kodus.io/user/email");
+        });
+
+        it("self-hosted with internal flag and NO port → https, no port (customer domain)", () => {
+            const createUrl = loadCreateUrl({ nodeEnv: "self-hosted" });
+            expect(
+                createUrl("api.cliente.com", undefined, "/x", {
+                    internal: true,
+                }),
+            ).toBe("https://api.cliente.com/x");
+        });
     });
 
     describe("legacy heuristic (no `internal` flag) — kept for back-compat", () => {

--- a/apps/web/src/core/utils/helpers.ts
+++ b/apps/web/src/core/utils/helpers.ts
@@ -41,21 +41,11 @@ export function pathToApiUrl(
     }
     const port = process.env.WEB_PORT_API;
 
-    // Two deployment shapes share this code path:
-    //   1. Docker compose / dev: WEB_HOSTNAME_API is an internal service
-    //      name (`kodus_api`) reached via http on WEB_PORT_API. Use the
-    //      explicit internal hop — no TLS, port required.
-    //   2. AWS QA/prod: WEB_HOSTNAME_API is a public domain (`qa.api.kodus.io`,
-    //      `app.api.kodus.io`) fronted by an ALB that only listens on 443
-    //      with TLS termination. WEB_PORT_API is not set in those envs.
-    //      Falling through to the heuristic path correctly produces an
-    //      `https://<host><path>` URL with no port.
-    //
-    // The presence/absence of WEB_PORT_API is the cleanest signal: a
-    // public ALB never has a port in the env, an internal compose service
-    // always does.
-    const isInternal = !!port;
-    return createUrl(hostName, port, path, { internal: isInternal });
+    // `internal: true` is the caller saying "this is a same-cluster
+    // hop". `createUrl` honours that only when a port is set (Docker
+    // compose / dev). On AWS, no port is set and `createUrl` falls
+    // through to the public-domain heuristic (https, no port).
+    return createUrl(hostName, port, path, { internal: true });
 }
 
 /**
@@ -94,7 +84,14 @@ export function createUrl(
     const portPart = port ? `:${port}` : "";
 
     // Explicit internal hop: same-cluster http+port, no heuristics.
-    if (options?.internal) {
+    // We require BOTH `internal` AND a port to take this path. The
+    // proxy routes (billing, mcp, api/*) all set `internal: true`
+    // unconditionally, but on AWS QA/prod the env doesn't ship
+    // WEB_PORT_* (the upstream is a public domain fronted by an ALB
+    // that terminates TLS on 443). Without `port`, treat the call as a
+    // public-domain hop and fall through to the heuristic below — that
+    // produces `https://<host><path>`, which is what the ALB expects.
+    if (options?.internal && port) {
         return `${schemeOverride ?? "http"}://${hostName}${portPart}${path}`;
     }
 


### PR DESCRIPTION
Rather than patch each caller of \`createUrl({ internal: true })\` one proxy at a time (api → billing → mcp → analytics, …), fix the rule at the root: \`internal\` only takes the http+port shortcut when the env actually has a port. Without one, fall through to the public-URL heuristic (https, no port) — which is what AWS QA/prod and any customer self-hosted on a public domain need.

This collapses three previous attempts (\`f88ed566a\`, \`ed2149a6c\`, \`24874ccdb\` are all valid orthogonally; this is the missing piece) and covers all four proxy routes plus the analytics fetcher with one change. The presence/absence of \`WEB_PORT_*\` in the env unambiguously maps to internal-cluster vs. public-domain across every deployment we support:

  - Dev / Docker compose:       hostname=localhost|kodus_api, PORT=3001  → http+port
  - Self-hosted local Docker:   hostname=localhost|kodus_api, PORT=3001  → http+port
  - Self-hosted public domain:  hostname=api.cliente.com,     PORT=—     → https
  - QA AWS (ALB):               hostname=qa.api.kodus.io,     PORT=—     → https
  - Prod AWS (ALB):             hostname=app.api.kodus.io,    PORT=—     → https

Two specs added to lock the regression-repro behaviour: \`internal: true\` with no port → https/no-port, both for production and self-hosted nodeEnv. Without those, a future refactor could resurrect the original "always http+port" behaviour and we'd hit ECONNREFUSED on QA/prod again.

---

<!-- kody-pr-summary:start -->
This pull request addresses an issue where internal API calls, particularly in AWS ALB-fronted or self-hosted environments, could fail due to incorrect URL construction.

Previously, when the `internal: true` flag was used for an API call, the system would attempt to construct an HTTP URL with an explicit or implied port. This caused connection failures in environments where an Application Load Balancer (ALB) or similar proxy terminates TLS on port 443 and does not listen on HTTP port 80 for upstream services.

The core change modifies the `createUrl` helper function:
*   It now requires *both* `internal: true` and an explicit `port` to construct an `http://<host>:<port>/<path>` URL.
*   If `internal: true` is set but no `port` is provided, the function correctly falls through to the public-domain URL heuristic, resulting in an `https://<host>/<path>` URL (without a port). This behavior is appropriate for environments where ALBs handle TLS termination.

Additionally, the `pathToApiUrl` function has been simplified to unconditionally pass `internal: true`, relying on the refined `createUrl` logic to handle the port-based differentiation.

New test cases have been added to validate this behavior for production and self-hosted environments, ensuring that URLs are correctly generated as `https://<host>/<path>` when `internal: true` is used without a specified port.
<!-- kody-pr-summary:end -->