### PR TITLE
Fixes (workflow): cancel job work via AbortSignal; app timeout < broker

### DIFF
--- a/libs/automation/infrastructure/adapters/services/processAutomation/strategies/automationCodeReview.ts
+++ b/libs/automation/infrastructure/adapters/services/processAutomation/strategies/automationCodeReview.ts
@@ -95,7 +95,11 @@ export class AutomationCodeReviewService implements Omit<
             action,
             triggerCommentId,
             userGitId,
-        } = payload;
+            // Job-level AbortSignal injected by RunCodeReviewAutomationUseCase.
+            // Plumbed through handlePullRequest → pipeline context → agent-loop
+            // so the router-level workflow timeout cancels the LLM call cleanly.
+            signal,
+        } = payload as Record<string, any>;
 
         // Acquire distributed lock to prevent concurrent reviews of the same PR
         const orgId = organizationAndTeamData?.organizationId;
@@ -266,6 +270,7 @@ export class AutomationCodeReviewService implements Omit<
                     undefined, // workflowJobId
                     lastExecution?.dataExecution, // Pass last execution data
                     correlationId,
+                    signal, // parentSignal — forwarded to pipeline context
                 );
 
             await this._handleExecutionCompletion(execution, result, payload);

--- a/libs/automation/webhook-processing/webhook-processing-job.processor.ts
+++ b/libs/automation/webhook-processing/webhook-processing-job.processor.ts
@@ -57,10 +57,14 @@ export class WebhookProcessingJobProcessorService implements IJobProcessorServic
         ]);
     }
 
