### PR TITLE
fix(byok): fixes in anthropic cache and effort parameters

### DIFF
--- a/libs/code-review/infrastructure/agents/llm/agent-loop.providerOptions.spec.ts
+++ b/libs/code-review/infrastructure/agents/llm/agent-loop.providerOptions.spec.ts
@@ -29,12 +29,12 @@ describe('buildReasoningProviderOptions', () => {
     });
 
     describe('Anthropic', () => {
-        it('uses adaptive thinking + outputConfig.effort for sonnet-4 family', () => {
+        it('uses adaptive thinking + effort for opus-4-7 (4.7+)', () => {
             expect(
                 buildReasoningProviderOptions(
                     BYOKProvider.ANTHROPIC,
                     'high',
-                    'claude-sonnet-4-5-20250929',
+                    'claude-opus-4-7',
                 ),
             ).toEqual({
                 anthropic: {
@@ -44,7 +44,39 @@ describe('buildReasoningProviderOptions', () => {
             });
         });
 
-        it('uses adaptive thinking for opus-4 family', () => {
+        it('uses adaptive thinking + effort for sonnet-4-6 (4.6+)', () => {
+            expect(
+                buildReasoningProviderOptions(
+                    BYOKProvider.ANTHROPIC,
+                    'medium',
+                    'claude-sonnet-4-6-20250929',
+                ),
+            ).toEqual({
+                anthropic: {
+                    thinking: { type: 'adaptive' },
+                    effort: 'medium',
+                },
+            });
+        });
+
+        it('falls back to budgetTokens for sonnet-4-5 (pre-4.6)', () => {
+            expect(
+                buildReasoningProviderOptions(
+                    BYOKProvider.ANTHROPIC,
+                    'high',
+                    'claude-sonnet-4-5-20250929',
+                ),
+            ).toEqual({
+                anthropic: {
+                    thinking: {
+                        type: 'enabled',
+                        budgetTokens: EFFORT_TO_BUDGET.high,
+                    },
+                },
+            });
+        });
+
+        it('falls back to budgetTokens for opus-4-1 (pre-4.6)', () => {
             expect(
                 buildReasoningProviderOptions(
                     BYOKProvider.ANTHROPIC,
@@ -53,8 +85,10 @@ describe('buildReasoningProviderOptions', () => {
                 ),
             ).toEqual({
                 anthropic: {
-                    thinking: { type: 'adaptive' },
-                    effort: 'medium',
+                    thinking: {
+                        type: 'enabled',
+                        budgetTokens: EFFORT_TO_BUDGET.medium,
+                    },
                 },
             });
         });

--- a/libs/code-review/infrastructure/agents/llm/agent-loop.ts
+++ b/libs/code-review/infrastructure/agents/llm/agent-loop.ts
@@ -239,6 +239,25 @@ import { createLogger } from '@kodus/flow';
 
 export type ReasoningEffort = 'none' | 'low' | 'medium' | 'high';
 
+/**
+ * Wrap a system prompt string with Anthropic cache_control when the model
+ * is Claude-based. Returns the string unchanged for other providers.
+ */
+function withAnthropicCacheControl(
+    systemPrompt: string,
+    model: any,
+): string | { role: 'system'; content: string; providerOptions: Record<string, any> } {
+    const modelId: string = model?.modelId ?? '';
+    if (/claude|anthropic/i.test(modelId)) {
+        return {
+            role: 'system' as const,
+            content: systemPrompt,
+            providerOptions: { anthropic: { cacheControl: { type: 'ephemeral' } } },
+        };
+    }
+    return systemPrompt;
+}
+
 export const EFFORT_TO_BUDGET: Record<ReasoningEffort, number> = {
     none: 0,
     low: 5_000,
@@ -274,13 +293,14 @@ export function buildReasoningProviderOptions(
 
     switch (provider) {
         case BYOKProvider.ANTHROPIC: {
-            // Newer models (Sonnet 4.6, Opus 4.6+) use adaptive thinking +
-            // effort parameter (low/medium/high). budget_tokens is deprecated.
-            // Older models (Sonnet 3.7, Opus 4.5) use enabled + budget_tokens.
+            // Models that support adaptive thinking (type: "adaptive" + effort):
+            //   - Opus 4.6+, Opus 4.7+, Sonnet 4.6+, Sonnet 4.7+, mythos
+            // Models that use enabled thinking (type: "enabled" + budget_tokens):
+            //   - Sonnet 4.5, Sonnet 4.0, Opus 4.0, Sonnet 3.7
             const isAdaptiveCapable =
                 modelName &&
-                (modelName.includes('sonnet-4') ||
-                    modelName.includes('opus-4') ||
+                (/claude-(opus|sonnet)-4-[6-9]/i.test(modelName) ||
+                    /claude-(opus|sonnet)-4-\d{2,}/i.test(modelName) ||
                     modelName.includes('mythos'));
 
             if (isAdaptiveCapable) {
@@ -935,7 +955,7 @@ export async function runAgentLoop(
                     ...({ __kodusHardTimeoutMs: AGENT_TIMEOUT_MS } as any),
                     model: input.model,
                     abortSignal: abortController.signal,
-                    system: input.systemPrompt,
+                    system: withAnthropicCacheControl(input.systemPrompt, input.model) as any,
                     prompt: input.userPrompt,
                     experimental_telemetry: _buildLangfuseTelemetry(
                         input.agentName ?? 'agent-loop',
@@ -1249,6 +1269,7 @@ export async function runAgentLoop(
                             totalCacheWriteTokens += u.cacheWriteTokens;
                             totalOutputTokens += u.outputTokens;
                             totalReasoningTokens += u.reasoningTokens;
+
                         }
 
                         input.onStepFinish?.(event);
@@ -1415,7 +1436,7 @@ export async function runAgentLoop(
                     generateText({
                         abortSignal: secondChanceSignal,
                         model: input.model,
-                        system: input.systemPrompt,
+                        system: withAnthropicCacheControl(input.systemPrompt, input.model) as any,
                         experimental_telemetry: _buildLangfuseTelemetry(
                             `${input.agentName ?? 'agent-loop'}-second-chance`,
                             input.telemetryMetadata,

--- a/packages/kodus-common/src/llm/byokProvider.service.ts
+++ b/packages/kodus-common/src/llm/byokProvider.service.ts
@@ -82,9 +82,22 @@ export class BYOKProviderService {
             disableReasoning?: boolean;
         },
     ): BaseChatModel {
-        const { provider, apiKey, model, baseURL, disableReasoning } =
-            config.main;
+        const {
+            provider,
+            apiKey,
+            model,
+            baseURL,
+            disableReasoning,
+            reasoningEffort,
+        } = config.main;
         const adapter = getAdapter(provider);
+
+        // Map config.main.reasoningEffort to reasoningLevel if caller didn't provide one
+        const resolvedReasoningLevel =
+            options?.reasoningLevel ??
+            (reasoningEffort && reasoningEffort !== 'none'
+                ? reasoningEffort
+                : undefined);
 
         if (provider === BYOKProvider.OPENAI_COMPATIBLE && !baseURL) {
             throw new Error(
@@ -106,9 +119,12 @@ export class BYOKProviderService {
                 maxTokens: options?.maxTokens,
                 jsonMode: options?.jsonMode,
                 maxReasoningTokens: options?.maxReasoningTokens,
-                reasoningLevel: options?.reasoningLevel,
+                reasoningLevel: resolvedReasoningLevel,
                 // Use config.main.disableReasoning or options.disableReasoning
-                disableReasoning: disableReasoning ?? options?.disableReasoning,
+                disableReasoning:
+                    reasoningEffort === 'none' ||
+                    disableReasoning ||
+                    options?.disableReasoning,
                 callbacks: options?.callbacks as Callbacks,
             },
         });

--- a/packages/kodus-common/src/llm/providerAdapters/anthropicAdapter.ts
+++ b/packages/kodus-common/src/llm/providerAdapters/anthropicAdapter.ts
@@ -64,7 +64,7 @@ export class AnthropicAdapter implements ProviderAdapter {
         if (effortLevel) {
             (payload as any).modelKwargs = {
                 ...((payload as any).modelKwargs ?? {}),
-                outputConfig: { effort: effortLevel },
+                output_config: { effort: effortLevel },
             };
         }
 

--- a/packages/kodus-common/src/llm/providerAdapters/anthropicAdapter.ts
+++ b/packages/kodus-common/src/llm/providerAdapters/anthropicAdapter.ts
@@ -1,6 +1,11 @@
 import { ChatAnthropic } from '@langchain/anthropic';
 import { resolveModelOptions } from './resolver';
-import { AdapterBuildParams, ProviderAdapter, LLM_TIMEOUT_MS, LLM_MAX_RETRIES } from './types';
+import {
+    AdapterBuildParams,
+    ProviderAdapter,
+    LLM_TIMEOUT_MS,
+    LLM_MAX_RETRIES,
+} from './types';
 
 export class AnthropicAdapter implements ProviderAdapter {
     build(params: AdapterBuildParams): ChatAnthropic {
@@ -8,37 +13,60 @@ export class AnthropicAdapter implements ProviderAdapter {
         const resolved = resolveModelOptions(model, {
             temperature: options?.temperature,
             maxTokens: options?.maxTokens,
+            maxReasoningTokens: options?.maxReasoningTokens,
+            reasoningLevel: options?.reasoningLevel,
         });
 
         const maxTokens = resolved.resolvedMaxTokens ?? 4096;
 
-        const reasoningBudget =
-            resolved.supportsReasoning && resolved.reasoningType === 'budget'
-                ? resolved.resolvedReasoningTokens
+        const isAdaptive = resolved.reasoningType === 'adaptive';
+        const isBudget = resolved.reasoningType === 'budget';
+
+        const reasoningBudget = options?.disableReasoning
+            ? undefined
+            : resolved.supportsReasoning && isBudget
+              ? resolved.resolvedReasoningTokens
+              : undefined;
+
+        let thinkingConfig: any;
+        if (isAdaptive && !options?.disableReasoning) {
+            // Opus 4.7+ uses thinking.type="adaptive" without budget_tokens
+            thinkingConfig = { type: 'adaptive' };
+        } else if (typeof reasoningBudget === 'number') {
+            thinkingConfig = {
+                type: 'enabled',
+                budget_tokens: reasoningBudget,
+            };
+        }
+
+        // Opus 4.7+ uses outputConfig.effort instead of budget_tokens
+        const effortLevel =
+            isAdaptive && !options?.disableReasoning
+                ? (resolved.resolvedReasoningLevel ?? 'low')
                 : undefined;
 
         const payload: ConstructorParameters<typeof ChatAnthropic>[0] = {
             model,
             apiKey,
-            ...(resolved.temperature !== undefined &&
-            typeof reasoningBudget !== 'number'
+            ...(resolved.temperature !== undefined && !thinkingConfig
                 ? { temperature: resolved.temperature }
                 : {}),
             maxTokens,
-            ...(typeof reasoningBudget === 'number'
-                ? {
-                      thinking: {
-                          type: 'enabled',
-                          budget_tokens: reasoningBudget,
-                      },
-                  }
-                : {}),
+            ...(thinkingConfig ? { thinking: thinkingConfig } : {}),
             callbacks: options?.callbacks,
             maxRetries: LLM_MAX_RETRIES,
             clientOptions: {
                 timeout: LLM_TIMEOUT_MS,
             },
         };
+
+        // Apply effort level for adaptive models via model kwargs
+        if (effortLevel) {
+            (payload as any).modelKwargs = {
+                ...((payload as any).modelKwargs ?? {}),
+                outputConfig: { effort: effortLevel },
+            };
+        }
 
         return new ChatAnthropic(payload);
     }

--- a/packages/kodus-common/src/llm/providerAdapters/capabilities.ts
+++ b/packages/kodus-common/src/llm/providerAdapters/capabilities.ts
@@ -13,6 +13,12 @@ function budget(
     return { type: 'budget', options: { min, default: defaultBudget } };
 }
 
+function adaptive(
+    options: Array<'low' | 'medium' | 'high'> = ['low', 'medium', 'high'],
+): ReasoningConfig {
+    return { type: 'adaptive', options };
+}
+
 function level(
     options: Array<'low' | 'medium' | 'high'> = ['low', 'medium', 'high'],
 ): ReasoningConfig {
@@ -150,7 +156,9 @@ const REASONING_PATTERN_RULES: Array<[RegExp, ReasoningConfig]> = [
     // Gemini 2.0 thinking experimental
     [/^gemini-2\.0-.*thinking.*/i, budget()],
 
-    // Anthropic Claude - budget for recent families
+    // Anthropic Claude - adaptive for 4.7+, budget for older families
+    [/^claude-opus-4-7(\b|[-_@])/, adaptive()],
+    [/^claude-sonnet-4-7(\b|[-_@])/, adaptive()],
     [/^claude-opus-4(\b|[-_@])/, budget()],
     [/^claude-sonnet-4(\b|[-_@])/, budget()],
     [/^claude-3-7-sonnet(\b|[-_@])/, budget()],
@@ -266,7 +274,7 @@ export function supportsReasoning(model: string): boolean {
 
 export function getReasoningType(
     model: string,
-): 'level' | 'budget' | undefined {
+): 'level' | 'budget' | 'adaptive' | undefined {
     return getModelCapabilities(model).reasoningConfig?.type;
 }
 

--- a/packages/kodus-common/src/llm/providerAdapters/modelTypes.ts
+++ b/packages/kodus-common/src/llm/providerAdapters/modelTypes.ts
@@ -8,6 +8,10 @@ export type ReasoningConfig =
     | {
           type: 'budget';
           options: { min: number; max?: number; default: number };
+      }
+    | {
+          type: 'adaptive';
+          options: Array<'low' | 'medium' | 'high'>;
       };
 
 export interface ModelCapabilities {

--- a/packages/kodus-common/src/llm/providerAdapters/resolver.ts
+++ b/packages/kodus-common/src/llm/providerAdapters/resolver.ts
@@ -16,7 +16,7 @@ export interface ResolvedModelOptions {
     resolvedReasoningTokens?: number;
     supportsTemperature: boolean;
     supportsReasoning: boolean;
-    reasoningType?: 'level' | 'budget';
+    reasoningType?: 'level' | 'budget' | 'adaptive';
     resolvedReasoningLevel?: 'low' | 'medium' | 'high';
 }
 
@@ -66,7 +66,7 @@ export function resolveModelOptions(
             typeof maxBudget === 'number'
                 ? Math.min(maxBudget, boundedBudget)
                 : boundedBudget;
-    } else if (rc?.type === 'level') {
+    } else if (rc?.type === 'level' || rc?.type === 'adaptive') {
         const allowedLevels = rc.options;
         const desiredLevel = user.reasoningLevel ?? FALLBACK_LEVEL;
 
@@ -82,7 +82,7 @@ export function resolveModelOptions(
 
     const temperature = caps.supportsTemperature ? user.temperature : undefined;
 
-    const reasoningType: 'level' | 'budget' | undefined = rc?.type;
+    const reasoningType: 'level' | 'budget' | 'adaptive' | undefined = rc?.type;
 
     return {
         model,


### PR DESCRIPTION
Closes #1074

---

<!-- kody-pr-summary:start -->
This pull request introduces several enhancements and fixes related to Anthropic LLM integration:

1.  **Updated Anthropic Reasoning Strategy**: The system now differentiates between newer and older Anthropic models for reasoning configuration.
    *   **Adaptive Thinking with Effort**: For newer models (Claude Opus 4.7+, Sonnet 4.7+, and generally 4.6+ models), the system utilizes Anthropic's "adaptive thinking" by setting `thinking: { type: 'adaptive' }` and passing an `outputConfig: { effort: 'low'|'medium'|'high' }` parameter based on the specified reasoning effort.
    *   **Budgeted Thinking**: Older Anthropic models (e.g., Sonnet 4.5, Opus 4.1, Sonnet 3.7) continue to use `thinking: { type: 'enabled', budget_tokens: <number> }` for reasoning, based on a token budget.
    *   This ensures optimal utilization of each model's specific reasoning capabilities.

2.  **Anthropic Cache Control**: A new `cacheControl: { type: 'ephemeral' }` option is applied to Anthropic system prompts. This prevents the LLM from caching prompts, ensuring that responses are always generated based on the most current context and preventing stale information.

3.  **Enhanced Reasoning Effort Integration**: The `reasoningEffort` parameter from the main configuration is now fully integrated into the LLM provider service. This allows for more precise control over reasoning levels and the ability to disable reasoning based on the configured effort.

4.  **Improved Test Coverage**: Unit tests have been updated to reflect these changes, verifying that the correct reasoning parameters are applied based on the Anthropic model version and specified effort.
<!-- kody-pr-summary:end -->