### PR TITLE
fix(cockpit/tier-guard): resolve org from nested UserEntity shape

### DIFF
--- a/apps/api/src/controllers/cockpit.controller.ts
+++ b/apps/api/src/controllers/cockpit.controller.ts
@@ -82,6 +82,11 @@ export class CockpitController {
         return this.healthService.runsSummary(source || undefined);
     }
 
+    // Public so the web shell can resolve the backend before it has a tier
+    // verdict — and so free-tier orgs (which the tier guard would 403) can
+    // still learn they belong on `legacy-bq`. Returns no PII, just the
+    // routing decision.
+    @Public()
     @Get('/source/:organizationId')
     @ApiOperation({ summary: 'Resolve cockpit data source per org' })
     async source(@Param('organizationId') organizationId: string) {

--- a/libs/cockpit/infrastructure/guards/cockpit-tier.guard.ts
+++ b/libs/cockpit/infrastructure/guards/cockpit-tier.guard.ts
@@ -24,9 +24,11 @@ import { isCockpitTierAllowed } from '../../domain/tier-policy';
  * raw HTTP call.
  *
  * Resolves the orgId in this priority order:
- *   1. `req.user.organizationId` from the JWT payload (standard path).
- *   2. `req.query.organizationId` as a fallback (public-ish endpoints
- *      like `/cockpit/source/:id` read the id from the URL).
+ *   1. The JWT-backed user's org — `req.user.organization.uuid` is the
+ *      shape `UserEntity` actually exposes; `organizationId` is kept as
+ *      a fallback in case future auth flows attach it directly.
+ *   2. `req.query.organizationId` as a fallback for endpoints that
+ *      receive the id explicitly (e.g. `/cockpit/validate`).
  *
  * Endpoints declared `@Public()` (e.g. `/cockpit/health`,
  * `/cockpit/source/:id`) shouldn't be decorated with this guard —
@@ -54,11 +56,20 @@ export class CockpitTierGuard implements CanActivate {
 
         const req = context.switchToHttp().getRequest<
             Request & {
-                user?: { organizationId?: string };
+                user?: {
+                    organizationId?: string;
+                    organization?: { uuid?: string };
+                };
             }
         >();
 
-        const orgFromJwt = req.user?.organizationId;
+        // `UserEntity` (libs/identity/.../user.entity.ts) exposes the org as
+        // `organization: { uuid }` — there is no flat `organizationId` field.
+        // The previous read returned `undefined` for every authenticated
+        // request, which made the guard fall through to the query string and
+        // 403 any cockpit endpoint that didn't pass `?organizationId=...`.
+        const orgFromJwt =
+            req.user?.organizationId ?? req.user?.organization?.uuid;
 
         // Reject non-string inputs outright. Without this the
         // `typeof === 'string'` check below silently coerces arrays

--- a/test/unit/cockpit/cockpit-tier.guard.spec.ts
+++ b/test/unit/cockpit/cockpit-tier.guard.spec.ts
@@ -18,14 +18,27 @@ import {
 
 function makeContext(args: {
     jwtOrg?: string;
+    /**
+     * Shape of the org claim on `req.user`. Real `JwtStrategy.validate`
+     * returns a `UserEntity` whose org lives at `organization.uuid`, not
+     * a flat `organizationId` — both shapes are exercised here so the
+     * guard stays compatible if/when the strategy is changed.
+     */
+    jwtOrgShape?: 'flat' | 'nested';
     queryOrg?: unknown;
     isPublic?: boolean;
 }): {
     ctx: ExecutionContext;
     reflector: Reflector;
 } {
+    const shape = args.jwtOrgShape ?? 'flat';
+    const user = args.jwtOrg
+        ? shape === 'nested'
+            ? { organization: { uuid: args.jwtOrg } }
+            : { organizationId: args.jwtOrg }
+        : undefined;
     const req = {
-        user: args.jwtOrg ? { organizationId: args.jwtOrg } : undefined,
+        user,
         query:
             args.queryOrg !== undefined
                 ? { organizationId: args.queryOrg }
@@ -183,6 +196,47 @@ describe('CockpitTierGuard', () => {
         await expect(guard.canActivate(ctx)).rejects.toThrow(
             ForbiddenException,
         );
+    });
+
+    it('resolves the org from the nested UserEntity shape (organization.uuid)', async () => {
+        // Regression: the previous read of `req.user.organizationId` was
+        // always `undefined` because `JwtStrategy.validate` returns a
+        // `UserEntity` (organization: { uuid }), not a flat object. That
+        // 403'd every cockpit endpoint that didn't pass `?organizationId=`.
+        const licenseService = makeLicenseService({
+            valid: true,
+            subscriptionStatus: SubscriptionStatus.ACTIVE,
+            planType: 'enterprise_managed',
+        });
+        const { ctx, reflector } = makeContext({
+            jwtOrg: 'org-A',
+            jwtOrgShape: 'nested',
+        });
+        const guard = new CockpitTierGuard(licenseService, reflector);
+
+        await expect(guard.canActivate(ctx)).resolves.toBe(true);
+        expect(
+            licenseService.validateOrganizationLicense,
+        ).toHaveBeenCalledWith({
+            organizationId: 'org-A',
+        });
+    });
+
+    it('blocks IDOR with the nested UserEntity shape too', async () => {
+        const licenseService = makeLicenseService({ valid: true });
+        const { ctx, reflector } = makeContext({
+            jwtOrg: 'org-A',
+            jwtOrgShape: 'nested',
+            queryOrg: 'org-B',
+        });
+        const guard = new CockpitTierGuard(licenseService, reflector);
+
+        await expect(guard.canActivate(ctx)).rejects.toThrow(
+            ForbiddenException,
+        );
+        expect(
+            licenseService.validateOrganizationLicense,
+        ).not.toHaveBeenCalled();
     });
 
     it('fails closed when license lookup throws', async () => {


### PR DESCRIPTION
JwtStrategy.validate returns a UserEntity (organization: { uuid }), so reading req.user.organizationId always yielded undefined. That made the guard 403 every cockpit endpoint not passing ?organizationId=, including the web's /cockpit/source/:id call — which falls back to legacy-bq silently and pinned every prod org to BigQuery regardless of the PostHog flag.

Also marks /cockpit/source/:id as @Public(), matching the documented intent in the guard header so free-tier orgs can still resolve their backend.

---

<!-- kody-pr-summary:start -->
This pull request fixes a regression in the `CockpitTierGuard` that prevented authenticated users from accessing Cockpit endpoints by incorrectly resolving their organization ID.

Key changes include:

*   **Corrected Organization ID Resolution**: The `CockpitTierGuard` now accurately resolves the organization ID from the `req.user.organization.uuid` property, which is the actual shape of the `UserEntity` returned by the JWT authentication strategy. Previously, the guard incorrectly looked for a flat `organizationId` field, leading to `undefined` for authenticated requests and subsequent incorrect fallback to query parameters or 403 errors.
*   **Updated Guard Documentation**: The internal documentation for the `CockpitTierGuard` has been updated to reflect the correct priority order for resolving the organization ID, explicitly listing `req.user.organization.uuid` as the primary source.
*   **Enhanced Test Coverage**: New unit tests have been added to verify that the guard correctly resolves the organization ID from the nested `UserEntity` shape and that IDOR (Insecure Direct Object Reference) protection remains effective with this new resolution logic.
*   **Public `/cockpit/source` Endpoint**: The `/cockpit/source/:organizationId` endpoint has been marked as `@Public()`. This allows the web shell to resolve the backend data source before a tier verdict is made and enables free-tier organizations to determine their routing without being blocked by the tier guard. This endpoint returns no PII, only routing decisions.

This ensures that tier-based access control for Cockpit endpoints functions as intended for authenticated users, while also providing necessary public access to the source resolution endpoint.
<!-- kody-pr-summary:end -->