### PR TITLE
chore(dev): parametrize host ports + bump analytics worker cap

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -51,9 +51,14 @@ services:
                 # docker waits for its healthcheck before starting.
                 required: false
         ports:
+            # Host-side port vars (`<HOST>_PORT:-default`) let parallel
+            # worktrees coexist by overriding to a per-slot offset (e.g.
+            # `.env.local` in worktree B sets API_DEBUG_PORT=9329 etc).
+            # Container-side ports stay fixed because each container has
+            # its own network namespace.
             - '${API_PORT:-3001}:${API_PORT:-3001}'
-            - '9229:9229'
-            - '8000:8000'
+            - '${API_DEBUG_PORT:-9229}:9229'
+            - '${API_METRICS_PORT:-8000}:8000'
         command: yarn start:dev:api
         deploy:
             resources:
@@ -108,8 +113,10 @@ services:
             - logs_data:/usr/src/app/logs
             - yalc_store:/root/.yalc
         ports:
-            - '9231:9231'
-            - '8001:8001'
+            # See kodus-api comment on host-side port parametrization for
+            # worktree coexistence.
+            - '${API_WORKER_DEBUG_PORT:-9231}:9231'
+            - '${API_WORKER_METRICS_PORT:-8001}:8001'
         command: yarn start:dev:worker
         deploy:
             resources:
@@ -162,8 +169,13 @@ services:
             - logs_data:/usr/src/app/logs
             - yalc_store:/root/.yalc
         ports:
-            - '9241:9241'
-            - '8011:8001'
+            # See kodus-api comment on host-side port parametrization for
+            # worktree coexistence. Container side is 8001 (same as the
+            # code-review worker — they're the same image; only WORKER_ROLE
+            # differs); host side is offset to 8011 so both workers can
+            # publish metrics in parallel.
+            - '${API_WORKER_ANALYTICS_DEBUG_PORT:-9241}:9241'
+            - '${API_WORKER_ANALYTICS_METRICS_PORT:-8011}:8001'
         command: yarn start:dev:worker
         deploy:
             resources:
@@ -213,9 +225,11 @@ services:
             - logs_data:/usr/src/app/logs
             - yalc_store:/root/.yalc
         ports:
+            # See kodus-api comment on host-side port parametrization for
+            # worktree coexistence.
             - '${API_WEBHOOKS_PORT:-3332}:${API_WEBHOOKS_PORT:-3332}'
-            - '9232:9232'
-            - '8002:8002'
+            - '${API_WEBHOOKS_DEBUG_PORT:-9232}:9232'
+            - '${API_WEBHOOKS_METRICS_PORT:-8002}:8002'
         command: yarn start:dev:webhooks
         deploy:
             resources:
@@ -247,8 +261,10 @@ services:
         image: kodus-ai-mcp-manager:latest
         container_name: kodus-mcp-manager
         ports:
+            # See kodus-api comment on host-side port parametrization for
+            # worktree coexistence.
             - '${API_MCP_MANAGER_PORT:-3101}:${API_MCP_MANAGER_PORT:-3101}'
-            - '9230:9230'
+            - '${API_MCP_MANAGER_DEBUG_PORT:-9230}:9230'
         # mcp-manager owns its own schema. ensure-schema + migration
         # run inline before the dev server boots (see fix(mcp-manager):
         # isolate migration ownership from API entrypoint). The api

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -180,7 +180,14 @@ services:
         deploy:
             resources:
                 limits:
-                    memory: 1G
+                    # Bumped from 1G after a smoke test on the heap-fixed
+                    # config showed steady-state RSS around 900MiB (~90%
+                    # of a 1G cap) — too tight for the cron-driven
+                    # analytics ingestion pipeline to absorb spikes.
+                    # Heap remains capped at 768M (see env block below);
+                    # the extra 0.5G is headroom for native modules,
+                    # thread stacks, and ingestion buffers.
+                    memory: 1.5G
                 reservations:
                     memory: 256M
         healthcheck:


### PR DESCRIPTION
## Summary

