### PR TITLE
Adding new path to find SKILL.md file

### DIFF
--- a/libs/agents/skills/skill-loader.service.ts
+++ b/libs/agents/skills/skill-loader.service.ts
@@ -624,6 +624,9 @@ export class SkillLoaderService {
             __dirname,
             // Built runtime fallback
             path.join(__dirname, '..', '..', 'skills'),
+            // Production build: webpack bundles to dist/apps/<app>/main.js
+            // but skill files land in dist/libs/agents/skills/
+            path.join(process.cwd(), 'dist', 'libs', 'agents', 'skills'),
         ];
 
         return [...new Set(candidates)];


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Added a new search path to the `SkillLoaderService` to correctly locate skill definition files (`SKILL.md`) in production builds. This addresses an issue where webpack's bundling process places skill files in `dist/libs/agents/skills/`, which was not previously included in the search paths, preventing skills from being found in a production environment.
<!-- kody-pr-summary:end -->