### PR TITLE
Fix/effort level claude

### DIFF
--- a/libs/code-review/infrastructure/agents/llm/agent-loop.providerOptions.spec.ts
+++ b/libs/code-review/infrastructure/agents/llm/agent-loop.providerOptions.spec.ts
@@ -39,7 +39,7 @@ describe('buildReasoningProviderOptions', () => {
             ).toEqual({
                 anthropic: {
                     thinking: { type: 'adaptive' },
-                    outputConfig: { effort: 'high' },
+                    effort: 'high',
                 },
             });
         });
@@ -54,7 +54,7 @@ describe('buildReasoningProviderOptions', () => {
             ).toEqual({
                 anthropic: {
                     thinking: { type: 'adaptive' },
-                    outputConfig: { effort: 'medium' },
+                    effort: 'medium',
                 },
             });
         });

--- a/libs/code-review/infrastructure/agents/llm/agent-loop.ts
+++ b/libs/code-review/infrastructure/agents/llm/agent-loop.ts
@@ -282,7 +282,7 @@ export function buildReasoningProviderOptions(
                 return {
                     anthropic: {
                         thinking: { type: 'adaptive' },
-                        outputConfig: { effort },
+                        effort,
                     },
                 };
             }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Refactored the configuration for the Anthropic LLM provider by moving the `effort` level property from being nested within `outputConfig` to being a direct property of the Anthropic configuration object. This update ensures the `effort` level is correctly applied when building reasoning provider options.
<!-- kody-pr-summary:end -->