### PR TITLE
chore(dev): harden dev-env — heap caps, log rotation, yarn cache mutex

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,3 +1,16 @@
+# Bound the per-container json log file size on EVERY host. OrbStack
+# defaults to a sensible cap (max-size 20m, max-file 5), but vanilla
+# Docker on Linux applies NO rotation by default — MongoDB's verbose
+# stdout filled `/var/lib/docker/containers/<id>/<id>-json.log` to tens
+# of GB on a teammate's machine and corrupted the partition before we
+# noticed. Shipping the cap in compose makes the fix portable across
+# Mac/Linux/CI without per-machine daemon.json edits.
+x-logging: &default-logging
+    driver: json-file
+    options:
+        max-size: '20m'
+        max-file: '5'
+
 x-app-service-template: &app-service-defaults
     build:
         context: .
@@ -20,6 +33,7 @@ x-app-service-template: &app-service-defaults
     networks:
         - kodus-backend-services
         - shared-network
+    logging: *default-logging
 
 services:
     #----------------------------------------------------------------
@@ -104,14 +118,25 @@ services:
                 reservations:
                     memory: 512M
         healthcheck:
-            test: ['CMD', 'node', '-e', 'process.exit(0)']
+            # `node -e 'process.exit(0)'` always passed regardless of app
+            # state — combined with the silent OOM bug fixed above, the
+            # container could be in a restart loop and still report
+            # healthy. pgrep matches the actual nest watch process so a
+            # crashed dev server is detected. procps is installed in the
+            # dev image (see Dockerfile.dev).
+            test: ['CMD-SHELL', 'pgrep -f "nest start worker" >/dev/null']
             interval: 30s
             timeout: 10s
             retries: 3
             start_period: 60s
         environment:
             - API_CLOUD_MODE=${API_CLOUD_MODE:-false}
-            - NODE_OPTIONS=--max-old-space-size=4096 --max-semi-space-size=64
+            # V8 heap kept below the 2G container cap (with ~500M headroom
+            # for native modules, thread stacks, and Node runtime overhead).
+            # Previously set to 4096M, which let V8 try to grow past the
+            # cgroup limit — kernel OOM-killed the process silently while
+            # the trivial healthcheck kept reporting "healthy".
+            - NODE_OPTIONS=--max-old-space-size=1536 --max-semi-space-size=64
             - DEBUG_PORT=9231
             - COMPONENT_TYPE=worker
             - API_LOG_PRETTY=true
@@ -147,14 +172,19 @@ services:
                 reservations:
                     memory: 256M
         healthcheck:
-            test: ['CMD', 'node', '-e', 'process.exit(0)']
+            # See worker service for rationale — pgrep replaces the
+            # always-passing trivial check.
+            test: ['CMD-SHELL', 'pgrep -f "nest start worker" >/dev/null']
             interval: 30s
             timeout: 10s
             retries: 3
             start_period: 60s
         environment:
             - API_CLOUD_MODE=${API_CLOUD_MODE:-false}
-            - NODE_OPTIONS=--max-old-space-size=1536 --max-semi-space-size=64
+            # V8 heap kept below the 1G container cap. 1536M heap on a
+            # 1G cgroup let V8 grow past the limit and triggered silent
+            # OOM kills — see worker service comment.
+            - NODE_OPTIONS=--max-old-space-size=768 --max-semi-space-size=64
             - DEBUG_PORT=9241
             - COMPONENT_TYPE=worker
             - API_LOG_PRETTY=true
@@ -194,14 +224,19 @@ services:
                 reservations:
                     memory: 256M
         healthcheck:
-            test: ['CMD', 'node', '-e', 'process.exit(0)']
+            # See worker service for rationale — pgrep replaces the
+            # always-passing trivial check.
+            test: ['CMD-SHELL', 'pgrep -f "nest start webhooks" >/dev/null']
             interval: 30s
             timeout: 10s
             retries: 3
             start_period: 60s
         environment:
             - API_CLOUD_MODE=${API_CLOUD_MODE:-false}
