### PR TITLE
fix(web): block app.kodus.io from search-engine indexing

### DIFF
--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -81,6 +81,10 @@ const nextConfig = {
                         key: 'Strict-Transport-Security',
                         value: 'max-age=31536000; includeSubDomains',
                     },
+                    {
+                        key: 'X-Robots-Tag',
+                        value: 'noindex, nofollow',
+                    },
                 ],
             },
         ];

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -28,6 +28,11 @@ export const metadata: Metadata = {
         template: "%s | Kodus",
     },
     icons: { icon: "/favicon.ico" },
+    robots: {
+        index: false,
+        follow: false,
+        googleBot: { index: false, follow: false, noimageindex: true },
+    },
     openGraph: {
         locale: "en_US",
         type: "website",

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,0 +1,7 @@
+import type { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+    return {
+        rules: { userAgent: "*", disallow: "/" },
+    };
+}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -139,6 +139,6 @@ export const config = {
     // exclusion, unauthenticated calls (e.g. email-existence check on
     // sign-up) get redirected to /sign-in and the client sees a 307 loop.
     matcher: [
-        "/((?!api/webhooks|api/play|api/proxy|_next|assets|favicon.ico|api/health).*)",
+        "/((?!api/webhooks|api/play|api/proxy|_next|assets|favicon.ico|api/health|robots.txt).*)",
     ],
 };


### PR DESCRIPTION
## Summary
- `app.kodus.io` had **zero** indexing controls — no `robots.txt`, no `<meta name="robots">`, no `X-Robots-Tag`. Brand search "kodus" was landing on `app.kodus.io/sign-in` (1.788 PV in April per PostHog) instead of the marketing site.
- Fix applies defense-in-depth at four layers so that misbehaving crawlers and non-HTML responses are also covered.

## Changes (`apps/web/`)
- **`src/app/robots.ts`** (new) — Next.js Metadata Route serving `User-Agent: * / Disallow: /` at `/robots.txt`.
- **`src/app/layout.tsx`** — added `robots: { index: false, follow: false, googleBot: { ..., noimageindex: true } }` to root metadata; renders `<meta name="robots">` and `<meta name="googlebot">` on every route.
- **`next.config.js`** — added `X-Robots-Tag: noindex, nofollow` to the global `headers()` block (covers non-HTML responses + redirects).
- **`src/middleware.ts`** — added `robots.txt` to the auth-middleware matcher exclusion. Without this, `/robots.txt` 307s to `/sign-in` (because it isn't in `publicPaths`) and crawlers never see the `Disallow` rule.

## Why this combo, not just one
- `<meta robots>` only covers HTML responses; bots that ignore HTML still respect `X-Robots-Tag` headers.
- `robots.txt` tells crawlers **not to crawl**, but `noindex` tells them **not to index** (what was crawled). Both are needed: brand search dropping `/sign-in` requires the noindex; reducing crawl traffic from the 4.098-session/day spike on 20/04 requires the disallow.
- I deliberately **did not** add `<link rel="canonical" href="https://kodus.io/">`. Pointing canonical from `/sign-in` to a marketing homepage is a known SEO antipattern when combined with `noindex` (GSC flags "Submitted URL marked noindex"). `noindex` alone is sufficient and correct.

## Test plan
Verified locally on a `next build` + `next start` against port 3099:
- [x] `curl /robots.txt` → 200, body `User-Agent: *\nDisallow: /`
- [x] `curl -I /sign-in | grep -i x-robots-tag` → `noindex, nofollow`
- [x] `/sign-in` HTML contains `<meta name="robots" content="noindex, nofollow"/>` and `<meta name="googlebot" content="noindex, nofollow, noimageindex"/>`
- [x] Root `/` also returns `X-Robots-Tag` header
- [x] Pre-push hook: full test suite (3087 tests) passed in 32s

## Post-deploy checklist (not in this PR)
- [ ] Hit `https://app.kodus.io/robots.txt` and `https://app.kodus.io/sign-in` in prod after deploy and confirm same 3 signals.
- [ ] GSC URL Inspection on `app.kodus.io/sign-in` → "Request Indexing" to accelerate recrawl.
- [ ] D+7..14: confirm GSC reports "Excluded by 'noindex' tag" for `app.kodus.io/*`.
- [ ] D+30: re-measure brand query `kodus` in GSC; landing should shift away from `app.kodus.io/*` and CTR should rise above 0%.

## Refs
- Card P0.3: *Bloquear app.kodus.io da indexação Google (noindex + robots.txt)*
- `GROWTH_PLAN.md` P0.3 (line 539), P31 (line 609), Insight 9 (line 141)
- Changelog v1.13 (01/mai), v1.14 (01/mai) — confirmation via PostHog (`/sign-in` 1.788 PV in April)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- kody-pr-summary:start -->
This pull request implements a comprehensive strategy to prevent search engines from indexing the `app.kodus.io` domain.

The changes include:
*   Adding an `X-Robots-Tag: noindex, nofollow` HTTP header to all responses via `next.config.js`.
*   Configuring `robots` metadata in the application's `layout.tsx` to explicitly set `index: false` and `follow: false` for all robots, including specific instructions for Googlebot.
*   Introducing a new `robots.ts` file to generate a `robots.txt` that disallows all user agents from crawling the entire site (`/`).
*   Updating the middleware configuration to exclude `robots.txt` from processing, ensuring it is served correctly to search engine crawlers.

These combined measures ensure that the application is not indexed or followed by search engines.
<!-- kody-pr-summary:end -->