### PR TITLE
ci(env-sync): close the cascade gap on self-hosted releases

### DIFF
--- a/.github/workflows/env-sync-release.yml
+++ b/.github/workflows/env-sync-release.yml
@@ -43,6 +43,11 @@ jobs:
               uses: actions/checkout@v4
               with:
                   path: kodus-ai
+                  # When invoked via workflow_call from selfhosted-build-push
+                  # (running in `main`), github.ref would be `main` and we'd
+                  # sync the wrong commit. Honour the explicit `tag` input
+                  # so we always check out the actual release tag.
+                  ref: ${{ inputs.tag || github.ref }}
 
             - name: Checkout kodus-installer
               uses: actions/checkout@v4
@@ -74,7 +79,11 @@ jobs:
               working-directory: kodus-installer
               env:
                   GH_TOKEN: ${{ secrets.CROSS_REPO_PAT }}
-                  TAG: ${{ github.ref_name }}
+                  # Prefer the explicit tag input (from workflow_call) over
+                  # github.ref_name. Without this, a workflow_call from main
+                  # produces TAG=main → branch env-sync/main, force-pushed
+                  # every release (losing per-release history).
+                  TAG: ${{ inputs.tag || github.ref_name }}
                   SHA: ${{ github.sha }}
               run: |
                   ../kodus-ai/scripts/env/open-sync-pr.sh \

--- a/.github/workflows/env-sync-release.yml
+++ b/.github/workflows/env-sync-release.yml
@@ -19,8 +19,20 @@ on:
         # selfhosted-build-push.yml). The legacy `v*` pattern only ever
         # matched `v0.0.1`, so the cross-repo sync never fired and
         # kodus-installer/.env.example drifted hundreds of lines.
+        #
+        # Heads up: this `push: tags` trigger does NOT fire when the tag
+        # is created by GITHUB_TOKEN inside another workflow run (Actions
+        # cascade-prevention). `selfhosted-build-push.yml` therefore
+        # invokes this workflow explicitly via `workflow_call` — same
+        # pattern as cli-release / changelog-publish.
         tags:
             - 'selfhosted-*'
+    workflow_call:
+        inputs:
+            tag:
+                description: "Self-hosted release tag this sync is associated with (e.g. selfhosted-2.1.13). Used in the PR body."
+                required: false
+                type: string
     workflow_dispatch: # allow manual re-run if a PR was closed without merge
 
 jobs:

--- a/.github/workflows/selfhosted-build-push.yml
+++ b/.github/workflows/selfhosted-build-push.yml
@@ -415,6 +415,22 @@ jobs:
             tag: ${{ needs.create-release.outputs.release_tag }}
         secrets: inherit
 
+    env-sync-installer:
+        name: Sync .env.example to kodus-installer
+        needs:
+            - create-release
+            - build-and-push
+        if: needs.build-and-push.result == 'success'
+        # Same cascading-events restriction as cli-release / changelog-
+        # publish: the selfhosted-X.Y.Z tag pushed by GITHUB_TOKEN above
+        # would not fire env-sync-release.yml's `push: tags` trigger.
+        # Invoke it explicitly so .env.example + schema-vars.sh in
+        # kodus-installer get regenerated for every self-hosted release.
+        uses: ./.github/workflows/env-sync-release.yml
+        with:
+            tag: ${{ needs.create-release.outputs.release_tag }}
+        secrets: inherit
+
     notify-discord-failure:
         name: Notify Discord (failure only)
         needs:


### PR DESCRIPTION
## Summary

`env-sync-release.yml` is supposed to open a PR in `kodus-installer` with the regenerated `.env.example` whenever the schema changes in a release. In practice it **never fires automatically** because the `selfhosted-X.Y.Z` tag is pushed by `GITHUB_TOKEN` inside `selfhosted-build-push` — and `GITHUB_TOKEN` pushes don't cascade into other workflows (GitHub Actions' loop-prevention).

Result: every self-hosted release silently leaves the installer drifting until someone disparates `env-sync-release` manually. We just discovered this when 4 schema fixes (PR #1079) sat in `main` without reaching the installer until we triggered the sync by hand — generating PR [kodustech/kodus-installer#17](https://github.com/kodustech/kodus-installer/pull/17).

`cli-release` and `changelog-publish` already hit the exact same wall and solved it by being invoked explicitly via `workflow_call` from `selfhosted-build-push`. Apply the same pattern to `env-sync-release`.

## Changes

```diff
# .github/workflows/env-sync-release.yml
  on:
      push:
          tags: ['selfhosted-*']     # still here; no-op for tags pushed by GITHUB_TOKEN
+     workflow_call:
+         inputs:
+             tag: { required: false, type: string }
      workflow_dispatch:
```

```diff
# .github/workflows/selfhosted-build-push.yml
  changelog-publish:
      uses: ./.github/workflows/changelog-publish.yml
      ...
+ env-sync-installer:
+     needs: [create-release, build-and-push]
+     if: needs.build-and-push.result == 'success'
+     uses: ./.github/workflows/env-sync-release.yml
+     with:
+         tag: ${{ needs.create-release.outputs.release_tag }}
+     secrets: inherit
  notify-discord-failure:
      ...
```

Same pattern as the existing `cli-release` and `changelog-publish` jobs sitting right next to it.

## What's NOT changing

- `CROSS_REPO_PAT` secret is already configured (env-sync uses it today for `actions/checkout` + `gh pr create` in the installer). No new secret.
- Behaviour for the legacy `push: tags` trigger is preserved. If a future flow pushes a tag from outside Actions, that path still works.
- The `workflow_dispatch` manual run still works.

## Test plan

- [x] YAML parses (validated locally)
- [x] Manual `workflow_dispatch` of env-sync confirmed to work today (run [25800798260](https://github.com/kodustech/kodus-ai/actions/runs/25800798260) → PR [kodustech/kodus-installer#17](https://github.com/kodustech/kodus-installer/pull/17))
- [ ] Next self-hosted release cuts a tag → `env-sync-installer` job runs automatically → installer PR opens without manual intervention

---

<!-- kody-pr-summary:start -->
This pull request addresses a long-standing issue where the `.env.example` and `schema-vars.sh` files in the `kodus-installer` repository were not being updated for self-hosted releases.

The problem stemmed from GitHub Actions' cascade-prevention mechanism, which prevented the `env-sync-release.yml` workflow from triggering automatically when a `selfhosted-*` tag was pushed by the `GITHUB_TOKEN` within the `selfhosted-build-push.yml` workflow. This led to the `kodus-installer/.env.example` file drifting out of sync.

To resolve this, the following changes were implemented:

1.  **`env-sync-release.yml`**: This workflow, responsible for syncing environment files, has been updated to support explicit invocation via `workflow_call`. It now accepts an optional `tag` input to provide context for the associated self-hosted release.
2.  **`selfhosted-build-push.yml`**: A new job, `env-sync-installer`, has been added to this workflow. After a self-hosted release tag is successfully created and pushed, this new job explicitly calls the `env-sync-release.yml` workflow, passing the relevant release tag.

This ensures that the `.env.example` and `schema-vars.sh` files in the `kodus-installer` repository are consistently regenerated and updated for every self-hosted release, preventing future synchronization issues.
<!-- kody-pr-summary:end -->