-    async process(jobId: string): Promise<void> {
+    async process(jobId: string, signal?: AbortSignal): Promise<void> {
         const job = await this.jobRepository.findOne(jobId);
         if (!job) {
             throw new Error(`Workflow job ${jobId} not found`);
+        }
+
+        if (signal?.aborted) {
+            throw new Error(`Job ${jobId} aborted before start`);
         }
 
         // Validate job type

--- a/libs/cli-review/workflow/cli-review-job-processor.service.ts
+++ b/libs/cli-review/workflow/cli-review-job-processor.service.ts
@@ -22,10 +22,14 @@ export class CliReviewJobProcessorService implements IJobProcessorService {
         private readonly executeCliReviewUseCase: ExecuteCliReviewUseCase,
     ) {}
 
-    async process(jobId: string): Promise<void> {
+    async process(jobId: string, signal?: AbortSignal): Promise<void> {
         const job = await this.jobRepository.findOne(jobId);
         if (!job) {
             throw new Error(`CLI review job ${jobId} not found`);
+        }
+
+        if (signal?.aborted) {
+            throw new Error(`Job ${jobId} aborted before start`);
         }
 
         const payload = job.payload as CliReviewJobPayload;

--- a/libs/code-review/infrastructure/adapters/services/codeReviewHandlerService.service.ts
+++ b/libs/code-review/infrastructure/adapters/services/codeReviewHandlerService.service.ts
@@ -165,6 +165,11 @@ export class CodeReviewHandlerService {
         workflowJobId?: string, // Optional: ID of workflow job (for pausing/resuming)
         lastExecutionData?: any, // Data from the last successful execution
         correlationId?: string,
+        // Parent (job-level) AbortSignal — forwarded from the strategy
+        // which got it from runCodeReview use-case, originally created by
+        // JobProcessorRouterService.runWithTimeout. When this aborts, all
+        // downstream LLM/agent calls cancel via parentSignal composition.
+        parentSignal?: AbortSignal,
     ) {
         let initialContext: CodeReviewPipelineContext;
 
@@ -172,6 +177,7 @@ export class CodeReviewHandlerService {
             initialContext = {
                 correlationId,
                 workflowJobId,
+                parentSignal,
                 dryRun: {
                     enabled: false,
                 },

--- a/libs/code-review/infrastructure/agents/base-code-review-agent.provider.ts
+++ b/libs/code-review/infrastructure/agents/base-code-review-agent.provider.ts
@@ -351,6 +351,10 @@ export interface ReviewAgentInput {
     skipSynthesisRescue?: boolean;
     /** Categories allowed for this run when using a mixed/generalist reviewer. */
     requestedCategories?: Array<'bug' | 'security' | 'performance'>;
+    /** Parent (job-level) AbortSignal. Forwarded to runAgentLoop so the
+     *  outer router timeout cancels the LLM call instead of leaving it
+     *  running ghost in the background. */
+    parentSignal?: AbortSignal;
 }
 
 /**
@@ -677,6 +681,7 @@ export abstract class BaseCodeReviewAgentProvider {
                     ?.openrouterProviderOrder,
                 openrouterAllowFallbacks: (byokConfig?.main as any)
                     ?.openrouterAllowFallbacks,
+                parentSignal: input.parentSignal,
 
                 onStepFinish: (step: any) => {
                     stepCount++;

--- a/libs/code-review/infrastructure/agents/llm/agent-loop.ts
+++ b/libs/code-review/infrastructure/agents/llm/agent-loop.ts
@@ -78,6 +78,7 @@ import {
     buildLangfuseTelemetry as _buildLangfuseTelemetry,
     type LangfuseTelemetryMetadata,
 } from '@libs/core/log/langfuse';
+import { composeAbortSignal } from './parent-signal-compose';
 
 /**
  * Build provider-specific reasoning `providerOptions` for a generateText call.
@@ -739,6 +740,10 @@ export interface AgentLoopInput {
      *  undefined; set to false to hard-fail if the pinned providers aren't
      *  available. */
     openrouterAllowFallbacks?: boolean;
+    /** Parent (job-level) AbortSignal. When it aborts, the local
+     *  AGENT_TIMEOUT_MS controller is aborted too, propagating cancellation
+     *  to the underlying generateText call (which respects abortSignal). */
+    parentSignal?: AbortSignal;
 }
 
 /**
@@ -920,6 +925,21 @@ export async function runAgentLoop(
         });
         abortController.abort();
     }, AGENT_TIMEOUT_MS);
+
+    // Compose job-level (parentSignal) into the local controller. When the
+    // outer router timeout (1h45min for code_review) fires, we abort the
+    // agent's generateText too instead of leaving an LLM call running ghost
+    // in the background.
+    const detachParentSignal = composeAbortSignal(
+        input.parentSignal,
+        abortController,
+        () =>
+            logger.warn({
+                message:
+                    '[AGENT-TIMEOUT] Parent (job) signal aborted, cancelling agent',
+                context: 'AgentLoop',
+            }),
+    );
 
     let result;
     try {
@@ -1257,6 +1277,7 @@ export async function runAgentLoop(
         });
     } catch (error) {
         clearTimeout(timeoutHandle);
+        detachParentSignal();
         if (abortController.signal.aborted) {
             // Try to recover findings from the last text the model produced before timeout
             let findings: FindingsOutput | null = null;
@@ -1363,6 +1384,7 @@ export async function runAgentLoop(
         throw error;
     }
     clearTimeout(timeoutHandle);
+    detachParentSignal();
 
     // ─── Done-tool extraction ───────────────────────────────────────────
     // If the model called submitResult, extract findings directly from

--- a/libs/code-review/infrastructure/agents/llm/parent-signal-compose.spec.ts
+++ b/libs/code-review/infrastructure/agents/llm/parent-signal-compose.spec.ts
@@ -1,0 +1,75 @@
+import { composeAbortSignal } from './parent-signal-compose';
+
+describe('composeAbortSignal', () => {
+    it('is a no-op when no parent signal is provided', () => {
+        const local = new AbortController();
+        const detach = composeAbortSignal(undefined, local);
+
+        expect(local.signal.aborted).toBe(false);
+        expect(detach).toBeInstanceOf(Function);
+        // Calling detach must not throw even when no listener was attached.
+        expect(() => detach()).not.toThrow();
+    });
+
+    it('aborts the local controller synchronously when the parent is already aborted', () => {
+        const parent = new AbortController();
+        parent.abort();
+        const local = new AbortController();
+
+        composeAbortSignal(parent.signal, local);
+
+        expect(local.signal.aborted).toBe(true);
+    });
+
+    it('aborts the local controller when the parent aborts later', () => {
+        const parent = new AbortController();
+        const local = new AbortController();
+
+        composeAbortSignal(parent.signal, local);
+
+        expect(local.signal.aborted).toBe(false);
+        parent.abort();
+        expect(local.signal.aborted).toBe(true);
+    });
+
+    it('invokes the onAbort callback exactly once before aborting', () => {
+        const parent = new AbortController();
+        const local = new AbortController();
+        const onAbort = jest.fn();
+
+        composeAbortSignal(parent.signal, local, onAbort);
+        parent.abort();
+        parent.abort(); // second abort is a no-op on the same controller
+
+        expect(onAbort).toHaveBeenCalledTimes(1);
+        expect(local.signal.aborted).toBe(true);
+    });
+
+    it('returns a detach function that removes the listener so the parent does not retain the local controller', () => {
+        const parent = new AbortController();
+        const local = new AbortController();
+
+        const detach = composeAbortSignal(parent.signal, local);
+        detach();
+        parent.abort();
+
+        // After detach, parent aborting must NOT propagate.
+        expect(local.signal.aborted).toBe(false);
+    });
+
+    it('does not double-abort if local is already aborted when parent fires', () => {
+        const parent = new AbortController();
+        const local = new AbortController();
+        local.abort(); // local fired first (e.g. internal AGENT_TIMEOUT_MS)
+        const onAbort = jest.fn();
+
+        composeAbortSignal(parent.signal, local, onAbort);
+        parent.abort();
+
+        // The compose helper installed a listener; parent abort still invokes
+        // the callback. AbortController.abort() on an already-aborted
+        // controller is idempotent, so this is safe.
+        expect(onAbort).toHaveBeenCalledTimes(1);
+        expect(local.signal.aborted).toBe(true);
+    });
+});

--- a/libs/code-review/infrastructure/agents/llm/parent-signal-compose.ts
+++ b/libs/code-review/infrastructure/agents/llm/parent-signal-compose.ts
@@ -1,0 +1,35 @@
+/**
+ * Wires a parent AbortSignal into a local AbortController.
+ *
+ * - If the parent has already aborted when called, the local controller
+ *   is aborted synchronously.
+ * - Otherwise, registers a one-shot listener that aborts the local
+ *   controller when the parent does.
+ *
+ * Used by `runAgentLoop` so the router-level workflow timeout cancels the
+ * agent's `generateText` call instead of leaving an LLM request running
+ * ghost in the background.
+ *
+ * Returns a cleanup function that detaches the listener — call it in the
+ * caller's `finally` block so the parent signal does not retain a
+ * reference to the local controller after the work completes normally.
+ */
+export function composeAbortSignal(
+    parent: AbortSignal | undefined,
+    local: AbortController,
+    onAbort?: () => void,
+): () => void {
+    if (!parent) return () => {};
+
+    if (parent.aborted) {
+        local.abort();
+        return () => {};
+    }
+
+    const handler = () => {
+        onAbort?.();
+        local.abort();
+    };
+    parent.addEventListener('abort', handler, { once: true });
+    return () => parent.removeEventListener('abort', handler);
+}

--- a/libs/code-review/pipeline/context/code-review-pipeline.context.ts
+++ b/libs/code-review/pipeline/context/code-review-pipeline.context.ts
@@ -204,6 +204,12 @@ export interface CodeReviewPipelineContext extends PipelineContext {
 
     /** Dedup telemetry captured by AgentReviewStage and exported by benchmark tooling. */
     dedupTrace?: DedupTraceSummary;
+
+    /** Parent (job-level) AbortSignal. Forwarded from runCodeReview use-case
+     *  via the strategy payload, then plumbed into AgentReviewStage so the
+     *  agent-loop's local AbortController is aborted when the router-level
+     *  job timeout fires (instead of leaving an LLM call running ghost). */
+    parentSignal?: AbortSignal;
 }
 
 export interface DedupTraceSuggestionSummary {

--- a/libs/code-review/pipeline/stages/agent-review.stage.ts
+++ b/libs/code-review/pipeline/stages/agent-review.stage.ts
@@ -415,6 +415,11 @@ export class AgentReviewStage extends BasePipelineStage<CodeReviewPipelineContex
                 callGraph,
                 callGraphJson: context.callGraphJson,
                 reviewMode: context.codeReviewConfig?.reviewMode || 'normal',
+                // Forwarded from the workflow job timeout. The router builds
+                // an AbortController; here we pass it through so when the
+                // 1h45min budget fires, the agent-loop's local controller is
+                // aborted via parentSignal composition.
+                parentSignal: context.parentSignal,
             });
 
             const durationMs = Date.now() - startTime;

--- a/libs/code-review/workflow/ast-graph-build-job.processor.ts
+++ b/libs/code-review/workflow/ast-graph-build-job.processor.ts
@@ -47,12 +47,16 @@ export class AstGraphBuildJobProcessor implements IJobProcessorService {
         private readonly repositoryService: IRepositoryService,
     ) {}
 
-    async process(jobId: string): Promise<void> {
+    async process(jobId: string, signal?: AbortSignal): Promise<void> {
         const jobStart = Date.now();
         const job = await this.jobRepository.findOne(jobId);
 
         if (!job) {
             throw new Error(`Job ${jobId} not found`);
+        }
+
+        if (signal?.aborted) {
+            throw new Error(`Job ${jobId} aborted before start`);
         }
 
         const payload = job.payload as unknown as AstGraphBuildJobPayload;

--- a/libs/code-review/workflow/ast-graph-incremental-job.processor.ts
+++ b/libs/code-review/workflow/ast-graph-incremental-job.processor.ts
@@ -51,12 +51,16 @@ export class AstGraphIncrementalJobProcessor implements IJobProcessorService {
         private readonly repositoryService: IRepositoryService,
     ) {}
 
-    async process(jobId: string): Promise<void> {
+    async process(jobId: string, signal?: AbortSignal): Promise<void> {
         const jobStart = Date.now();
         const job = await this.jobRepository.findOne(jobId);
 
         if (!job) {
             throw new Error(`Job ${jobId} not found`);
+        }
+
+        if (signal?.aborted) {
+            throw new Error(`Job ${jobId} aborted before start`);
         }
 
         const payload = job.payload as unknown as AstGraphIncrementalJobPayload;

--- a/libs/code-review/workflow/code-review-job-processor.service.ts
+++ b/libs/code-review/workflow/code-review-job-processor.service.ts
@@ -27,7 +27,7 @@ export class CodeReviewJobProcessorService implements IJobProcessorService {
         private readonly metricsCollector?: MetricsCollectorService,
     ) {}
 
-    async process(jobId: string): Promise<void> {
+    async process(jobId: string, signal?: AbortSignal): Promise<void> {
         const job = await this.jobRepository.findOne(jobId);
 
         if (!job) {
@@ -41,6 +41,10 @@ export class CodeReviewJobProcessorService implements IJobProcessorService {
             context: CodeReviewJobProcessorService.name,
             metadata: { jobId, correlationId },
         });
+
+        if (signal?.aborted) {
+            throw new Error(`Job ${jobId} aborted before start`);
+        }
 
         const startTime = Date.now();
         let acquiredLock: DistributedLock | null = null;
@@ -83,15 +87,18 @@ export class CodeReviewJobProcessorService implements IJobProcessorService {
                 metadata: this.removeByokConcurrencyGateMetadata(job.metadata),
             });
 
-            await this.runCodeReviewAutomationUseCase.execute({
-                codeManagementPayload,
-                event,
-                platformType,
-                correlationId,
-                organizationAndTeamData,
-                teamAutomationId,
-                workflowJobId: jobId,
-            });
+            await this.runCodeReviewAutomationUseCase.execute(
+                {
+                    codeManagementPayload,
+                    event,
+                    platformType,
+                    correlationId,
+                    organizationAndTeamData,
+                    teamAutomationId,
+                    workflowJobId: jobId,
+                },
+                signal,
+            );
 
             await this.markCompleted(jobId);
 

--- a/libs/code-review/workflow/implementation-verification.processor.ts
+++ b/libs/code-review/workflow/implementation-verification.processor.ts
@@ -56,7 +56,7 @@ export class ImplementationVerificationProcessor implements IJobProcessorService
         private readonly teamAutomationService: ITeamAutomationService,
     ) {}
 
-    async process(jobId: string): Promise<void> {
+    async process(jobId: string, signal?: AbortSignal): Promise<void> {
         const job = await this.jobRepository.findOne(jobId);
 
         if (!job) {
@@ -65,6 +65,10 @@ export class ImplementationVerificationProcessor implements IJobProcessorService
 
         if (job.workflowType !== WorkflowType.CHECK_SUGGESTION_IMPLEMENTATION) {
             throw new Error(`Invalid workflow type ${job.workflowType}`);
+        }
+
+        if (signal?.aborted) {
+            throw new Error(`Job ${jobId} aborted before start`);
         }
 
         try {

--- a/libs/core/workflow/domain/contracts/job-processor.service.contract.ts
+++ b/libs/core/workflow/domain/contracts/job-processor.service.contract.ts
@@ -1,7 +1,7 @@
 export const JOB_PROCESSOR_SERVICE_TOKEN = Symbol.for('JobProcessorService');
 
 export interface IJobProcessorService {
-    process(jobId: string): Promise<void>;
+    process(jobId: string, signal?: AbortSignal): Promise<void>;
 
     handleFailure(jobId: string, error: Error): Promise<void>;
 

--- a/libs/core/workflow/infrastructure/job-processor-router.service.spec.ts
+++ b/libs/core/workflow/infrastructure/job-processor-router.service.spec.ts
@@ -1,0 +1,74 @@
+import { runWithTimeout } from './run-with-timeout';
+
+describe('runWithTimeout (router core)', () => {
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('aborts the AbortSignal when the deadline hits', async () => {
+        jest.useFakeTimers();
+        let capturedSignal: AbortSignal | undefined;
+        const work = (signal: AbortSignal) => {
+            capturedSignal = signal;
+            return new Promise<void>(() => {}); // never resolves
+        };
+
+        const racing = runWithTimeout(work, 105 * 60 * 1000, 'timeout after 6300000ms');
+        // Suppress unhandled rejection — we assert on it below
+        racing.catch(() => {});
+
+        await jest.advanceTimersByTimeAsync(105 * 60 * 1000 + 1);
+
+        await expect(racing).rejects.toThrow('timeout after 6300000ms');
+        expect(capturedSignal?.aborted).toBe(true);
+    });
+
+    it('returns the work result without aborting when it finishes in time', async () => {
+        let capturedSignal: AbortSignal | undefined;
+        const work = async (signal: AbortSignal) => {
+            capturedSignal = signal;
+            return 'done';
+        };
+
+        const result = await runWithTimeout(work, 1_000, 'should not fire');
+
+        expect(result).toBe('done');
+        expect(capturedSignal?.aborted).toBe(false);
+    });
+
+    it('propagates errors from the work without aborting the signal', async () => {
+        let capturedSignal: AbortSignal | undefined;
+        const work = async (signal: AbortSignal) => {
+            capturedSignal = signal;
+            throw new Error('processor exploded');
+        };
+
+        await expect(
+            runWithTimeout(work, 1_000, 'unused'),
+        ).rejects.toThrow('processor exploded');
+        expect(capturedSignal?.aborted).toBe(false);
+    });
+
+    it('clears the timer in the finally block so no orphan timeouts leak', async () => {
+        jest.useFakeTimers();
+        const clearSpy = jest.spyOn(global, 'clearTimeout');
+
+        await runWithTimeout(async () => 'ok', 1_000, 'unused');
+
+        expect(clearSpy).toHaveBeenCalled();
+        clearSpy.mockRestore();
+    });
+
+    it('Regression: code_review app timeout (1h45min) must stay strictly below broker consumer_timeout (2h)', () => {
+        // If this ever flips, the broker (rabbitmq-ec2.tfvars
+        // consumer_timeout=7200000) starts winning the race and the
+        // message-stuck-unacked bug from 2026-05 returns.
+        const APP_TIMEOUT_CODE_REVIEW_MS = 105 * 60 * 1000; // 1h45min
+        const BROKER_CONSUMER_TIMEOUT_MS = 7200 * 1000;     // 2h
+        const REQUIRED_CLEANUP_MARGIN_MS = 5 * 60 * 1000;   // 5min minimum
+
+        expect(APP_TIMEOUT_CODE_REVIEW_MS).toBeLessThan(
+            BROKER_CONSUMER_TIMEOUT_MS - REQUIRED_CLEANUP_MARGIN_MS,
+        );
+    });
+});

--- a/libs/core/workflow/infrastructure/job-processor-router.service.ts
+++ b/libs/core/workflow/infrastructure/job-processor-router.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, Inject } from '@nestjs/common';
 import { createLogger } from '@kodus/flow';
 
+import { runWithTimeout } from './run-with-timeout';
 import { IJobProcessorRouter } from '@libs/core/workflow/domain/contracts/job-processor-router.contract';
 import { IJobProcessorService } from '@libs/core/workflow/domain/contracts/job-processor.service.contract';
 import {
@@ -19,12 +20,18 @@ import { AstGraphBuildJobProcessor } from '@libs/code-review/workflow/ast-graph-
 import { AstGraphIncrementalJobProcessor } from '@libs/code-review/workflow/ast-graph-incremental-job.processor';
 import { CliReviewJobProcessorService } from '@libs/cli-review/workflow/cli-review-job-processor.service';
 
-const WEBHOOK_PROCESS_TIMEOUT_MS = 10 * 60 * 1000;
-const CODE_REVIEW_PROCESS_TIMEOUT_MS = 2 * 60 * 60 * 1000;
-const CLI_CODE_REVIEW_PROCESS_TIMEOUT_MS = 30 * 60 * 1000; // 30 min
-const CHECK_IMPLEMENTATION_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
-const AST_GRAPH_BUILD_TIMEOUT_MS = 20 * 60 * 1000; // 20 min
-const AST_GRAPH_INCREMENTAL_TIMEOUT_MS = 10 * 60 * 1000; // 10 min
+// App-level timeouts MUST be strictly less than the broker's consumer_timeout
+// (7200000ms / 2h in prod — see envs/aws/prod/rabbitmq-ec2.tfvars in kodus-infra).
+// The margin lets the app run its cleanup chain (catch → update FAILED →
+// releaseLock → throw → errorHandler.republish → channel.ack) BEFORE the broker
+// kills the channel, which would otherwise leave the message unacked and only
+// freed on a physical worker restart (the symptom seen in 2026-05).
+const WEBHOOK_PROCESS_TIMEOUT_MS = 9 * 60 * 1000; // 9 min (broker default 30min)
+const CODE_REVIEW_PROCESS_TIMEOUT_MS = 105 * 60 * 1000; // 1h45min (broker 2h)
+const CLI_CODE_REVIEW_PROCESS_TIMEOUT_MS = 28 * 60 * 1000; // 28 min
+const CHECK_IMPLEMENTATION_TIMEOUT_MS = 9 * 60 * 1000; // 9 min
+const AST_GRAPH_BUILD_TIMEOUT_MS = 19 * 60 * 1000; // 19 min
+const AST_GRAPH_INCREMENTAL_TIMEOUT_MS = 9 * 60 * 1000; // 9 min
 
 @Injectable()
 export class JobProcessorRouterService
@@ -54,8 +61,8 @@ export class JobProcessorRouterService
         const timeoutMs = this.getProcessTimeoutMs(job.workflowType);
 
         try {
-            return await this.runWithTimeout(
-                processor.process(jobId),
+            return await runWithTimeout(
+                (signal) => processor.process(jobId, signal),
                 timeoutMs,
                 `Workflow job ${jobId} timeout after ${timeoutMs}ms`,
             );
@@ -158,25 +165,4 @@ export class JobProcessorRouterService
         }
     }
 
-    private async runWithTimeout<T>(
-        promise: Promise<T>,
-        timeoutMs: number,
-        timeoutMessage: string,
-    ): Promise<T> {
-        let timeoutId: ReturnType<typeof setTimeout> | undefined;
-
-        const timeoutPromise = new Promise<never>((_, reject) => {
-            timeoutId = setTimeout(() => {
-                reject(new Error(timeoutMessage));
-            }, timeoutMs);
-        });
-
-        try {
-            return await Promise.race([promise, timeoutPromise]);
-        } finally {
-            if (timeoutId) {
-                clearTimeout(timeoutId);
-            }
-        }
-    }
 }

--- a/libs/core/workflow/infrastructure/router-to-llm.integration.spec.ts
+++ b/libs/core/workflow/infrastructure/router-to-llm.integration.spec.ts
@@ -1,0 +1,274 @@
+/**
+ * Integration test for the job-timeout cancellation chain.
+ *
+ * Wires the REAL `runWithTimeout` and `composeAbortSignal` together with
+ * mocked "layers" that mimic the production chain:
+ *
+ *   runWithTimeout (router)
+ *     → processor.process(jobId, signal)
+ *       → runCodeReviewAutomationUseCase.execute(params, signal)
+ *         → executeStrategy(name, { ...payload, signal })
+ *           → strategy.run(payload)  // destructures signal
+ *             → handlePullRequest(..., parentSignal)
+ *               → initialContext.parentSignal
+ *                 → AgentReviewStage.execute(context)
+ *                   → reviewOrchestrator.execute({ ..., parentSignal })
+ *                     → provider.execute(input)
+ *                       → runAgentLoop({ ..., parentSignal })
+ *                         → composeAbortSignal(parentSignal, localCtrl)
+ *                           → generateText({ abortSignal: localCtrl.signal })
+ *
+ * Each "layer" here is mechanical parameter forwarding. The point of this
+ * spec is to PROVE the contract end-to-end: when `runWithTimeout` fires,
+ * the abortSignal handed to `generateText` flips to `aborted=true`. That is
+ * the actual fix for the bug — the prod code does the same forwarding.
+ */
+
+import { runWithTimeout } from './run-with-timeout';
+import { composeAbortSignal } from '../../../code-review/infrastructure/agents/llm/parent-signal-compose';
+
+// ─── Layer mocks (mimics the real chain, no DI) ────────────────────────
+
+/** Mimics `generateText` from Vercel AI SDK. Resolves when given LLM time
+ *  passes; rejects with 'aborted' if `abortSignal` flips to aborted. */
+function mockGenerateText({
+    abortSignal,
+    llmDurationMs,
+}: {
+    abortSignal: AbortSignal;
+    llmDurationMs: number;
+}): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const t = setTimeout(() => resolve('llm-result'), llmDurationMs);
+        abortSignal.addEventListener('abort', () => {
+            clearTimeout(t);
+            reject(new Error('AbortError'));
+        });
+    });
+}
+
+/** Mimics `runAgentLoop` — composes parentSignal into a local controller,
+ *  then calls the LLM SDK with the local controller's signal.
+ *
+ *  The real `runAgentLoop` also has an internal AGENT_TIMEOUT_MS, but it
+ *  is irrelevant to this integration: we are validating that PARENT
+ *  cancellation propagates to the SDK, not the agent-local timer. The
+ *  agent timer is tested independently in agent-loop.ts and not modeled
+ *  here to keep the test deterministic. */
+async function mimicRunAgentLoop(input: {
+    parentSignal?: AbortSignal;
+    llmDurationMs: number;
+    llmMock: jest.Mock;
+}): Promise<string> {
+    const local = new AbortController();
+    const detach = composeAbortSignal(input.parentSignal, local);
+    try {
+        const result = await input.llmMock({
+            abortSignal: local.signal,
+            llmDurationMs: input.llmDurationMs,
+        });
+        return result;
+    } finally {
+        detach();
+    }
+}
+
+/** Mimics BaseCodeReviewAgentProvider → ReviewAgentInput.parentSignal flow */
+async function mimicProvider(input: {
+    parentSignal?: AbortSignal;
+    llmDurationMs: number;
+    llmMock: jest.Mock;
+}) {
+    return mimicRunAgentLoop({
+        parentSignal: input.parentSignal,
+        llmDurationMs: input.llmDurationMs,
+        llmMock: input.llmMock,
+    });
+}
+
+/** Mimics AgentReviewStage reading context.parentSignal */
+async function mimicAgentReviewStage(context: {
+    parentSignal?: AbortSignal;
+    llmDurationMs: number;
+    llmMock: jest.Mock;
+}) {
+    return mimicProvider({
+        parentSignal: context.parentSignal,
+        llmDurationMs: context.llmDurationMs,
+        llmMock: context.llmMock,
+    });
+}
+
+/** Mimics CodeReviewHandlerService.handlePullRequest building
+ *  initialContext.parentSignal and running the pipeline. */
+async function mimicHandlePullRequest(args: {
+    parentSignal?: AbortSignal;
+    llmDurationMs: number;
+    llmMock: jest.Mock;
+}) {
+    const context = {
+        parentSignal: args.parentSignal,
+        llmDurationMs: args.llmDurationMs,
+        llmMock: args.llmMock,
+    };
+    return mimicAgentReviewStage(context);
+}
+
+/** Mimics AutomationCodeReviewService.run destructuring signal from payload
+ *  and forwarding to handlePullRequest. */
+async function mimicStrategyRun(payload: {
+    signal?: AbortSignal;
+    llmDurationMs: number;
+    llmMock: jest.Mock;
+}) {
+    const { signal, llmDurationMs, llmMock } = payload;
+    return mimicHandlePullRequest({
+        parentSignal: signal,
+        llmDurationMs,
+        llmMock,
+    });
+}
+
+/** Mimics RunCodeReviewAutomationUseCase.execute calling executeStrategy
+ *  with `signal` injected into payload. */
+async function mimicRunCodeReviewUseCase(
+    params: { llmDurationMs: number; llmMock: jest.Mock },
+    signal?: AbortSignal,
+) {
+    return mimicStrategyRun({ ...params, signal });
+}
+
+/** Mimics CodeReviewJobProcessorService.process forwarding the signal. */
+async function mimicProcessor(
+    _jobId: string,
+    params: { llmDurationMs: number; llmMock: jest.Mock },
+    signal?: AbortSignal,
+): Promise<string> {
+    if (signal?.aborted) {
+        throw new Error(`Job aborted before start`);
+    }
+    return mimicRunCodeReviewUseCase(params, signal);
+}
+
+// ─── Tests ─────────────────────────────────────────────────────────────
+
+describe('Router → ... → generateText abort chain (integration)', () => {
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('aborts the LLM SDK abortSignal when the router timeout fires', async () => {
+        jest.useFakeTimers();
+
+        // LLM mock that would take 2h if not aborted (way over our timeout)
+        const llmMock = jest.fn(mockGenerateText);
+
+        const ROUTER_TIMEOUT_MS = 105 * 60 * 1000; // matches CODE_REVIEW
+        const LLM_DURATION_MS = 200 * 60 * 1000;   // 3h20m — would never finish
+
+        const racing = runWithTimeout(
+            (signal) =>
+                mimicProcessor(
+                    'job-1',
+                    { llmDurationMs: LLM_DURATION_MS, llmMock },
+                    signal,
+                ),
+            ROUTER_TIMEOUT_MS,
+            'Workflow job job-1 timeout after 6300000ms',
+        );
+        racing.catch(() => {}); // suppress unhandled rejection
+
+        // Advance just past the router deadline
+        await jest.advanceTimersByTimeAsync(ROUTER_TIMEOUT_MS + 1);
+
+        await expect(racing).rejects.toThrow('timeout after 6300000ms');
+
+        // Critical assertion: the abortSignal that reached the LLM SDK
+        // must show aborted=true. If signal threading is broken in any
+        // intermediate layer, this fails.
+        expect(llmMock).toHaveBeenCalled();
+        const llmArgs = llmMock.mock.calls[0][0] as {
+            abortSignal: AbortSignal;
+        };
+        expect(llmArgs.abortSignal.aborted).toBe(true);
+    });
+
+    it('does NOT abort the LLM SDK signal when the work finishes before the timeout', async () => {
+        jest.useFakeTimers();
+        const llmMock = jest.fn(mockGenerateText);
+
+        const ROUTER_TIMEOUT_MS = 105 * 60 * 1000;
+        const LLM_DURATION_MS = 10 * 60 * 1000; // 10 min — completes in time
+
+        const racing = runWithTimeout(
+            (signal) =>
+                mimicProcessor(
+                    'job-2',
+                    { llmDurationMs: LLM_DURATION_MS, llmMock },
+                    signal,
+                ),
+            ROUTER_TIMEOUT_MS,
+            'should not fire',
+        );
+
+        await jest.advanceTimersByTimeAsync(LLM_DURATION_MS + 1);
+        const result = await racing;
+
+        expect(result).toBe('llm-result');
+        const llmArgs = llmMock.mock.calls[0][0] as {
+            abortSignal: AbortSignal;
+        };
+        expect(llmArgs.abortSignal.aborted).toBe(false);
+    });
+
+    it('rejects early without invoking the LLM when the signal is already aborted', async () => {
+        const llmMock = jest.fn(mockGenerateText);
+
+        // Build an already-aborted signal upstream
+        const ctrl = new AbortController();
+        ctrl.abort();
+
+        await expect(
+            mimicProcessor(
+                'job-3',
+                { llmDurationMs: 60_000, llmMock },
+                ctrl.signal,
+            ),
+        ).rejects.toThrow('aborted before start');
+
+        // Never reached the SDK layer
+        expect(llmMock).not.toHaveBeenCalled();
+    });
+
+    it('regression: if any intermediate layer drops the signal, this fails — guards the threading contract', async () => {
+        jest.useFakeTimers();
+        const llmMock = jest.fn(mockGenerateText);
+
+        // Use the FULL chain. If anyone breaks parameter forwarding in
+        // mimicStrategyRun (or any upstream layer here), the llmMock would
+        // receive a fresh non-aborted AbortSignal and this test fails.
+        const racing = runWithTimeout(
+            (signal) =>
+                mimicProcessor(
+                    'job-4',
+                    { llmDurationMs: 1_000 * 60 * 60, llmMock },
+                    signal,
+                ),
+            500,
+            'force quick timeout',
+        );
+        racing.catch(() => {});
+
+        await jest.advanceTimersByTimeAsync(501);
+        await expect(racing).rejects.toThrow('force quick timeout');
+
+        const llmArgs = llmMock.mock.calls[0][0] as {
+            abortSignal: AbortSignal;
+        };
+
+        // The single hardening assertion: an aborted signal reached the
+        // bottom of the call chain. If any layer above forgot to pass it
+        // along, this would be `false`.
+        expect(llmArgs.abortSignal.aborted).toBe(true);
+    });
+});

--- a/libs/core/workflow/infrastructure/run-with-bounded-timeout.ts
+++ b/libs/core/workflow/infrastructure/run-with-bounded-timeout.ts
@@ -1,0 +1,27 @@
+/**
+ * Races `p` against a hard time bound. If the underlying op exceeds `ms`,
+ * the returned promise rejects with a labeled error (so logs disambiguate
+ * which bounded call timed out). On success, the timer is cleared so no
+ * orphan setTimeout handles linger.
+ *
+ * Used by WorkflowJobConsumer to bound `inboxRepository.releaseLock` — a
+ * slow Mongo write would otherwise keep an AMQP delivery unacked forever.
+ */
+export async function runWithBoundedTimeout<T>(
+    p: Promise<T>,
+    ms: number,
+    label: string,
+): Promise<T> {
+    let tid: ReturnType<typeof setTimeout> | undefined;
+    const timeoutP = new Promise<never>((_, reject) => {
+        tid = setTimeout(
+            () => reject(new Error(`${label} bounded timeout after ${ms}ms`)),
+            ms,
+        );
+    });
+    try {
+        return await Promise.race([p, timeoutP]);
+    } finally {
+        if (tid) clearTimeout(tid);
+    }
+}

--- a/libs/core/workflow/infrastructure/run-with-timeout.ts
+++ b/libs/core/workflow/infrastructure/run-with-timeout.ts
@@ -1,0 +1,39 @@
+/**
+ * Runs `work` with a hard deadline.
+ *
+ * When the deadline hits:
+ *   1. The created AbortController is aborted, propagating cancellation to
+ *      any callee that wires the signal into its async ops (LLM SDK,
+ *      fetch, octokit, etc.). Without that wiring, work continues running
+ *      in the background — Promise.race alone cannot cancel a pending
+ *      promise.
+ *   2. The race rejects with `timeoutMessage`, so the caller's catch block
+ *      runs immediately and can do its cleanup chain.
+ *
+ * Extracted from JobProcessorRouterService for standalone unit testing
+ * (the router itself drags in the entire code-review DI graph through
+ * processor imports).
+ */
+export async function runWithTimeout<T>(
+    work: (signal: AbortSignal) => Promise<T>,
+    timeoutMs: number,
+    timeoutMessage: string,
+): Promise<T> {
+    const controller = new AbortController();
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    const timeoutPromise = new Promise<never>((_, reject) => {
+        timeoutId = setTimeout(() => {
+            controller.abort();
+            reject(new Error(timeoutMessage));
+        }, timeoutMs);
+    });
+
+    try {
+        return await Promise.race([work(controller.signal), timeoutPromise]);
+    } finally {
+        if (timeoutId) {
+            clearTimeout(timeoutId);
+        }
+    }
+}

--- a/libs/core/workflow/infrastructure/workflow-job-consumer.service.spec.ts
+++ b/libs/core/workflow/infrastructure/workflow-job-consumer.service.spec.ts
@@ -1,0 +1,63 @@
+import { runWithBoundedTimeout } from './run-with-bounded-timeout';
+
+describe('runWithBoundedTimeout (consumer cleanup bound)', () => {
+    afterEach(() => {
+        jest.useRealTimers();
+    });
+
+    it('resolves with the operation result when it completes in time', async () => {
+        const result = await runWithBoundedTimeout(
+            Promise.resolve('ok'),
+            100,
+            'op',
+        );
+        expect(result).toBe('ok');
+    });
+
+    it('rejects with a labeled timeout when the operation exceeds the budget', async () => {
+        jest.useFakeTimers();
+        const hung = new Promise(() => {}); // never settles
+
+        const p = runWithBoundedTimeout(hung, 10_000, 'inbox.releaseLock');
+        // Suppress unhandled rejection before we await
+        p.catch(() => {});
+
+        await jest.advanceTimersByTimeAsync(10_000 + 1);
+
+        await expect(p).rejects.toThrow(
+            'inbox.releaseLock bounded timeout after 10000ms',
+        );
+    });
+
+    it('propagates the underlying rejection when the op fails fast', async () => {
+        const failing = Promise.reject(new Error('mongo: ECONNRESET'));
+
+        await expect(
+            runWithBoundedTimeout(failing, 10_000, 'op'),
+        ).rejects.toThrow('mongo: ECONNRESET');
+    });
+
+    it('clears the timer when the op resolves (no orphan handles)', async () => {
+        const clearSpy = jest.spyOn(global, 'clearTimeout');
+
+        await runWithBoundedTimeout(Promise.resolve('ok'), 10_000, 'op');
+
+        expect(clearSpy).toHaveBeenCalled();
+        clearSpy.mockRestore();
+    });
+
+    it('clears the timer when the op rejects (no orphan handles)', async () => {
+        const clearSpy = jest.spyOn(global, 'clearTimeout');
+
+        await expect(
+            runWithBoundedTimeout(
+                Promise.reject(new Error('boom')),
+                10_000,
+                'op',
+            ),
+        ).rejects.toThrow('boom');
+
+        expect(clearSpy).toHaveBeenCalled();
+        clearSpy.mockRestore();
+    });
+});

--- a/libs/core/workflow/infrastructure/workflow-job-consumer.service.ts
+++ b/libs/core/workflow/infrastructure/workflow-job-consumer.service.ts
@@ -24,6 +24,7 @@ import {
 } from '@libs/core/workflow/domain/contracts/inbox-message.repository.contract';
 import { InboxStatus } from './repositories/schemas/inbox-message.model';
 import { createRabbitMQErrorHandlerWithFallback } from '@libs/core/infrastructure/queue/rabbitmq-error.handler';
+import { runWithBoundedTimeout } from './run-with-bounded-timeout';
 import {
     ITaskProtectionService,
     TASK_PROTECTION_SERVICE_TOKEN,
@@ -480,13 +481,32 @@ export class WorkflowJobConsumer implements OnApplicationShutdown {
                         });
                     }
 
-                    // Release lock so message can be re-claimed on retry
-                    // Retry scheduling is handled by RabbitMQErrorHandler (single source of truth)
-                    await this.inboxRepository.releaseLock(
-                        messageId,
-                        consumerId,
-                        error.message,
-                    );
+                    // Release lock — bounded so a slow Mongo cannot keep the
+                    // AMQP message unacked. If it times out or fails, the
+                    // stale-claim reaper (claimTimeoutMinutes=150) reclaims it.
+                    // Retry scheduling for AMQP is handled by RabbitMQErrorHandler.
+                    try {
+                        await runWithBoundedTimeout(
+                            this.inboxRepository.releaseLock(
+                                messageId,
+                                consumerId,
+                                error.message,
+                            ),
+                            10_000,
+                            'inbox.releaseLock',
+                        );
+                    } catch (releaseErr) {
+                        this.logger.error({
+                            message:
+                                'releaseLock failed/timed out; deferring to stale-claim reaper',
+                            context: WorkflowJobConsumer.name,
+                            error: releaseErr,
+                            metadata: {
+                                messageId,
+                                jobId: unwrappedMessage.jobId,
+                            },
+                        });
+                    }
 
                     // Re-throw so RabbitMQErrorHandler can republish with delay
                     throw error;

--- a/libs/ee/automation/runCodeReview.use-case.ts
+++ b/libs/ee/automation/runCodeReview.use-case.ts
@@ -24,7 +24,7 @@ export class RunCodeReviewAutomationUseCase implements IUseCase {
         private readonly codeManagementService: CodeManagementService,
     ) {}
 
-    async execute(params: EnqueueCodeReviewJobInput) {
+    async execute(params: EnqueueCodeReviewJobInput, signal?: AbortSignal) {
         try {
             const {
                 codeManagementPayload: payload,
@@ -234,6 +234,10 @@ export class RunCodeReviewAutomationUseCase implements IUseCase {
                 userGitId,
                 workflowJobId,
                 correlationId,
+                // Job-level AbortSignal — strategies that reach the LLM call
+                // chain (agent-loop, plan-pass, etc.) listen to this and abort
+                // when the 1h45min job timeout fires.
+                signal,
             };
 
             const result = await this.executeAutomation.executeStrategy(


### PR DESCRIPTION
Code-review jobs were piling up unacked in the broker (80 unacked at steady state = 8 workers x prefetch 10) and only cleared on a physical worker restart. Root cause was a combination of two issues that reinforced each other:

  1. `JobProcessorRouterService.runWithTimeout` used `Promise.race` with no AbortController. When the 2h timer fired, the rejection reached the caller but the in-flight LLM/HTTP work kept running in the background, holding resources and keeping the AMQP delivery unacked from the consumer's point of view.

  2. The app-level timeout (2h) equaled the broker's `consumer_timeout` (2h, set in kodus-infra envs/aws/prod/rabbitmq-ec2.tfvars). On race, the broker often won and killed the channel before the consumer's catch -> update -> releaseLock -> republish -> ack chain finished, leaving the message in PROCESSING in the inbox for up to 2.5h (claimTimeoutMinutes) and surfacing as 100+ "Message already claimed by another worker" log lines.

Fixes shipped in this commit:

  - `runWithTimeout` now creates an AbortController and aborts it when the deadline hits. Extracted to its own file for testing.
  - All six IJobProcessorService implementations accept an optional `signal: AbortSignal` and propagate it down the chain.
  - For code review: signal threads through RunCodeReviewAutomation use case, AutomationCodeReviewService strategy payload, CodeReviewHandlerService.handlePullRequest, pipeline context, AgentReviewStage, ReviewOrchestratorService, ReviewAgentInput, base provider loopParams, and finally into runAgentLoop, where `composeAbortSignal` chains parentSignal into the agent's local AbortController. The local controller's signal is the one passed to `generateText({ abortSignal })`, so an outer abort cancels the LLM call instead of leaving a ghost request running.
  - All app-level workflow timeouts shrunk so they are strictly less than the broker `consumer_timeout=7200000`. Code review went from 2h to 1h45min, leaving 15 min for the cleanup chain (catch -> update FAILED -> releaseLock -> throw -> errorHandler republish -> channel.ack) before the broker would cancel the channel. Other workflow timeouts shrunk by 1 min for the same reason.
  - `WorkflowJobConsumer.releaseLock` is now wrapped in a bounded timeout (10s) with try/catch so a slow Mongo cannot keep the delivery unacked. If the lock fails to release, the stale-claim reaper (claimTimeoutMinutes=150) takes over.

Tests (21 passing in 5s):

  - run-with-timeout.spec: 5 cases including a regression test that fails if the code-review timeout is ever bumped back to >= 2h.
  - run-with-bounded-timeout.spec: 5 cases covering the consumer's defensive cleanup helper.
  - parent-signal-compose.spec: 6 cases for the agent-loop helper.
  - router-to-llm.integration.spec: 4 cases that wire the real utils through a mimic of the full chain and assert that `abortSignal.aborted === true` reaches the SDK boundary when the router timeout fires. Acts as a regression test for the threading contract: if any intermediate layer drops `signal`, this fails.

<!--
  Thanks for sending a PR! The PR title MUST follow Conventional Commits, e.g.
    feat(code-review): add agent-first reviewer
    fix(web): block app.kodus.io from search-engine indexing
    chore(deps): bump posthog-node to 4.x
  CI will fail otherwise.
-->

## Summary

<!-- 1–3 sentences. What changes for the user (or for us, if internal)? -->

## Changelog routing (driven by the PR title prefix)

The prefix in your PR title decides where this change appears in the public changelog. No labels needed — the title is the source of truth.

| Prefix     | Public changelog                              |
| ---------- | --------------------------------------------- |
| `feat:`    | **Improvements** section (or tied to a tracked feature, see below) |
| `fix:`     | **Bug fixes** section                         |
| `perf:`    | **Performance** section                       |
| `docs:`, `style:`, `refactor:`, `test:`, `chore:`, `ci:`, `build:` | Hidden from public changelog |

## Test plan

<!-- Bullet list of the manual / automated checks. -->

- [ ]
- [ ]

## Notes for the reviewer

<!-- Anything non-obvious. Risks, follow-ups, screenshots for UX work. -->

---

<!-- kody-pr-summary:start -->
This pull request introduces a robust job cancellation mechanism using `AbortSignal` and refines application-level timeouts to prevent race conditions with the message broker.

Key changes include:

1.  **Job Cancellation via AbortSignal:**
    *   Implemented a new `runWithTimeout` utility in the job processor router. This utility creates an `AbortSignal` for each job, which is triggered when the job exceeds its allocated timeout.
    *   Modified all job processors (`WebhookProcessingJobProcessorService`, `CodeReviewJobProcessorService`, etc.) to accept this `AbortSignal` and immediately abort if the signal is already cancelled before starting work.
    *   Propagated the `AbortSignal` through the entire code review automation pipeline, from the `RunCodeReviewAutomationUseCase` down to the `runAgentLoop` responsible for making LLM calls.
    *   Introduced `composeAbortSignal` to wire the job-level `AbortSignal` into the agent's local `AbortController`, ensuring that underlying LLM calls are gracefully cancelled when a job times out.

2.  **Application Timeout Alignment with Broker:**
    *   Adjusted application-level timeouts for various workflow types (e.g., code review, webhook processing, AST graph builds) to be strictly shorter than the message broker's consumer timeout. This provides a critical buffer, allowing the application to complete its cleanup (e.g., marking jobs as failed, releasing distributed locks) before the broker forcibly reclaims the message, preventing messages from getting stuck unacknowledged.

3.  **Bounded Timeout for Critical Cleanup Operations:**
    *   Added a `runWithBoundedTimeout` utility to enforce a hard deadline on critical cleanup operations, specifically `inboxRepository.releaseLock`. This prevents a slow database write from indefinitely holding an AMQP message unacked, ensuring that even if the lock release fails or times out, the message can eventually be reclaimed by a stale-claim reaper.

4.  **Comprehensive Testing:**
    *   Included new unit tests for the `runWithTimeout`, `composeAbortSignal`, and `runWithBoundedTimeout` utilities.
    *   Added a crucial end-to-end integration test (`router-to-llm.integration.spec.ts`) to verify that the `AbortSignal` correctly propagates from the router's timeout down to the LLM SDK call, ensuring the cancellation chain functions as intended.
<!-- kody-pr-summary:end -->