### PR TITLE
fix(agent-chunk): adding validation to avoid infinity loop on the agent when basic prompt is bigger than prompt budget

### DIFF
--- a/libs/code-review/infrastructure/agents/base-code-review-agent.provider.ts
+++ b/libs/code-review/infrastructure/agents/base-code-review-agent.provider.ts
@@ -43,6 +43,15 @@ import {
 /** Rough token estimate: 1 token ≈ 4 characters */
 const CHARS_PER_TOKEN = 4;
 /**
+ * Hard cap on execute() → executeChunked() → execute() recursion. Set to
+ * 2 because the only legitimate recursion is one level deep (root review
+ * fans out into per-batch executes). Anything beyond that means the
+ * chunker couldn't reduce the file count and we'd loop forever — see
+ * executeChunked's fail-fast guard, which catches the same condition at
+ * its source. This guard remains as defense-in-depth.
+ */
+const MAX_RECURSION_DEPTH = 2;
+/**
  * Ceiling on the ESTIMATED full prompt (not just diffs) as a fraction of
  * the model context window. At 0.55 we reserve ~45% of the window for
  * accumulated tool results, LLM reasoning, and response — which in
@@ -356,6 +365,12 @@ export interface ReviewAgentInput {
      *  outer router timeout cancels the LLM call instead of leaving it
      *  running ghost in the background. */
     parentSignal?: AbortSignal;
+    /** Internal: how many times executeChunked has re-entered execute()
+     *  for this review. Bounded to MAX_RECURSION_DEPTH by execute() to
+     *  prevent the historical execute() ↔ executeChunked() loop from
+     *  exhausting the worker heap. Always undefined at the public entry
+     *  point; populated by executeChunked when fanning out per-batch. */
+    recursionDepth?: number;
 }
 
 /**
@@ -446,6 +461,21 @@ export abstract class BaseCodeReviewAgentProvider {
             name: input.agentRuntimeName || baseIdentity.name,
         };
         const agentCategory = this.getCategoryLabel();
+
+        const recursionDepth = input.recursionDepth ?? 0;
+        if (recursionDepth >= MAX_RECURSION_DEPTH) {
+            this.agentLogger.error({
+                message: `[AGENT] ${identity.name} recursion limit reached (depth=${recursionDepth}); aborting to protect the worker heap`,
+                context: identity.name,
+                metadata: {
+                    prNumber: input.prNumber,
+                    recursionDepth,
+                    maxRecursionDepth: MAX_RECURSION_DEPTH,
+                    filesCount: input.changedFiles.length,
+                },
+            });
+            throw new Error('AGENT_RECURSION_LIMIT_EXCEEDED');
+        }
 
         // When this execute() call is one batch of a chunked review
         // (executeChunked has split a large PR by token budget), enrich
@@ -1193,6 +1223,30 @@ export abstract class BaseCodeReviewAgentProvider {
         } = ctx;
         const chunks = chunkFilesByTokenBudget(input.changedFiles, diffBudget);
 
+        // Fail-fast on useless chunking: when chunkFilesByTokenBudget cannot
+        // reduce the file count (one chunk containing every input file), the
+        // prompt overhead — not the diff size — is what's blowing the budget.
+        // Recursing back into execute() with the same file set would just
+        // re-fire the same gate forever (the historical worker-OOM loop).
+        // Aborting here surfaces the real cause in the orchestrator's
+        // failures[] instead of silently exhausting the worker heap.
+        if (
+            chunks.length === 1 &&
+            chunks[0].length === input.changedFiles.length &&
+            input.changedFiles.length > 1
+        ) {
+            this.agentLogger.error({
+                message: `[AGENT] ${identity.name} chunking did not reduce file count (${input.changedFiles.length} files in 1 chunk); static prompt overhead exceeds budget on its own — aborting before recursion`,
+                context: identity.name,
+                metadata: {
+                    prNumber: input.prNumber,
+                    filesCount: input.changedFiles.length,
+                    diffBudget,
+                },
+            });
+            throw new Error('AGENT_PROMPT_OVERHEAD_EXCEEDS_BUDGET');
+        }
+
         this.agentLogger.log({
             message: `[AGENT] ${identity.name} PR#${input.prNumber}: reviewing ${input.changedFiles.length} files in ${chunks.length} batch(es)`,
             context: identity.name,
@@ -1216,7 +1270,12 @@ export abstract class BaseCodeReviewAgentProvider {
             const batchFiles = chunks[i];
             const batchFileSet = new Set(batchFiles.map((f) => f.filename));
             const batchIndex = i + 1;
-            const batchLabel = `${identity.name} batch ${batchIndex}/${batchTotal}`;
+            // Always use the unmodified getIdentity().name to build the label
+            // so recursive chunked runs do not accumulate
+            // " batch X/Y batch X/Y ..." suffixes in the agent name
+            // (logs grew unbounded — see the production smoking-gun trace
+            // captured in issue #1056).
+            const batchLabel = `${this.getIdentity().name} batch ${batchIndex}/${batchTotal}`;
             const batchStartedAt = Date.now();
 
             this.agentLogger.log({
@@ -1248,6 +1307,9 @@ export abstract class BaseCodeReviewAgentProvider {
                     // execute() can include it in their labels.
                     batchIndex,
                     batchTotal,
+                    // Increment the recursion counter so the depth guard in
+                    // execute() can short-circuit any unexpected re-entry.
+                    recursionDepth: (input.recursionDepth ?? 0) + 1,
                 };
 
                 const batchResult = await this.execute(batchInput);

--- a/packages/kodus-flow/src/observability/exporters/mongodb-exporter.ts
+++ b/packages/kodus-flow/src/observability/exporters/mongodb-exporter.ts
@@ -688,10 +688,13 @@ export class MongoDBExporter implements LogProcessor, ObservabilityExporter {
         // with config↔request↔response, Mongoose documents, Error.cause
         // loops). Without sanitizing, BSON serialization in `insertMany`
         // throws "Cannot convert circular structure to BSON" and the
-        // entire batch is dropped. `deepSanitize` already replaces cycles
-        // with '[Circular]' and redacts sensitive keys — same helper the
-        // logger uses for stdout serializers, so behavior is consistent.
-        const logItem: MongoDBLogItem = {
+        // entire batch is dropped. We run `deepSanitize` over the WHOLE
+        // logItem (not just metadata/attributes) so cycles in any field —
+        // including `error.message` from atypical Error subclasses and
+        // top-level identifiers like `executionId`/`correlationId` that
+        // callers may accidentally hand in as objects — get replaced with
+        // '[Circular]' before they reach the buffer.
+        const rawLogItem: MongoDBLogItem = {
             timestamp: new Date(),
             level,
             message,
@@ -700,8 +703,8 @@ export class MongoDBExporter implements LogProcessor, ObservabilityExporter {
             tenantId: metadata.tenantId,
             executionId: normalizedContext?.executionId as string | undefined,
             sessionId: normalizedContext?.sessionId as string | undefined,
-            metadata: deepSanitize(metadata), // Clean bucket key
-            attributes: deepSanitize(attributes), // Detailed payload (schema-less)
+            metadata, // Clean bucket key — sanitized below as part of logItem
+            attributes, // Detailed payload (schema-less) — sanitized below
             error: error
                 ? {
                       name: error.name,
@@ -711,6 +714,8 @@ export class MongoDBExporter implements LogProcessor, ObservabilityExporter {
                 : undefined,
             createdAt: new Date(),
         } as any; // Cast necessary due to dynamic 'attributes' field injection
+
+        const logItem = deepSanitize(rawLogItem) as MongoDBLogItem;
 
         this.logBuffer.push(logItem);
 
@@ -859,6 +864,41 @@ export class MongoDBExporter implements LogProcessor, ObservabilityExporter {
         const logsToFlush = [...this.logBuffer];
         this.logBuffer = [];
 
+        // Pre-screen every log for serialization readiness. Logs that
+        // can't even round-trip through JSON.stringify — cycles missed
+        // by deepSanitize (BigInt, getters that throw, Symbol-keyed
+        // payloads) — would poison the whole insertMany batch at BSON
+        // time AND get re-pushed onto the buffer by the catch block
+        // below, forming the loop responsible for 24.7k consecutive
+        // "Failed to flush logs to MongoDB" errors observed in prod.
+        // Dropping the offenders here keeps the healthy majority on
+        // the happy path.
+        const sanitizedLogs: MongoDBLogItem[] = [];
+        let poisonedCount = 0;
+        for (const log of logsToFlush) {
+            try {
+                JSON.stringify(log);
+                sanitizedLogs.push(log);
+            } catch {
+                poisonedCount++;
+            }
+        }
+        if (poisonedCount > 0) {
+            this.logger.warn({
+                message: `Dropping ${poisonedCount} non-serializable log entr${poisonedCount === 1 ? 'y' : 'ies'} from flush batch (would have poisoned insertMany)`,
+                context: this.constructor.name,
+                metadata: {
+                    droppedCount: poisonedCount,
+                    batchSize: logsToFlush.length,
+                },
+            });
+        }
+
+        if (sanitizedLogs.length === 0) {
+            this.isFlushingLogs = false;
+            return;
+        }
+
         // PERFORMANCE OPTIMIZATION: Sort by Bucket Keys before inserting.
         // This drastically improves Time-Series compression and write throughput.
         const bucketKeys = this.config.bucketKeys || [
@@ -866,7 +906,7 @@ export class MongoDBExporter implements LogProcessor, ObservabilityExporter {
             'teamId',
         ];
 
-        logsToFlush.sort((a, b) => {
+        sanitizedLogs.sort((a, b) => {
             for (const key of bucketKeys) {
                 const valA = (a.metadata as any)?.[key] || '';
                 const valB = (b.metadata as any)?.[key] || '';
@@ -878,7 +918,7 @@ export class MongoDBExporter implements LogProcessor, ObservabilityExporter {
         });
 
         try {
-            await this.collections.logs.insertMany(logsToFlush);
+            await this.collections.logs.insertMany(sanitizedLogs);
             // Removed debug log to avoid recursive logging and pollution
         } catch (error) {
             this.logger.error({
@@ -889,13 +929,14 @@ export class MongoDBExporter implements LogProcessor, ObservabilityExporter {
 
             await this.handleConnectionError(error as Error, 'flushLogs');
 
-            // Put logs back (LIFO to preserve order roughly, or just push back)
-            // But respect max buffer size
+            // Re-buffer the (already-screened) sanitized batch only —
+            // never the poisoned originals, which were dropped above.
+            // Respect max buffer size; keep the most recent entries if
+            // capacity forces us to drop.
             const availableSpace = this.maxBufferSize - this.logBuffer.length;
             if (availableSpace > 0) {
-                // Keep the most recent ones if we have to drop
-                const toKeep = logsToFlush.slice(
-                    Math.max(0, logsToFlush.length - availableSpace),
+                const toKeep = sanitizedLogs.slice(
+                    Math.max(0, sanitizedLogs.length - availableSpace),
                 );
                 this.logBuffer.unshift(...toKeep);
             }

--- a/packages/kodus-flow/tests/observability/mongodb-exporter.unit.test.ts
+++ b/packages/kodus-flow/tests/observability/mongodb-exporter.unit.test.ts
@@ -9,7 +9,7 @@
  * and the entire batch is lost.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { MongoDBExporter } from '../../src/observability/exporters/mongodb-exporter.js';
 
 const buildExporter = () =>
@@ -19,6 +19,65 @@ const buildExporter = () =>
         connectionString: 'mongodb://localhost:27017/kodus-test',
         database: 'kodus-test',
     });
+
+/**
+ * Walks an object graph the way BSON serialization would, looking for
+ * back-edges. Returns true if any cycle exists. Used by the in-memory
+ * insertMany mock to faithfully reproduce the production failure mode
+ * ("Cannot convert circular structure to BSON") without needing a real
+ * MongoDB client in the test loop.
+ */
+function hasCircular(obj: any, seen: WeakSet<object> = new WeakSet()): boolean {
+    if (obj === null || typeof obj !== 'object') return false;
+    // BSON natively serializes these — don't follow their internal refs.
+    if (obj instanceof Date) return false;
+    if (obj instanceof RegExp) return false;
+    if (seen.has(obj)) return true;
+    seen.add(obj);
+    if (Array.isArray(obj)) {
+        for (const item of obj) {
+            if (hasCircular(item, seen)) return true;
+        }
+        return false;
+    }
+    for (const key of Object.keys(obj)) {
+        try {
+            if (hasCircular(obj[key], seen)) return true;
+        } catch {
+            // Some getters throw — treat as opaque.
+        }
+    }
+    return false;
+}
+
+/**
+ * Mimics the MongoDB driver's insertMany. Fails the WHOLE batch (like real
+ * BSON does) the moment any doc contains a cycle. Captures successful
+ * inserts so tests can assert on what landed in the "database".
+ */
+function makeMockCollections() {
+    const insertedBatches: any[][] = [];
+    const failedBatches: any[][] = [];
+    const insertMany = vi.fn(async (docs: any[]) => {
+        for (const doc of docs) {
+            if (hasCircular(doc)) {
+                failedBatches.push(docs);
+                throw new Error('Cannot convert circular structure to BSON');
+            }
+        }
+        insertedBatches.push(docs);
+        return { acknowledged: true, insertedCount: docs.length };
+    });
+    return {
+        collections: {
+            logs: { insertMany },
+            telemetry: { insertMany: vi.fn() },
+        },
+        insertedBatches,
+        failedBatches,
+        insertMany,
+    };
+}
 
 describe('MongoDBExporter — circular ref safety', () => {
     it('replaces circular references in metadata/attributes with [Circular] before buffering', async () => {
@@ -80,5 +139,195 @@ describe('MongoDBExporter — circular ref safety', () => {
         // would no longer be able to query/sort by it.
         expect(buffer[0].attributes.occurredAt).toBeInstanceOf(Date);
         expect(buffer[0].attributes.occurredAt.getTime()).toBe(ts.getTime());
+    });
+});
+
+/**
+ * Fix A — sanitize the full logItem before pushing into the buffer.
+ *
+ * The shipped fix in 4dedc831a sanitizes metadata + attributes but leaves
+ * gaps elsewhere: `error.message` (assignable to a non-string in custom
+ * Error subclasses), top-level identifier fields like `executionId`,
+ * `sessionId`, `correlationId`, `tenantId` (typed as string but not
+ * enforced at runtime), and any future field added to the logItem shape.
+ *
+ * The robust answer is to sanitize the whole object once, just before it
+ * lands in the buffer — so no field can carry a cycle into insertMany.
+ */
+describe('MongoDBExporter — full logItem sanitization (Fix A)', () => {
+    it('sanitizes a cycle attached to error.message (atypical Error subclasses)', async () => {
+        const exporter = buildExporter();
+
+        const cycle: any = { a: 1 };
+        cycle.self = cycle;
+
+        const err = new Error('boom');
+        // Custom Error subclasses in the wild occasionally overwrite
+        // `message` with a structured payload — TypeScript doesn't enforce
+        // it at runtime, and the exporter copies the field straight into
+        // the logItem.
+        (err as any).message = cycle;
+
+        await exporter.exportLog('error', 'request failed', undefined, err);
+
+        const buffer = (exporter as any).logBuffer as any[];
+        expect(buffer).toHaveLength(1);
+        expect(() => JSON.stringify(buffer[0])).not.toThrow();
+        expect(JSON.stringify(buffer[0])).toContain('[Circular]');
+    });
+
+    it('sanitizes a cycle assigned to executionId (top-level identifier fields)', async () => {
+        const exporter = buildExporter();
+
+        const cycle: any = { foo: 1 };
+        cycle.back = cycle;
+
+        await exporter.exportLog('info', 'event', {
+            component: 'service-x',
+            executionId: cycle, // bypasses the per-field deepSanitize that
+            // only covers metadata/attributes today.
+        } as any);
+
+        const buffer = (exporter as any).logBuffer as any[];
+        expect(buffer).toHaveLength(1);
+        expect(() => JSON.stringify(buffer[0])).not.toThrow();
+    });
+
+    it('sanitizes a cycle assigned to correlationId', async () => {
+        const exporter = buildExporter();
+
+        const cycle: any = { x: 1 };
+        cycle.cycle = cycle;
+
+        await exporter.exportLog('info', 'event', {
+            component: 'service-x',
+            correlationId: cycle,
+        } as any);
+
+        const buffer = (exporter as any).logBuffer as any[];
+        expect(buffer).toHaveLength(1);
+        expect(() => JSON.stringify(buffer[0])).not.toThrow();
+    });
+
+    it('produces a logItem that the mock insertMany can serialize end-to-end', async () => {
+        // End-to-end: build a context that today would explode at insertMany.
+        const exporter = buildExporter();
+        const { collections, insertedBatches, failedBatches } =
+            makeMockCollections();
+        (exporter as any).collections = collections;
+
+        const cycle: any = { hint: 'boom' };
+        cycle.parent = cycle;
+
+        await exporter.exportLog('error', 'cycle everywhere', {
+            component: 'svc',
+            executionId: cycle,
+            correlationId: cycle,
+        } as any);
+
+        await (exporter as any).flushLogs();
+
+        // No batch failed (the fix means insertMany only sees clean docs)
+        // and exactly one batch with one doc was inserted successfully.
+        expect(failedBatches).toHaveLength(0);
+        expect(insertedBatches).toHaveLength(1);
+        expect(insertedBatches[0]).toHaveLength(1);
+    });
+});
+
+/**
+ * Fix B — isolate poisoned logs from healthy ones at flush time.
+ *
+ * Even after Fix A, fringe non-serializable payloads (BigInt, Symbol keys,
+ * getters that throw, etc.) can sneak past deepSanitize. The current catch
+ * block in flushLogs() puts the failed logsToFlush back into the buffer
+ * verbatim — so the same poisoned entry keeps blowing up every subsequent
+ * flush and dragging the rest of the batch with it. That's the loop that
+ * generated 24.7k "Failed to flush logs to MongoDB" errors in a 24h window
+ * in prod. The exporter must:
+ *
+ *   1. Either pre-screen each log so the bad ones never reach insertMany, or
+ *   2. On insertMany failure, drop the offending entries and retry the rest.
+ *
+ * The contract these tests enforce is the same either way: the healthy
+ * majority of a batch must make it to the DB, and the poisoned entry must
+ * NOT come back into the buffer on the next tick.
+ */
+describe('MongoDBExporter — poisoned batch isolation (Fix B)', () => {
+    it('persists healthy logs even when one entry in the batch is non-serializable', async () => {
+        const exporter = buildExporter();
+        const { collections, insertedBatches } = makeMockCollections();
+        (exporter as any).collections = collections;
+
+        // Inject 4 healthy logs + 1 poisoned log directly into the buffer
+        // (bypassing exportLog's sanitization is intentional here — we're
+        // proving the flush path itself is resilient).
+        const poisoned: any = { name: 'BoomError', message: 'boom' };
+        poisoned.self = poisoned;
+
+        const healthy = (id: string) => ({
+            timestamp: new Date(),
+            level: 'info',
+            message: `msg-${id}`,
+            component: 'test',
+            correlationId: id,
+            tenantId: 'tenant-a',
+            metadata: { component: 'test', level: 'info' },
+            attributes: { id },
+            createdAt: new Date(),
+        });
+
+        (exporter as any).logBuffer = [
+            healthy('a'),
+            healthy('b'),
+            { ...healthy('c'), error: poisoned }, // poisoned entry
+            healthy('d'),
+            healthy('e'),
+        ];
+
+        await (exporter as any).flushLogs();
+
+        // The 4 healthy logs made it to "the DB" across one or more calls.
+        const totalInserted = insertedBatches.reduce(
+            (n, batch) => n + batch.length,
+            0,
+        );
+        expect(totalInserted).toBe(4);
+    });
+
+    it('does NOT push a poisoned log back into the buffer (no infinite-loop)', async () => {
+        const exporter = buildExporter();
+        const { collections } = makeMockCollections();
+        (exporter as any).collections = collections;
+
+        const poisoned: any = { name: 'BoomError', message: 'boom' };
+        poisoned.self = poisoned;
+
+        const healthy = {
+            timestamp: new Date(),
+            level: 'info' as const,
+            message: 'msg',
+            component: 'test',
+            correlationId: 'cid',
+            tenantId: 'tenant-a',
+            metadata: { component: 'test', level: 'info' },
+            attributes: {},
+            createdAt: new Date(),
+        };
+
+        (exporter as any).logBuffer = [
+            healthy,
+            { ...healthy, error: poisoned },
+        ];
+
+        await (exporter as any).flushLogs();
+
+        const bufferAfter = (exporter as any).logBuffer as any[];
+        // The poisoned entry must not survive the flush — otherwise the
+        // next tick re-runs the same failure forever.
+        const bufferHasPoisoned = bufferAfter.some(
+            (log: any) => log.error === poisoned,
+        );
+        expect(bufferHasPoisoned).toBe(false);
     });
 });

--- a/test/unit/code-review/agents/base-code-review-agent.recursion.spec.ts
+++ b/test/unit/code-review/agents/base-code-review-agent.recursion.spec.ts
@@ -1,0 +1,315 @@
+/**
+ * Failing tests covering the recursion bug in BaseCodeReviewAgentProvider
+ * AND the two-pronged fix proposed in the loop-production discussion:
+ *
+ *   - Opção B (root cause): when chunkFilesByTokenBudget returns a single
+ *     chunk that contains EVERY input file, recursing back into execute()
+ *     with the same set is pointless and infinite. executeChunked should
+ *     fail fast with AGENT_PROMPT_OVERHEAD_EXCEEDS_BUDGET BEFORE the
+ *     recursive call.
+ *
+ *   - Opção A (defense in depth): execute() should enforce a recursion
+ *     depth limit, throwing AGENT_RECURSION_LIMIT_EXCEEDED if any future
+ *     code path manages to recurse past 2 levels. recursionDepth must be
+ *     forwarded by executeChunked when it calls execute() per-batch.
+ *
+ *   - Log readability: batchLabel must be built from the unmodified
+ *     baseIdentity.name so the agent name in logs stays bounded instead
+ *     of growing one " batch X/Y" suffix per recursion level.
+ *
+ * The healthy paths (chunking that legitimately reduces file count, and
+ * small PRs that bypass chunking entirely) are also covered as regression
+ * guards: they must keep working after the fixes are applied.
+ *
+ * Mocks are scoped to external collaborators only. The recursion mechanics
+ * (estimatePromptTokens, chunkFilesByTokenBudget) are exercised with real
+ * inputs because those are the gates the bug rides on.
+ */
+
+jest.mock('@kodus/flow', () => ({
+    createLogger: () => ({
+        log: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+        debug: jest.fn(),
+        info: jest.fn(),
+    }),
+}));
+
+jest.mock(
+    '@/code-review/infrastructure/agents/llm/byok-to-vercel',
+    () => ({
+        byokToVercelModel: jest.fn(() => ({ id: 'fake-model' })),
+        getModelName: jest.fn(() => 'fake-model'),
+    }),
+);
+
+jest.mock(
+    '@/code-review/infrastructure/agents/llm/model-context-window',
+    () => ({
+        resolveContextWindow: jest.fn(() => 200_000),
+    }),
+);
+
+jest.mock('@libs/core/log/langfuse', () => ({
+    shouldTrace: jest.fn(() => false),
+}));
+
+jest.mock('@/code-review/infrastructure/agents/llm/agent-loop', () => ({
+    runAgentLoop: jest.fn(async () => ({
+        findings: { suggestions: [] },
+        text: '',
+        steps: 0,
+        toolCalls: [],
+        finishReason: 'stop',
+        source: 'empty',
+        usage: {
+            inputTokens: 0,
+            cacheReadTokens: 0,
+            cacheWriteTokens: 0,
+            outputTokens: 0,
+            reasoningTokens: 0,
+            totalTokens: 0,
+        },
+        discardedBySeverity: [],
+        droppedByVerify: [],
+        coverage: {
+            totalTargets: 0,
+            touchedTargets: 0,
+            pendingTargets: 0,
+            touchedFiles: [],
+            pendingFiles: [],
+            criticalTotal: 0,
+            criticalTouched: 0,
+            criticalPending: 0,
+            warmTotal: 0,
+            warmTouched: 0,
+            warmPending: 0,
+            optionalTotal: 0,
+            optionalTouched: 0,
+            optionalPending: 0,
+        },
+        verification: null,
+        anomalies: {
+            stepsLe2: false,
+            zeroToolCalls: false,
+            zeroStrongEvidenceFiles: false,
+            zeroCoverage: false,
+            lowCoverage: false,
+            lowStrongEvidenceFiles: false,
+        },
+    })),
+}));
+
+import {
+    BaseCodeReviewAgentProvider,
+    type ReviewAgentIdentity,
+    type ReviewAgentInput,
+} from '@/code-review/infrastructure/agents/base-code-review-agent.provider';
+import type { FileChange } from '@libs/core/infrastructure/config/types/general/codeReview.type';
+
+class TestAgent extends BaseCodeReviewAgentProvider {
+    constructor() {
+        const permissionService: any = {
+            getBYOKConfig: jest.fn().mockResolvedValue(null),
+        };
+        super(null as any, permissionService, null as any);
+    }
+
+    protected getIdentity(): ReviewAgentIdentity {
+        return {
+            name: 'kodus-test-agent',
+            description: 'test',
+            goal: 'test',
+            expertise: ['test'],
+        };
+    }
+
+    protected getCategoryPrompt(): string {
+        return 'category-prompt-stub';
+    }
+
+    protected getCategoryLabel(): string {
+        return 'bug';
+    }
+}
+
+function makeFile(name: string, patchChars: number): FileChange {
+    const patch = 'a'.repeat(patchChars);
+    return {
+        filename: name,
+        sha: 'abc',
+        status: 'modified',
+        additions: 1,
+        deletions: 0,
+        changes: 1,
+        patch,
+        patchWithLinesStr: patch,
+    } as any;
+}
+
+const BASE_INPUT_FIELDS = {
+    organizationAndTeamData: { organizationId: 'org-1', teamId: 'team-1' },
+    prNumber: 42,
+    repositoryFullName: 'kodus/test',
+    languageResultPrompt: 'en',
+    remoteCommands: undefined,
+    // 'deep' skips the aggressive filter / tiering branch so the chunking
+    // gate is the only branch exercised here.
+    reviewMode: 'deep' as const,
+    maxSteps: 1,
+};
+
+/**
+ * Pathological scenario: three tiny files plus a 400k-char callGraph.
+ *   estimatePromptTokens ≈ 115k tokens (> promptBudget = 110k → gate fires)
+ *   chunkFilesByTokenBudget(files, 94_500) → ONE chunk with all 3 files
+ *     because each diff is ~20 tokens, well below the chunk budget.
+ * executeChunked then calls execute() with the same 3 files, the gate
+ * fires again, and we recurse forever.
+ */
+function makePathologicalInput(): ReviewAgentInput {
+    return {
+        ...BASE_INPUT_FIELDS,
+        changedFiles: [
+            makeFile('src/a.ts', 80),
+            makeFile('src/b.ts', 80),
+            makeFile('src/c.ts', 80),
+        ],
+        callGraph: 'x'.repeat(400_000),
+    } as ReviewAgentInput;
+}
+
+/**
+ * Healthy scenario: two 200k-char diffs. Each file individually fits in
+ * chunkDiffBudget (50k ≤ 94.5k tokens) but the pair doesn't, so the
+ * chunker produces two chunks of one file each. No recursion.
+ */
+function makeHealthyChunkingInput(): ReviewAgentInput {
+    return {
+        ...BASE_INPUT_FIELDS,
+        changedFiles: [
+            makeFile('src/large1.ts', 200_000),
+            makeFile('src/large2.ts', 200_000),
+        ],
+    } as ReviewAgentInput;
+}
+
+/**
+ * Small scenario: one tiny file, no callGraph. estimatedPromptTokens
+ * stays well below promptBudget → chunking gate never fires.
+ */
+function makeSmallInput(): ReviewAgentInput {
+    return {
+        ...BASE_INPUT_FIELDS,
+        changedFiles: [makeFile('src/tiny.ts', 80)],
+    } as ReviewAgentInput;
+}
+
+/**
+ * Wrap agent.execute() with a counter + hard cap so a runaway recursion
+ * cannot hang the test runner. The cap throw is caught by executeChunked's
+ * per-batch try/catch and absorbed into an empty result — exactly what
+ * happens in production today, just bounded.
+ */
+const RECURSION_CAP = 25;
+
+function setupExecuteSpy(agent: TestAgent) {
+    const original = TestAgent.prototype.execute;
+    let count = 0;
+    const calls: ReviewAgentInput[] = [];
+    const spy = jest
+        .spyOn(agent, 'execute')
+        .mockImplementation(async function (
+            this: TestAgent,
+            input: ReviewAgentInput,
+        ) {
+            count++;
+            calls.push(input);
+            if (count > RECURSION_CAP) {
+                throw new Error(
+                    `TEST_RECURSION_CAP_EXCEEDED after ${count} calls`,
+                );
+            }
+            return original.call(this, input);
+        });
+    return { spy, calls, getCount: () => count };
+}
+
+describe('BaseCodeReviewAgentProvider — recursion bug + proposed fixes', () => {
+    let agent: TestAgent;
+
+    beforeEach(() => {
+        agent = new TestAgent();
+        jest.clearAllMocks();
+    });
+
+    describe('Fix B — fail-fast when chunker cannot reduce file count', () => {
+        it('rejects with AGENT_PROMPT_OVERHEAD_EXCEEDS_BUDGET', async () => {
+            setupExecuteSpy(agent);
+            await expect(
+                agent.execute(makePathologicalInput()),
+            ).rejects.toThrow('AGENT_PROMPT_OVERHEAD_EXCEEDS_BUDGET');
+        });
+
+        it('does NOT recurse — execute() is called exactly once before failing', async () => {
+            const { getCount } = setupExecuteSpy(agent);
+            await agent
+                .execute(makePathologicalInput())
+                .catch(() => undefined);
+            expect(getCount()).toBe(1);
+        });
+    });
+
+    describe('Fix A — recursion-depth guard (defense in depth)', () => {
+        it('rejects with AGENT_RECURSION_LIMIT_EXCEEDED when execute() is called directly with recursionDepth >= 2', async () => {
+            const input = makeSmallInput() as any;
+            input.recursionDepth = 2;
+            await expect(agent.execute(input)).rejects.toThrow(
+                'AGENT_RECURSION_LIMIT_EXCEEDED',
+            );
+        });
+
+        it('propagates an incrementing recursionDepth from executeChunked into each per-batch execute() call', async () => {
+            const { calls } = setupExecuteSpy(agent);
+            await agent
+                .execute(makeHealthyChunkingInput())
+                .catch(() => undefined);
+            // calls[0] = root execute, calls[1] = batch 1, calls[2] = batch 2
+            expect(calls.length).toBeGreaterThanOrEqual(3);
+            expect((calls[0] as any)?.recursionDepth ?? 0).toBe(0);
+            expect((calls[1] as any)?.recursionDepth).toBe(1);
+            expect((calls[2] as any)?.recursionDepth).toBe(1);
+        });
+    });
+
+    describe('Log readability — batchLabel must not accumulate " batch X/Y" suffixes', () => {
+        it('agentRuntimeName seen at every recursion level carries at most ONE " batch " segment', async () => {
+            const { calls } = setupExecuteSpy(agent);
+            await agent
+                .execute(makePathologicalInput())
+                .catch(() => undefined);
+            for (const call of calls) {
+                const name = call.agentRuntimeName || '';
+                const occurrences = (name.match(/ batch /g) || []).length;
+                expect(occurrences).toBeLessThanOrEqual(1);
+            }
+        });
+    });
+
+    describe('Regression guard — healthy paths must keep working', () => {
+        it('chunker that reduces file count completes without recursing (root + 2 batches = 3 execute() calls)', async () => {
+            const { getCount } = setupExecuteSpy(agent);
+            const result = await agent.execute(makeHealthyChunkingInput());
+            expect(result).toBeDefined();
+            expect(getCount()).toBe(3);
+        });
+
+        it('small PR skips the chunking gate entirely (execute called once)', async () => {
+            const { getCount } = setupExecuteSpy(agent);
+            const result = await agent.execute(makeSmallInput());
+            expect(result).toBeDefined();
+            expect(getCount()).toBe(1);
+        });
+    });
+});


### PR DESCRIPTION
Closes #1056

---

<!-- kody-pr-summary:start -->
This pull request implements critical fixes to prevent infinite loops and improve system stability in two key areas:

1.  **Code Review Agent Recursion Loop Prevention**:
    *   **Addresses an infinite loop scenario** where the code review agent could get stuck if the basic prompt (e.g., `callGraph`) exceeded the model's token budget, causing the chunking mechanism to repeatedly call `execute()` with the same set of files without reducing the file count.
    *   **Introduces a fail-fast guard** in `executeChunked()` that detects this specific condition and aborts early, throwing an `AGENT_PROMPT_OVERHEAD_EXCEEDS_BUDGET` error. This prevents the recursion at its source.
    *   **Adds a defense-in-depth recursion depth limit** (`MAX_RECURSION_DEPTH`) to `execute()`. If any unexpected code path leads to recursion beyond a single level, it now throws an `AGENT_RECURSION_LIMIT_EXCEEDED` error, protecting the worker heap.
    *   **Improves log readability** by ensuring that agent names in logs do not accumulate redundant "batch X/Y" suffixes during chunked reviews.

2.  **MongoDB Exporter Robustness for Log Flushing**:
    *   **Enhances circular reference sanitization** by applying `deepSanitize` to the entire log item before it's buffered. This prevents "Cannot convert circular structure to BSON" errors that could arise from circular references in fields beyond `metadata` and `attributes` (e.g., `error.message` or top-level identifiers).
    *   **Implements a pre-screening mechanism** for logs before `insertMany` operations. Logs that are not serializable (e.g., due to BigInt, Symbol keys, or throwing getters) are now identified and dropped from the batch, preventing a single "poisoned" log from causing the entire `insertMany` operation to fail.
    *   **Ensures that only healthy, sanitized logs are re-buffered** if an `insertMany` operation fails, preventing an infinite loop of failed log flushes caused by repeatedly attempting to insert problematic entries.

Comprehensive unit tests have been added for both the code review agent's recursion logic and the MongoDB exporter's serialization and flushing mechanisms to validate these fixes and prevent regressions.
<!-- kody-pr-summary:end -->