### PR TITLE
fix(gitlab): normalize self-hosted host URLs

### DIFF
--- a/libs/platform/infrastructure/adapters/services/gitlab.service.spec.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.spec.ts
@@ -1,10 +1,14 @@
 import { ConfigService } from '@nestjs/config';
+import { Gitlab } from '@gitbeaker/rest';
 import axios from 'axios';
 
 import { AuthMode } from '@libs/platform/domain/platformIntegrations/enums/codeManagement/authMode.enum';
 import { GitlabService } from './gitlab.service';
 
 jest.mock('axios');
+jest.mock('@gitbeaker/rest', () => ({
+    Gitlab: jest.fn(),
+}));
 jest.mock('@libs/mcp-server/services/mcp-manager.service', () => ({
     MCPManagerService: jest.fn(),
 }));
@@ -23,6 +27,7 @@ describe('GitlabService', () => {
     let cacheService: Record<string, never>;
 
     const mockedAxios = axios as jest.Mocked<typeof axios>;
+    const mockedGitlab = Gitlab as unknown as jest.Mock;
 
     beforeEach(() => {
         integrationService = {
@@ -44,6 +49,21 @@ describe('GitlabService', () => {
         );
 
         jest.clearAllMocks();
+    });
+
+    it('normalizes bare stored hosts before creating the GitLab API client', () => {
+        (service as any).instanceGitlabApi({
+            accessToken: 'oauth-token',
+            authMode: AuthMode.OAUTH,
+            host: 'gitlab.example.com/',
+        });
+
+        expect(mockedGitlab).toHaveBeenCalledWith({
+            oauthToken: 'oauth-token',
+            host: 'https://gitlab.example.com',
+            queryTimeout: 600000,
+            camelize: false,
+        });
     });
 
     it('normalizes bare self-hosted GitLab hosts when authenticating with a token', async () => {

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.spec.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.spec.ts
@@ -1,0 +1,103 @@
+import { ConfigService } from '@nestjs/config';
+import axios from 'axios';
+
+import { AuthMode } from '@libs/platform/domain/platformIntegrations/enums/codeManagement/authMode.enum';
+import { GitlabService } from './gitlab.service';
+
+jest.mock('axios');
+jest.mock('@libs/mcp-server/services/mcp-manager.service', () => ({
+    MCPManagerService: jest.fn(),
+}));
+
+describe('GitlabService', () => {
+    const organizationAndTeamData = {
+        organizationId: 'org-1',
+        teamId: 'team-1',
+    };
+
+    let service: GitlabService;
+    let integrationService: { findOne: jest.Mock };
+    let integrationConfigService: Record<string, never>;
+    let authIntegrationService: Record<string, never>;
+    let configService: ConfigService;
+    let cacheService: Record<string, never>;
+
+    const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+    beforeEach(() => {
+        integrationService = {
+            findOne: jest.fn().mockResolvedValue({ uuid: 'integration-1' }),
+        };
+        integrationConfigService = {};
+        authIntegrationService = {};
+        configService = {
+            get: jest.fn(),
+        } as unknown as ConfigService;
+        cacheService = {};
+
+        service = new GitlabService(
+            integrationService as any,
+            integrationConfigService as any,
+            authIntegrationService as any,
+            configService,
+            cacheService as any,
+        );
+
+        jest.clearAllMocks();
+    });
+
+    it('normalizes bare self-hosted GitLab hosts when authenticating with a token', async () => {
+        mockedAxios.get.mockResolvedValue({ data: { id: 1 } });
+        const checkRepositoryPermissions = jest
+            .spyOn(service as any, 'checkRepositoryPermissions')
+            .mockResolvedValue({ success: true });
+        jest.spyOn(service as any, 'handleIntegration').mockResolvedValue(
+            undefined,
+        );
+
+        await service.authenticateWithToken({
+            token: 'pat-token',
+            host: 'gitlab.example.com/',
+            authMode: AuthMode.TOKEN,
+            organizationAndTeamData,
+        });
+
+        expect(mockedAxios.get).toHaveBeenCalledWith(
+            'https://gitlab.example.com/api/v4/user',
+            expect.objectContaining({
+                headers: { Authorization: 'Bearer pat-token' },
+                timeout: 30000,
+            }),
+        );
+        expect(checkRepositoryPermissions).toHaveBeenCalledWith({
+            authDetails: expect.objectContaining({
+                authMode: AuthMode.TOKEN,
+                host: 'https://gitlab.example.com',
+            }),
+        });
+    });
+
+    it('does not duplicate the protocol when building clone params for self-hosted GitLab', async () => {
+        jest.spyOn(service as any, 'getAuthDetails').mockResolvedValue({
+            accessToken: 'oauth-token',
+            authMode: AuthMode.OAUTH,
+            host: 'https://gitlab.example.com/',
+        });
+
+        const cloneParams = await service.getCloneParams({
+            organizationAndTeamData,
+            repository: {
+                id: 'repo-1',
+                name: 'repo',
+                fullName: 'group/repo',
+                defaultBranch: 'main',
+            },
+        });
+
+        expect(cloneParams.url).toBe('https://gitlab.example.com/group/repo');
+        expect(cloneParams.auth).toMatchObject({
+            type: AuthMode.OAUTH,
+            token: 'oauth-token',
+        });
+    });
+});

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -292,7 +292,9 @@ export class GitlabService implements Omit<
                 gitlabAuthDetail.authMode === AuthMode.OAUTH
                     ? gitlabAuthDetail.accessToken
                     : decrypt(gitlabAuthDetail.accessToken),
-            ...(gitlabAuthDetail.host && { host: gitlabAuthDetail.host }),
+            ...(gitlabAuthDetail.host && {
+                host: this.getGitlabWebBaseUrl(gitlabAuthDetail.host),
+            }),
             queryTimeout: 600000,
             camelize: false,
         });
@@ -308,7 +310,7 @@ export class GitlabService implements Omit<
             ? normalized
             : `https://${normalized}`;
 
-        return withProtocol.replace(/\/+$/, '');
+        return withProtocol;
     }
 
     private getGitlabWebBaseUrl(host?: string): string {

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -298,6 +298,23 @@ export class GitlabService implements Omit<
         });
     }
 
+    private normalizeGitlabHost(host?: string): string | undefined {
+        if (!host?.trim()) {
+            return undefined;
+        }
+
+        const normalized = host.trim().replace(/\/+$/, '');
+        const withProtocol = /^https?:\/\//i.test(normalized)
+            ? normalized
+            : `https://${normalized}`;
+
+        return withProtocol.replace(/\/+$/, '');
+    }
+
+    private getGitlabWebBaseUrl(host?: string): string {
+        return this.normalizeGitlabHost(host) || 'https://gitlab.com';
+    }
+
     async findRepositoryByName(params: {
         organizationAndTeamData: OrganizationAndTeamData;
         name: string;
@@ -791,12 +808,11 @@ export class GitlabService implements Omit<
 
     async authenticateWithToken(params: any): Promise<any> {
         try {
-            let host = 'https://gitlab.com/api/v4/user';
             const { token, host: hostParam } = params;
+            const normalizedHost = this.normalizeGitlabHost(hostParam);
+            const userApiUrl = `${this.getGitlabWebBaseUrl(hostParam)}/api/v4/user`;
 
-            host = hostParam ? `${hostParam}/api/v4/user` : host;
-
-            const testResponse = await axios.get(host, {
+            const testResponse = await axios.get(userApiUrl, {
                 headers: {
                     Authorization: `Bearer ${token}`,
                 },
@@ -810,7 +826,7 @@ export class GitlabService implements Omit<
             const authDetails = {
                 accessToken: encrypt(token),
                 authMode: params?.authMode || AuthMode.OAUTH,
-                host: hostParam ?? '',
+                host: normalizedHost ?? '',
             };
 
             const checkRepos = await this.checkRepositoryPermissions({
@@ -3123,12 +3139,11 @@ export class GitlabService implements Omit<
                 throw new Error('GitLab authentication details not found');
             }
 
-            const gitlabHost = gitlabAuthDetail.host || 'gitlab.com';
             const encodedPath = (params?.repository?.fullName || '')
                 .split('/')
                 .map(encodeURIComponent)
                 .join('/');
-            const fullGitlabUrl = `https://${gitlabHost}/${encodedPath}`;
+            const fullGitlabUrl = `${this.getGitlabWebBaseUrl(gitlabAuthDetail.host)}/${encodedPath}`;
 
             return {
                 organizationId: params.organizationAndTeamData.organizationId,


### PR DESCRIPTION
## Summary

Fixes #1063

Self-hosted GitLab hosts were handled inconsistently across the GitLab integration. Token authentication validated `${host}/api/v4/user`, which requires a scheme-qualified host, but clone params later built repository URLs with `https://${gitlabHost}`. When a self-hosted GitLab origin was saved as `https://gitlab.example.com`, code review and AST graph clone jobs could end up fetching `https://https://gitlab.example.com/...`; when users entered `gitlab.example.com`, PAT validation could fail before the integration was saved.

This PR normalizes GitLab hosts in one place, adding `https://` when the user enters a bare hostname and trimming trailing slashes. The normalized web base URL is then reused for PAT validation and clone URL generation, so self-hosted GitLab works for both PAT and OAuth-stored hosts without duplicating the protocol.

## Changelog routing (driven by the PR title prefix)

`fix:` routes this change to the public **Bug fixes** changelog section.

## Test plan

- [x] `corepack yarn jest libs/platform/infrastructure/adapters/services/gitlab.service.spec.ts --runInBand --config jest.config.ts`
- [x] `corepack yarn prettier --write libs/platform/infrastructure/adapters/services/gitlab.service.ts libs/platform/infrastructure/adapters/services/gitlab.service.spec.ts`

## Notes for the reviewer

The regression coverage checks both sides of the bug:

- Bare self-hosted PAT host input like `gitlab.example.com/` is validated against `https://gitlab.example.com/api/v4/user` and saved normalized.
- Scheme-qualified stored hosts like `https://gitlab.example.com/` produce clone URLs like `https://gitlab.example.com/group/repo`, not `https://https://...`.

The default GitLab.com behavior remains unchanged for empty hosts.


---

<!-- kody-pr-summary:start -->
This pull request introduces host URL normalization for GitLab self-hosted instances.

Previously, inconsistencies in user-provided host URLs (e.g., missing protocols, trailing slashes) could lead to malformed API requests or incorrect repository clone URLs.

The changes implement a `normalizeGitlabHost` utility to ensure that all GitLab host URLs are consistently formatted with `https://` and without trailing slashes. This normalization is applied when:

*   Authenticating with a personal access token, ensuring API calls are made to the correct endpoint.
*   Generating repository clone URLs, preventing issues like duplicated protocols or extra slashes in the URL.

This fix improves the reliability of integrating with self-hosted GitLab instances by standardizing how host URLs are handled throughout the service.
<!-- kody-pr-summary:end -->