### PR TITLE
ci: split Trivy SARIF uploads per image (CodeQL v4 deduplication)

### DIFF
--- a/.github/workflows/prod-build-push-and-pr-green.yml
+++ b/.github/workflows/prod-build-push-and-pr-green.yml
@@ -207,11 +207,27 @@ jobs:
                   ignore-unfixed: true
                   exit-code: "0"
 
-            - name: Upload Trivy SARIF reports
+            # CodeQL Action v4 rejects multiple SARIF runs sharing a
+            # category, so each image gets its own upload step with a
+            # distinct category. (v3 silently combined them; v4 requires
+            # one upload per category.)
+            - name: Upload Trivy SARIF — api
               uses: github/codeql-action/upload-sarif@v4
               with:
-                  sarif_file: "."
-                  category: "trivy-prod-backend"
+                  sarif_file: trivy-api.sarif
+                  category: trivy-prod-api
+
+            - name: Upload Trivy SARIF — webhooks
+              uses: github/codeql-action/upload-sarif@v4
+              with:
+                  sarif_file: trivy-webhooks.sarif
+                  category: trivy-prod-webhooks
+
+            - name: Upload Trivy SARIF — worker
+              uses: github/codeql-action/upload-sarif@v4
+              with:
+                  sarif_file: trivy-worker.sarif
+                  category: trivy-prod-worker
 
             - name: Checkout infra repo
               uses: actions/checkout@v6.0.2

--- a/.github/workflows/qa-build-push-and-pr-green.yml
+++ b/.github/workflows/qa-build-push-and-pr-green.yml
@@ -192,11 +192,25 @@ jobs:
                   ignore-unfixed: true
                   exit-code: "0"
 
-            - name: Upload Trivy SARIF reports
+            # CodeQL Action v4 rejects multiple SARIF runs sharing a
+            # category — one upload step per image with its own category.
+            - name: Upload Trivy SARIF — api
               uses: github/codeql-action/upload-sarif@v4
               with:
-                  sarif_file: "."
-                  category: "trivy-qa-backend"
+                  sarif_file: trivy-api.sarif
+                  category: trivy-qa-api
+
+            - name: Upload Trivy SARIF — webhooks
+              uses: github/codeql-action/upload-sarif@v4
+              with:
+                  sarif_file: trivy-webhooks.sarif
+                  category: trivy-qa-webhooks
+
+            - name: Upload Trivy SARIF — worker
+              uses: github/codeql-action/upload-sarif@v4
+              with:
+                  sarif_file: trivy-worker.sarif
+                  category: trivy-qa-worker
 
             - name: Checkout infra repo
               uses: actions/checkout@v6.0.2

--- a/.github/workflows/selfhosted-build-push.yml
+++ b/.github/workflows/selfhosted-build-push.yml
@@ -233,11 +233,31 @@ jobs:
                   ignore-unfixed: true
                   exit-code: "0"
 
-            - name: Upload Trivy SARIF reports
+            # CodeQL Action v4 rejects multiple SARIF runs sharing a
+            # category — one upload step per image with its own category.
+            - name: Upload Trivy SARIF — api
               uses: github/codeql-action/upload-sarif@v4
               with:
-                  sarif_file: "."
-                  category: "trivy-selfhosted"
+                  sarif_file: trivy-api.sarif
+                  category: trivy-selfhosted-api
+
+            - name: Upload Trivy SARIF — webhook
+              uses: github/codeql-action/upload-sarif@v4
+              with:
+                  sarif_file: trivy-webhook.sarif
+                  category: trivy-selfhosted-webhook
+
+            - name: Upload Trivy SARIF — worker
+              uses: github/codeql-action/upload-sarif@v4
+              with:
+                  sarif_file: trivy-worker.sarif
+                  category: trivy-selfhosted-worker
+
+            - name: Upload Trivy SARIF — web
+              uses: github/codeql-action/upload-sarif@v4
+              with:
+                  sarif_file: trivy-web.sarif
+                  category: trivy-selfhosted-web
 
     notify-discord:
         name: Notify Discord


### PR DESCRIPTION
CodeQL Action v4 stopped silently combining multiple SARIF runs that share a category. The old \`sarif_file: "."\` + single category \`trivy-prod-backend\` worked on v3 but now fails:

    Error: The CodeQL Action does not support uploading multiple
    SARIF runs with the same category.

Each image (api / webhooks / worker / web) gets its own upload step with a distinct category — \`trivy-{env}-{component}\`. Single-image workflows (web-build-push-production, rabbitmq-build-push) already upload one SARIF per category, so they don't change.

Reference: https://github.blog/changelog/2025-07-21-code-scanning-will-stop-combining-multiple-sarif-runs-uploaded-in-the-same-sarif-file/

---

<!-- kody-pr-summary:start -->
CI: Updated Trivy SARIF report uploads in build workflows to ensure compatibility with CodeQL Action v4.

Previously, Trivy SARIF reports for multiple images were uploaded in a single step with a shared category. CodeQL Action v4 now requires each SARIF run to have a distinct category to prevent deduplication issues.

This change splits the Trivy SARIF upload step into individual steps for each scanned image (e.g., `api`, `webhooks`, `worker`, `web`), assigning a unique category to each, across the `prod-build-push-and-pr-green.yml`, `qa-build-push-and-pr-green.yml`, and `selfhosted-build-push.yml` workflows. This ensures all security scan results are correctly processed and displayed by CodeQL.
<!-- kody-pr-summary:end -->