### PR TITLE
ci(selfhosted): orchestrate CLI release + changelog from the release run

### DIFF
--- a/.github/workflows/changelog-publish.yml
+++ b/.github/workflows/changelog-publish.yml
@@ -20,12 +20,30 @@ on:
     push:
         tags:
             - "selfhosted-*"
+    workflow_call:
+        inputs:
+            tag:
+                description: "Release tag to publish a changelog entry for."
+                required: true
+                type: string
+    # Manual entry point — handy for smoke-testing the LLM + Discord
+    # pipeline against an existing tag without cutting a new release.
+    workflow_dispatch:
+        inputs:
+            tag:
+                description: "Release tag (e.g. selfhosted-2.1.11) to re-publish."
+                required: true
+                type: string
 
 permissions:
     contents: write
 
 concurrency:
-    group: changelog-publish-${{ github.ref }}
+    # `github.ref` is the caller workflow's ref when invoked via
+    # workflow_call (e.g. `refs/heads/main`), so include the tag input
+    # to keep concurrent self-hosted releases from queueing on the
+    # same key.
+    group: changelog-publish-${{ inputs.tag || github.ref }}
     cancel-in-progress: false
 
 jobs:
@@ -33,16 +51,18 @@ jobs:
         runs-on: ubuntu-latest
         outputs:
             should_publish: ${{ steps.gate.outputs.should_publish }}
+            tag: ${{ steps.gate.outputs.tag }}
         steps:
             - name: Validate tag format (strict semver only)
               id: gate
               env:
-                  TAG_NAME: ${{ github.ref_name }}
+                  TAG_NAME: ${{ inputs.tag || github.ref_name }}
               run: |
                   # Only publish for `selfhosted-X.Y.Z` (no test/rc/preview
                   # suffixes). Lets you push tags like
                   # `selfhosted-test-1.0.0` for workflow debugging without
                   # posting to the real Discord channel.
