### PR TITLE
fix(docker): set web bake target context to monorepo root

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -77,8 +77,8 @@ target "web" {
   # Unified Dockerfile for cloud and self-hosted — env values come from
   # ConfigProvider/useConfig() at runtime now (see
   # web-runtime-config-migration plan).
-  context = "./apps/web"
-  dockerfile = "../../docker/Dockerfile.web"
+  context = "."
+  dockerfile = "./docker/Dockerfile.web"
   args = {
     RELEASE_VERSION = "${RELEASE_VERSION}"
   }


### PR DESCRIPTION
The web target was inheriting `context = "./apps/web"` from before Dockerfile.web.selfhosted was retired. The unified Dockerfile.web COPYs `apps/web`, `libs/feature-gate`, and `release/features-snapshot.json` relative to the monorepo root (its header comment makes this explicit and the Next.js `outputFileTracingRoot` is pinned there too), so with the old context BuildKit couldn't see `libs/` or `release/` and the selfhosted-build-push workflow failed with "/libs/feature-gate not found" and "/release/features-snapshot.json not found".

Aligns `web` with the other targets that already inherit `context = "."` from `base`. Other workflows (prod/qa bake calls, web-qa-deploy, web-build-push-production) build with monorepo-root context already, so this only affects the selfhosted bake group.

<!--
  Thanks for sending a PR! The PR title MUST follow Conventional Commits, e.g.
    feat(code-review): add agent-first reviewer
    fix(web): block app.kodus.io from search-engine indexing
    chore(deps): bump posthog-node to 4.x
  CI will fail otherwise.
-->

## Summary

<!-- 1–3 sentences. What changes for the user (or for us, if internal)? -->

## Changelog routing (driven by the PR title prefix)

The prefix in your PR title decides where this change appears in the public changelog. No labels needed — the title is the source of truth.

| Prefix     | Public changelog                              |
| ---------- | --------------------------------------------- |
| `feat:`    | **Improvements** section (or tied to a tracked feature, see below) |
| `fix:`     | **Bug fixes** section                         |
| `perf:`    | **Performance** section                       |
| `docs:`, `style:`, `refactor:`, `test:`, `chore:`, `ci:`, `build:` | Hidden from public changelog |

## Test plan

<!-- Bullet list of the manual / automated checks. -->

- [ ]
- [ ]

## Notes for the reviewer

<!-- Anything non-obvious. Risks, follow-ups, screenshots for UX work. -->


---

<!-- kody-pr-summary:start -->
Fixes the Docker build configuration for the `web` target by setting its build context to the monorepo root (`.`). Previously, the context was set to `./apps/web`. The `dockerfile` path has also been adjusted from `"../../docker/Dockerfile.web"` to `"./docker/Dockerfile.web"` to correctly reference the Dockerfile from the new root context.
<!-- kody-pr-summary:end -->