### PR TITLE
feat: fetch members from both platform and PRs to show all contributo…

### DIFF
--- a/libs/platform/application/use-cases/codeManagement/get-code-management-members-list.use-case.ts
+++ b/libs/platform/application/use-cases/codeManagement/get-code-management-members-list.use-case.ts
@@ -54,36 +54,27 @@ export class GetCodeManagementMemberListUseCase implements IUseCase {
             // Cache miss or error, proceed with fetch
         }
 
-        const platformMembers = await this.fetchMembersFromCodeIntegration(
-            organizationAndTeamData,
-        );
+         const [platformMembers, prMembers] = await Promise.all([
+        this.fetchMembersFromCodeIntegration(organizationAndTeamData),
+        this.fetchMembersFromPullRequests(organizationAndTeamData),
+    ]);
+    const mergedMembers = this.normalizeMembers([
+        ...platformMembers,
+        ...prMembers,
+    ]);
 
-        if (platformMembers.length > 0) {
+
+        if (mergedMembers.length > 0) {
             await this.cacheService
                 .addToCache(
                     cacheKey,
-                    platformMembers,
-                    GetCodeManagementMemberListUseCase.CACHE_TTL,
-                )
-                .catch(() => {});
-            return platformMembers;
-        }
-
-        const prMembers = await this.fetchMembersFromPullRequests(
-            organizationAndTeamData,
-        );
-
-        if (prMembers.length > 0) {
-            await this.cacheService
-                .addToCache(
-                    cacheKey,
-                    prMembers,
+                    mergedMembers,
                     GetCodeManagementMemberListUseCase.CACHE_TTL,
                 )
                 .catch(() => {});
         }
 
-        return prMembers;
+        return mergedMembers;
     }
 
     public async refreshMembers(


### PR DESCRIPTION
#984 

---

<!-- kody-pr-summary:start -->
feat: Fetch and combine all code management contributors

This change updates the `GetCodeManagementMemberListUseCase` to fetch and consolidate all code management contributors.

Previously, the system would prioritize fetching members from code integration platforms and only retrieve members from pull requests if no platform members were found.

Now, the system concurrently fetches members from both code integration platforms and pull requests, merges them into a single normalized list, and then caches and returns this comprehensive list. This ensures that all contributors, regardless of their source, are included in the code management members list.
<!-- kody-pr-summary:end -->