### PR TITLE
fix(azure repos): Fixing path in comments

### DIFF
--- a/libs/code-review/infrastructure/agents/base-code-review-agent.provider.ts
+++ b/libs/code-review/infrastructure/agents/base-code-review-agent.provider.ts
@@ -888,9 +888,17 @@ export abstract class BaseCodeReviewAgentProvider {
                 // Observability is best-effort
             }
 
-            // Map findings to CodeSuggestion format
-            const validFiles = new Set(
-                input.changedFiles.map((f) => normalizeRepoPath(f.filename)),
+            // Map findings to CodeSuggestion format.
+            // The map keys on the normalized path so we tolerate LLM-emitted
+            // variations (missing leading slash, backslashes), but the value
+            // preserves the provider's original filename so downstream calls
+            // (e.g. Azure threadContext.filePath) get the exact path the
+            // provider gave us.
+            const validFilesByNormalized = new Map<string, string>(
+                input.changedFiles.map((f) => [
+                    normalizeRepoPath(f.filename),
+                    f.filename,
+                ]),
             );
             const isKodyRules = this.getCategoryLabel() === 'kody_rules';
             const kodyRulesByUuid = new Map(
@@ -935,7 +943,7 @@ export abstract class BaseCodeReviewAgentProvider {
                         return false;
                     }
                     // PR-level kody_rules omit relevantFile by design.
-                    const kodyRulePathMatch = !s.relevantFile || validFiles.has(normalizeRepoPath(s.relevantFile));
+                    const kodyRulePathMatch = !s.relevantFile || validFilesByNormalized.has(normalizeRepoPath(s.relevantFile));
                     if (!kodyRulePathMatch) {
                         this.agentLogger.warn({
                             message: `@@PATH_MISMATCH@@ Dropping kody_rules suggestion — relevantFile not in changedFiles after normalization`,
@@ -944,7 +952,7 @@ export abstract class BaseCodeReviewAgentProvider {
                                 prNumber: input.prNumber,
                                 relevantFile: s.relevantFile,
                                 normalizedRelevantFile: normalizeRepoPath(s.relevantFile),
-                                changedFiles: [...validFiles],
+                                changedFiles: [...validFilesByNormalized.values()],
                                 suggestionPreview: (s.oneSentenceSummary || s.suggestionContent || '').slice(0, 140),
                             },
                         });
@@ -952,7 +960,7 @@ export abstract class BaseCodeReviewAgentProvider {
                     return kodyRulePathMatch;
                 }
 
-                const pathMatch = !!s.relevantFile && validFiles.has(normalizeRepoPath(s.relevantFile));
+                const pathMatch = !!s.relevantFile && validFilesByNormalized.has(normalizeRepoPath(s.relevantFile));
                 if (!pathMatch && s.relevantFile) {
                     this.agentLogger.warn({
                         message: `@@PATH_MISMATCH@@ Dropping suggestion — relevantFile not in changedFiles after normalization`,
@@ -961,7 +969,7 @@ export abstract class BaseCodeReviewAgentProvider {
                             prNumber: input.prNumber,
                             relevantFile: s.relevantFile,
                             normalizedRelevantFile: normalizeRepoPath(s.relevantFile),
-                            changedFiles: [...validFiles],
+                            changedFiles: [...validFilesByNormalized.values()],
                             severity: s.severity,
                             suggestionPreview: (s.oneSentenceSummary || s.suggestionContent || '').slice(0, 140),
                         },
@@ -975,8 +983,18 @@ export abstract class BaseCodeReviewAgentProvider {
                     ? kodyRulesByUuid.get(s.ruleUuid)
                     : undefined;
 
+                // Replace the LLM-emitted relevantFile with the provider's
+                // original filename so downstream comment posting uses the
+                // exact path shape the provider expects (e.g. Azure requires
+                // the leading slash it returns from its API).
+                const canonicalRelevantFile = s.relevantFile
+                    ? validFilesByNormalized.get(
+                          normalizeRepoPath(s.relevantFile),
+                      ) ?? s.relevantFile
+                    : s.relevantFile;
+
                 return {
-                    relevantFile: s.relevantFile,
+                    relevantFile: canonicalRelevantFile,
                     language: s.language || '',
                     suggestionContent: s.suggestionContent,
                     existingCode: s.existingCode || '',

--- a/libs/code-review/infrastructure/agents/llm/valid-files-matching.spec.ts
+++ b/libs/code-review/infrastructure/agents/llm/valid-files-matching.spec.ts
@@ -3,16 +3,22 @@ import { normalizeRepoPath } from './coverage-ledger';
 /**
  * Reproduces the validFiles matching logic from base-code-review-agent.provider.ts:
  *
- *   const validFiles = new Set(
- *       input.changedFiles.map((f) => normalizeRepoPath(f.filename)),
+ *   const validFilesByNormalized = new Map(
+ *       input.changedFiles.map((f) => [normalizeRepoPath(f.filename), f.filename]),
  *   );
- *   return !!s.relevantFile && validFiles.has(normalizeRepoPath(s.relevantFile));
+ *   return !!s.relevantFile && validFilesByNormalized.has(normalizeRepoPath(s.relevantFile));
  *
- * Tests confirm that path normalization handles all 4 Git providers.
+ * Tests confirm that path normalization handles all 4 Git providers
+ * AND that the suggestion's relevantFile is canonicalized back to the
+ * provider's original path shape (so e.g. Azure keeps its leading slash).
  */
 
 function buildValidFilesSet(filenames: string[]): Set<string> {
     return new Set(filenames.map((f) => normalizeRepoPath(f)));
+}
+
+function buildValidFilesMap(filenames: string[]): Map<string, string> {
+    return new Map(filenames.map((f) => [normalizeRepoPath(f), f]));
 }
 
 function matchesSuggestion(
@@ -20,6 +26,14 @@ function matchesSuggestion(
     relevantFile: string | undefined,
 ): boolean {
     return !!relevantFile && validFiles.has(normalizeRepoPath(relevantFile));
+}
+
+function canonicalizeRelevantFile(
+    validFiles: Map<string, string>,
+    relevantFile: string | undefined,
+): string | undefined {
+    if (!relevantFile) return relevantFile;
+    return validFiles.get(normalizeRepoPath(relevantFile)) ?? relevantFile;
 }
 
 describe('validFiles path matching across Git providers', () => {
@@ -169,6 +183,70 @@ describe('validFiles path matching across Git providers', () => {
             expect(
                 matchesSuggestion(validFiles, 'gitlab-style/file.rb'),
             ).toBe(true);
+        });
+    });
+
+    describe('canonicalization back to provider path', () => {
+        it('restores Azure leading slash from LLM-emitted path', () => {
+            const validFiles = buildValidFilesMap([
+                '/Kodus.Api/Exceptions/ExceptionHandler.php',
+            ]);
+            expect(
+                canonicalizeRelevantFile(
+                    validFiles,
+                    'Kodus.Api/Exceptions/ExceptionHandler.php',
+                ),
+            ).toBe('/Kodus.Api/Exceptions/ExceptionHandler.php');
+        });
+
+        it('keeps GitHub-style path untouched', () => {
+            const validFiles = buildValidFilesMap([
+                'src/components/Button.tsx',
+            ]);
+            expect(
+                canonicalizeRelevantFile(
+                    validFiles,
+                    'src/components/Button.tsx',
+                ),
+            ).toBe('src/components/Button.tsx');
+        });
+
+        it('strips an extra leading slash from the LLM when provider had none', () => {
+            const validFiles = buildValidFilesMap([
+                'src/components/Button.tsx',
+            ]);
+            expect(
+                canonicalizeRelevantFile(
+                    validFiles,
+                    '/src/components/Button.tsx',
+                ),
+            ).toBe('src/components/Button.tsx');
+        });
+
+        it('normalizes backslashes back to the provider path', () => {
+            const validFiles = buildValidFilesMap([
+                'src/components/Button.tsx',
+            ]);
+            expect(
+                canonicalizeRelevantFile(
+                    validFiles,
+                    'src\\components\\Button.tsx',
+                ),
+            ).toBe('src/components/Button.tsx');
+        });
+
+        it('falls back to the LLM path when no provider match exists', () => {
+            const validFiles = buildValidFilesMap(['src/known.ts']);
+            expect(
+                canonicalizeRelevantFile(validFiles, 'src/unknown.ts'),
+            ).toBe('src/unknown.ts');
+        });
+
+        it('passes undefined through unchanged for PR-level kody_rules', () => {
+            const validFiles = buildValidFilesMap(['src/known.ts']);
+            expect(canonicalizeRelevantFile(validFiles, undefined)).toBe(
+                undefined,
+            );
         });
     });
 });


### PR DESCRIPTION
Closes #1077

---

<!-- kody-pr-summary:start -->
This pull request fixes an issue where code review suggestions might not be posted correctly on certain Git hosting platforms, particularly Azure Repos, due to discrepancies in file path formats.

Previously, the system would normalize file paths for internal matching, but the `relevantFile` in a suggestion could retain the LLM's emitted path, which might not precisely match the format expected by the Git provider (e.g., Azure Repos requires a leading slash for its file paths).

The changes introduce a mechanism to "canonicalize" the `relevantFile` in a code suggestion. The system now stores both the normalized path and the original, provider-specific path for all changed files. When processing an LLM suggestion, the `relevantFile` is normalized and then used to retrieve the original path from this stored mapping. This ensures that the `relevantFile` used when creating a `CodeSuggestion` (and subsequently posting comments) matches the exact format expected by the Git provider, resolving issues with suggestions not appearing on platforms like Azure Repos.

This enhancement improves the reliability of code review suggestions by ensuring path consistency across different Git hosting services.
<!-- kody-pr-summary:end -->