### PR TITLE
chore(dev): drop unused chokidar-cli from dev image

### DIFF
--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -35,7 +35,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 COPY --from=bun-source /usr/local/bin/bun /usr/local/bin/bun
 RUN bun install -g @kodus/kodus-graph
 
-RUN npm i -g yalc chokidar-cli nodemon @ast-grep/cli
+RUN npm i -g yalc nodemon @ast-grep/cli
 
 COPY package.json yarn.lock ./
 COPY nest-cli.json tsconfig*.json ./


### PR DESCRIPTION
## Summary

`chokidar-cli` was installed alongside yalc / nodemon / `@ast-grep/cli`
in `Dockerfile.dev`'s global `npm i -g` step but is referenced by
exactly zero files in the repo — no script, no service code, no
entrypoint, no test, no doc. Likely a historical leftover from an
earlier file-watching attempt before the project standardized on
`nest start --watch` (which uses chokidar programmatically via Nest
CLI, not the CLI binary).

## Audit

```sh
grep -rE "chokidar-cli|chokidar -p" --include="*.ts" --include="*.js" \
     --include="*.json" --include="*.sh" --include="*.yml"
# → no matches outside node_modules / dist
```

Other globals on the same `npm i -g` line stay (verified usage):

| Global | Used at | Decision |
|---|---|---|
| `yalc` | `.yalc` store + `dev:yalc:*` scripts | keep |
| `nodemon` | `docker/dev-entrypoint.sh:154` fallback | keep |
| `@ast-grep/cli` | `libs/sandbox/infrastructure/providers/local-sandbox.service.ts` | keep |

## Impact

- Image size: ~10-30 MB smaller (chokidar-cli + chokidar transitive deps)
- Build time: marginally faster (one less npm global)
- No runtime behavior change (nothing called it)

## Test plan

- [x] `grep -rE "chokidar-cli"` returns no in-repo usage outside the deleted line
- [ ] Reviewer: `git pull && yarn docker:start` — stack should come up identically (chokidar-cli wasn't doing anything)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- kody-pr-summary:start -->
Removes `chokidar-cli` from the global npm packages installed in the development Docker image (`Dockerfile.dev`). This change indicates that `chokidar-cli` is no longer required or used in the development environment.
<!-- kody-pr-summary:end -->