### PR TITLE
  feat(cli): integrate Hunk TUI viewer for diff and review

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -56,6 +56,7 @@
         "execa": "^9.6.1",
         "figlet": "^1.11.0",
         "gradient-string": "^3.0.0",
+        "hunkdiff": "^0.10.0",
         "latest-version": "^9.0.0",
         "node-machine-id": "^1.1.12",
         "open": "^11.0.0",

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -56,7 +56,7 @@
         "execa": "^9.6.1",
         "figlet": "^1.11.0",
         "gradient-string": "^3.0.0",
-        "hunkdiff": "^0.10.0",
+        "hunkdiff": "0.10.0",
         "latest-version": "^9.0.0",
         "node-machine-id": "^1.1.12",
         "open": "^11.0.0",

--- a/apps/cli/skills/README.md
+++ b/apps/cli/skills/README.md
@@ -14,6 +14,8 @@ This directory contains the agent skills shipped with the Kodus CLI repository.
     - Fetch PR suggestions and apply fixes with judgment.
 - `kodus-centralized-config`
     - Manage centralized config from CLI (status, init, sync, disable, download).
+- `hunk-review` (vendored from [`hunkdiff`](https://github.com/modem-dev/hunk))
+    - Drive a live Hunk diff review session: inspect, navigate, reload, and add inline comments via `hunk session ...`. Pairs with `kodus diff` and the hunk-backed `kodus review` viewer.
 
 ## Trigger Map (recommended)
 
@@ -30,6 +32,8 @@ This directory contains the agent skills shipped with the Kodus CLI repository.
     - Use `kodus-business-rules-validation`.
 - User asks to enable/disable/sync/download centralized config or choose centralized config source repository
     - Use `kodus-centralized-config`.
+- User has a Hunk session open or asks to navigate / comment / reload a live Hunk diff
+    - Use `hunk-review`. Triggers also include "abrir hunk", "hunk session", "comentar no hunk".
 
 ## Notes
 

--- a/apps/cli/skills/hunk-review/SKILL.md
+++ b/apps/cli/skills/hunk-review/SKILL.md
@@ -1,0 +1,154 @@
+---
+name: hunk-review
+description: Interacts with live Hunk diff review sessions via CLI. Inspects review focus, navigates files and hunks, reloads session contents, and adds inline review comments. Use when the user has a Hunk session running or wants to review diffs interactively.
+---
+
+# Hunk Review
+
+Hunk is an interactive terminal diff viewer. The TUI is for the user -- do NOT run `hunk diff`, `hunk show`, or other interactive commands directly. Use `hunk session *` CLI commands to inspect and control live sessions through the local daemon.
+
+If no session exists, ask the user to launch Hunk in their terminal first.
+
+## Workflow
+
+```text
+1. hunk session list                                    # find live sessions
+2. hunk session get --repo .                            # inspect path / repo / source
+3. hunk session review --repo . --json                  # inspect file/hunk structure first
+4. hunk session review --repo . --include-patch --json  # opt into raw diff text only when needed
+5. hunk session context --repo .                        # check current focus when needed
+6. hunk session navigate ...                            # move to the right place
+7. hunk session reload -- <command>                     # swap contents if needed
+8. hunk session comment add ...                         # leave one review note
+9. hunk session comment apply ...                       # apply many agent notes in one stdin batch
+```
+
+## Session selection
+
+Most session commands accept:
+
+- `--repo <path>` -- match the live session by its current loaded repo root (most common)
+- `<session-id>` -- match by exact ID (use when multiple sessions share a repo)
+- If only one session exists, it auto-resolves
+
+`reload` also supports:
+
+- `--session-path <path>` -- match the live Hunk window by its current working directory
+- `--source <path>` -- load the replacement `diff` / `show` command from a different directory
+
+Use `--source` only for advanced reloads where the live session you want to control is not already associated with the checkout you want to load next. For a normal worktree session, prefer selecting it directly with `--repo /path/to/worktree`.
+
+## Commands
+
+### Inspect
+
+```bash
+hunk session list [--json]
+hunk session get (--repo . | <id>) [--json]
+hunk session context (--repo . | <id>) [--json]
+hunk session review (--repo . | <id>) [--json] [--include-patch]
+```
+
+- `get` shows the session `Path`, `Repo`, and `Source`, which helps when choosing between `--repo` and `--session-path`
+- `Repo` is what `--repo` matches; `Path` is what `--session-path` matches
+- `review --json` returns file and hunk structure by default; add `--include-patch` only when a caller truly needs raw unified diff text
+
+### Navigate
+
+Absolute navigation requires `--file` and exactly one of `--hunk`, `--new-line`, or `--old-line`:
+
+```bash
+hunk session navigate --repo . --file src/App.tsx --hunk 2
+hunk session navigate --repo . --file src/App.tsx --new-line 372
+hunk session navigate --repo . --file src/App.tsx --old-line 355
+```
+
+Relative comment navigation jumps between annotated hunks and does not require `--file`:
+
+```bash
+hunk session navigate --repo . --next-comment
+hunk session navigate --repo . --prev-comment
+```
+
+- `--hunk <n>` is 1-based
+- `--new-line` / `--old-line` are 1-based line numbers on that diff side
+- Use either `--next-comment` or `--prev-comment`, not both
+
+### Reload
+
+Swaps the live session's contents. Pass a Hunk review command after `--`:
+
+```bash
+hunk session reload --repo . -- diff
+hunk session reload --repo . -- diff main...feature -- src/ui
+hunk session reload --repo . -- show HEAD~1
+hunk session reload --repo . -- show HEAD~1 -- README.md
+hunk session reload --repo /path/to/worktree -- diff
+hunk session reload --session-path /path/to/live-window --source /path/to/other-checkout -- diff
+```
+
+- Always include `--` before the nested Hunk command
+- `--repo` or `<session-id>` usually selects the session you want
+- `--source` is advanced: it does not select the session; it only changes where the replacement review command runs
+- If the live session is already showing the target worktree, prefer `hunk session reload --repo /path/to/worktree -- diff`
+- `--session-path` targets the live window when you need to keep session selection separate from reload source
+
+### Comments
+
+```bash
+hunk session comment add --repo . --file README.md --new-line 103 --summary "Tighten this wording" [--rationale "..."] [--author "agent"] [--focus]
+printf '%s\n' '{"comments":[{"filePath":"README.md","newLine":103,"summary":"Tighten this wording"}]}' | hunk session comment apply --repo . --stdin [--focus]
+hunk session comment list --repo . [--file README.md]
+hunk session comment rm --repo . <comment-id>
+hunk session comment clear --repo . --yes [--file README.md]
+```
+
+- `comment add` is best for one note; `comment apply` is best when an agent already has several notes ready
+- `comment add` requires `--file`, `--summary`, and exactly one of `--old-line` or `--new-line`
+- `comment apply` payload items require `filePath`, `summary`, and exactly one target such as `hunk`, `hunkNumber`, `oldLine`, or `newLine`
+- `comment apply` reads a JSON batch from stdin and validates the full batch before mutating the live session
+- Pass `--focus` when you want to jump to the new note or the first note in a batch
+- `comment list` and `comment clear` accept optional `--file`
+- Quote `--summary` and `--rationale` defensively in the shell
+
+## New files in working-tree reviews
+
+`hunk diff` includes untracked files by default. If the user wants tracked changes only, reload with `--exclude-untracked`:
+
+```bash
+hunk session reload --repo . -- diff --exclude-untracked
+```
+
+## Guiding a review
+
+The user may ask you to walk them through a changeset or review code using Hunk. Start with `hunk session review --json` to understand the file/hunk structure without inflating agent context, then use `--include-patch` only for the files you truly need to read in raw diff form. Use `context` and `navigate` to line up the user's current view before adding comments.
+
+Your role is to narrate: steer the user's view to what matters and leave comments that explain what they're looking at.
+
+Typical flow:
+
+1. Load the right content (`reload` if needed)
+2. Navigate to the first interesting file / hunk
+3. Add a comment explaining what's happening and why
+4. If you already have several notes ready, prefer one `comment apply` batch over many separate shell invocations
+5. Summarize when done
+
+Guidelines:
+
+- Work in the order that tells the clearest story, not necessarily file order
+- Navigate before commenting so the user sees the code you're discussing
+- Use `comment apply` for agent-generated batches and `comment add` for one-off notes
+- Use `--focus` sparingly when the note itself should actively steer the review
+- Keep comments focused: intent, structure, risks, or follow-ups
+- Don't comment on every hunk -- highlight what the user wouldn't spot themselves
+
+## Common errors
+
+- **"No visible diff file matches ..."** -- the file is not in the loaded review. Check `context`, then `reload` if needed.
+- **"No active Hunk sessions"** -- ask the user to open Hunk in their terminal.
+- **"Multiple active sessions match"** -- pass `<session-id>` explicitly.
+- **"No active Hunk session matches session path ..."** -- for advanced split-path reloads, verify the live window `Path` via `hunk session get` or `list`, then use `--session-path`.
+- **"Pass the replacement Hunk command after `--`"** -- include `--` before the nested `diff` / `show` command.
+- **"Pass --stdin to read batch comments from stdin JSON."** -- `comment apply` only reads its batch payload from stdin.
+- **"Specify exactly one navigation target"** -- pick one of `--hunk`, `--old-line`, or `--new-line`.
+- **"Specify either --next-comment or --prev-comment, not both."** -- choose one comment-navigation direction.

--- a/apps/cli/src/cli.ts
+++ b/apps/cli/src/cli.ts
@@ -2,6 +2,7 @@ import { Command } from 'commander';
 import { createRequire } from 'node:module';
 import { authCommand } from './commands/auth/index.js';
 import { configCommand } from './commands/config.js';
+import { diffCommand } from './commands/diff.js';
 import { hookCommand } from './commands/hook/index.js';
 import { decisionsCommand } from './commands/memory/index.js';
 import { prCommand } from './commands/pr.js';
@@ -37,6 +38,7 @@ program
     .option('--agent', 'Agent mode: deterministic machine-readable output');
 
 program.addCommand(reviewCommand);
+program.addCommand(diffCommand);
 program.addCommand(authCommand);
 program.addCommand(subscribeCommand);
 program.addCommand(updateCommand);

--- a/apps/cli/src/commands/diff.ts
+++ b/apps/cli/src/commands/diff.ts
@@ -1,0 +1,31 @@
+import { Command } from 'commander';
+import chalk from 'chalk';
+import { cliError } from '../utils/logger.js';
+import { runHunk } from '../utils/hunk.js';
+
+export const diffCommand = new Command('diff')
+    .description(
+        'Open the current changeset in the Hunk terminal diff viewer (wraps `hunk diff`)',
+    )
+    .allowUnknownOption(true)
+    .helpOption(false)
+    .argument('[args...]', 'Arguments forwarded to `hunk diff`')
+    .action(async (_args: string[], _opts, command: Command) => {
+        const forwarded = command.args;
+
+        try {
+            const { exitCode } = await runHunk(['diff', ...forwarded]);
+            if (exitCode !== 0) {
+                process.exit(exitCode);
+            }
+        } catch (error) {
+            cliError(
+                chalk.red(
+                    `hunk diff failed: ${
+                        error instanceof Error ? error.message : String(error)
+                    }`,
+                ),
+            );
+            process.exit(1);
+        }
+    });

--- a/apps/cli/src/features/review/__tests__/hunk-context.test.ts
+++ b/apps/cli/src/features/review/__tests__/hunk-context.test.ts
@@ -1,0 +1,293 @@
+import { describe, expect, it } from 'vitest';
+import {
+    convertReviewToHunkContext,
+    countHunkAnnotations,
+} from '../hunk-context.js';
+import type { ReviewResult } from '../../../types/review.js';
+
+const baseResult: ReviewResult = {
+    summary: 'two issues across two files',
+    filesAnalyzed: 2,
+    duration: 42,
+    issues: [],
+};
+
+describe('convertReviewToHunkContext', () => {
+    it('groups issues by file, sorts files alphabetically and annotations by line', () => {
+        const result: ReviewResult = {
+            ...baseResult,
+            issues: [
+                {
+                    file: 'src/utils.ts',
+                    line: 10,
+                    severity: 'warning',
+                    message: 'extracted helper',
+                },
+                {
+                    file: 'src/auth.ts',
+                    line: 42,
+                    endLine: 48,
+                    severity: 'error',
+                    category: 'security_vulnerability',
+                    message: 'token logged in plaintext',
+                    suggestion: 'redact the JWT before logging',
+                    ruleId: 'sec/no-token-log',
+                },
+                {
+                    file: 'src/auth.ts',
+                    line: 5,
+                    severity: 'info',
+                    message: 'consider const',
+                },
+            ],
+        };
+
+        const context = convertReviewToHunkContext(result);
+
+        expect(context.version).toBe(1);
+        expect(context.files.map((f) => f.path)).toEqual([
+            'src/auth.ts',
+            'src/utils.ts',
+        ]);
+        const auth = context.files[0]!;
+        expect(auth.summary).toBe('2 findings');
+        expect(auth.annotations.map((a) => a.newRange)).toEqual([
+            [5, 5],
+            [42, 48],
+        ]);
+        expect(auth.annotations[1]!.summary).toBe(
+            '✖ token logged in plaintext',
+        );
+        // Single-paragraph rationale so hunk's word-wrap renders it cleanly.
+        const rationale = auth.annotations[1]!.rationale!;
+        expect(rationale).not.toContain('\n\n');
+        expect(rationale).toContain('Fix: redact the JWT before logging.');
+        // Attribution sits at the end so the prose reads first and the
+        // metadata becomes the closing tag.
+        expect(
+            rationale.endsWith(
+                '— Kody · severity error · security_vulnerability · sec/no-token-log',
+            ),
+        ).toBe(true);
+        expect(auth.annotations[0]!.summary).toBe('ℹ consider const');
+
+        const utils = context.files[1]!;
+        expect(utils.summary).toBe('1 finding');
+    });
+
+    it('falls back to a single-line range when endLine is missing or invalid', () => {
+        const result: ReviewResult = {
+            ...baseResult,
+            issues: [
+                {
+                    file: 'a.ts',
+                    line: 7,
+                    severity: 'info',
+                    message: 'tiny note',
+                },
+                {
+                    file: 'a.ts',
+                    line: 9,
+                    endLine: 4,
+                    severity: 'info',
+                    message: 'inverted endLine',
+                },
+            ],
+        };
+
+        const context = convertReviewToHunkContext(result);
+        expect(context.files[0]!.annotations.map((a) => a.newRange)).toEqual([
+            [7, 7],
+            [9, 9],
+        ]);
+    });
+
+    it('drops issues that lack a usable file or line anchor', () => {
+        const result: ReviewResult = {
+            ...baseResult,
+            issues: [
+                { file: '', line: 1, severity: 'info', message: 'no file' },
+                {
+                    file: 'a.ts',
+                    line: 0,
+                    severity: 'info',
+                    message: 'zero line',
+                },
+                {
+                    file: 'a.ts',
+                    line: -3,
+                    severity: 'info',
+                    message: 'negative line',
+                },
+                {
+                    file: 'a.ts',
+                    line: 12,
+                    severity: 'info',
+                    message: 'kept',
+                },
+            ],
+        };
+
+        const context = convertReviewToHunkContext(result);
+        expect(context.files).toHaveLength(1);
+        expect(context.files[0]!.annotations).toHaveLength(1);
+        expect(context.files[0]!.annotations[0]!.newRange).toEqual([12, 12]);
+    });
+
+    it('reports zero annotations when every finding is PR-level (no file/line)', () => {
+        // Mirrors the API response we saw in the wild: a critical finding
+        // about the PR description with no file/line anchor.
+        const context = convertReviewToHunkContext({
+            ...baseResult,
+            summary: 'PR description is missing the issue closing statement',
+            issues: [
+                {
+                    file: '',
+                    line: 0,
+                    severity: 'critical',
+                    message:
+                        'The PR description is empty and lacks a required GitHub closing statement.',
+                },
+            ],
+        });
+
+        expect(countHunkAnnotations(context)).toBe(0);
+        expect(context.files).toHaveLength(0);
+    });
+
+    it('renders a clean-summary headline when there are no findings', () => {
+        const context = convertReviewToHunkContext({
+            ...baseResult,
+            summary: '',
+            issues: [],
+        });
+        expect(context.summary).toBe('Kodus review: no findings.');
+        expect(context.files).toHaveLength(0);
+    });
+
+    it('builds a severity breakdown headline and preserves the API summary', () => {
+        const context = convertReviewToHunkContext({
+            ...baseResult,
+            summary: 'tightening auth and config',
+            issues: [
+                { file: 'a.ts', line: 1, severity: 'critical', message: 'x' },
+                { file: 'a.ts', line: 2, severity: 'critical', message: 'y' },
+                { file: 'a.ts', line: 3, severity: 'warning', message: 'z' },
+                { file: 'b.ts', line: 4, severity: 'info', message: 'w' },
+            ],
+        });
+
+        expect(context.summary).toContain('Kodus review: 4 findings');
+        expect(context.summary).toContain('2 critical');
+        expect(context.summary).toContain('1 warning');
+        expect(context.summary).toContain('1 info');
+        expect(context.summary).toContain('tightening auth and config');
+    });
+
+    it('uses the first sentence as headline and pushes the rest into rationale body', () => {
+        const longMessage =
+            'The selectedResult is computed before the hunk viewer check, resulting in dead computation if applyFieldMask mutates the object. ' +
+            'Move the computation below the if (useHunkViewer) block to ensure the hunk viewer receives all required fields.';
+        const context = convertReviewToHunkContext({
+            ...baseResult,
+            issues: [
+                {
+                    file: 'src/cmd.ts',
+                    line: 347,
+                    endLine: 348,
+                    severity: 'error',
+                    category: 'bug',
+                    message: longMessage,
+                },
+            ],
+        });
+
+        const annotation = context.files[0]!.annotations[0]!;
+        expect(annotation.summary).toBe(
+            '✖ The selectedResult is computed before the hunk viewer check, resulting in dead computation if applyFieldMask mutates the object.',
+        );
+
+        // The rest of the message becomes the lead of the rationale, then a
+        // single trailing attribution tag with metadata.
+        expect(annotation.rationale).toBe(
+            'Move the computation below the if (useHunkViewer) block to ensure the hunk viewer receives all required fields. — Kody · severity error · bug',
+        );
+        expect(annotation.rationale).not.toContain('\n');
+    });
+
+    it('does not split on abbreviations like "e.g." or "i.e."', () => {
+        const message =
+            'Use a redacting logger, e.g. pino-redact, for credentials.';
+        const context = convertReviewToHunkContext({
+            ...baseResult,
+            issues: [
+                {
+                    file: 'a.ts',
+                    line: 1,
+                    severity: 'warning',
+                    message,
+                },
+            ],
+        });
+
+        const annotation = context.files[0]!.annotations[0]!;
+        expect(annotation.summary).toBe(`⚠ ${message}`);
+    });
+
+    it('truncates a long single-sentence headline at a word boundary with ellipsis', () => {
+        const message =
+            'this is a single very long sentence without any periods that just keeps going and going describing in detail every single thing that could possibly be wrong with the code under review forever and ever amen';
+        const context = convertReviewToHunkContext({
+            ...baseResult,
+            issues: [
+                {
+                    file: 'a.ts',
+                    line: 1,
+                    severity: 'info',
+                    message,
+                },
+            ],
+        });
+
+        const summary = context.files[0]!.annotations[0]!.summary;
+        expect(summary.startsWith('ℹ ')).toBe(true);
+        expect(summary.endsWith('…')).toBe(true);
+        // glyph + space + capped headline + ellipsis must fit comfortably.
+        expect(summary.length).toBeLessThanOrEqual(150);
+        // The headline must end on a complete word from the original message
+        // (cut on a space boundary), never mid-word.
+        const headlineWord = summary
+            .replace(/^ℹ\s+/, '')
+            .replace(/…$/, '')
+            .split(/\s+/)
+            .pop()!;
+        expect(message.split(/\s+/)).toContain(headlineWord);
+    });
+
+    it('embeds suggested fix code into the rationale when present', () => {
+        const context = convertReviewToHunkContext({
+            ...baseResult,
+            issues: [
+                {
+                    file: 'a.ts',
+                    line: 10,
+                    endLine: 12,
+                    severity: 'error',
+                    message: 'mutates argument',
+                    fix: {
+                        type: 'replace',
+                        startLine: 10,
+                        endLine: 12,
+                        oldCode: 'arr.push(x);',
+                        newCode: 'return [...arr, x];',
+                    },
+                },
+            ],
+        });
+
+        const rationale = context.files[0]!.annotations[0]!.rationale!;
+        expect(rationale).toContain('Suggested replace (lines 10-12):');
+        expect(rationale).toContain('return [...arr, x];');
+        expect(rationale).not.toContain('\n');
+    });
+});

--- a/apps/cli/src/features/review/__tests__/result.test.ts
+++ b/apps/cli/src/features/review/__tests__/result.test.ts
@@ -3,6 +3,7 @@ import {
     formatFailOnExitMessage,
     formatTrialCompletionMessage,
     shouldFailReview,
+    shouldUseHunkViewer,
     shouldUseInteractiveReview,
 } from '../result.js';
 import type { ReviewResult, TrialReviewResult } from '../../../types/review.js';
@@ -75,6 +76,35 @@ describe('review result helpers', () => {
             'Exiting with code 1 because 2 issues meet or exceed `--fail-on warning`.',
         );
         expect(formatFailOnExitMessage(result, 'critical')).toBeNull();
+    });
+
+    it('routes to hunk viewer only for fully interactive humans on supported scopes', () => {
+        const baseline = {
+            isAgent: false,
+            interactive: undefined,
+            noHunk: false,
+            output: undefined,
+            format: 'terminal',
+            ttyOut: true,
+            scopeSupported: true,
+        } as const;
+
+        expect(shouldUseHunkViewer(baseline)).toBe(true);
+        expect(shouldUseHunkViewer({ ...baseline, isAgent: true })).toBe(false);
+        expect(shouldUseHunkViewer({ ...baseline, noHunk: true })).toBe(false);
+        expect(shouldUseHunkViewer({ ...baseline, interactive: true })).toBe(
+            false,
+        );
+        expect(
+            shouldUseHunkViewer({ ...baseline, output: '/tmp/out.json' }),
+        ).toBe(false);
+        expect(shouldUseHunkViewer({ ...baseline, format: 'json' })).toBe(
+            false,
+        );
+        expect(shouldUseHunkViewer({ ...baseline, ttyOut: false })).toBe(false);
+        expect(
+            shouldUseHunkViewer({ ...baseline, scopeSupported: false }),
+        ).toBe(false);
     });
 
     it('formats trial completion message from trial info or rate limit', () => {

--- a/apps/cli/src/features/review/__tests__/result.test.ts
+++ b/apps/cli/src/features/review/__tests__/result.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
     formatFailOnExitMessage,
     formatTrialCompletionMessage,
+    isHunkPlatformSupported,
     shouldFailReview,
     shouldUseHunkViewer,
     shouldUseInteractiveReview,
@@ -78,7 +79,7 @@ describe('review result helpers', () => {
         expect(formatFailOnExitMessage(result, 'critical')).toBeNull();
     });
 
-    it('routes to hunk viewer only for fully interactive humans on supported scopes', () => {
+    it('routes to hunk viewer only for fully interactive humans on supported scopes and platforms', () => {
         const baseline = {
             isAgent: false,
             interactive: undefined,
@@ -87,6 +88,7 @@ describe('review result helpers', () => {
             format: 'terminal',
             ttyOut: true,
             scopeSupported: true,
+            platformSupported: true,
         } as const;
 
         expect(shouldUseHunkViewer(baseline)).toBe(true);
@@ -105,6 +107,16 @@ describe('review result helpers', () => {
         expect(
             shouldUseHunkViewer({ ...baseline, scopeSupported: false }),
         ).toBe(false);
+        expect(
+            shouldUseHunkViewer({ ...baseline, platformSupported: false }),
+        ).toBe(false);
+    });
+
+    it('treats Windows as an unsupported hunk platform', () => {
+        // hunkdiff currently ships prebuilt binaries for darwin/linux only.
+        expect(isHunkPlatformSupported('win32')).toBe(false);
+        expect(isHunkPlatformSupported('darwin')).toBe(true);
+        expect(isHunkPlatformSupported('linux')).toBe(true);
     });
 
     it('formats trial completion message from trial info or rate limit', () => {

--- a/apps/cli/src/features/review/command.ts
+++ b/apps/cli/src/features/review/command.ts
@@ -34,8 +34,14 @@ import {
     formatFailOnExitMessage,
     formatTrialCompletionMessage,
     shouldFailReview,
+    shouldUseHunkViewer,
     shouldUseInteractiveReview,
 } from './result.js';
+import { canRenderScopeInHunk, openReviewInHunk } from './hunk-viewer.js';
+import {
+    convertReviewToHunkContext,
+    countHunkAnnotations,
+} from './hunk-context.js';
 import { ApiError } from '../../types/errors.js';
 import type { GlobalOptions } from '../../types/cli.js';
 import type { ReviewResult, TrialReviewResult } from '../../types/review.js';
@@ -53,6 +59,7 @@ type ReviewCommandOptions = {
     failOn?: string;
     fields?: string;
     githubPat?: string;
+    hunk?: boolean;
 };
 
 /**
@@ -61,7 +68,9 @@ type ReviewCommandOptions = {
  * developer convenience. Returns undefined when none are set so the
  * sandbox falls back to anonymous clone (works for public repos).
  */
-function resolveTrialGithubPat(options: ReviewCommandOptions): string | undefined {
+function resolveTrialGithubPat(
+    options: ReviewCommandOptions,
+): string | undefined {
     return (
         options.githubPat?.trim() ||
         process.env.KODUS_GITHUB_PAT?.trim() ||
@@ -73,14 +82,16 @@ function resolveTrialGithubPat(options: ReviewCommandOptions): string | undefine
 
 export function createReviewCommand(): Command {
     return new Command('review')
-        .description(`Analyze modified files for code review
+        .description(
+            `Analyze modified files for code review
 
 Examples:
   kodus review
   kodus review --staged
   kodus review --branch main
   kodus review src/auth.ts src/config.ts
-  kodus review --fail-on error`)
+  kodus review --fail-on error`,
+        )
         .argument('[files...]', 'Specific files to analyze')
         .option('-s, --staged', 'Analyze only staged files')
         .option('-c, --commit <sha>', 'Analyze diff from a specific commit')
@@ -114,6 +125,10 @@ Examples:
         .option(
             '--github-pat <token>',
             'GitHub Personal Access Token (read:repo). Trial users only — needed to clone private repos. Can also be set via KODUS_GITHUB_PAT env var. Held in memory only, never persisted.',
+        )
+        .option(
+            '--no-hunk',
+            'Skip the hunk TUI viewer and use the legacy interactive list (interactive sessions only)',
         )
         .action(reviewAction);
 }
@@ -176,7 +191,9 @@ async function reviewAction(
             }
 
             if (globalOpts.verbose) {
-                cliDebug(chalk.dim('[verbose] Reading project context files...'));
+                cliDebug(
+                    chalk.dim('[verbose] Reading project context files...'),
+                );
             }
 
             diff = await contextService.enrichDiffWithContext(
@@ -205,7 +222,7 @@ async function reviewAction(
                         branch: options.branch,
                         quiet: globalOpts.quiet,
                         onProgress: (status) => {
-                            if (globalOpts.quiet || ctx.isAgent) return;
+                            if (globalOpts.quiet || ctx.isAgent) {return;}
                             if (status === 'PENDING') {
                                 spinner.text = chalk.cyan(
                                     'Queued for review...',
@@ -228,10 +245,7 @@ async function reviewAction(
                 // setup doesn't block a one-off review. We only fall back on
                 // 401 — other errors (rate limit, server error, network)
                 // bubble up unchanged.
-                if (
-                    !(error instanceof ApiError) ||
-                    error.statusCode !== 401
-                ) {
+                if (!(error instanceof ApiError) || error.statusCode !== 401) {
                     throw error;
                 }
 
@@ -293,7 +307,9 @@ async function reviewAction(
             }
 
             if (globalOpts.verbose) {
-                cliDebug(chalk.dim('[verbose] Reading project context files...'));
+                cliDebug(
+                    chalk.dim('[verbose] Reading project context files...'),
+                );
             }
 
             diff = await contextService.enrichDiffWithContext(
@@ -338,6 +354,110 @@ async function reviewAction(
         }
 
         const selectedResult = fields ? applyFieldMask(result, fields) : result;
+        const ttyOut = Boolean(process.stdout.isTTY);
+        const scopeSupported = canRenderScopeInHunk({
+            files,
+            commit: options.commit,
+            branch: options.branch,
+        });
+        const wouldUseHunkButForScope =
+            !ctx.isAgent &&
+            options.hunk !== false &&
+            options.interactive !== true &&
+            !globalOpts.output &&
+            (!globalOpts.format || globalOpts.format === 'terminal') &&
+            ttyOut &&
+            !scopeSupported;
+
+        if (wouldUseHunkButForScope) {
+            cliInfo(
+                chalk.dim(
+                    'ℹ Hunk viewer skipped: --branch / --commit / explicit files have no direct hunk scope yet. Showing the interactive list instead. Pass --no-hunk to silence this hint.',
+                ),
+            );
+        }
+
+        const useHunkViewer = shouldUseHunkViewer({
+            isAgent: ctx.isAgent,
+            interactive: options.interactive,
+            noHunk: options.hunk === false,
+            output: globalOpts.output,
+            format: globalOpts.format,
+            ttyOut,
+            scopeSupported,
+        });
+
+        if (globalOpts.verbose) {
+            cliDebug(
+                chalk.dim(
+                    `[verbose] hunk routing: useHunkViewer=${useHunkViewer} ttyOut=${ttyOut} scopeSupported=${scopeSupported} format=${globalOpts.format} output=${globalOpts.output ?? '∅'} agent=${ctx.isAgent} interactive=${options.interactive ?? false} hunkOpt=${options.hunk}`,
+                ),
+            );
+        }
+
+        if (useHunkViewer) {
+            const reviewResult = result as ReviewResult;
+            const issues = reviewResult.issues ?? [];
+
+            if (globalOpts.verbose) {
+                cliDebug(
+                    chalk.dim(
+                        `[verbose] hunk: feeding ${issues.length} issue(s) to converter`,
+                    ),
+                );
+                for (const [idx, issue] of issues.entries()) {
+                    const preview = issue.message
+                        ? issue.message.slice(0, 80).replace(/\s+/g, ' ')
+                        : '∅';
+                    cliDebug(
+                        chalk.dim(
+                            `[verbose]   #${idx + 1} file=${JSON.stringify(issue.file)} line=${issue.line} endLine=${issue.endLine ?? '∅'} severity=${issue.severity} msg=${JSON.stringify(preview)}`,
+                        ),
+                    );
+                }
+            }
+
+            const hunkContext = convertReviewToHunkContext(reviewResult);
+            const annotationCount = countHunkAnnotations(hunkContext);
+
+            // PR-level findings have no file/line anchor and can't be inlined
+            // into a hunk panel. If every finding is unanchored, hunk would
+            // open empty. Bail out so the legacy interactive list (which does
+            // surface those findings) takes over.
+            const allUnanchored = annotationCount === 0 && issues.length > 0;
+
+            if (allUnanchored) {
+                cliInfo(
+                    chalk.dim(
+                        'ℹ Hunk viewer skipped: findings have no file/line anchor (likely PR-level). Showing the interactive list instead. Pass --no-hunk to silence this hint.',
+                    ),
+                );
+                // Fall through to the legacy interactive UI / formatter below.
+            } else {
+                const { exitCode } = await openReviewInHunk({
+                    result: reviewResult,
+                    scope: { staged: Boolean(options.staged) },
+                    keepContextOnExit: Boolean(globalOpts.verbose),
+                });
+
+                if (shouldFailReview(result, options.failOn)) {
+                    const failMessage = formatFailOnExitMessage(
+                        result,
+                        options.failOn,
+                    );
+                    if (failMessage) {
+                        cliInfo(chalk.yellow(failMessage));
+                    }
+                    exitWithCode(1);
+                }
+
+                if (exitCode !== 0) {
+                    exitWithCode(exitCode);
+                }
+                return;
+            }
+        }
+
         const shouldUseInteractive = shouldUseInteractiveReview({
             isAgent: ctx.isAgent,
             interactive: options.interactive,
@@ -460,9 +580,7 @@ async function runTrialFallback({
     const trialResult = await reviewService.trialAnalyze(diff, { githubPat });
 
     if (!globalOpts.quiet && !ctx.isAgent) {
-        spinner.succeed(
-            chalk.green(formatTrialCompletionMessage(trialResult)),
-        );
+        spinner.succeed(chalk.green(formatTrialCompletionMessage(trialResult)));
     }
 
     return trialResult;

--- a/apps/cli/src/features/review/command.ts
+++ b/apps/cli/src/features/review/command.ts
@@ -33,6 +33,7 @@ import { validateReviewOptions } from './options.js';
 import {
     formatFailOnExitMessage,
     formatTrialCompletionMessage,
+    isHunkPlatformSupported,
     shouldFailReview,
     shouldUseHunkViewer,
     shouldUseInteractiveReview,
@@ -355,21 +356,30 @@ async function reviewAction(
 
         const selectedResult = fields ? applyFieldMask(result, fields) : result;
         const ttyOut = Boolean(process.stdout.isTTY);
+        const platformSupported = isHunkPlatformSupported();
         const scopeSupported = canRenderScopeInHunk({
             files,
             commit: options.commit,
             branch: options.branch,
         });
-        const wouldUseHunkButForScope =
+        // The user is in an "interactive human" context where we'd otherwise
+        // route to hunk; we use this to decide whether to surface a one-line
+        // hint explaining why hunk was skipped.
+        const interactiveHumanContext =
             !ctx.isAgent &&
             options.hunk !== false &&
             options.interactive !== true &&
             !globalOpts.output &&
             (!globalOpts.format || globalOpts.format === 'terminal') &&
-            ttyOut &&
-            !scopeSupported;
+            ttyOut;
 
-        if (wouldUseHunkButForScope) {
+        if (interactiveHumanContext && !platformSupported) {
+            cliInfo(
+                chalk.dim(
+                    'ℹ Hunk viewer skipped: not yet supported on this platform (Windows). Showing the interactive list instead. Pass --no-hunk to silence this hint.',
+                ),
+            );
+        } else if (interactiveHumanContext && !scopeSupported) {
             cliInfo(
                 chalk.dim(
                     'ℹ Hunk viewer skipped: --branch / --commit / explicit files have no direct hunk scope yet. Showing the interactive list instead. Pass --no-hunk to silence this hint.',
@@ -385,12 +395,13 @@ async function reviewAction(
             format: globalOpts.format,
             ttyOut,
             scopeSupported,
+            platformSupported,
         });
 
         if (globalOpts.verbose) {
             cliDebug(
                 chalk.dim(
-                    `[verbose] hunk routing: useHunkViewer=${useHunkViewer} ttyOut=${ttyOut} scopeSupported=${scopeSupported} format=${globalOpts.format} output=${globalOpts.output ?? '∅'} agent=${ctx.isAgent} interactive=${options.interactive ?? false} hunkOpt=${options.hunk}`,
+                    `[verbose] hunk routing: useHunkViewer=${useHunkViewer} ttyOut=${ttyOut} platformSupported=${platformSupported} scopeSupported=${scopeSupported} format=${globalOpts.format} output=${globalOpts.output ?? '∅'} agent=${ctx.isAgent} interactive=${options.interactive ?? false} hunkOpt=${options.hunk}`,
                 ),
             );
         }

--- a/apps/cli/src/features/review/hunk-context.ts
+++ b/apps/cli/src/features/review/hunk-context.ts
@@ -1,0 +1,231 @@
+import type {
+    ReviewIssue,
+    ReviewResult,
+    Severity,
+} from '../../types/review.js';
+
+/**
+ * Schema accepted by `hunk diff --agent-context <file>` — a sidecar of agent
+ * notes the TUI renders inline next to the matching hunks. Mirrors the v1
+ * shape documented in modem-dev/hunk's docs/agent-workflows.md and the
+ * examples/3-agent-review-demo/agent-context.json sample.
+ */
+export interface HunkAgentContext {
+    version: 1;
+    summary?: string;
+    files: HunkAgentContextFile[];
+}
+
+export interface HunkAgentContextFile {
+    path: string;
+    summary?: string;
+    annotations: HunkAgentAnnotation[];
+}
+
+export interface HunkAgentAnnotation {
+    newRange: [number, number];
+    summary: string;
+    rationale?: string;
+}
+
+const SEVERITY_LABEL: Record<Severity, string> = {
+    info: 'info',
+    warning: 'warning',
+    error: 'error',
+    critical: 'critical',
+};
+
+/** Compact severity glyphs that scan at a glance in the hunk panel title. */
+const SEVERITY_GLYPH: Record<Severity, string> = {
+    info: 'ℹ',
+    warning: '⚠',
+    error: '✖',
+    critical: '‼',
+};
+
+const HEADLINE_MAX = 140;
+
+export function countHunkAnnotations(context: HunkAgentContext): number {
+    return context.files.reduce(
+        (sum, file) => sum + file.annotations.length,
+        0,
+    );
+}
+
+export function convertReviewToHunkContext(
+    result: ReviewResult,
+): HunkAgentContext {
+    const filesMap = new Map<string, HunkAgentContextFile>();
+
+    for (const issue of result.issues ?? []) {
+        if (!issue.file) {
+            continue;
+        }
+
+        const annotation = toAnnotation(issue);
+        if (!annotation) {
+            continue;
+        }
+
+        let bucket = filesMap.get(issue.file);
+        if (!bucket) {
+            bucket = { path: issue.file, annotations: [] };
+            filesMap.set(issue.file, bucket);
+        }
+        bucket.annotations.push(annotation);
+    }
+
+    for (const file of filesMap.values()) {
+        const count = file.annotations.length;
+        file.summary = `${count} ${count === 1 ? 'finding' : 'findings'}`;
+        file.annotations.sort(
+            (a, b) =>
+                a.newRange[0] - b.newRange[0] || a.newRange[1] - b.newRange[1],
+        );
+    }
+
+    return {
+        version: 1,
+        summary: buildTopLevelSummary(result),
+        files: [...filesMap.values()].sort((a, b) =>
+            a.path.localeCompare(b.path),
+        ),
+    };
+}
+
+function toAnnotation(issue: ReviewIssue): HunkAgentAnnotation | null {
+    const start = normalizeLine(issue.line);
+    if (start === null) {
+        return null;
+    }
+    const end = Math.max(start, normalizeLine(issue.endLine) ?? start);
+
+    const message = issue.message?.trim() ?? '';
+    const suggestion = issue.suggestion?.trim() ?? '';
+    const recommendation = issue.recommendation?.trim() ?? '';
+    const advice = firstNonEmpty(suggestion, recommendation);
+
+    const source =
+        firstNonEmpty(message, suggestion, recommendation) ?? 'Kodus finding';
+    const { head, rest } = splitFirstSentence(source);
+    const headline = capHeadline(head, HEADLINE_MAX);
+    const glyph = SEVERITY_GLYPH[issue.severity] ?? '';
+    const summary = glyph ? `${glyph} ${headline}` : headline;
+
+    // Hunk's TUI word-wraps the rationale as a single paragraph and ignores
+    // `\n\n` separators, so we keep this as one tight piece of prose: body
+    // text first, then the fix, then a small attribution tail. Reads naturally
+    // even when collapsed onto a single wrapped line.
+    const sentences: string[] = [];
+
+    if (rest) {
+        sentences.push(rest);
+    }
+
+    if (advice && advice !== message && advice !== source) {
+        sentences.push(`Fix: ${withTrailingPeriod(advice)}`);
+    }
+
+    if (issue.fix) {
+        const fixLabel = `Suggested ${issue.fix.type} (lines ${issue.fix.startLine}-${issue.fix.endLine}):`;
+        sentences.push(`${fixLabel} ${issue.fix.newCode.trim()}`);
+    }
+
+    const attributionBits: string[] = [
+        `severity ${SEVERITY_LABEL[issue.severity] ?? issue.severity}`,
+    ];
+    if (issue.category) {
+        attributionBits.push(issue.category);
+    }
+    if (issue.ruleId) {
+        attributionBits.push(issue.ruleId);
+    }
+    sentences.push(`— Kody · ${attributionBits.join(' · ')}`);
+
+    return {
+        newRange: [start, end],
+        summary,
+        rationale: sentences.join(' '),
+    };
+}
+
+function withTrailingPeriod(text: string): string {
+    return /[.!?]$/.test(text) ? text : `${text}.`;
+}
+
+/**
+ * Splits a paragraph into a headline (first sentence) and body (the rest).
+ * Conservative: only splits on `. `, `! `, or `? ` followed by an uppercase
+ * letter, so abbreviations like "e.g." and "i.e." don't trigger a false break.
+ */
+function splitFirstSentence(text: string): { head: string; rest: string } {
+    const trimmed = text.trim();
+    if (!trimmed) {
+        return { head: '', rest: '' };
+    }
+    const match = trimmed.match(/^([\s\S]+?[.!?])\s+(?=[A-Z0-9])/);
+    if (match) {
+        return {
+            head: match[1].trim(),
+            rest: trimmed.slice(match[0].length).trim(),
+        };
+    }
+    return { head: trimmed, rest: '' };
+}
+
+function capHeadline(text: string, max: number): string {
+    if (text.length <= max) {
+        return text;
+    }
+    const slice = text.slice(0, max);
+    const lastSpace = slice.lastIndexOf(' ');
+    const cut =
+        lastSpace > Math.floor(max * 0.6) ? slice.slice(0, lastSpace) : slice;
+    return `${cut.replace(/[\s,.;:]+$/, '')}…`;
+}
+
+function normalizeLine(value: number | undefined): number | null {
+    if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+        return null;
+    }
+    return Math.floor(value);
+}
+
+function firstNonEmpty(
+    ...candidates: Array<string | undefined>
+): string | undefined {
+    for (const candidate of candidates) {
+        if (candidate && candidate.trim().length > 0) {
+            return candidate.trim();
+        }
+    }
+    return undefined;
+}
+
+function buildTopLevelSummary(result: ReviewResult): string {
+    const total = (result.issues ?? []).length;
+    if (total === 0) {
+        return result.summary?.trim()
+            ? result.summary.trim()
+            : 'Kodus review: no findings.';
+    }
+
+    const counts: Partial<Record<Severity, number>> = {};
+    for (const issue of result.issues) {
+        counts[issue.severity] = (counts[issue.severity] ?? 0) + 1;
+    }
+
+    const breakdown = (['critical', 'error', 'warning', 'info'] as Severity[])
+        .filter((s) => counts[s])
+        .map((s) => `${counts[s]} ${SEVERITY_LABEL[s]}`)
+        .join(', ');
+
+    const headline = `Kodus review: ${total} ${total === 1 ? 'finding' : 'findings'}${
+        breakdown ? ` (${breakdown})` : ''
+    }.`;
+
+    if (result.summary?.trim()) {
+        return `${headline}\n\n${result.summary.trim()}`;
+    }
+    return headline;
+}

--- a/apps/cli/src/features/review/hunk-viewer.ts
+++ b/apps/cli/src/features/review/hunk-viewer.ts
@@ -1,0 +1,102 @@
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { randomUUID } from 'node:crypto';
+import chalk from 'chalk';
+import { runHunk } from '../../utils/hunk.js';
+import { cliDebug, isCliVerboseMode } from '../../utils/logger.js';
+import { convertReviewToHunkContext } from './hunk-context.js';
+import type { ReviewResult } from '../../types/review.js';
+
+export interface HunkViewerScope {
+    /** When true, opens hunk against the staged index instead of the working tree. */
+    staged?: boolean;
+}
+
+/**
+ * Subset of `kodus review` options the hunk viewer can faithfully render.
+ * Anything beyond this (specific files, --commit, --branch) currently has no
+ * direct hunk equivalent so the caller should fall back to the terminal output.
+ */
+export function canRenderScopeInHunk(opts: {
+    files?: string[];
+    commit?: string;
+    branch?: string;
+}): boolean {
+    if (opts.files && opts.files.length > 0) {
+        return false;
+    }
+    if (opts.commit) {
+        return false;
+    }
+    if (opts.branch) {
+        return false;
+    }
+    return true;
+}
+
+export interface OpenReviewInHunkOptions {
+    result: ReviewResult;
+    scope: HunkViewerScope;
+    /** When true, keep the agent-context tempfile after hunk exits (debugging). */
+    keepContextOnExit?: boolean;
+}
+
+export async function openReviewInHunk(
+    options: OpenReviewInHunkOptions,
+): Promise<{ exitCode: number }> {
+    const context = convertReviewToHunkContext(options.result);
+    const contextPath = path.join(
+        os.tmpdir(),
+        `kodus-review-${randomUUID()}.json`,
+    );
+
+    await fs.writeFile(contextPath, JSON.stringify(context, null, 2), 'utf-8');
+
+    if (isCliVerboseMode()) {
+        const totalAnnotations = context.files.reduce(
+            (sum, file) => sum + file.annotations.length,
+            0,
+        );
+        cliDebug(
+            chalk.dim(
+                `[verbose] hunk: agent-context written to ${contextPath}`,
+            ),
+        );
+        cliDebug(
+            chalk.dim(
+                `[verbose] hunk: ${context.files.length} file(s), ${totalAnnotations} annotation(s) after conversion`,
+            ),
+        );
+        for (const file of context.files) {
+            cliDebug(
+                chalk.dim(
+                    `[verbose]   - ${file.path}: ${file.annotations
+                        .map((a) => `${a.newRange[0]}-${a.newRange[1]}`)
+                        .join(', ')}`,
+                ),
+            );
+        }
+    }
+
+    try {
+        const args = ['diff'];
+        if (options.scope.staged) {
+            args.push('--staged');
+        }
+        args.push('--agent-context', contextPath, '--agent-notes');
+        return await runHunk(args);
+    } finally {
+        if (options.keepContextOnExit) {
+            cliDebug(
+                chalk.dim(
+                    `[verbose] hunk: agent-context kept at ${contextPath} (inspect with: cat ${contextPath})`,
+                ),
+            );
+        } else {
+            await fs.unlink(contextPath).catch(() => {
+                // best-effort cleanup; tempdir is reaped by the OS anyway.
+            });
+        }
+    }
+}

--- a/apps/cli/src/features/review/result.ts
+++ b/apps/cli/src/features/review/result.ts
@@ -8,10 +8,37 @@ export function shouldUseInteractiveReview(params: {
 }): boolean {
     return (
         (!params.isAgent && params.interactive === true) ||
-        (!params.isAgent &&
-            !params.output &&
-            params.format === 'terminal')
+        (!params.isAgent && !params.output && params.format === 'terminal')
     );
+}
+
+/**
+ * Whether `kodus review` should hand the result off to the hunk TUI viewer
+ * instead of the legacy inquirer menu / flat formatter. We only auto-promote
+ * when every signal points to "interactive human": real TTY, no agent envelope,
+ * no file output, default terminal format, and the review scope maps cleanly
+ * onto something hunk can render (working tree or staged index).
+ *
+ * `--no-hunk` is the explicit escape hatch; `--interactive` keeps the legacy
+ * navigation+fix UI for users who rely on it.
+ */
+export function shouldUseHunkViewer(params: {
+    isAgent: boolean;
+    interactive?: boolean;
+    noHunk?: boolean;
+    output?: string;
+    format?: string;
+    ttyOut: boolean;
+    scopeSupported: boolean;
+}): boolean {
+    if (params.isAgent) {return false;}
+    if (params.noHunk) {return false;}
+    if (params.interactive === true) {return false;}
+    if (params.output) {return false;}
+    if (params.format && params.format !== 'terminal') {return false;}
+    if (!params.ttyOut) {return false;}
+    if (!params.scopeSupported) {return false;}
+    return true;
 }
 
 export function shouldFailReview(
@@ -60,7 +87,8 @@ export function formatFailOnExitMessage(
     }
 
     const issueLabel = blockingCount > 1 ? 'issues' : 'issue';
-    const verbPhrase = blockingCount > 1 ? 'meet or exceed' : 'meets or exceeds';
+    const verbPhrase =
+        blockingCount > 1 ? 'meet or exceed' : 'meets or exceeds';
 
     return `Exiting with code 1 because ${blockingCount} ${issueLabel} ${verbPhrase} \`--fail-on ${failOn}\`.`;
 }

--- a/apps/cli/src/features/review/result.ts
+++ b/apps/cli/src/features/review/result.ts
@@ -16,8 +16,10 @@ export function shouldUseInteractiveReview(params: {
  * Whether `kodus review` should hand the result off to the hunk TUI viewer
  * instead of the legacy inquirer menu / flat formatter. We only auto-promote
  * when every signal points to "interactive human": real TTY, no agent envelope,
- * no file output, default terminal format, and the review scope maps cleanly
- * onto something hunk can render (working tree or staged index).
+ * no file output, default terminal format, the review scope maps cleanly onto
+ * something hunk can render (working tree or staged index), and the host
+ * platform actually has a hunk binary (hunkdiff currently ships prebuilt
+ * binaries for darwin/linux × x64/arm64; Windows is unsupported upstream).
  *
  * `--no-hunk` is the explicit escape hatch; `--interactive` keeps the legacy
  * navigation+fix UI for users who rely on it.
@@ -30,15 +32,45 @@ export function shouldUseHunkViewer(params: {
     format?: string;
     ttyOut: boolean;
     scopeSupported: boolean;
+    platformSupported: boolean;
 }): boolean {
-    if (params.isAgent) {return false;}
-    if (params.noHunk) {return false;}
-    if (params.interactive === true) {return false;}
-    if (params.output) {return false;}
-    if (params.format && params.format !== 'terminal') {return false;}
-    if (!params.ttyOut) {return false;}
-    if (!params.scopeSupported) {return false;}
+    if (params.isAgent) {
+        return false;
+    }
+    if (params.noHunk) {
+        return false;
+    }
+    if (params.interactive === true) {
+        return false;
+    }
+    if (params.output) {
+        return false;
+    }
+    if (params.format && params.format !== 'terminal') {
+        return false;
+    }
+    if (!params.ttyOut) {
+        return false;
+    }
+    if (!params.platformSupported) {
+        return false;
+    }
+    if (!params.scopeSupported) {
+        return false;
+    }
     return true;
+}
+
+/**
+ * Whether the current host has a usable hunk binary. hunkdiff prebuilt
+ * binaries cover darwin/linux × x64/arm64; everything else (notably Windows)
+ * has no binary, so spawning hunk would crash. We skip the routing rather
+ * than letting the user pay for a full review that ends in an empty viewer.
+ */
+export function isHunkPlatformSupported(
+    platform: NodeJS.Platform = process.platform,
+): boolean {
+    return platform !== 'win32';
 }
 
 export function shouldFailReview(

--- a/apps/cli/src/utils/hunk.ts
+++ b/apps/cli/src/utils/hunk.ts
@@ -1,0 +1,67 @@
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { execa, type ExecaError, type Options as ExecaOptions } from 'execa';
+
+const require = createRequire(import.meta.url);
+
+interface HunkPackageJson {
+    bin?: string | Record<string, string>;
+}
+
+let cachedHunkBin: string | null = null;
+
+export function resolveHunkBin(): string {
+    if (cachedHunkBin) {
+        return cachedHunkBin;
+    }
+
+    const pkgPath = require.resolve('hunkdiff/package.json');
+    const pkg = require('hunkdiff/package.json') as HunkPackageJson;
+
+    let binRelative: string | undefined;
+    if (typeof pkg.bin === 'string') {
+        binRelative = pkg.bin;
+    } else if (pkg.bin && typeof pkg.bin === 'object') {
+        binRelative = pkg.bin.hunk ?? Object.values(pkg.bin)[0];
+    }
+
+    if (!binRelative) {
+        throw new Error(
+            'hunkdiff package.json is missing a bin entry — cannot locate the hunk binary.',
+        );
+    }
+
+    cachedHunkBin = path.resolve(path.dirname(pkgPath), binRelative);
+    return cachedHunkBin;
+}
+
+export interface RunHunkResult {
+    exitCode: number;
+}
+
+/**
+ * Spawn the bundled hunk binary with `process.execPath` so we don't depend on
+ * the shebang resolving correctly across platforms. stdio defaults to inherit
+ * so the TUI takes over the terminal.
+ */
+export async function runHunk(
+    args: string[],
+    options: { execa?: ExecaOptions } = {},
+): Promise<RunHunkResult> {
+    const bin = resolveHunkBin();
+    const result = await execa(process.execPath, [bin, ...args], {
+        stdio: 'inherit',
+        reject: false,
+        ...(options.execa ?? {}),
+    });
+
+    return { exitCode: result.exitCode ?? 0 };
+}
+
+export function isHunkExecError(error: unknown): error is ExecaError {
+    return Boolean(
+        error &&
+        typeof error === 'object' &&
+        'shortMessage' in (error as Record<string, unknown>),
+    );
+}

--- a/apps/cli/yarn.lock
+++ b/apps/cli/yarn.lock
@@ -1207,6 +1207,36 @@ human-signals@^8.0.1:
   resolved "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz"
   integrity sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==
 
+hunkdiff-darwin-arm64@0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/hunkdiff-darwin-arm64/-/hunkdiff-darwin-arm64-0.10.0.tgz#886c0dbbe3f328fe3d09e80ac01d1863eb055b53"
+  integrity sha512-oJALanUcIFp19LQbTTNKEk/RA0QIeeqwXzUciTzBlze1IA5GPe+rq+OLy66fFUA5tiO6qj6sXf1UqK9cL8o0Mw==
+
+hunkdiff-darwin-x64@0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/hunkdiff-darwin-x64/-/hunkdiff-darwin-x64-0.10.0.tgz#9500719e6c110580a975aafcc06b47e502e8c638"
+  integrity sha512-5sVwIN7OQ4x6/K1TfP4n0wUZinL9nPKmbZ/oHJWhMD6FScGuOOYYZQtN+q2j3ahzlu36Iio7OXajuyQZulwU4A==
+
+hunkdiff-linux-arm64@0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/hunkdiff-linux-arm64/-/hunkdiff-linux-arm64-0.10.0.tgz#cd758f357bd95f440489580330164b120c677f0d"
+  integrity sha512-h3yY1cxEmer3StCppvQ4kZyK10971t6dMO76jMnWNhREWML2H2hCiPrNw5Yjx0tI0AyI1P4D3guNCcvylLmO4A==
+
+hunkdiff-linux-x64@0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/hunkdiff-linux-x64/-/hunkdiff-linux-x64-0.10.0.tgz#906bbee2a6c259b66ce7ab0d67688ec8b0b9a0b2"
+  integrity sha512-me3Pl6Tqb46yoZP930iCUdE3pE5lDOtfsWUcCZXqEpsg0WPbW6PjO6tjX7MRnkLFPacPDrqfPZpEHr2bxK0X9A==
+
+hunkdiff@^0.10.0:
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/hunkdiff/-/hunkdiff-0.10.0.tgz#e587b17f692834a47cd86e6a9ad16d2cff64a8f5"
+  integrity sha512-GfUYNCzEnZ0OTdg340YRFbW1SvvwgRMyQmn44t2GKoSjYqiXGaDCeOG66fpIzU8WRdbUi2uzdGIVkEsCps8TeA==
+  optionalDependencies:
+    hunkdiff-darwin-arm64 "0.10.0"
+    hunkdiff-darwin-x64 "0.10.0"
+    hunkdiff-linux-arm64 "0.10.0"
+    hunkdiff-linux-x64 "0.10.0"
+
 iconv-lite@^0.7.2:
   version "0.7.2"
   resolved "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz"

--- a/apps/cli/yarn.lock
+++ b/apps/cli/yarn.lock
@@ -1227,7 +1227,7 @@ hunkdiff-linux-x64@0.10.0:
   resolved "https://registry.yarnpkg.com/hunkdiff-linux-x64/-/hunkdiff-linux-x64-0.10.0.tgz#906bbee2a6c259b66ce7ab0d67688ec8b0b9a0b2"
   integrity sha512-me3Pl6Tqb46yoZP930iCUdE3pE5lDOtfsWUcCZXqEpsg0WPbW6PjO6tjX7MRnkLFPacPDrqfPZpEHr2bxK0X9A==
 
-hunkdiff@^0.10.0:
+hunkdiff@0.10.0:
   version "0.10.0"
   resolved "https://registry.yarnpkg.com/hunkdiff/-/hunkdiff-0.10.0.tgz#e587b17f692834a47cd86e6a9ad16d2cff64a8f5"
   integrity sha512-GfUYNCzEnZ0OTdg340YRFbW1SvvwgRMyQmn44t2GKoSjYqiXGaDCeOG66fpIzU8WRdbUi2uzdGIVkEsCps8TeA==


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request integrates the Hunk terminal UI (TUI) diff viewer into the Kodus CLI, enhancing the interactive code review experience and enabling AI agent interaction with live diff sessions.

Key changes include:

*   **New `kodus diff` command**: A new `kodus diff` command is introduced, which acts as a wrapper for `hunk diff`, allowing users to open the current changeset directly in the Hunk TUI viewer.
*   **Hunk TUI integration for `kodus review`**:
    *   The `kodus review` command now automatically launches the Hunk TUI viewer for interactive human users when certain conditions are met (e.g., running in a TTY, on a supported platform like Linux/macOS, and reviewing the working tree or staged changes).
    *   Review findings from Kodus are converted into Hunk's agent context format, allowing them to be displayed as inline annotations within the Hunk diff viewer.
    *   A new `--no-hunk` option is added to `kodus review` to explicitly bypass the Hunk viewer and use the legacy interactive list.
    *   Informative messages are displayed when the Hunk viewer is skipped due to unsupported platforms (e.g., Windows), review scopes (e.g., `--branch`, `--commit`, or specific files), or when all findings are PR-level without file/line anchors.
*   **AI Agent Hunk Review Skill**: A new `hunk-review` skill is added, enabling the Kodus AI agent to interact with live Hunk diff review sessions. This skill provides commands for the agent to inspect session context, navigate files and hunks, reload session contents, and add or apply inline review comments.
*   **Platform Compatibility**: The Hunk TUI integration is currently supported on Linux and macOS, with a fallback to the legacy interactive review list on Windows due to upstream binary availability.
<!-- kody-pr-summary:end -->