### PR TITLE
Changing logic for auto-assign licenses - for users to perform manual…

### DIFF
--- a/libs/code-review/pipeline/stages/validate-prerequisites.stage.ts
+++ b/libs/code-review/pipeline/stages/validate-prerequisites.stage.ts
@@ -203,8 +203,42 @@ export class ValidatePrerequisitesStage extends BasePipelineStage<CodeReviewPipe
             });
         }
 
-        // If auto-review is disabled and this is not a command-triggered review,
-        // skip silently without posting notifications (e.g. BYOK required).
+        // If validation failed due to USER_NOT_LICENSED, try auto-assign FIRST
+        // (before checking autoReviewEnabled, because auto-assign should work regardless)
+        if (validationResult.errorType === ValidationErrorType.USER_NOT_LICENSED) {
+            const failureHandled = await this.handleValidationFailure(
+                context,
+                validationResult,
+                showStatusFeedback,
+            );
+
+            if (failureHandled === 'auto_assigned') {
+                // Auto-assign succeeded, continue with review
+                return this.updateContext(context, (draft) => {
+                    applyShowStatusFeedbackMetadata(draft);
+                });
+            }
+
+            // Auto-assign failed - skip review with notification already handled
+            return this.updateContext(context, (draft) => {
+                applyShowStatusFeedbackMetadata(draft);
+                draft.statusInfo = {
+                    status: AutomationStatus.SKIPPED,
+                    message: StageMessageHelper.skippedWithReason(
+                        this.getLicenseSkipReason(validationResult.errorType),
+                    ),
+                };
+                // Notification already posted by handleValidationFailure above
+                if (!draft.pipelineMetadata) {
+                    draft.pipelineMetadata = {};
+                }
+                draft.pipelineMetadata.notificationHandled = true;
+            });
+        }
+
+        // For other errors, check autoReviewEnabled BEFORE handling failure
+        // (these errors don't benefit from auto-assign)
+
         try {
             if (context.origin !== 'command') {
                 const autoReviewEnabled =
@@ -228,40 +262,26 @@ export class ValidatePrerequisitesStage extends BasePipelineStage<CodeReviewPipe
             });
         }
 
-        // Validation failed
-        const failureHandled = await this.handleValidationFailure(
+        // Handle other validation failures (INVALID_LICENSE, BYOK_REQUIRED, etc.)
+        await this.handleValidationFailure(
             context,
             validationResult,
             showStatusFeedback,
         );
 
-        if (failureHandled === 'auto_assigned') {
-            return this.updateContext(context, (draft) => {
-                applyShowStatusFeedbackMetadata(draft);
-            });
-        }
-
+        // Return SKIPPED - notification already handled by handleValidationFailure
         return this.updateContext(context, (draft) => {
             applyShowStatusFeedbackMetadata(draft);
             draft.statusInfo = {
-                status: AutomationStatus.SKIPPED, // Or FAILED? Usually SKIPPED if business logic prevents it.
+                status: AutomationStatus.SKIPPED,
                 message: StageMessageHelper.skippedWithReason(
                     this.getLicenseSkipReason(validationResult.errorType),
                 ),
             };
-
-            // If we failed validation, we likely sent a specific license notification (for Azure/Bitbucket).
-            // Mark it so the handler doesn't send a generic "Skipped" message on top.
-            if (
-                context.platformType === PlatformType.AZURE_REPOS ||
-                context.platformType === PlatformType.BITBUCKET ||
-                !showStatusFeedback
-            ) {
-                if (!draft.pipelineMetadata) {
-                    draft.pipelineMetadata = {};
-                }
-                draft.pipelineMetadata.notificationHandled = true;
+            if (!draft.pipelineMetadata) {
+                draft.pipelineMetadata = {};
             }
+            draft.pipelineMetadata.notificationHandled = true;
         });
     }
 


### PR DESCRIPTION
#970 

---

<!-- kody-pr-summary:start -->
This pull request modifies the license validation logic within the `ValidatePrerequisitesStage` of the code review pipeline.

The key changes are:

1.  **Prioritized Auto-Assignment for Unlicensed Users:** When a user is identified as `USER_NOT_LICENSED`, the system will now attempt to auto-assign a license immediately. If auto-assignment is successful, the code review pipeline will proceed.
2.  **Consistent Handling for Auto-Assignment Failure:** If auto-assignment fails for a `USER_NOT_LICENSED` error, or for any other license-related validation failure (e.g., `INVALID_LICENSE`, `BYOK_REQUIRED`), the code review pipeline will be skipped.
3.  **Streamlined Notification Management:** For all validation failures that result in skipping the pipeline, the system now consistently marks that a specific notification about the license issue has been handled, preventing duplicate "Skipped" messages.
4.  **Independent Auto-Assignment:** The check for whether auto-review is generally enabled for the repository now occurs *after* the attempt to auto-assign a license for `USER_NOT_LICENSED` errors, allowing auto-assignment to function independently of the general auto-review setting.

This update ensures that license auto-assignment is attempted proactively for unlicensed users, improving the user experience by potentially resolving license issues automatically before other prerequisites are checked.
<!-- kody-pr-summary:end -->