-            - NODE_OPTIONS=--max-old-space-size=4096 --max-semi-space-size=64
+            # V8 heap kept below the 1G container cap. 4096M heap on a
+            # 1G cgroup let V8 grow past the limit and triggered silent
+            # OOM kills — see worker service comment.
+            - NODE_OPTIONS=--max-old-space-size=768 --max-semi-space-size=64
             - DEBUG_PORT=9232
             - API_LOG_PRETTY=true
             - PYROSCOPE_SERVER_ADDRESS=${PYROSCOPE_SERVER_ADDRESS:-http://pyroscope:4040}
@@ -243,7 +278,9 @@ services:
             # migrations from inside this container — those belong to the
             # api/worker services, not here.
             - RUN_MIGRATIONS=false
-            - NODE_OPTIONS=--max-old-space-size=1024 --max-semi-space-size=64
+            # V8 heap kept below the 1G container cap with headroom for
+            # native modules and runtime overhead.
+            - NODE_OPTIONS=--max-old-space-size=768 --max-semi-space-size=64
             - DEBUG_PORT=9230
             - API_MCP_MANAGER_PORT=${API_MCP_MANAGER_PORT:-3101}
             - API_MCP_MANAGER_LOG_LEVEL=${API_MCP_MANAGER_LOG_LEVEL:-info}
@@ -312,6 +349,7 @@ services:
                     memory: 2G
                 reservations:
                     memory: 512M
+        logging: *default-logging
 
     #----------------------------------------------------------------
     # Observability & Profiling
@@ -329,6 +367,7 @@ services:
         networks:
             - kodus-backend-services
         restart: unless-stopped
+        logging: *default-logging
 
     #----------------------------------------------------------------
     # Databases & Infrastructure
@@ -372,6 +411,7 @@ services:
             nofile:
                 soft: 65536
                 hard: 65536
+        logging: *default-logging
 
         command: /usr/local/bin/init-definitions.sh
 
@@ -403,6 +443,7 @@ services:
             timeout: 3s
             retries: 20
             start_period: 10s
+        logging: *default-logging
 
     db_mongodb:
         profiles:
@@ -431,6 +472,7 @@ services:
             timeout: 5s
             retries: 20
             start_period: 20s
+        logging: *default-logging
 
 volumes:
     yalc_store:

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -45,18 +45,30 @@ COPY packages/kodus-flow ./packages/kodus-flow
 
 # Build local packages first. Shared yarn cache mount survives across
 # rebuilds so dependency changes don't trigger a full re-download.
-RUN --mount=type=cache,target=/yarn-cache,sharing=locked \
+#
+# `sharing=shared` (vs the historical `sharing=locked`) lets the parallel
+# service builds (api/worker/webhooks/worker-analytics/mcp-manager) all
+# read the cache concurrently — observed `yarn install` ballooning past
+# 30min during cold-cache rebuilds purely from lock waits when the mount
+# was `sharing=locked`.
+#
+# Yarn 1's in-process write lock does NOT span containers, so concurrent
+# extracts from a shared cache can race (EEXIST on the same package tgz,
+# partial writes leaving the cache inconsistent). `--mutex file:<path>`
+# inside the cache mount creates a cross-process file lock that serializes
+# the brief write windows without re-introducing global contention.
+RUN --mount=type=cache,target=/yarn-cache,sharing=shared \
     cd packages/kodus-common \
-  && YARN_CACHE_FOLDER=/yarn-cache yarn install \
+  && YARN_CACHE_FOLDER=/yarn-cache yarn install --mutex file:/yarn-cache/.yarn-mutex \
   && YARN_CACHE_FOLDER=/yarn-cache yarn prepack
-RUN --mount=type=cache,target=/yarn-cache,sharing=locked \
+RUN --mount=type=cache,target=/yarn-cache,sharing=shared \
     cd packages/kodus-flow \
-  && YARN_CACHE_FOLDER=/yarn-cache yarn install \
+  && YARN_CACHE_FOLDER=/yarn-cache yarn install --mutex file:/yarn-cache/.yarn-mutex \
   && YARN_CACHE_FOLDER=/yarn-cache yarn build
 
 # Install dependencies and link local packages
-RUN --mount=type=cache,target=/yarn-cache,sharing=locked \
-    YARN_CACHE_FOLDER=/yarn-cache yarn install --frozen-lockfile
+RUN --mount=type=cache,target=/yarn-cache,sharing=shared \
+    YARN_CACHE_FOLDER=/yarn-cache yarn install --frozen-lockfile --mutex file:/yarn-cache/.yarn-mutex
 RUN rm -rf node_modules/@kodus/kodus-common && cp -r packages/kodus-common node_modules/@kodus/kodus-common
 RUN rm -rf node_modules/@kodus/flow && cp -r packages/kodus-flow node_modules/@kodus/flow
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request hardens the development environment by implementing several resource management and build reliability improvements.

Key changes include:

*   **Log Rotation for Docker Containers:** Configured all services in `docker-compose.dev.yml` to use `json-file` logging with a maximum size of 20MB per file and a maximum of 5 files. This prevents Docker log files from growing indefinitely and consuming excessive disk space, especially on vanilla Docker installations.
*   **Improved Health Checks:** Updated health checks for Node.js services (`api`, `worker`, `webhooks`, `worker-analytics`, `mcp-manager`) to use `pgrep` to verify the actual `nest start` process is running. This replaces the previous trivial health check that always passed, ensuring more accurate detection of crashed services.
*   **Optimized Node.js Heap Memory Limits:** Adjusted `NODE_OPTIONS` to set `max-old-space-size` for Node.js services (`api`, `worker`, `webhooks`, `worker-analytics`, `mcp-manager`) to values that fit within their respective container memory limits. This prevents silent Out-Of-Memory (OOM) kills by the kernel that occurred when V8 tried to allocate more memory than the container's cgroup limit.
*   **Enhanced Yarn Cache Management:** Modified the `Dockerfile.dev` to use `sharing=shared` for the Yarn cache mount and added `--mutex file:/yarn-cache/.yarn-mutex` to `yarn install` commands. This allows parallel service builds to read from the cache concurrently, significantly reducing build times, while the file-based mutex prevents race conditions during concurrent writes to the shared cache.
<!-- kody-pr-summary:end -->