### PR TITLE
Adding log to investigatre mcp problem

### DIFF
--- a/libs/agents/skills/generic-skill-runner.service.ts
+++ b/libs/agents/skills/generic-skill-runner.service.ts
@@ -202,6 +202,19 @@ export class GenericSkillRunnerService {
                 try {
                     await orchestration.connectMCP();
                     await orchestration.registerMCPTools();
+
+                    const registeredTools = orchestration.getRegisteredTools();
+                    this.logger.log({
+                        message: `[GenericSkillRunner] MCP tools registered for skill '${skillName}'`,
+                        context: 'createFetcherOrchestration',
+                        metadata: {
+                            skillName,
+                            registeredToolCount: registeredTools.length,
+                            registeredToolNames: registeredTools.map(
+                                (t: { name?: string }) => t.name,
+                            ),
+                        },
+                    });
                 } catch (error) {
                     if (executionPolicy.onMcpConnectError === 'fallback') {
                         this.logger.warn(
@@ -624,6 +637,15 @@ export class GenericSkillRunnerService {
             });
 
         if (!filteredServers.length) {
+            this.logger.warn({
+                message: `[GenericSkillRunner] No servers remaining after filtering for skill '${skillName}'`,
+                context: 'createMCPAdapter',
+                metadata: {
+                    skillName,
+                    totalServers: mcpManagerServers?.length,
+                    resolvedRequiredTools,
+                },
+            });
             return null;
         }
         if (resolvedRequiredTools.length && !hasRequiredTools) {
@@ -634,6 +656,26 @@ export class GenericSkillRunnerService {
             );
             return null;
         }
+
+        this.logger.log({
+            message: `[GenericSkillRunner] MCP adapter created for skill '${skillName}'`,
+            context: 'createMCPAdapter',
+            metadata: {
+                skillName,
+                serverCount: filteredServers.length,
+                servers: filteredServers.map((s) => ({
+                    name: s.name,
+                    provider: s.provider,
+                    allowedToolCount: Array.isArray(s.allowedTools)
+                        ? s.allowedTools.length
+                        : 0,
+                    allowedTools: Array.isArray(s.allowedTools)
+                        ? s.allowedTools
+                        : [],
+                })),
+                resolvedRequiredTools,
+            },
+        });
 
         return createMCPAdapter({
             servers: filteredServers,

--- a/libs/agents/skills/runtime/capability-runtime.resolver.ts
+++ b/libs/agents/skills/runtime/capability-runtime.resolver.ts
@@ -1,6 +1,10 @@
+import { createLogger } from '@kodus/flow';
+
 import { resolveCapabilityToolSelection } from '../skill-capabilities';
 
 import { SkillCapabilityRuntimeConfig } from './skill-runtime.types';
+
+const logger = createLogger('CapabilityToolRuntime');
 
 export interface CapabilityToolRuntime {
     toolByCapability: Record<string, string | undefined>;
@@ -22,6 +26,22 @@ export function createCapabilityToolRuntime(params: {
         registeredTools: params.registeredTools,
         toolMode: params.config.fetcherPolicy.toolMode,
     });
+
+    if (selection.missingCapabilities.length > 0) {
+        logger.warn({
+            message: 'Capability tool resolution has missing capabilities',
+            context: 'createCapabilityToolRuntime',
+            metadata: {
+                missingCapabilities: selection.missingCapabilities,
+                toolByCapability: selection.toolByCapability,
+                registeredToolCount: params.registeredTools.length,
+                registeredTools: params.registeredTools,
+                allowedTools: params.config.allowedTools,
+                capabilities: params.config.capabilities,
+                toolMode: params.config.fetcherPolicy.toolMode,
+            },
+        });
+    }
 
     return {
         ...selection,


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces enhanced logging across the `GenericSkillRunnerService` and `CapabilityToolRuntime` to improve visibility and aid in debugging issues related to Micro-Capability Platform (MCP) integration and skill execution.

Key changes include:
*   **MCP Tool Registration Logging**: Added a log to confirm successful MCP tool registration for a skill, detailing the count and names of registered tools.
*   **MCP Server Filtering Warnings**: Implemented a warning log when no suitable MCP servers are found after filtering for a specific skill, providing context on total servers and resolved required tools.
*   **MCP Adapter Creation Logging**: Added detailed logging upon successful creation of an MCP adapter, including information about the selected servers, their allowed tools, and resolved required tools.
*   **Capability Tool Resolution Warnings**: Introduced a warning log when capability tool resolution results in missing capabilities, providing comprehensive metadata about the resolution process, registered tools, and configured capabilities.
<!-- kody-pr-summary:end -->