### PR TITLE
fix(weekly-recap): owner-only recipients, aligned implementation rate…

### DIFF
--- a/apps/api/src/controllers/cockpit.controller.ts
+++ b/apps/api/src/controllers/cockpit.controller.ts
@@ -262,7 +262,7 @@ export class CockpitProductivityController {
 // -------------------------------------------------------------------------
 // /cockpit/weekly-recap  — admin-triggered weekly summary email
 // Replaces the legacy n8n flow that called Customer.io. Sends one email
-// per ACTIVE user in the org with metrics from the cockpit warehouse.
+// per ACTIVE owner of the org with metrics from the cockpit warehouse.
 // -------------------------------------------------------------------------
 
 type SendWeeklyRecapBody = {
@@ -281,7 +281,7 @@ export class CockpitWeeklyRecapController {
     @Post('/')
     @ApiOperation({
         summary:
-            'Send the weekly recap email to all ACTIVE users of an organization. Skips orgs with zero PRs in the window.',
+            'Send the weekly recap email to ACTIVE owners of an organization. Skips orgs with zero PRs in the window.',
     })
     send(@Body() body: SendWeeklyRecapBody) {
         if (!body?.organizationId || !body?.startDate || !body?.endDate) {

--- a/libs/cockpit/application/use-cases/send-weekly-recap.use-case.ts
+++ b/libs/cockpit/application/use-cases/send-weekly-recap.use-case.ts
@@ -4,6 +4,7 @@ import { ConfigService } from '@nestjs/config';
 
 import { EmailService } from '@libs/common/email/services/email.service';
 import { STATUS } from '@libs/core/infrastructure/config/types/database/status.type';
+import { Role } from '@libs/identity/domain/permissions/enums/permissions.enum';
 import {
     IUsersService,
     USER_SERVICE_TOKEN,
@@ -88,7 +89,7 @@ export class SendWeeklyRecapUseCase {
         }
 
         const users = await this.usersService.find(
-            { organization: { uuid: organizationId } },
+            { organization: { uuid: organizationId }, role: Role.OWNER },
             [STATUS.ACTIVE],
         );
         if (!users || users.length === 0) {
@@ -240,8 +241,12 @@ export class SendWeeklyRecapUseCase {
         const suggestionsApplied =
             dashboard.additionalMetrics.suggestionsImplementedCount ?? 0;
 
+        // currentPeriod.ratio is already a percentage (e.g. 17.51), but the
+        // template's `bugRatio` prop is contracted as 0..1 and multiplies by
+        // 100 again — pass the fraction here to honour that contract.
         const bugRatio =
-            dashboard.additionalMetrics.bugRatio?.currentPeriod.ratio ?? 0;
+            (dashboard.additionalMetrics.bugRatio?.currentPeriod.ratio ?? 0) /
+            100;
         const bugRatioTrend =
             dashboard.additionalMetrics.bugRatio?.comparison.trend ??
             'unchanged';

--- a/libs/cockpit/infrastructure/services/cockpit-code-health.service.ts
+++ b/libs/cockpit/infrastructure/services/cockpit-code-health.service.ts
@@ -214,25 +214,50 @@ export class CockpitCodeHealthService {
     }
 
     async getImplementationRate(
-        q: Pick<CockpitRangeQuery, 'organizationId' | 'repository'>,
+        q: Pick<CockpitRangeQuery, 'organizationId' | 'repository'> &
+            Partial<Pick<CockpitRangeQuery, 'startDate' | 'endDate'>>,
     ): Promise<SuggestionsImplementationRate> {
         const params: unknown[] = [q.organizationId];
         const repoFilter = q.repository
             ? (params.push(q.repository), `AND pr.repo_full_name = $${params.length}`)
             : '';
 
+        // When the caller supplies a window, scope both the suggestion and PR
+        // populations to PRs closed inside it — the weekly recap needs the
+        // numerator (implemented) and denominator (sent) to share the same
+        // recap range. Otherwise fall back to the legacy "last 14 days" view
+        // used by the cockpit highlight endpoint.
+        const hasRange = Boolean(q.startDate && q.endDate);
+        let svFilter: string;
+        let prFilter: string;
+        if (hasRange) {
+            params.push(q.startDate, q.endDate);
+            const startIdx = params.length - 1;
+            const endIdx = params.length;
+            svFilter = `s."suggestionDeliveryStatus" = 'sent'`;
+            prFilter = `pr."organizationId" = $1
+                   AND pr."closedAt" IS NOT NULL AND pr."closedAt" <> ''
+                   AND pr."status" = 'closed'
+                   AND pr.parsed_closed_at >= $${startIdx}::timestamptz
+                   AND pr.parsed_closed_at <= $${endIdx}::timestamptz
+                   ${repoFilter}`;
+        } else {
+            svFilter = `s."suggestionDeliveryStatus" = 'sent'
+                   AND s."suggestionCreatedAt" >= (now() - interval '14 days')`;
+            prFilter = `pr."organizationId" = $1
+                   ${repoFilter}`;
+        }
+
         const rows = (await this.ds.query(
             `WITH sv AS (
                 SELECT s.*
                   FROM "analytics"."suggestions_mv" s
-                 WHERE s."suggestionDeliveryStatus" = 'sent'
-                   AND s."suggestionCreatedAt" >= (now() - interval '14 days')
+                 WHERE ${svFilter}
             ),
             pr AS (
                 SELECT "_id"
                   FROM "analytics"."pull_requests_opt" pr
-                 WHERE pr."organizationId" = $1
-                   ${repoFilter}
+                 WHERE ${prFilter}
             )
             SELECT
                 COUNT(*)::int AS suggestions_sent,

--- a/libs/cockpit/infrastructure/services/cockpit-developer-productivity.service.ts
+++ b/libs/cockpit/infrastructure/services/cockpit-developer-productivity.service.ts
@@ -711,6 +711,8 @@ export class CockpitDeveloperProductivityService {
             this.codeHealth.getImplementationRate({
                 organizationId: q.organizationId,
                 repository: q.repository,
+                startDate: q.startDate,
+                endDate: q.endDate,
             }),
             this.getLeadTimeHighlight(q),
             this.getDeployFrequencyHighlight(q),


### PR DESCRIPTION
…, bug ratio scale

- Send the recap to ACTIVE owners only (was: every active user in the org)
- Scope getImplementationRate to the recap window so numerator/denominator share the same population; legacy "last 14 days" path kept for the cockpit highlight endpoint
- Stop double-multiplying bugRatio: pass 0..1 to the template, which already converts to percent (was rendering e.g. 1751% instead of 17.51%)

---

<!-- kody-pr-summary:start -->
This pull request introduces several fixes and refinements to the weekly recap email functionality:

1.  **Recipient Scope narrowed to Owners:** The weekly recap email is now exclusively sent to users with the `OWNER` role within an organization. Previously, it was sent to all active users.
2.  **Corrected Bug Ratio Calculation:** The `bugRatio` metric passed to the weekly recap email template has been adjusted. It now sends a fractional value (0-1) instead of a percentage (0-100), aligning with the template's expected input format.
3.  **Aligned Implementation Rate Calculation:** The "implementation rate" metric now correctly uses the `startDate` and `endDate` of the weekly recap period for its calculation. This ensures that the rate reflects suggestions sent and pull requests closed within the specific reporting window, rather than relying on a fixed 14-day lookback period.
<!-- kody-pr-summary:end -->