### PR TITLE
Allowing everyone in the organization to see the rule

### DIFF
--- a/libs/identity/infrastructure/adapters/services/permissions/permissionsAbility.factory.ts
+++ b/libs/identity/infrastructure/adapters/services/permissions/permissionsAbility.factory.ts
@@ -92,7 +92,7 @@ export class PermissionsAbilityFactory {
                 canInRepo(Action.Update, ResourceType.CodeReviewSettings);
                 canInRepo(Action.Create, ResourceType.CodeReviewSettings);
 
-                canInRepo(Action.Read, ResourceType.KodyRules, {}, true);
+                canInOrg(Action.Read, ResourceType.KodyRules);
                 canInRepo(Action.Update, ResourceType.KodyRules);
                 canInRepo(Action.Create, ResourceType.KodyRules);
                 canInRepo(Action.Delete, ResourceType.KodyRules);
@@ -142,7 +142,7 @@ export class PermissionsAbilityFactory {
                     true,
                 );
 
-                canInRepo(Action.Read, ResourceType.KodyRules, {}, true);
+                canInOrg(Action.Read, ResourceType.KodyRules);
 
                 canInRepo(Action.Read, ResourceType.Issues);
 


### PR DESCRIPTION
#1078

---

<!-- kody-pr-summary:start -->
Updated permission definitions to allow all members within an organization to read Kody Rules. The ability to read `KodyRules` (identified as `ResourceType.KodyRules` with `Action.Read`) has been changed from a repository-scoped permission (`canInRepo`) to an organization-scoped permission (`canInOrg`) in the `PermissionsAbilityFactory`.
<!-- kody-pr-summary:end -->