### PR TITLE
fix(mcp-manager): register entities by class to avoid TypeORM metadata mismatch

### DIFF
--- a/apps/mcp-manager/src/config/typeorm.config.ts
+++ b/apps/mcp-manager/src/config/typeorm.config.ts
@@ -2,6 +2,10 @@ import * as dotenv from 'dotenv';
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import { DataSource, DataSourceOptions } from 'typeorm';
 
+import { MCPConnectionEntity } from '../modules/mcp/entities/mcp-connection.entity';
+import { MCPIntegrationEntity } from '../modules/integrations/entities/mcp-integration.entity';
+import { MCPIntegrationOAuthEntity } from '../modules/integrations/entities/mcp-integration-oauth.entity';
+
 dotenv.config();
 
 const requiredEnvVars = [
@@ -35,7 +39,11 @@ const dataSourceConfig: DataSourceOptions = {
     password: process.env.API_PG_DB_PASSWORD,
     database: process.env.API_PG_DB_DATABASE,
     schema: 'mcp-manager',
-    entities: [__dirname + '/../**/*.entity{.ts,.js}'],
+    entities: [
+        MCPConnectionEntity,
+        MCPIntegrationEntity,
+        MCPIntegrationOAuthEntity,
+    ],
     migrations: [__dirname + '/../database/migrations/*{.ts,.js}'],
     migrationsTableName: 'migrations',
     synchronize: false,


### PR DESCRIPTION
## Summary

The `mcp-manager` `DataSource` was loading entities via filesystem glob:

```ts
entities: [__dirname + '/../**/*.entity{.ts,.js}'],
```

At runtime the dist tree contains both webpack-bundled entity classes (inside `dist/apps/mcp-manager/main.js`) and the loose `.entity.js` files that nest-build emits alongside the bundle. The repository code imports the **bundled** class via `__webpack_require__`, while the glob registers the **loose-file** class — two distinct class objects with the same name.

TypeORM's metadata lookup is by class reference (object identity), not by name, so any repository call (e.g. `integrationRepository.find(...)` or `.save(...)` while creating an MCP integration) throws:

```
EntityMetadataNotFound: No metadata for "MCPIntegrationEntity" was found.
```

This surfaces as a 500 from `GET /mcp/integrations`, `POST /mcp/integration/:provider`, etc. and breaks the **Memory** feature end-to-end (saving a memory in the UI fails silently — the toast says "tracked" but nothing is persisted because the underlying integration row can't be created).

The change replaces the glob with explicit class imports so that registration and runtime use the same class instances. Migrations are unaffected (still discovered via glob, since they're loaded by the standalone CLI / TypeORM's migration runner, not via webpack).

Closes #1048.

## Test plan

Tested on a self-hosted Kubernetes deployment (`mcp-manager` Pod restarted with a freshly-built image carrying this fix):

- [x] `GET /mcp/integrations` — previously returned `500 EntityMetadataNotFound`, now successfully runs `SELECT … FROM "mcp-manager"."mcp_integrations"` and returns rows (the only remaining 500 is the unrelated upstream Composio 401, which proves the DB call succeeded).
- [x] `POST /mcp/integration/custom` with a valid payload — previously failed at `integrationRepository.create + save()`. Now returns `201 Created` with a fully populated `MCPIntegrationEntity` (id, encrypted auth/headers, timestamps).
- [x] `DELETE /mcp/integration/custom/:integrationId` — `200 OK`; the row is removed cleanly.
- [x] `mcp-manager` boots without warnings/errors related to entity metadata.
- [x] Migrations still resolve via the existing glob and run normally.

## Notes

- Diff is intentionally minimal: 1 file, 9 insertions / 1 deletion. No public API or schema change.
- The same pattern (explicit class imports) is already used in the `api` app's TypeORM config in this repo, so this aligns `mcp-manager` with the rest of the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- kody-pr-summary:start -->
Refactored the TypeORM configuration in the `mcp-manager` application to explicitly register database entities by their class names.

Previously, entities were discovered using a glob pattern (`__dirname + '/../**/*.entity{.ts,.js}'`). This change replaces the glob pattern with a direct list of entity classes: `MCPConnectionEntity`, `MCPIntegrationEntity`, and `MCPIntegrationOAuthEntity`.

This modification aims to prevent potential TypeORM metadata mismatch issues by ensuring entities are correctly identified and registered, particularly in environments where glob-based discovery might be unreliable.
<!-- kody-pr-summary:end -->