### PR TITLE
Fixing paths

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -100,6 +100,7 @@ RUN bun install -g @kodus/kodus-graph
 
 COPY --chown=1000:1000 --from=prod-deps /usr/src/app/node_modules ./node_modules
 COPY --chown=1000:1000 --from=build /usr/src/app/dist ./dist
+COPY --chown=1000:1000 --from=build /usr/src/app/libs/agents/skills ./libs/agents/skills
 COPY --chown=1000:1000 --from=build /usr/src/app/package.json ./package.json
 COPY --chown=1000:1000 --from=build /usr/src/app/default-kodus-config.yml ./default-kodus-config.yml
 COPY --chown=1000:1000 --from=build /usr/src/app/kodus-config.yml ./kodus-config.yml

--- a/libs/agents/skills/skill-loader.service.ts
+++ b/libs/agents/skills/skill-loader.service.ts
@@ -624,9 +624,6 @@ export class SkillLoaderService {
             __dirname,
             // Built runtime fallback
             path.join(__dirname, '..', '..', 'skills'),
-            // Production build: webpack bundles to dist/apps/<app>/main.js
-            // but skill files land in dist/libs/agents/skills/
-            path.join(process.cwd(), 'dist', 'libs', 'agents', 'skills'),
         ];
 
         return [...new Set(candidates)];


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request addresses issues with locating and loading agent skills in production environments, specifically within Docker containers.

The changes include:
- **Dockerfile Update**: The `Dockerfile` now explicitly copies the `libs/agents/skills` directory into the final Docker image. This ensures that all necessary skill files are present and accessible at runtime.
- **Skill Loader Path Adjustment**: An outdated or incorrect skill search path, which previously looked for skills within the `dist/libs/agents/skills` directory in a production build, has been removed from the `SkillLoaderService`. This aligns the skill loading mechanism with the new Docker packaging strategy, where skills are now directly available under `./libs/agents/skills`.

These modifications ensure that the application can correctly find and utilize agent skills when deployed in a Dockerized production environment.
<!-- kody-pr-summary:end -->