Two related changes to `docker-compose.dev.yml` that together unblock parallel worktrees and resolve a memory headroom issue surfaced after the heap-cap fix in #1061. Dev-tooling only — no impact on prod / Railway / self-hosted / CI compose paths.

### 1. Parametrize host-side ports (`276025fdb`)

Wraps every previously hard-coded host-side port with an env-var override + default that matches today's value. Backward-compatible: zero env vars set ⇒ identical behavior to before.

The OS rejects two stacks binding the same host port, so this was the blocker for running multiple `kodus-ai` worktrees in parallel.

| Service | Var | Default |
|---|---|---|
| api | `API_DEBUG_PORT` / `API_METRICS_PORT` | 9229 / 8000 |
| worker | `API_WORKER_DEBUG_PORT` / `API_WORKER_METRICS_PORT` | 9231 / 8001 |
| worker-analytics | `API_WORKER_ANALYTICS_DEBUG_PORT` / `API_WORKER_ANALYTICS_METRICS_PORT` | 9241 / 8011 |
| webhooks | `API_WEBHOOKS_DEBUG_PORT` / `API_WEBHOOKS_METRICS_PORT` | 9232 / 8002 |
| mcp-manager | `API_MCP_MANAGER_DEBUG_PORT` | 9230 |

Container-side ports stay fixed — each container has its own network namespace, no collision risk on the inside.

**Worktree usage**: per-slot `.env.local` with offset (e.g. slot 1 = `+100`: `API_PORT=3101`, `API_DEBUG_PORT=9329`, `WEB_PORT=3100`, etc).

### 2. Bump `worker-analytics` memory cap 1G → 1.5G (`f440497dc`)

Smoke-test discovery after the heap fix from #1061 landed:

| | Before (cap 1G) | After (cap 1.5G) |
|---|---|---|
| Steady-state RSS | 918 MiB | 918 MiB |
| Cap utilization | **89.7% ⚠️** | **59.8% ✅** |

Steady-state was already pushing the 1G cap with no room for the cron-driven analytics ingestion bursts — exactly the OOM territory the heap fix was meant to prevent. V8 heap stays at 768M (well under the new cap); the extra 0.5G is buffer for native modules, thread stacks, and ingestion-time allocations.

Other backend services already have similar headroom ratios (api: 43% of 3G; worker: 46% of 2G; webhooks: 55% of 1G).

## Test plan

- [x] `docker compose -f docker-compose.dev.yml config --quiet` parses clean with defaults
- [x] `docker compose config` honors per-port env overrides (verified with slot-1 offsets)
- [x] `yarn docker:down && yarn docker:start` — all 10 containers `(healthy)`, RestartCount=0, OOMKilled=false
- [x] `docker stats` — `kodus_analytics_worker` at 59.8% of new 1.5G cap (was 89.7% of 1G)
- [x] Pre-push test suite: 326/331 suites passed (43 skipped), 3125/3168 tests passed
- [ ] Reviewer: `git pull && yarn docker:down && yarn docker:start` — confirms backward-compat (containers recreate once with new config, behavior identical for default users)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- kody-pr-summary:start -->
This pull request introduces two main changes to the `docker-compose.dev.yml` configuration:

1.  **Parametrized Host Ports for Development Services**: Host-side ports for debug and metrics (and some main application ports) across several services (`kodus-api`, `kodus-api-worker`, `kodus-api-worker-analytics`, `kodus-api-webhooks`, `kodus-mcp-manager`) are now configurable via environment variables (e.g., `${API_DEBUG_PORT:-9229}`). This allows developers to run multiple instances of the application concurrently (e.g., in different Git worktrees) by overriding these ports, preventing conflicts while keeping container-side ports fixed.
2.  **Increased Memory Limit for Analytics Worker**: The memory limit for the `kodus-api-worker-analytics` service has been increased from `1G` to `1.5G`. This adjustment provides more headroom for the cron-driven analytics ingestion pipeline, addressing observed memory usage patterns and preventing potential resource exhaustion during spikes.
<!-- kody-pr-summary:end -->