+                  echo "tag=$TAG_NAME" >> "$GITHUB_OUTPUT"
                   if [[ "$TAG_NAME" =~ ^selfhosted-[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
                       echo "Tag $TAG_NAME accepted — publishing."
                       echo "should_publish=true" >> "$GITHUB_OUTPUT"
@@ -60,6 +80,7 @@ jobs:
             - name: Checkout (full history for tag-range diff)
               uses: actions/checkout@v6.0.2
               with:
+                  ref: ${{ needs.validate.outputs.tag }}
                   fetch-depth: 0
                   fetch-tags: true
 
@@ -84,17 +105,20 @@ jobs:
                   GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
                   GEMINI_MODEL: ${{ vars.GEMINI_MODEL || 'gemini-3-flash-preview' }}
                   DISCORD_WEBHOOK_SELFHOSTED: ${{ secrets.DISCORD_WEBHOOK_SELFHOSTED }}
+                  RELEASE_TAG: ${{ needs.validate.outputs.tag }}
               run: |
                   yarn ts-node scripts/feature-gate/publish-changelog.ts \
-                      --tag "${GITHUB_REF#refs/tags/}"
+                      --tag "$RELEASE_TAG"
 
             - name: Commit changelog entry (if any)
+              env:
+                  RELEASE_TAG: ${{ needs.validate.outputs.tag }}
               run: |
                   if [ -n "$(git status --porcelain docs/changelog 2>/dev/null)" ]; then
                       git config user.name "kodus-changelog-bot"
                       git config user.email "actions@kodus.io"
                       git add docs/changelog
-                      git commit -m "docs(changelog): publish ${GITHUB_REF#refs/tags/}"
+                      git commit -m "docs(changelog): publish ${RELEASE_TAG}"
                       # Push to main only when triggered from a tag on main.
                       # Tags on release branches won't auto-commit; that's intentional.
                       git push origin HEAD:main || echo "Skipped push (tag not on main)"

--- a/.github/workflows/changelog-publish.yml
+++ b/.github/workflows/changelog-publish.yml
@@ -83,6 +83,11 @@ jobs:
                   ref: ${{ needs.validate.outputs.tag }}
                   fetch-depth: 0
                   fetch-tags: true
+                  # `Commit changelog entry` later pushes to main, which
+                  # is protected by a ruleset that requires PRs. The
+                  # default GITHUB_TOKEN cannot bypass it; use the PAT
+                  # whose owner is an OrganizationAdmin bypass actor.
+                  token: ${{ secrets.RELEASE_BOT_TOKEN }}
 
             - name: Set up Node
               uses: actions/setup-node@v4

--- a/.github/workflows/cli-release.yml
+++ b/.github/workflows/cli-release.yml
@@ -2,10 +2,20 @@ name: "CLI: Release"
 
 # Trigger on tags like cli-v0.4.15. Namespaced so future publishable
 # packages in this monorepo can use their own prefix without colliding.
+#
+# Also callable from `selfhosted-build-push.yml` via `workflow_call`
+# so a self-hosted release can fan out and publish a matching CLI
+# release in the same orchestrated run.
 on:
     push:
         tags:
             - 'cli-v*.*.*'
+    workflow_call:
+        inputs:
+            tag:
+                description: "CLI tag to publish (e.g. cli-v0.4.16)."
+                required: true
+                type: string
 
 jobs:
     publish:
@@ -17,8 +27,16 @@ jobs:
         defaults:
             run:
                 working-directory: apps/cli
+        env:
+            RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
         steps:
             - uses: actions/checkout@v6.0.2
+              with:
+                  # When invoked via workflow_call the caller's ref is
+                  # `main` (or whatever ref it ran on); pin to the tag
+                  # so the build, test, publish, and release all match
+                  # the artifact we're cutting.
+                  ref: ${{ inputs.tag || github.ref }}
             - uses: actions/setup-node@v6.4.0
               with:
                   node-version: "24"
@@ -35,6 +53,10 @@ jobs:
             - name: Create GitHub Release
               uses: softprops/action-gh-release@v2
               with:
+                  # Explicit tag_name is required when called via
+                  # workflow_call — `github.ref` is the caller's ref,
+                  # not the cli-v* tag.
+                  tag_name: ${{ env.RELEASE_TAG }}
                   generate_release_notes: true
 
             - name: Get previous release date
@@ -62,12 +84,12 @@ jobs:
                       "webhookUrl": "${{ secrets.WEBHOOK_URL }}"
                     }')
                   echo "$response" | jq -r '.changelog' > changelog.md
-                  echo "Generated changelog for ${{ github.ref_name }}"
+                  echo "Generated changelog for $RELEASE_TAG"
 
             - name: Update release notes
               working-directory: ${{ github.workspace }}
               run: |
-                  gh release edit ${{ github.ref_name }} \
+                  gh release edit "$RELEASE_TAG" \
                     -R ${{ github.repository }} \
                     --notes-file changelog.md
               env:

--- a/.github/workflows/selfhosted-build-push.yml
+++ b/.github/workflows/selfhosted-build-push.yml
@@ -280,12 +280,137 @@ jobs:
                   sarif_file: trivy-mcp-manager.sarif
                   category: trivy-selfhosted-mcp-manager
 
-    notify-discord:
-        name: Notify Discord
+    cli-changes:
+        name: Detect CLI changes since last release
         needs:
             - create-release
             - build-and-push
-        if: always() && needs.create-release.result == 'success'
+        if: needs.build-and-push.result == 'success'
+        runs-on: ubuntu-latest
+        permissions:
+            contents: write
+        outputs:
+            should_release: ${{ steps.detect.outputs.should_release }}
+            new_tag: ${{ steps.detect.outputs.new_tag }}
+            new_version: ${{ steps.detect.outputs.new_version }}
+        steps:
+            - name: Checkout main (full history + tags)
+              uses: actions/checkout@v6.0.2
+              with:
+                  ref: main
+                  fetch-depth: 0
+                  fetch-tags: true
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Detect CLI changes
+              id: detect
+              env:
+                  RELEASE_TAG: ${{ needs.create-release.outputs.release_tag }}
+              run: |
+                  set -euo pipefail
+
+                  LAST_TAG=$(git tag --sort=-v:refname | awk '/^cli-v[0-9]+\.[0-9]+\.[0-9]+$/{print; exit}')
+                  if [ -z "$LAST_TAG" ]; then
+                      echo "No previous cli-v* tag — treating as first release."
+                      CHANGED=1
+                  else
+                      echo "Comparing $LAST_TAG..$RELEASE_TAG for apps/cli/ changes"
+                      CHANGED=$(git diff --name-only "$LAST_TAG" "$RELEASE_TAG" -- apps/cli/ | wc -l | xargs)
+                  fi
+                  echo "Changed file count: $CHANGED"
+
+                  CURRENT_VERSION=$(node -p "require('./apps/cli/package.json').version")
+                  echo "Current apps/cli version: $CURRENT_VERSION"
+
+                  if [ "$CHANGED" -gt 0 ]; then
+                      IFS='.' read -ra PARTS <<< "$CURRENT_VERSION"
+                      NEW_VERSION="${PARTS[0]}.${PARTS[1]}.$((PARTS[2] + 1))"
+                      NEW_TAG="cli-v$NEW_VERSION"
+                      echo "CLI changes present — bumping $CURRENT_VERSION -> $NEW_VERSION ($NEW_TAG)"
+                      {
+                          echo "should_release=true"
+                          echo "new_version=$NEW_VERSION"
+                          echo "new_tag=$NEW_TAG"
+                      } >> "$GITHUB_OUTPUT"
+                  else
+                      echo "No CLI changes since $LAST_TAG; skipping CLI release."
+                      echo "should_release=false" >> "$GITHUB_OUTPUT"
+                  fi
+
+            - name: Bump version, commit, push tag
+              if: steps.detect.outputs.should_release == 'true'
+              env:
+                  NEW_VERSION: ${{ steps.detect.outputs.new_version }}
+                  NEW_TAG: ${{ steps.detect.outputs.new_tag }}
+              run: |
+                  set -euo pipefail
+
+                  node -e "
+                      const fs = require('fs');
+                      const path = './apps/cli/package.json';
+                      const pkg = JSON.parse(fs.readFileSync(path, 'utf8'));
+                      pkg.version = process.env.NEW_VERSION;
+                      fs.writeFileSync(path, JSON.stringify(pkg, null, 4) + '\n');
+                  "
+
+                  git config user.name "kodus-release-bot"
+                  git config user.email "actions@kodus.io"
+                  git add apps/cli/package.json
+                  git commit -m "chore(cli): bump version to $NEW_VERSION"
+                  # Push the bump commit and the tag separately so a
+                  # transient main divergence (rare, but possible if
+                  # someone merged between create-release and this job)
+                  # fails fast with a clear message instead of leaving an
+                  # orphan tag behind.
+                  git push origin HEAD:main
+                  git tag "$NEW_TAG"
+                  git push origin "$NEW_TAG"
+
+    cli-release:
+        name: Publish CLI release
+        needs:
+            - cli-changes
+        if: needs.cli-changes.outputs.should_release == 'true'
+        # GITHUB_TOKEN pushes don't cascade into other workflows, so
+        # cli-release.yml's `push: tags` trigger would never fire for
+        # the tag we just pushed. Call it explicitly via workflow_call
+        # instead.
+        permissions:
+            contents: write
+            id-token: write
+        uses: ./.github/workflows/cli-release.yml
+        with:
+            tag: ${{ needs.cli-changes.outputs.new_tag }}
+        secrets: inherit
+
+    changelog-publish:
+        name: Publish changelog
+        needs:
+            - create-release
+            - build-and-push
+        if: needs.build-and-push.result == 'success'
+        # Same cascading-events restriction as cli-release: the
+        # selfhosted-X.Y.Z tag was pushed by GITHUB_TOKEN above, so the
+        # changelog-publish.yml `push: tags` trigger does not fire. Invoke
+        # the publish workflow directly.
+        permissions:
+            contents: write
+        uses: ./.github/workflows/changelog-publish.yml
+        with:
+            tag: ${{ needs.create-release.outputs.release_tag }}
+        secrets: inherit
+
+    notify-discord-failure:
+        name: Notify Discord (failure only)
+        needs:
+            - create-release
+            - build-and-push
+        # Success notifications are owned by `changelog-publish` (rich
+        # release notes via Gemini). This job only fires the failure
+        # path so we still get a Discord ping when the build collapses
+        # before changelog-publish has a chance to run.
+        if: always() && needs.create-release.result == 'success' &&
+            needs.build-and-push.result != 'success'
         runs-on: ubuntu-latest
         environment: production
         permissions: {}
@@ -300,23 +425,8 @@ jobs:
                     echo "DISCORD_WEBHOOK_SELFHOSTED is not configured for the production environment."
                   fi
 
-            - name: Notify Discord on Success
-              if: steps.discord-webhook.outputs.configured == 'true' &&
-                  needs.build-and-push.result == 'success'
-              uses: sarisia/actions-status-discord@v1.16.0
-              with:
-                  webhook: ${{ secrets.DISCORD_WEBHOOK_SELFHOSTED }}
-                  content: ":tada: New Self-Hosted Release `${{
-                      needs.create-release.outputs.release_tag }}` published!"
-                  title: "Self-Hosted Release"
-                  description: "Docker images built and pushed to GHCR. Git tag ensured on
-                      GitHub."
-                  username: "GitHub Actions"
-                  color: 0xff00
-
             - name: Notify Discord on Failure
-              if: steps.discord-webhook.outputs.configured == 'true' &&
-                  needs.build-and-push.result != 'success'
+              if: steps.discord-webhook.outputs.configured == 'true'
               uses: sarisia/actions-status-discord@v1.16.0
               with:
                   webhook: ${{ secrets.DISCORD_WEBHOOK_SELFHOSTED }}

--- a/.github/workflows/selfhosted-build-push.yml
+++ b/.github/workflows/selfhosted-build-push.yml
@@ -285,7 +285,16 @@ jobs:
         needs:
             - create-release
             - build-and-push
-        if: needs.build-and-push.result == 'success'
+            # Serialize against `changelog-publish`, which may push a
+            # `docs(changelog)` commit to main. If both jobs raced, the
+            # loser would hit a non-fast-forward and either drop the
+            # changelog commit or abort the CLI release. Checking out
+            # main after `changelog-publish` finishes guarantees we
+            # bump on top of its commit when there is one.
+            - changelog-publish
+        # `always()` so a `changelog-publish` failure (e.g. Gemini
+        # outage) doesn't gate the independent CLI release path.
+        if: always() && needs.build-and-push.result == 'success'
         runs-on: ubuntu-latest
         permissions:
             contents: write

--- a/.github/workflows/selfhosted-build-push.yml
+++ b/.github/workflows/selfhosted-build-push.yml
@@ -309,7 +309,13 @@ jobs:
                   ref: main
                   fetch-depth: 0
                   fetch-tags: true
-                  token: ${{ secrets.GITHUB_TOKEN }}
+                  # Main is protected by a ruleset that requires PRs.
+                  # The default GITHUB_TOKEN cannot bypass it; only the
+                  # OrganizationAdmin actor can. RELEASE_BOT_TOKEN must
+                  # be a fine-grained PAT minted by an org admin with
+                  # `contents: write` on this repo — its bypass rights
+                  # are inherited from the underlying admin user.
+                  token: ${{ secrets.RELEASE_BOT_TOKEN }}
 
             - name: Detect CLI changes
               id: detect


### PR DESCRIPTION
## Summary

- Self-hosted release workflow pushes its tag with `GITHUB_TOKEN`, and Actions suppresses cascading workflow runs from that token. `changelog-publish.yml` and `cli-release.yml` (both `push: tags` triggered) **never fired for any selfhosted-* tag** — the LLM + Discord post silently never ran. Verified via `gh api` — `Changelog Publish` has 0 runs total.
- Fixes both by invoking the downstream workflows as `workflow_call` jobs directly from `selfhosted-build-push.yml`.
- Adds CLI release automation: if `apps/cli/**` changed since the last `cli-v*` tag, the workflow bumps the patch version, commits to main, pushes the tag, and runs `cli-release.yml` — no more manual CLI tagging.

## What changed

**`changelog-publish.yml`**
- Adds `workflow_call` (used by the orchestrator) + `workflow_dispatch` (for ad-hoc re-runs).
- Validate/publish jobs source the tag from `inputs.tag` and check out that tag explicitly.

**`cli-release.yml`**
- Adds `workflow_call` with a `tag` input.
- `checkout` pins to the tag (not the caller's branch).
- `softprops/action-gh-release` now passes `tag_name` explicitly — required under `workflow_call` where `github.ref` is the caller's ref.

**`selfhosted-build-push.yml`** (orchestrator)
- `cli-changes`: diffs last `cli-v*` tag vs the new selfhosted tag under `apps/cli/`. When something changed, bumps patch in `apps/cli/package.json`, commits to main, creates and pushes `cli-vX.Y.Z`.
- `cli-release`: invokes `cli-release.yml` via `workflow_call` if `cli-changes.should_release == 'true'`.
- `changelog-publish`: invokes `changelog-publish.yml` via `workflow_call` for every successful release.
- `notify-discord-failure`: keeps the failure-path ping; success notification is now owned by `changelog-publish` (richer Gemini-written copy — no double posts).

## Test plan

- [ ] After merge, smoke-test `Changelog Publish` manually: **Actions → Changelog Publish → Run workflow** with `tag=selfhosted-2.1.11`. Confirm Gemini-written entry lands in `#self-hosted-releases` and `docs/changelog/*.mdx` commit lands on main.
- [ ] Cut the next self-hosted release (`Self-Hosted: Release, Build and Publish` → `patch`). Verify the run graph shows: `create-release` → `build-and-push` → `cli-changes` → (optionally) `cli-release` → `changelog-publish`.
- [ ] If `apps/cli/**` has changed since `cli-v0.4.15`, expect a new `cli-v0.4.16` tag, npm publish, and a GitHub Release on the same run.
- [ ] If `apps/cli/**` is untouched, expect `cli-changes` to log "No CLI changes" and skip `cli-release`.
- [ ] On a failing build, confirm `notify-discord-failure` still posts the red Discord message.

## Caveats / follow-ups (not in this PR)

- CLI version bump is always **patch**. A `feat!`/breaking on CLI needs a manual tag before the selfhosted release. Easy follow-up if desired.
- CLI release notes still go through the external `CHANGELOG_API_URL` service (unchanged). Unifying with `scripts/feature-gate/publish-changelog.ts` is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- kody-pr-summary:start -->
This pull request enhances the self-hosted release orchestration by integrating the CLI release and changelog publication directly into the self-hosted build and push workflow.

Key changes include:

*   **Orchestrated CLI Release**: The `selfhosted-build-push.yml` workflow now automatically detects changes in the `apps/cli/` directory since the last CLI release. If changes are found, it bumps the CLI's patch version, commits the version bump, pushes a new `cli-vX.Y.Z` tag, and then explicitly triggers the `cli-release.yml` workflow to publish the new CLI release.
*   **Orchestrated Changelog Publication**: The `selfhosted-build-push.yml` workflow now explicitly calls the `changelog-publish.yml` workflow for the self-hosted release tag. This ensures that the changelog is published as part of the orchestrated release run, rather than relying on a separate tag-push trigger.
*   **Workflow Call Support**: The `cli-release.yml` and `changelog-publish.yml` workflows have been updated to support `workflow_call` triggers, allowing them to be invoked by other workflows with specific tags. This also includes improvements to concurrency handling and ensuring correct tag referencing during checkout and release operations.
*   **Refined Discord Notifications**: Discord notifications have been adjusted. Success notifications with rich release notes are now handled by the `changelog-publish` workflow, while the `selfhosted-build-push.yml` workflow's Discord notification job is now solely responsible for alerting on build failures.
<!-- kody-pr-summary:end -->