### PR TITLE
Hotfix/file path for azure repos

### DIFF
--- a/libs/code-review/infrastructure/agents/base-code-review-agent.provider.ts
+++ b/libs/code-review/infrastructure/agents/base-code-review-agent.provider.ts
@@ -36,6 +36,7 @@ import {
     CoverageSummary,
     CoverageTier,
     formatCoverageTargetsForPrompt,
+    normalizeRepoPath,
 } from './llm/coverage-ledger';
 
 /** Rough token estimate: 1 token ≈ 4 characters */
@@ -870,7 +871,7 @@ export abstract class BaseCodeReviewAgentProvider {
 
             // Map findings to CodeSuggestion format
             const validFiles = new Set(
-                input.changedFiles.map((f) => f.filename),
+                input.changedFiles.map((f) => normalizeRepoPath(f.filename)),
             );
             const isKodyRules = this.getCategoryLabel() === 'kody_rules';
             const kodyRulesByUuid = new Map(
@@ -915,10 +916,10 @@ export abstract class BaseCodeReviewAgentProvider {
                         return false;
                     }
                     // PR-level kody_rules omit relevantFile by design.
-                    return !s.relevantFile || validFiles.has(s.relevantFile);
+                    return !s.relevantFile || validFiles.has(normalizeRepoPath(s.relevantFile));
                 }
 
-                return !!s.relevantFile && validFiles.has(s.relevantFile);
+                return !!s.relevantFile && validFiles.has(normalizeRepoPath(s.relevantFile));
             });
 
             const suggestions = rawSuggestions.map((s) => {

--- a/libs/code-review/infrastructure/agents/base-code-review-agent.provider.ts
+++ b/libs/code-review/infrastructure/agents/base-code-review-agent.provider.ts
@@ -916,10 +916,39 @@ export abstract class BaseCodeReviewAgentProvider {
                         return false;
                     }
                     // PR-level kody_rules omit relevantFile by design.
-                    return !s.relevantFile || validFiles.has(normalizeRepoPath(s.relevantFile));
+                    const kodyRulePathMatch = !s.relevantFile || validFiles.has(normalizeRepoPath(s.relevantFile));
+                    if (!kodyRulePathMatch) {
+                        this.agentLogger.warn({
+                            message: `@@PATH_MISMATCH@@ Dropping kody_rules suggestion — relevantFile not in changedFiles after normalization`,
+                            context: this.getIdentity().name,
+                            metadata: {
+                                prNumber: input.prNumber,
+                                relevantFile: s.relevantFile,
+                                normalizedRelevantFile: normalizeRepoPath(s.relevantFile),
+                                changedFiles: [...validFiles],
+                                suggestionPreview: (s.oneSentenceSummary || s.suggestionContent || '').slice(0, 140),
+                            },
+                        });
+                    }
+                    return kodyRulePathMatch;
                 }
 
-                return !!s.relevantFile && validFiles.has(normalizeRepoPath(s.relevantFile));
+                const pathMatch = !!s.relevantFile && validFiles.has(normalizeRepoPath(s.relevantFile));
+                if (!pathMatch && s.relevantFile) {
+                    this.agentLogger.warn({
+                        message: `@@PATH_MISMATCH@@ Dropping suggestion — relevantFile not in changedFiles after normalization`,
+                        context: this.getIdentity().name,
+                        metadata: {
+                            prNumber: input.prNumber,
+                            relevantFile: s.relevantFile,
+                            normalizedRelevantFile: normalizeRepoPath(s.relevantFile),
+                            changedFiles: [...validFiles],
+                            severity: s.severity,
+                            suggestionPreview: (s.oneSentenceSummary || s.suggestionContent || '').slice(0, 140),
+                        },
+                    });
+                }
+                return pathMatch;
             });
 
             const suggestions = rawSuggestions.map((s) => {

--- a/libs/code-review/infrastructure/agents/llm/valid-files-matching.spec.ts
+++ b/libs/code-review/infrastructure/agents/llm/valid-files-matching.spec.ts
@@ -1,0 +1,174 @@
+import { normalizeRepoPath } from './coverage-ledger';
+
+/**
+ * Reproduces the validFiles matching logic from base-code-review-agent.provider.ts:
+ *
+ *   const validFiles = new Set(
+ *       input.changedFiles.map((f) => normalizeRepoPath(f.filename)),
+ *   );
+ *   return !!s.relevantFile && validFiles.has(normalizeRepoPath(s.relevantFile));
+ *
+ * Tests confirm that path normalization handles all 4 Git providers.
+ */
+
+function buildValidFilesSet(filenames: string[]): Set<string> {
+    return new Set(filenames.map((f) => normalizeRepoPath(f)));
+}
+
+function matchesSuggestion(
+    validFiles: Set<string>,
+    relevantFile: string | undefined,
+): boolean {
+    return !!relevantFile && validFiles.has(normalizeRepoPath(relevantFile));
+}
+
+describe('validFiles path matching across Git providers', () => {
+    describe('GitHub', () => {
+        it('matches paths without leading slash', () => {
+            const validFiles = buildValidFilesSet([
+                'src/components/Button.tsx',
+                'src/utils/helpers.ts',
+            ]);
+            expect(
+                matchesSuggestion(validFiles, 'src/components/Button.tsx'),
+            ).toBe(true);
+            expect(
+                matchesSuggestion(validFiles, 'src/utils/helpers.ts'),
+            ).toBe(true);
+        });
+
+        it('rejects non-existent files', () => {
+            const validFiles = buildValidFilesSet([
+                'src/components/Button.tsx',
+            ]);
+            expect(
+                matchesSuggestion(validFiles, 'src/components/Other.tsx'),
+            ).toBe(false);
+        });
+    });
+
+    describe('GitLab', () => {
+        it('matches paths without leading slash', () => {
+            const validFiles = buildValidFilesSet([
+                'app/models/user.rb',
+                'spec/models/user_spec.rb',
+            ]);
+            expect(
+                matchesSuggestion(validFiles, 'app/models/user.rb'),
+            ).toBe(true);
+        });
+    });
+
+    describe('Azure Repos', () => {
+        it('matches when changedFiles have leading slash and suggestion does not', () => {
+            const validFiles = buildValidFilesSet([
+                '/Kodus.Api/Exceptions/ExceptionHandler.php',
+                '/Kodus.Api/Entities/User.php',
+            ]);
+            expect(
+                matchesSuggestion(
+                    validFiles,
+                    'Kodus.Api/Exceptions/ExceptionHandler.php',
+                ),
+            ).toBe(true);
+            expect(
+                matchesSuggestion(
+                    validFiles,
+                    'Kodus.Api/Entities/User.php',
+                ),
+            ).toBe(true);
+        });
+
+        it('matches when both have leading slash', () => {
+            const validFiles = buildValidFilesSet([
+                '/Kodus.Api/Exceptions/ExceptionHandler.php',
+            ]);
+            expect(
+                matchesSuggestion(
+                    validFiles,
+                    '/Kodus.Api/Exceptions/ExceptionHandler.php',
+                ),
+            ).toBe(true);
+        });
+
+        it('matches when changedFiles have no slash but suggestion has leading slash', () => {
+            const validFiles = buildValidFilesSet([
+                'Kodus.Api/Exceptions/ExceptionHandler.php',
+            ]);
+            expect(
+                matchesSuggestion(
+                    validFiles,
+                    '/Kodus.Api/Exceptions/ExceptionHandler.php',
+                ),
+            ).toBe(true);
+        });
+
+        it('matches with multiple leading slashes', () => {
+            const validFiles = buildValidFilesSet([
+                '///src/Program.php',
+            ]);
+            expect(
+                matchesSuggestion(validFiles, 'src/Program.php'),
+            ).toBe(true);
+        });
+    });
+
+    describe('Bitbucket', () => {
+        it('matches standard paths', () => {
+            const validFiles = buildValidFilesSet([
+                'src/main/java/com/example/App.java',
+            ]);
+            expect(
+                matchesSuggestion(
+                    validFiles,
+                    'src/main/java/com/example/App.java',
+                ),
+            ).toBe(true);
+        });
+    });
+
+    describe('edge cases', () => {
+        it('rejects undefined relevantFile', () => {
+            const validFiles = buildValidFilesSet(['src/file.ts']);
+            expect(matchesSuggestion(validFiles, undefined)).toBe(false);
+        });
+
+        it('rejects empty string relevantFile', () => {
+            const validFiles = buildValidFilesSet(['src/file.ts']);
+            expect(matchesSuggestion(validFiles, '')).toBe(false);
+        });
+
+        it('normalizes backslashes to forward slashes', () => {
+            const validFiles = buildValidFilesSet([
+                'src\\components\\Button.tsx',
+            ]);
+            expect(
+                matchesSuggestion(validFiles, 'src/components/Button.tsx'),
+            ).toBe(true);
+        });
+
+        it('trims whitespace from paths', () => {
+            const validFiles = buildValidFilesSet([
+                '  src/file.ts  ',
+            ]);
+            expect(matchesSuggestion(validFiles, 'src/file.ts')).toBe(true);
+        });
+
+        it('handles mixed providers in the same set', () => {
+            const validFiles = buildValidFilesSet([
+                '/azure-style/file.php',
+                'github-style/file.ts',
+                'gitlab-style/file.rb',
+            ]);
+            expect(
+                matchesSuggestion(validFiles, 'azure-style/file.php'),
+            ).toBe(true);
+            expect(
+                matchesSuggestion(validFiles, 'github-style/file.ts'),
+            ).toBe(true);
+            expect(
+                matchesSuggestion(validFiles, 'gitlab-style/file.rb'),
+            ).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
Closes #1035 

<!-- kody-pr-summary:start -->
This pull request introduces a hotfix to improve the reliability of file path matching for code review suggestions, particularly addressing inconsistencies observed with Azure Repos.

The core change involves applying a `normalizeRepoPath` utility function to standardize file paths. This function is now used consistently when:
1.  Building the set of changed files for a pull request.
2.  Comparing a suggestion's `relevantFile` path against the list of changed files.

This ensures that variations in path formatting (e.g., presence or absence of leading slashes, use of backslashes) across different Git providers (GitHub, GitLab, Azure Repos, Bitbucket) do not lead to suggestions being incorrectly discarded.

Additionally, detailed warning logs have been added. These logs will now provide specific context, including the original and normalized paths, when a suggestion is dropped due to a path mismatch, significantly aiding in debugging and troubleshooting.

New unit tests have been added to thoroughly validate the path normalization logic across various Git providers and edge cases, confirming its robustness and ensuring consistent behavior.

This fix prevents relevant code review suggestions from being missed due to path formatting discrepancies, thereby enhancing the accuracy and completeness of the code review process.
<!-- kody-pr-summary:end -->