### PR TITLE
fix(feature-gate): import TelemetryModule explicitly to avoid DI boot race

### DIFF
--- a/libs/feature-gate/modules/feature-gate.module.ts
+++ b/libs/feature-gate/modules/feature-gate.module.ts
@@ -1,9 +1,18 @@
 import { Global, Module } from '@nestjs/common';
 
+import { TelemetryModule } from '@libs/telemetry/modules/telemetry.module';
+
 import { FeatureGateService } from '../application/feature-gate.service';
 
 @Global()
 @Module({
+    // `FeatureGateService` injects `POSTHOG_PROVIDER_TOKEN`, which is
+    // registered by `TelemetryModule`. Even though both modules are
+    // `@Global()`, making the dependency explicit here removes the boot
+    // race where `FeatureGateService` could be instantiated before
+    // `TelemetryModule` had registered the token (observed in the
+    // webhooks app — `UnknownDependenciesException` at startup).
+    imports: [TelemetryModule],
     providers: [FeatureGateService],
     exports: [FeatureGateService],
 })


### PR DESCRIPTION
… race

After migrating `FeatureGateService` to inject `POSTHOG_PROVIDER_TOKEN`, the webhooks app boot started failing with:

    UnknownDependenciesException [Error]: Nest can't resolve dependencies
    of the FeatureGateService (?). Please make sure that the argument at
    index [0] is available in the current module.

Both `TelemetryModule` and `FeatureGateModule` are `@Global()`, but Nest still required `TelemetryModule` to be initialised before `FeatureGateService` could resolve the token. The other apps (api, worker) happened to import `TelemetryModule` higher in their tree, so the ordering was fine; the webhooks app loaded `FeatureGateModule` first.

Importing `TelemetryModule` directly from `FeatureGateModule` makes the dependency explicit and removes the ordering hazard.

<!--
  Thanks for sending a PR! The PR title MUST follow Conventional Commits, e.g.
    feat(code-review): add agent-first reviewer
    fix(web): block app.kodus.io from search-engine indexing
    chore(deps): bump posthog-node to 4.x
  CI will fail otherwise.
-->

## Summary

<!-- 1–3 sentences. What changes for the user (or for us, if internal)? -->

## Changelog routing (driven by the PR title prefix)

The prefix in your PR title decides where this change appears in the public changelog. No labels needed — the title is the source of truth.

| Prefix     | Public changelog                              |
| ---------- | --------------------------------------------- |
| `feat:`    | **Improvements** section (or tied to a tracked feature, see below) |
| `fix:`     | **Bug fixes** section                         |
| `perf:`    | **Performance** section                       |
| `docs:`, `style:`, `refactor:`, `test:`, `chore:`, `ci:`, `build:` | Hidden from public changelog |

## Test plan

<!-- Bullet list of the manual / automated checks. -->

- [ ]
- [ ]

## Notes for the reviewer

<!-- Anything non-obvious. Risks, follow-ups, screenshots for UX work. -->


---

<!-- kody-pr-summary:start -->
Fixes a dependency injection boot race condition in the `FeatureGateModule`.

Previously, the `FeatureGateService` could be instantiated before the `TelemetryModule` had registered the `POSTHOG_PROVIDER_TOKEN` it depends on, leading to an `UnknownDependenciesException` at application startup. This issue occurred despite both modules being global.

By explicitly importing `TelemetryModule` into `FeatureGateModule`, the dependency is now clearly defined, ensuring that `TelemetryModule` and its providers are initialized before `FeatureGateService` attempts to inject `POSTHOG_PROVIDER_TOKEN`. This resolves the startup error and improves application stability.
<!-- kody-pr-summary:end -->