### PR TITLE
fix(self-hosted): unblock SSO signup and show Cockpit icon for Enterprise license

### DIFF
--- a/apps/web/src/core/layout/navbar/index.tsx
+++ b/apps/web/src/core/layout/navbar/index.tsx
@@ -25,6 +25,7 @@ import {
 import { ErrorBoundary } from "react-error-boundary";
 import { UserNav } from "src/core/layout/navbar/_components/user-nav";
 import { cn } from "src/core/utils/components";
+import { isCockpitTierAllowed } from "src/features/ee/cockpit/_helpers/tier-policy";
 import { SubscriptionBadge } from "src/features/ee/subscription/_components/subscription-badge";
 import { useSubscriptionContext } from "src/features/ee/subscription/_providers/subscription-context";
 
@@ -70,11 +71,10 @@ export const NavMenu = () => {
             {
                 label: "Cockpit",
                 href: "/cockpit",
-                visible:
-                    subscription.license.valid &&
-                    subscription.license.subscriptionStatus !== "self-hosted" &&
-                    subscription.license.subscriptionStatus !==
-                        "licensed-self-hosted",
+                // Mirrors the /cockpit route guard (apps/web/.../cockpit/layout.tsx)
+                // and the backend tier-policy. Self-hosted on Enterprise gets the
+                // icon; unlicensed self-hosted / free_byok stays hidden.
+                visible: isCockpitTierAllowed(subscription.license),
                 icon: <GaugeIcon className="size-6" />,
             },
 
@@ -138,6 +138,9 @@ export const NavMenu = () => {
     }, [
         subscription.license.valid,
         subscription.license.subscriptionStatus,
+        "planType" in subscription.license
+            ? subscription.license.planType
+            : undefined,
         canReadCodeReviewSettings,
         canReadGitSettings,
         canReadBilling,

--- a/apps/web/src/features/ee/cockpit/_helpers/tier-policy.spec.ts
+++ b/apps/web/src/features/ee/cockpit/_helpers/tier-policy.spec.ts
@@ -1,0 +1,130 @@
+import { isCockpitTierAllowed } from "./tier-policy";
+
+import type { OrganizationLicense } from "../../subscription/_services/billing/types";
+
+// Mirrors test/unit/cockpit/tier-policy.spec.ts. Kept here too because
+// the navbar reads this helper directly — a regression in the gate would
+// re-introduce the customer-reported "Cockpit icon missing on Enterprise
+// self-hosted" bug. The two files MUST stay in sync.
+
+const teamsPlans = [
+    "teams_byok",
+    "teams_byok_annual",
+    "teams_managed",
+    "teams_managed_annual",
+    "teams_managed_legacy",
+] as const;
+
+const enterprisePlans = [
+    "enterprise_byok",
+    "enterprise_byok_annual",
+    "enterprise_managed",
+    "enterprise_managed_annual",
+    "enterprise",
+] as const;
+
+describe("isCockpitTierAllowed (web mirror)", () => {
+    it("cloud active + Teams → allowed", () => {
+        for (const plan of teamsPlans) {
+            expect(
+                isCockpitTierAllowed({
+                    valid: true,
+                    subscriptionStatus: "active",
+                    numberOfLicenses: 5,
+                    planType: plan,
+                } satisfies OrganizationLicense),
+            ).toBe(true);
+        }
+    });
+
+    it("cloud active + Enterprise → allowed", () => {
+        for (const plan of enterprisePlans) {
+            expect(
+                isCockpitTierAllowed({
+                    valid: true,
+                    subscriptionStatus: "active",
+                    numberOfLicenses: 5,
+                    planType: plan,
+                } satisfies OrganizationLicense),
+            ).toBe(true);
+        }
+    });
+
+    it("cloud active + free_byok → blocked", () => {
+        expect(
+            isCockpitTierAllowed({
+                valid: true,
+                subscriptionStatus: "active",
+                numberOfLicenses: 0,
+                planType: "free_byok",
+            } satisfies OrganizationLicense),
+        ).toBe(false);
+    });
+
+    it("licensed self-hosted + Enterprise → allowed (Dmitry case)", () => {
+        for (const plan of enterprisePlans) {
+            expect(
+                isCockpitTierAllowed({
+                    valid: true,
+                    subscriptionStatus: "licensed-self-hosted",
+                    planType: plan,
+                    numberOfLicenses: 50,
+                } satisfies OrganizationLicense),
+            ).toBe(true);
+        }
+    });
+
+    it("licensed self-hosted + Teams → blocked (Teams is cloud-only)", () => {
+        for (const plan of teamsPlans) {
+            expect(
+                isCockpitTierAllowed({
+                    valid: true,
+                    subscriptionStatus: "licensed-self-hosted",
+                    planType: plan,
+                    numberOfLicenses: 50,
+                } satisfies OrganizationLicense),
+            ).toBe(false);
+        }
+    });
+
+    it("unlicensed self-hosted → blocked", () => {
+        expect(
+            isCockpitTierAllowed({
+                valid: true,
+                subscriptionStatus: "self-hosted",
+            } satisfies OrganizationLicense),
+        ).toBe(false);
+    });
+
+    it("trial → allowed", () => {
+        expect(
+            isCockpitTierAllowed({
+                valid: true,
+                subscriptionStatus: "trial",
+                trialEnd: "2026-12-31",
+            } satisfies OrganizationLicense),
+        ).toBe(true);
+    });
+
+    it("invalid / expired / canceled → blocked", () => {
+        for (const status of [
+            "payment_failed",
+            "canceled",
+            "expired",
+            "inactive",
+        ] as const) {
+            expect(
+                isCockpitTierAllowed({
+                    valid: false,
+                    subscriptionStatus: status,
+                    numberOfLicenses: 0,
+                } satisfies OrganizationLicense),
+            ).toBe(false);
+        }
+    });
+
+    it("null / undefined → blocked", () => {
+        expect(isCockpitTierAllowed(null)).toBe(false);
+        expect(isCockpitTierAllowed(undefined)).toBe(false);
+    });
+});

--- a/libs/ee/sso/use-cases/sso-login.use-case.ts
+++ b/libs/ee/sso/use-cases/sso-login.use-case.ts
@@ -28,13 +28,17 @@ export class SSOLoginUseCase implements IUseCase {
             let user = await this.authService.validateUser({ email });
 
             if (!user) {
-                user = await this.signUpUseCase.execute({
-                    email,
-                    name:
-                        `${firstName || ''} ${lastName || ''}`.trim() || email,
-                    password: randomBytes(32).toString('base64').slice(0, 32),
-                    organizationId,
-                });
+                user = await this.signUpUseCase.execute(
+                    {
+                        email,
+                        name:
+                            `${firstName || ''} ${lastName || ''}`.trim() ||
+                            email,
+                        password: randomBytes(32).toString('base64').slice(0, 32),
+                        organizationId,
+                    },
+                    { preVerified: true },
+                );
             }
 
             const { accessToken, refreshToken } = await this.authService.login(

--- a/libs/identity/application/use-cases/auth/signup.use-case.spec.ts
+++ b/libs/identity/application/use-cases/auth/signup.use-case.spec.ts
@@ -1,0 +1,132 @@
+import { environment } from '@libs/ee/configs/environment';
+import { STATUS } from '@libs/core/infrastructure/config/types/database/status.type';
+import { Role } from '@libs/identity/domain/permissions/enums/permissions.enum';
+
+import { SignUpUseCase } from './signup.use-case';
+
+describe('SignUpUseCase — user status when joining an existing org', () => {
+    // Matrix: (CLOUD vs SELF-HOSTED) × (self-claim vs IdP-verified).
+    // The owner-create branch (no organizationId) is unconditionally ACTIVE and
+    // exercised separately below to lock that contract in.
+
+    let originalCloudMode: boolean;
+
+    const buildDeps = () => {
+        const org = { uuid: 'org-1', name: 'Acme' };
+        return {
+            organizationService: {
+                findOne: jest.fn().mockResolvedValue(org),
+                createOrganizationWithTenant: jest.fn().mockResolvedValue(org),
+            },
+            usersService: {
+                count: jest.fn().mockResolvedValue(0),
+                register: jest
+                    .fn()
+                    .mockImplementation(async (u) => ({
+                        ...u,
+                        uuid: 'user-1',
+                        organization: org,
+                        toObject: () => ({
+                            ...u,
+                            uuid: 'user-1',
+                            organization: org,
+                        }),
+                    })),
+            },
+            teamMembersService: {
+                create: jest.fn().mockResolvedValue({ uuid: 'tm-1' }),
+            },
+            teamService: {
+                findOne: jest.fn().mockResolvedValue({ uuid: 'team-1' }),
+            },
+            createProfileUseCase: { execute: jest.fn() },
+            createTeamUseCase: {
+                execute: jest.fn().mockResolvedValue({ uuid: 'team-1' }),
+            },
+            emailService: { createContact: jest.fn() },
+            telemetry: { userSignedUp: jest.fn() },
+        };
+    };
+
+    const buildUseCase = (deps: ReturnType<typeof buildDeps>) =>
+        new SignUpUseCase(
+            deps.organizationService as any,
+            deps.usersService as any,
+            deps.teamMembersService as any,
+            deps.teamService as any,
+            deps.createProfileUseCase as any,
+            deps.createTeamUseCase as any,
+            deps.emailService as any,
+            deps.telemetry as any,
+        );
+
+    const runWith = async (
+        cloudMode: boolean,
+        options?: Parameters<SignUpUseCase['execute']>[1],
+    ) => {
+        environment.API_CLOUD_MODE = cloudMode;
+        const deps = buildDeps();
+        await buildUseCase(deps).execute(
+            {
+                email: 'sso-user@scorpion.co',
+                name: 'SSO User',
+                password: 'random-bytes',
+                organizationId: 'org-1',
+            } as any,
+            options,
+        );
+        return deps.usersService.register.mock.calls[0][0];
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        originalCloudMode = environment.API_CLOUD_MODE;
+    });
+
+    afterEach(() => {
+        environment.API_CLOUD_MODE = originalCloudMode;
+    });
+
+    describe('with organizationId (auto-join / SSO path)', () => {
+        it('cloud + self-claim → PENDING (must confirm email)', async () => {
+            const registered = await runWith(true);
+            expect(registered.status).toBe(STATUS.PENDING);
+            expect(registered.role).toBe(Role.CONTRIBUTOR);
+        });
+
+        it('self-hosted + self-claim → ACTIVE (no email infra)', async () => {
+            const registered = await runWith(false);
+            expect(registered.status).toBe(STATUS.ACTIVE);
+        });
+
+        it('cloud + preVerified (SSO) → ACTIVE (IdP attested)', async () => {
+            const registered = await runWith(true, { preVerified: true });
+            expect(registered.status).toBe(STATUS.ACTIVE);
+        });
+
+        it('self-hosted + preVerified (SSO) → ACTIVE', async () => {
+            const registered = await runWith(false, { preVerified: true });
+            expect(registered.status).toBe(STATUS.ACTIVE);
+        });
+    });
+
+    describe('without organizationId (owner self-signup)', () => {
+        // This branch is the path 1 case — user creates their own org and is
+        // always ACTIVE owner. preVerified / cloud mode shouldn't matter here.
+        it('always ACTIVE owner regardless of cloud mode', async () => {
+            environment.API_CLOUD_MODE = true;
+            const deps = buildDeps();
+            deps.organizationService.findOne.mockResolvedValue(null);
+
+            await buildUseCase(deps).execute({
+                email: 'owner@scorpion.co',
+                name: 'Owner',
+                password: 'random-bytes',
+            } as any);
+
+            const registered = deps.usersService.register.mock.calls[0][0];
+            expect(registered.status).toBe(STATUS.ACTIVE);
+            expect(registered.role).toBe(Role.OWNER);
+        });
+    });
+});

--- a/libs/identity/application/use-cases/auth/signup.use-case.ts
+++ b/libs/identity/application/use-cases/auth/signup.use-case.ts
@@ -1,6 +1,7 @@
 import { createLogger } from '@kodus/flow';
 import { Inject, Injectable } from '@nestjs/common';
 
+import { environment } from '@libs/ee/configs/environment';
 import { IUseCase } from '@libs/core/domain/interfaces/use-case.interface';
 import { STATUS } from '@libs/core/infrastructure/config/types/database/status.type';
 import { DuplicateRecordException } from '@libs/core/infrastructure/filters/duplicate-record.exception';
@@ -32,6 +33,10 @@ import { CreateProfileUseCase } from '../profile/create.use-case';
 import { CreateTeamUseCase } from '@libs/organization/application/use-cases/team/create.use-case';
 import { SignUpDTO } from '@libs/identity/dtos/create-user-organization.dto';
 
+export interface SignUpOptions {
+    preVerified?: boolean;
+}
+
 @Injectable()
 export class SignUpUseCase implements IUseCase {
     private readonly logger = createLogger(SignUpUseCase.name);
@@ -50,7 +55,10 @@ export class SignUpUseCase implements IUseCase {
         private readonly telemetry: TelemetryService,
     ) {}
 
-    public async execute(payload: SignUpDTO): Promise<Partial<IUser>> {
+    public async execute(
+        payload: SignUpDTO,
+        options?: SignUpOptions,
+    ): Promise<Partial<IUser>> {
         const { email, password, name, organizationId } = payload;
 
         this.logger.error({
@@ -65,11 +73,15 @@ export class SignUpUseCase implements IUseCase {
                 throw new DuplicateRecordException('User already exists');
             }
 
+            const status =
+                options?.preVerified || !environment.API_CLOUD_MODE
+                    ? STATUS.ACTIVE
+                    : STATUS.PENDING;
             const user: Omit<IUser, 'uuid'> = {
                 email,
                 password,
                 role: Role.CONTRIBUTOR,
-                status: STATUS.PENDING,
+                status,
                 organization: {
                     name: generateRandomOrgName(name),
                 },
@@ -151,10 +163,7 @@ export class SignUpUseCase implements IUseCase {
                 throw new Error('Failed to create team member');
             }
 
-            void this.emailService.createContact(
-                { email, name },
-                this.logger,
-            );
+            void this.emailService.createContact({ email, name }, this.logger);
 
             void this.telemetry.userSignedUp({
                 userId: createdUser.uuid,


### PR DESCRIPTION
<!--
  Thanks for sending a PR! The PR title MUST follow Conventional Commits, e.g.
    feat(code-review): add agent-first reviewer
    fix(web): block app.kodus.io from search-engine indexing
    chore(deps): bump posthog-node to 4.x
  CI will fail otherwise.
-->

## Summary

<!-- 1–3 sentences. What changes for the user (or for us, if internal)? -->

## Changelog routing (driven by the PR title prefix)

The prefix in your PR title decides where this change appears in the public changelog. No labels needed — the title is the source of truth.

| Prefix     | Public changelog                              |
| ---------- | --------------------------------------------- |
| `feat:`    | **Improvements** section (or tied to a tracked feature, see below) |
| `fix:`     | **Bug fixes** section                         |
| `perf:`    | **Performance** section                       |
| `docs:`, `style:`, `refactor:`, `test:`, `chore:`, `ci:`, `build:` | Hidden from public changelog |

## Test plan

<!-- Bullet list of the manual / automated checks. -->

- [ ]
- [ ]

## Notes for the reviewer

<!-- Anything non-obvious. Risks, follow-ups, screenshots for UX work. -->

---

<!-- kody-pr-summary:start -->
This pull request introduces the following changes:

*   **Fixes Cockpit Icon Visibility for Enterprise Self-Hosted Deployments**: The visibility logic for the "Cockpit" navigation item has been updated to correctly display the icon for Enterprise customers running self-hosted instances. Previously, it was hidden for all self-hosted deployments. This change aligns the frontend display with the backend tier policy, resolving a customer-reported issue.
*   **Optimizes User Status for SSO Sign-ups**: Users signing up via Single Sign-On (SSO) are now immediately set to an `ACTIVE` status, bypassing the email verification step. This is because their identity is already attested by the Identity Provider (IdP).
*   **Streamlines User Status for Self-Hosted Deployments**: New users in self-hosted environments are now automatically set to an `ACTIVE` status upon registration. This accounts for scenarios where email verification infrastructure might not be available or configured in self-hosted setups.
*   **Adds Comprehensive Unit Tests**: New unit tests have been introduced for both the Cockpit tier policy helper and the user signup use case. These tests validate the updated logic across various scenarios, including cloud vs. self-hosted modes, and self-claimed vs. SSO pre-verified user registrations, ensuring the correctness of the implemented fixes.
<!-- kody-pr-summary:end -->