### PR TITLE
fix(cli-review): import GithubModule so GitHubRateLimitGateService ca…

### DIFF
--- a/libs/cli-review/cli-review.module.ts
+++ b/libs/cli-review/cli-review.module.ts
@@ -24,6 +24,7 @@ import { WaitForCliReviewJobUseCase } from './application/use-cases/wait-for-cli
 import { CliReviewJobProcessorService } from './workflow/cli-review-job-processor.service';
 import { GitHubRateLimitGateService } from '@libs/platform/infrastructure/adapters/services/github/github-rate-limit-gate.service';
 import { RATE_LIMIT_GATE_SERVICE_TOKEN } from '@libs/core/workflow/domain/contracts/rate-limit-gate.service.contract';
+import { GithubModule } from '@libs/platform/modules/github.module';
 
 // Services
 import { CliInputConverter } from './infrastructure/converters/cli-input.converter';
@@ -86,6 +87,7 @@ import { OutboxMessageModel } from '@libs/core/workflow/infrastructure/repositor
         forwardRef(() => AutomationModule), // For tracking executions
         forwardRef(() => LicenseModule), // For license validation and auto-assign
         forwardRef(() => KodyRulesModule), // For loading kody rules in CLI review
+        forwardRef(() => GithubModule), // For GitHubRateLimitGateService dependency
     ],
     providers: [
         // Strategy


### PR DESCRIPTION
…n resolve

QA bootstrap failed because the cli-review providers list registers GitHubRateLimitGateService, but the CliReviewModule never imported the module that provides its `GithubService` dependency. The DI graph resolved successfully in the unit tests (each test instantiates the gate by hand), but the real Nest container needs the GithubModule explicitly listed in `imports:`.

CodeReviewPipelineModule already did this; this aligns CliReviewModule with the same pattern.

  UnknownDependenciesException: Nest can't resolve dependencies of the
  GitHubRateLimitGateService (?, CacheService). Please make sure that
  the argument GithubService at index [0] is available in the
  CliReviewModule module.

<!--
  Thanks for sending a PR! The PR title MUST follow Conventional Commits, e.g.
    feat(code-review): add agent-first reviewer
    fix(web): block app.kodus.io from search-engine indexing
    chore(deps): bump posthog-node to 4.x
  CI will fail otherwise.
-->

## Summary

<!-- 1–3 sentences. What changes for the user (or for us, if internal)? -->

## Changelog routing (driven by the PR title prefix)

The prefix in your PR title decides where this change appears in the public changelog. No labels needed — the title is the source of truth.

| Prefix     | Public changelog                              |
| ---------- | --------------------------------------------- |
| `feat:`    | **Improvements** section (or tied to a tracked feature, see below) |
| `fix:`     | **Bug fixes** section                         |
| `perf:`    | **Performance** section                       |
| `docs:`, `style:`, `refactor:`, `test:`, `chore:`, `ci:`, `build:` | Hidden from public changelog |

## Test plan

<!-- Bullet list of the manual / automated checks. -->

- [ ]
- [ ]

## Notes for the reviewer

<!-- Anything non-obvious. Risks, follow-ups, screenshots for UX work. -->

---

<!-- kody-pr-summary:start -->
Imports the `GithubModule` into the `CliReviewModule`. This change ensures that the `GitHubRateLimitGateService` has its necessary dependencies resolved, allowing it to function correctly within the CLI review process.
<!-- kody-pr-summary:end -->