### PR TITLE
ci(selfhosted-build-push): dispatch E2E in kodus-installer after publish

### DIFF
--- a/.github/workflows/selfhosted-build-push.yml
+++ b/.github/workflows/selfhosted-build-push.yml
@@ -431,6 +431,36 @@ jobs:
             tag: ${{ needs.create-release.outputs.release_tag }}
         secrets: inherit
 
+    trigger-installer-e2e:
+        name: Trigger self-hosted E2E in kodus-installer
+        needs:
+            - create-release
+            - build-and-push
+        if: needs.build-and-push.result == 'success'
+        runs-on: ubuntu-latest
+        # GITHUB_TOKEN only scopes to this repo, so a separate PAT is needed
+        # to fire repository_dispatch into kodustech/kodus-installer. The
+        # PAT must have `repo` scope on the installer (or fine-grained:
+        # Contents=read + Actions=write).
+        steps:
+            - name: Fire repository_dispatch into kodus-installer
+              env:
+                  GH_TOKEN: ${{ secrets.KODUS_INSTALLER_DISPATCH_TOKEN }}
+                  RELEASE_TAG: ${{ needs.create-release.outputs.release_tag }}
+              run: |
+                  if [ -z "$GH_TOKEN" ]; then
+                      echo "::warning::KODUS_INSTALLER_DISPATCH_TOKEN is not set — skipping E2E dispatch."
+                      exit 0
+                  fi
+                  gh api \
+                      --method POST \
+                      "repos/kodustech/kodus-installer/dispatches" \
+                      -f event_type=selfhosted-image-published \
+                      -f client_payload[release_tag]="$RELEASE_TAG" \
+                      -f client_payload[image_tag]=latest \
+                      -f client_payload[source_run_url]="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+                  echo "::notice::Dispatched selfhosted-image-published to kodustech/kodus-installer for tag $RELEASE_TAG"
+
     notify-discord-failure:
         name: Notify Discord (failure only)
         needs:

--- a/.github/workflows/selfhosted-build-push.yml
+++ b/.github/workflows/selfhosted-build-push.yml
@@ -438,18 +438,20 @@ jobs:
             - build-and-push
         if: needs.build-and-push.result == 'success'
         runs-on: ubuntu-latest
-        # GITHUB_TOKEN only scopes to this repo, so a separate PAT is needed
-        # to fire repository_dispatch into kodustech/kodus-installer. The
-        # PAT must have `repo` scope on the installer (or fine-grained:
-        # Contents=read + Actions=write).
+        # GITHUB_TOKEN only scopes to this repo, so a cross-repo PAT is
+        # needed to fire repository_dispatch into kodustech/kodus-installer.
+        # We reuse CROSS_REPO_PAT (already used by env-sync-release.yml to
+        # checkout + push + open PRs in the installer). It needs
+        # `Contents: Read and write` on kodus-installer — same permission
+        # env-sync already requires, so no new secret to manage.
         steps:
             - name: Fire repository_dispatch into kodus-installer
               env:
-                  GH_TOKEN: ${{ secrets.KODUS_INSTALLER_DISPATCH_TOKEN }}
+                  GH_TOKEN: ${{ secrets.CROSS_REPO_PAT }}
                   RELEASE_TAG: ${{ needs.create-release.outputs.release_tag }}
               run: |
                   if [ -z "$GH_TOKEN" ]; then
-                      echo "::warning::KODUS_INSTALLER_DISPATCH_TOKEN is not set — skipping E2E dispatch."
+                      echo "::warning::CROSS_REPO_PAT is not set — skipping E2E dispatch."
                       exit 0
                   fi
                   gh api \


### PR DESCRIPTION
## Summary

After a successful self-hosted release publish, fire a `repository_dispatch` into `kodustech/kodus-installer` so its new `scripts/test-e2e-vm.sh` end-to-end test runs against a fresh DigitalOcean droplet. The test signs up, onboards a GitHub integration via PAT, opens a `@kody review` comment on a fixture PR, and waits for Kody to respond — covering the exact "fresh self-hosted boot" path a customer goes through.

## How it works

```
selfhosted-build-push.yml (this workflow)
  ├─ create-release
  ├─ build-and-push                ← publishes ghcr.io/kodustech/kodus-ai-*
  ├─ cli-release
  ├─ changelog-publish
  ├─ trigger-installer-e2e ◄── NEW: gh api ... /dispatches
  └─ notify-discord-failure

kodus-installer/.github/workflows/e2e-self-hosted.yml (separate PR)
  ├─ on: repository_dispatch[selfhosted-image-published] + workflow_dispatch
  ├─ run-e2e: provisions DO droplet, runs test-e2e-vm.sh, destroys droplet
  └─ notify-discord-failure: pings DISCORD_WEBHOOK_E2E on failure
```

## Token

Reuses the existing `CROSS_REPO_PAT` secret — already used by `env-sync-release.yml` to check out, push and open PRs in `kodus-installer`. `POST /repos/.../dispatches` only needs **Contents: Read and write**, which `CROSS_REPO_PAT` already has. **No new secret to provision.**

If `CROSS_REPO_PAT` is somehow unset, the step **warns and skips** — it does not fail the release.

## Cost

~\$0.04 per release on DigitalOcean (CX22, ~6 min, droplet destroyed in teardown trap). Failures ping Discord via `DISCORD_WEBHOOK_E2E` (configured in `kodus-installer`).

## Companion PR

The matching `kodus-installer` workflow is shipped together with the test-e2e suite in [kodustech/kodus-installer#16](https://github.com/kodustech/kodus-installer/pull/16).

## Test plan

- [x] Workflow YAML parses (validated locally)
- [ ] After merge, the next manual run of `selfhosted-build-push` should dispatch the installer workflow (verify in `kodus-installer` Actions tab)
- [ ] If `CROSS_REPO_PAT` is absent, the step warns + skips without failing the release