### PR TITLE
perf(github): batch file/user fetches via GraphQL, extend cache TTLs

### DIFF
--- a/libs/code-review/infrastructure/adapters/services/pullRequestManager.service.ts
+++ b/libs/code-review/infrastructure/adapters/services/pullRequestManager.service.ts
@@ -344,7 +344,12 @@ export class PullRequestHandlerService implements IPullRequestManagerService {
     /**
      * Enriquece arquivos com conteúdo.
      * Usado para buscar conteúdo apenas dos arquivos que passaram pelo filtro ignorePaths.
-     * Usa p-limit para controlar concorrência e evitar secondary rate limit do GitHub.
+     *
+     * GitHub: 1 GraphQL request por batch de 50 arquivos (custa 1 ponto no
+     * bucket graphql), vs N REST `repos.getContent` (1 ponto cada no
+     * bucket core). Cai pra REST per-file quando a plataforma não suporta
+     * batch ou quando o batch falha. Demais plataformas: REST per-file
+     * com pLimit (comportamento original preservado).
      */
     async enrichFilesWithContent(
         organizationAndTeamData: OrganizationAndTeamData,
@@ -356,9 +361,75 @@ export class PullRequestHandlerService implements IPullRequestManagerService {
             return [];
         }
 
-        const limit = pLimit(this.FILE_CONTENT_CONCURRENCY);
+        const decode = (fc: any) => {
+            const content = fc?.data?.content;
+            if (
+                typeof content === 'string' &&
+                fc?.data?.encoding === 'base64'
+            ) {
+                return Buffer.from(content, 'base64').toString('utf-8');
+            }
+            return content;
+        };
 
         try {
+            // Batch path. The platform adapter returns null when it
+            // doesn't support batch (GitLab/Bitbucket/Azure/Forgejo
+            // today) — falls through to the per-file path below.
+            // Wrapped in its own try/catch so a throw from the batch
+            // method (e.g., GraphQL client setup failure, expired
+            // installation token) degrades gracefully to per-file REST
+            // instead of aborting the whole stage.
+            let batchMap: Map<string, any> | null | undefined;
+            try {
+                batchMap =
+                    await this.codeManagementService.getRepositoryContentBatch(
+                        {
+                            organizationAndTeamData,
+                            repository,
+                            files,
+                            pullRequest,
+                        },
+                    );
+            } catch (batchErr) {
+                this.logger.warn({
+                    message:
+                        'getRepositoryContentBatch threw — falling back to REST per-file',
+                    context: PullRequestHandlerService.name,
+                    error: batchErr,
+                    metadata: {
+                        organizationAndTeamData,
+                        prNumber: pullRequest?.number,
+                        repositoryName: repository?.name,
+                        fileCount: files.length,
+                    },
+                });
+                batchMap = null;
+            }
+
+            if (batchMap) {
+                return files.map((file) => {
+                    const fc = batchMap.get(file.filename);
+                    if (!fc) {
+                        this.logger.warn({
+                            message: `Batch returned no content for file: ${file.filename}`,
+                            context: PullRequestHandlerService.name,
+                            metadata: {
+                                organizationAndTeamData,
+                                prNumber: pullRequest?.number,
+                                filename: file.filename,
+                            },
+                        });
+                        return file;
+                    }
+                    return { ...file, fileContent: decode(fc) };
+                });
+            }
+
+            // REST per-file fallback (GitLab/Bitbucket/Azure or batch
+            // returned null). pLimit caps concurrency to keep secondary
+            // rate-limit and connection pressure in check.
+            const limit = pLimit(this.FILE_CONTENT_CONCURRENCY);
             const filesWithContent = await Promise.all(
                 files.map((file) =>
                     limit(async () => {
@@ -373,22 +444,9 @@ export class PullRequestHandlerService implements IPullRequestManagerService {
                                     },
                                 );
 
-                            const content = fileContent?.data?.content;
-                            let decodedContent = content;
-
-                            if (
-                                content &&
-                                fileContent?.data?.encoding === 'base64'
-                            ) {
-                                decodedContent = Buffer.from(
-                                    content,
-                                    'base64',
-                                ).toString('utf-8');
-                            }
-
                             return {
                                 ...file,
-                                fileContent: decodedContent,
+                                fileContent: decode(fileContent),
                             };
                         } catch (error) {
                             this.logger.error({

--- a/libs/platform/domain/platformIntegrations/interfaces/code-management.interface.ts
+++ b/libs/platform/domain/platformIntegrations/interfaces/code-management.interface.ts
@@ -125,6 +125,20 @@ export interface ICodeManagementService extends ICommonPlatformIntegrationServic
     createReviewComment(params: any): Promise<any | null>;
     createCommentInPullRequest(params): Promise<any[] | null>;
     getRepositoryContentFile(params: any): Promise<any | null>;
+
+    /**
+     * Batch-fetch file contents in a single round-trip. Implementations
+     * that support it (GitHub via GraphQL aliasing) return a Map keyed
+     * by filename. Adapters without a batch capability return `null` —
+     * callers fall back to per-file `getRepositoryContentFile`.
+     */
+    getRepositoryContentBatch(params: {
+        organizationAndTeamData: OrganizationAndTeamData;
+        repository: { name: string; id: any };
+        files: Array<{ filename: string; sha?: string }>;
+        pullRequest?: any;
+    }): Promise<Map<string, any> | null>;
+
     getPullRequestByNumber(params: any): Promise<any | null>;
 
     getCommitsForPullRequestForCodeReview(params: any): Promise<any[] | null>;
@@ -177,6 +191,18 @@ export interface ICodeManagementService extends ICommonPlatformIntegrationServic
         organizationAndTeamData: OrganizationAndTeamData;
         username: string;
     }): Promise<any>;
+
+    /**
+     * Batch-fetch user data by login in a single round-trip. Pre-warms
+     * the cache used by `getUserByUsername`. Implementations that
+     * support it (GitHub via GraphQL aliasing) return a Map keyed by
+     * normalized login. Adapters without a batch capability return
+     * `null` — callers fall back to per-user `getUserByUsername`.
+     */
+    getUsersByUsername(params: {
+        organizationAndTeamData: OrganizationAndTeamData;
+        usernames: string[];
+    }): Promise<Map<string, any> | null>;
 
     getUserByEmailOrName(params: {
         organizationAndTeamData: OrganizationAndTeamData;

--- a/libs/platform/infrastructure/adapters/services/azureRepos/azureRepos.service.ts
+++ b/libs/platform/infrastructure/adapters/services/azureRepos/azureRepos.service.ts
@@ -5110,4 +5110,20 @@ ${copyPrompt}
             return null;
         }
     }
+
+    async getRepositoryContentBatch(
+        _params: any,
+    ): Promise<Map<string, any> | null> {
+        // Not implemented for Azure Repos — callers fall back to
+        // per-file `getRepositoryContentFile`.
+        return null;
+    }
+
+    async getUsersByUsername(
+        _params: any,
+    ): Promise<Map<string, any> | null> {
+        // Not implemented for Azure Repos — callers fall back to
+        // per-user `getUserByUsername`.
+        return null;
+    }
 }

--- a/libs/platform/infrastructure/adapters/services/bitbucket.service.ts
+++ b/libs/platform/infrastructure/adapters/services/bitbucket.service.ts
@@ -672,4 +672,18 @@ export class BitbucketService implements Omit<
         );
         return impl.isDraftPullRequest(params);
     }
+
+    async getRepositoryContentBatch(params: any) {
+        const impl = await this.getImplementation(
+            params.organizationAndTeamData,
+        );
+        return impl.getRepositoryContentBatch(params);
+    }
+
+    async getUsersByUsername(params: any) {
+        const impl = await this.getImplementation(
+            params.organizationAndTeamData,
+        );
+        return impl.getUsersByUsername(params);
+    }
 }

--- a/libs/platform/infrastructure/adapters/services/bitbucket/bitbucket-cloud.service.ts
+++ b/libs/platform/infrastructure/adapters/services/bitbucket/bitbucket-cloud.service.ts
@@ -5371,4 +5371,20 @@ export class BitbucketCloudService implements Omit<
             type: file?.type ?? 'blob',
         };
     }
+
+    async getRepositoryContentBatch(
+        _params: any,
+    ): Promise<Map<string, any> | null> {
+        // Not implemented for Bitbucket Cloud — callers fall back to
+        // per-file `getRepositoryContentFile`.
+        return null;
+    }
+
+    async getUsersByUsername(
+        _params: any,
+    ): Promise<Map<string, any> | null> {
+        // Not implemented for Bitbucket Cloud — callers fall back to
+        // per-user `getUserByUsername`.
+        return null;
+    }
 }

--- a/libs/platform/infrastructure/adapters/services/bitbucket/bitbucket-data-center.service.ts
+++ b/libs/platform/infrastructure/adapters/services/bitbucket/bitbucket-data-center.service.ts
@@ -3143,4 +3143,20 @@ export class BitbucketDataCenterService implements Omit<
             return false;
         }
     }
+
+    async getRepositoryContentBatch(
+        _params: any,
+    ): Promise<Map<string, any> | null> {
+        // Not implemented for Bitbucket Data Center — callers fall
+        // back to per-file `getRepositoryContentFile`.
+        return null;
+    }
+
+    async getUsersByUsername(
+        _params: any,
+    ): Promise<Map<string, any> | null> {
+        // Not implemented for Bitbucket Data Center — callers fall
+        // back to per-user `getUserByUsername`.
+        return null;
+    }
 }

--- a/libs/platform/infrastructure/adapters/services/codeManagement.service.ts
+++ b/libs/platform/infrastructure/adapters/services/codeManagement.service.ts
@@ -495,6 +495,46 @@ export class CodeManagementService implements ICodeManagementService {
         return codeManagementService.getRepositoryContentFile(params);
     }
 
+    async getRepositoryContentBatch(
+        params: {
+            organizationAndTeamData: OrganizationAndTeamData;
+            repository: { name: string; id: any };
+            files: Array<{ filename: string; sha?: string }>;
+            pullRequest?: any;
+        },
+        type?: PlatformType,
+    ): Promise<Map<string, any> | null> {
+        if (!type) {
+            type = await this.getTypeIntegration(
+                extractOrganizationAndTeamData(params),
+            );
+        }
+
+        const codeManagementService =
+            this.platformIntegrationFactory.getCodeManagementService(type);
+
+        return codeManagementService.getRepositoryContentBatch(params);
+    }
+
+    async getUsersByUsername(
+        params: {
+            organizationAndTeamData: OrganizationAndTeamData;
+            usernames: string[];
+        },
+        type?: PlatformType,
+    ): Promise<Map<string, any> | null> {
+        if (!type) {
+            type = await this.getTypeIntegration(
+                extractOrganizationAndTeamData(params),
+            );
+        }
+
+        const codeManagementService =
+            this.platformIntegrationFactory.getCodeManagementService(type);
+
+        return codeManagementService.getUsersByUsername(params);
+    }
+
     async getPullRequestByNumber(
         params: {
             organizationAndTeamData: OrganizationAndTeamData;

--- a/libs/platform/infrastructure/adapters/services/forgejo.service.ts
+++ b/libs/platform/infrastructure/adapters/services/forgejo.service.ts
@@ -3959,4 +3959,20 @@ export class ForgejoService implements Omit<
             return [];
         }
     }
+
+    async getRepositoryContentBatch(
+        _params: any,
+    ): Promise<Map<string, any> | null> {
+        // Not implemented for Forgejo — callers fall back to per-file
+        // `getRepositoryContentFile`.
+        return null;
+    }
+
+    async getUsersByUsername(
+        _params: any,
+    ): Promise<Map<string, any> | null> {
+        // Not implemented for Forgejo — callers fall back to per-user
+        // `getUserByUsername`.
+        return null;
+    }
 }

--- a/libs/platform/infrastructure/adapters/services/github/github.service.cache.spec.ts
+++ b/libs/platform/infrastructure/adapters/services/github/github.service.cache.spec.ts
@@ -118,7 +118,7 @@ describe('GithubService — cache behavior', () => {
             expect(cacheService.addToCache).toHaveBeenCalledWith(
                 'gh:user:org-1:octocat',
                 { id: 1, login: 'octocat' },
-                10 * 60 * 1000,
+                24 * 60 * 60 * 1000,
             );
         });
 
@@ -136,12 +136,15 @@ describe('GithubService — cache behavior', () => {
 
             expect(result).toBeNull();
             expect(octokit.rest.users.getByUsername).toHaveBeenCalled();
-            // Negative cache stored for 1h — much longer than the positive
-            // TTL because 404s rarely "become 200" within a review window.
+            // Negative cache stored for 24h — same TTL as the positive
+            // path. A deleted/nonexistent GitHub user doesn't reappear
+            // within a working day, and a long null-cache saves the
+            // round-trip when a stale reviewer is referenced repeatedly
+            // across saves.
             expect(cacheService.addToCache).toHaveBeenCalledWith(
                 'gh:user:org-1:ghost',
                 null,
-                60 * 60 * 1000,
+                24 * 60 * 60 * 1000,
             );
         });
 

--- a/libs/platform/infrastructure/adapters/services/github/github.service.ts
+++ b/libs/platform/infrastructure/adapters/services/github/github.service.ts
@@ -4406,28 +4406,23 @@ This is an experimental feature that generates committable changes. Review the d
                         // 15s+ stall on the FetchChangedFiles stage.
                         // Same concurrency cap as the original
                         // pullRequestManager `enrichFilesWithContent`.
+                        // allSettled lets individual file failures
+                        // reject without aborting the rest of the batch.
                         const limit = pLimit(30);
-                        await Promise.all(
+                        await Promise.allSettled(
                             batch.map(({ file }) =>
                                 limit(async () => {
-                                    try {
-                                        const fallback =
-                                            await this.getRepositoryContentFile(
-                                                {
-                                                    organizationAndTeamData,
-                                                    repository,
-                                                    file,
-                                                    pullRequest,
-                                                },
-                                            );
-                                        if (fallback)
-                                            result.set(
-                                                file.filename,
-                                                fallback,
-                                            );
-                                    } catch {
-                                        /* skip */
-                                    }
+                                    const fallback =
+                                        await this.getRepositoryContentFile(
+                                            {
+                                                organizationAndTeamData,
+                                                repository,
+                                                file,
+                                                pullRequest,
+                                            },
+                                        );
+                                    if (fallback)
+                                        result.set(file.filename, fallback);
                                 }),
                             ),
                         );
@@ -4439,24 +4434,20 @@ This is an experimental feature that generates committable changes. Review the d
         // 4. Files without usable blob sha — REST fallback only.
         //    Concurrent with pLimit, same rationale as the in-batch
         //    catch above: avoid serializing N round-trips when GraphQL
-        //    isn't usable for these entries.
+        //    isn't usable for these entries. allSettled keeps a
+        //    single-file failure from aborting the rest.
         if (pullRequest && restOnly.length > 0) {
             const limit = pLimit(30);
-            await Promise.all(
+            await Promise.allSettled(
                 restOnly.map(({ file }) =>
                     limit(async () => {
-                        try {
-                            const fallback =
-                                await this.getRepositoryContentFile({
-                                    organizationAndTeamData,
-                                    repository,
-                                    file,
-                                    pullRequest,
-                                });
-                            if (fallback) result.set(file.filename, fallback);
-                        } catch {
-                            /* skip */
-                        }
+                        const fallback = await this.getRepositoryContentFile({
+                            organizationAndTeamData,
+                            repository,
+                            file,
+                            pullRequest,
+                        });
+                        if (fallback) result.set(file.filename, fallback);
                     }),
                 ),
             );

--- a/libs/platform/infrastructure/adapters/services/github/github.service.ts
+++ b/libs/platform/infrastructure/adapters/services/github/github.service.ts
@@ -4152,16 +4152,18 @@ This is an experimental feature that generates committable changes. Review the d
                 })) as any;
 
                 if (cacheKey && lines) {
-                    // 15 min TTL. The cache key already contains the
-                    // blob sha, so stale-on-content-change is impossible
-                    // — a TTL longer than `getFileWithContent`'s 5 min
-                    // is safe and gives more cross-retry hits on the
-                    // same job (router timeout retries can land 30s+
-                    // apart with backoff).
+                    // 24h TTL. The cache key includes the blob sha, and
+                    // a blob's content is immutable in Git by design —
+                    // the same sha always resolves to the same bytes
+                    // forever — so there is no stale-cache risk. Long
+                    // TTL maximizes cross-PR hits when reviews touch
+                    // overlapping unchanged files (cross-file context,
+                    // documentation manifests, retried/duplicated
+                    // webhooks, manual reruns).
                     await this.cacheService.addToCache(
                         cacheKey,
                         lines,
-                        15 * 60 * 1000,
+                        24 * 60 * 60 * 1000,
                     );
                 }
                 return lines;
@@ -4204,6 +4206,239 @@ This is an experimental feature that generates committable changes. Review the d
                 metadata: { ...params },
             });
         }
+    }
+
+    // Fetch many file contents in a single GraphQL request, keyed by blob
+    // SHA. Each PR file from `pulls.listFiles` already carries its blob
+    // sha, so we can resolve N files in 1 GraphQL point instead of N REST
+    // points (~5000/h on the installation bucket). Cache key shape is
+    // identical to `getRepositoryContentFile`, so warm entries from
+    // either path are reused.
+    //
+    // Falls back to per-file REST for: missing/invalid sha, binary
+    // blobs, blobs over ~1 MB (GraphQL returns text=null in both cases),
+    // and any GraphQL-side error (whole-batch fallback).
+    public async getRepositoryContentBatch(params: {
+        organizationAndTeamData: OrganizationAndTeamData;
+        repository: { name: string; id: any };
+        files: Array<{ filename: string; sha?: string; [key: string]: any }>;
+        pullRequest?: any;
+    }): Promise<Map<string, any>> {
+        const { organizationAndTeamData, repository, files, pullRequest } =
+            params;
+        const result = new Map<string, any>();
+
+        if (!files?.length) return result;
+
+        const githubAuthDetail = await this.getGithubAuthDetails(
+            organizationAndTeamData,
+        );
+        if (!githubAuthDetail) return result;
+
+        const makeCacheKey = (file: { filename: string; sha?: string }) =>
+            file?.sha
+                ? `gh:contents:${githubAuthDetail?.org}/${repository.name}:${file.sha}:${file.filename}`
+                : undefined;
+
+        // 1. Cache lookup — collect hits, queue misses
+        const misses: Array<{ file: any; cacheKey?: string }> = [];
+        for (const file of files) {
+            const cacheKey = makeCacheKey(file);
+            if (cacheKey) {
+                const cached =
+                    await this.cacheService.getFromCache<any>(cacheKey);
+                if (cached) {
+                    result.set(file.filename, cached);
+                    continue;
+                }
+            }
+            misses.push({ file, cacheKey });
+        }
+
+        if (misses.length === 0) return result;
+
+        // 2. Split: batchable (valid 40-hex blob sha) vs REST-only
+        const SHA_RE = /^[a-f0-9]{40}$/i;
+        const batchable: Array<{ file: any; cacheKey?: string }> = [];
+        const restOnly: Array<{ file: any; cacheKey?: string }> = [];
+        for (const m of misses) {
+            if (SHA_RE.test(m.file?.sha || '')) batchable.push(m);
+            else restOnly.push(m);
+        }
+
+        // 3. GraphQL batch fetch (size 50 — conservative; GitHub accepts
+        //    up to ~100 aliases but 50 keeps payloads small and limits
+        //    blast radius on transient errors)
+        if (batchable.length > 0) {
+            const graphqlClient =
+                await this.instanceGraphQL(organizationAndTeamData);
+            const BATCH_SIZE = 50;
+
+            for (let i = 0; i < batchable.length; i += BATCH_SIZE) {
+                const batch = batchable.slice(i, i + BATCH_SIZE);
+                const varDefs = ['$owner: String!', '$repo: String!'];
+                const fields: string[] = [];
+                const variables: Record<string, any> = {
+                    owner: githubAuthDetail.org,
+                    repo: repository.name,
+                };
+
+                batch.forEach(({ file }, idx) => {
+                    varDefs.push(`$sha${idx}: GitObjectID!`);
+                    fields.push(
+                        `f${idx}: object(oid: $sha${idx}) { ... on Blob { text isBinary byteSize } }`,
+                    );
+                    variables[`sha${idx}`] = file.sha;
+                });
+
+                const query = `
+                    query(${varDefs.join(', ')}) {
+                        repository(owner: $owner, name: $repo) {
+                            ${fields.join('\n                            ')}
+                        }
+                        rateLimit {
+                            cost
+                            remaining
+                            limit
+                            resetAt
+                        }
+                    }
+                `;
+
+                try {
+                    const response: any = await graphqlClient(
+                        query,
+                        variables,
+                    );
+                    const repoNode = response?.repository;
+
+                    // Temporary instrumentation: log the actual GraphQL
+                    // cost reported by GitHub for this batch. Distinct
+                    // tag for easy `docker logs ... | grep` lookup.
+                    // Remove once we've validated the cost model.
+                    const rl = response?.rateLimit;
+                    if (rl) {
+                        this.logger.log({
+                            message: `[GRAPHQL_BATCH_COST] files=${batch.length} cost=${rl.cost} remaining=${rl.remaining} limit=${rl.limit} resetAt=${rl.resetAt}`,
+                            context: GithubService.name,
+                            metadata: {
+                                instrumentation:
+                                    'graphql_batch_content_cost',
+                                batchSize: batch.length,
+                                cost: rl.cost,
+                                remaining: rl.remaining,
+                                limit: rl.limit,
+                                resetAt: rl.resetAt,
+                                organizationAndTeamData,
+                                repositoryName: repository?.name,
+                            },
+                        });
+                    }
+
+                    for (let j = 0; j < batch.length; j++) {
+                        const { file, cacheKey } = batch[j];
+                        const blob = repoNode?.[`f${j}`];
+
+                        if (
+                            blob &&
+                            blob.isBinary === false &&
+                            typeof blob.text === 'string'
+                        ) {
+                            // Shape mirrors octokit's `repos.getContent`
+                            // response so `enrichFilesWithContent` reads
+                            // it transparently. Encoding `utf-8` skips
+                            // the base64 decode path on the caller.
+                            const fileContent = {
+                                data: {
+                                    content: blob.text,
+                                    encoding: 'utf-8',
+                                },
+                            };
+                            result.set(file.filename, fileContent);
+                            if (cacheKey) {
+                                // 24h TTL — see `getRepositoryContentFile`
+                                // for the immutability argument. Same
+                                // cache key shape, same safety guarantees.
+                                await this.cacheService.addToCache(
+                                    cacheKey,
+                                    fileContent,
+                                    24 * 60 * 60 * 1000,
+                                );
+                            }
+                        } else {
+                            // Binary, oversize, or missing — fall back
+                            // to REST single-file (which handles both
+                            // base64 binary returns and the head→base
+                            // ref fallback). Skip silently if we don't
+                            // have the PR refs available.
+                            if (pullRequest) {
+                                try {
+                                    const fallback =
+                                        await this.getRepositoryContentFile({
+                                            organizationAndTeamData,
+                                            repository,
+                                            file,
+                                            pullRequest,
+                                        });
+                                    if (fallback)
+                                        result.set(file.filename, fallback);
+                                } catch {
+                                    /* keep result without this file */
+                                }
+                            }
+                        }
+                    }
+                } catch (err) {
+                    this.logger.warn({
+                        message:
+                            'GraphQL batch content fetch failed — falling back to REST per-file for the batch',
+                        context: GithubService.name,
+                        error: err,
+                        metadata: {
+                            organizationAndTeamData,
+                            repositoryName: repository?.name,
+                            batchSize: batch.length,
+                        },
+                    });
+                    if (pullRequest) {
+                        for (const { file } of batch) {
+                            try {
+                                const fallback =
+                                    await this.getRepositoryContentFile({
+                                        organizationAndTeamData,
+                                        repository,
+                                        file,
+                                        pullRequest,
+                                    });
+                                if (fallback)
+                                    result.set(file.filename, fallback);
+                            } catch {
+                                /* skip */
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // 4. Files without usable blob sha — REST fallback only
+        if (pullRequest && restOnly.length > 0) {
+            for (const { file } of restOnly) {
+                try {
+                    const fallback = await this.getRepositoryContentFile({
+                        organizationAndTeamData,
+                        repository,
+                        file,
+                        pullRequest,
+                    });
+                    if (fallback) result.set(file.filename, fallback);
+                } catch {
+                    /* skip */
+                }
+            }
+        }
+
+        return result;
     }
 
     async getCommitsForPullRequestForCodeReview(
@@ -5552,19 +5787,28 @@ This is an experimental feature that generates committable changes. Review the d
 
             const userData = userResponse.data;
 
+            // 24h TTL. User identity (login, name, email) changes rarely
+            // — and when it does, our save flow doesn't depend on
+            // realtime freshness. A long TTL lets follow-up saves of
+            // the same PR (webhook handler + pipeline-internal save)
+            // hit cache instead of refetching 4× per review.
             await this.cacheService.addToCache(
                 cacheKey,
                 userData,
-                10 * 60 * 1000,
+                24 * 60 * 60 * 1000,
             );
 
             return userData;
         } catch (error) {
             if (error?.response?.status === 404) {
+                // 24h null-cache: a deleted/nonexistent GitHub user
+                // doesn't reappear within a working day, and a cached
+                // null saves the round-trip when a stale reviewer is
+                // referenced repeatedly across saves.
                 await this.cacheService.addToCache(
                     cacheKey,
                     null,
-                    60 * 60 * 1000,
+                    24 * 60 * 60 * 1000,
                 );
                 this.logger.warn({
                     message: `Github user not found: ${username}`,
@@ -5583,6 +5827,156 @@ This is an experimental feature that generates committable changes. Review the d
             });
             throw error;
         }
+    }
+
+    // Batch-fetch many users in a single GraphQL request using login
+    // aliases. Reads from the same Redis cache as `getUserByUsername`
+    // (key `gh:user:{orgId}:{login}`), so an entry warmed by either
+    // path is reused by both. Designed to be called as a pre-flight
+    // before extractUser/extractUsers fans out per-user, eliminating
+    // the N parallel REST round-trips during PR saves.
+    //
+    // Failure mode is opportunistic: on any GraphQL error this method
+    // logs and returns whatever it has so far. Callers proceed to
+    // their per-user REST path; uncached users pay the original cost.
+    public async getUsersByUsername(params: {
+        organizationAndTeamData: OrganizationAndTeamData;
+        usernames: string[];
+    }): Promise<Map<string, any>> {
+        const { organizationAndTeamData, usernames } = params;
+        const result = new Map<string, any>();
+
+        if (!usernames?.length) return result;
+
+        // Dedupe & normalize. GitHub usernames are case-insensitive.
+        const normalized = Array.from(
+            new Set(
+                usernames
+                    .filter((u) => typeof u === 'string' && u.length > 0)
+                    .map((u) => u.toLowerCase()),
+            ),
+        );
+
+        const makeCacheKey = (login: string) =>
+            `gh:user:${organizationAndTeamData?.organizationId}:${login}`;
+
+        // 1. Cache lookup. Matches existing getUserByUsername semantics:
+        //    cached null falls through to refetch (the function reads
+        //    it as "absent"), so we re-batch nulls. With the 24h TTL
+        //    that's still much cheaper than the original 10min churn.
+        const misses: string[] = [];
+        for (const login of normalized) {
+            const cached = await this.cacheService.getFromCache<any | null>(
+                makeCacheKey(login),
+            );
+            if (cached !== null && cached !== undefined) {
+                result.set(login, cached);
+            } else {
+                misses.push(login);
+            }
+        }
+
+        if (misses.length === 0) return result;
+
+        // 2. GraphQL batch fetch. Aliases u0..uN; GitHub allows up to
+        //    ~100 in one query but we cap at 50 to stay consistent with
+        //    the file-content batch (smaller payload, less blast radius
+        //    on transient errors).
+        const BATCH_SIZE = 50;
+        let graphqlClient: any;
+        try {
+            graphqlClient = await this.instanceGraphQL(
+                organizationAndTeamData,
+            );
+        } catch (err) {
+            this.logger.warn({
+                message:
+                    'instanceGraphQL failed for getUsersByUsername — skipping batch (caller falls back to per-user REST)',
+                context: GithubService.name,
+                error: err,
+                metadata: { organizationAndTeamData },
+            });
+            return result;
+        }
+
+        for (let i = 0; i < misses.length; i += BATCH_SIZE) {
+            const batch = misses.slice(i, i + BATCH_SIZE);
+            const varDefs: string[] = [];
+            const fields: string[] = [];
+            const variables: Record<string, any> = {};
+
+            batch.forEach((login, idx) => {
+                varDefs.push(`$u${idx}: String!`);
+                fields.push(
+                    `u${idx}: user(login: $u${idx}) { login databaseId name email }`,
+                );
+                variables[`u${idx}`] = login;
+            });
+
+            const query = `
+                query(${varDefs.join(', ')}) {
+                    ${fields.join('\n                    ')}
+                }
+            `;
+
+            try {
+                const response: any = await graphqlClient(query, variables);
+
+                for (let j = 0; j < batch.length; j++) {
+                    const login = batch[j];
+                    const gqlUser = response?.[`u${j}`];
+                    const cacheKey = makeCacheKey(login);
+
+                    if (gqlUser) {
+                        // Map GraphQL shape → REST-like minimal shape
+                        // so downstream consumers (`extractUser` reads
+                        // `.email`, `.name`, `.id`) see what they
+                        // expect from `getUserByUsername`.
+                        const userData = {
+                            login: gqlUser.login,
+                            id: gqlUser.databaseId,
+                            name: gqlUser.name,
+                            email: gqlUser.email,
+                            type: 'User',
+                        };
+                        result.set(login, userData);
+                        await this.cacheService.addToCache(
+                            cacheKey,
+                            userData,
+                            24 * 60 * 60 * 1000,
+                        );
+                    } else {
+                        // Null result = user not found. Cache the null
+                        // with the same 24h TTL as getUserByUsername's
+                        // 404 path so future per-user lookups also
+                        // short-circuit (matching shape).
+                        await this.cacheService.addToCache(
+                            cacheKey,
+                            null,
+                            24 * 60 * 60 * 1000,
+                        );
+                    }
+                }
+            } catch (err) {
+                this.logger.warn({
+                    message:
+                        'GraphQL batch user fetch failed — partial results returned; caller falls back to per-user REST for the rest',
+                    context: GithubService.name,
+                    error: err,
+                    metadata: {
+                        organizationAndTeamData,
+                        batchSize: batch.length,
+                    },
+                });
+                // Don't process more batches if one fails — they're
+                // independent but a single GraphQL error usually
+                // indicates auth/quota issue that won't recover within
+                // the same request.
+                break;
+            }
+        }
+
+        return result;
     }
 
     getUserByEmailOrName(_params: {

--- a/libs/platform/infrastructure/adapters/services/github/github.service.ts
+++ b/libs/platform/infrastructure/adapters/services/github/github.service.ts
@@ -4401,41 +4401,65 @@ This is an experimental feature that generates committable changes. Review the d
                         },
                     });
                     if (pullRequest) {
-                        for (const { file } of batch) {
-                            try {
-                                const fallback =
-                                    await this.getRepositoryContentFile({
-                                        organizationAndTeamData,
-                                        repository,
-                                        file,
-                                        pullRequest,
-                                    });
-                                if (fallback)
-                                    result.set(file.filename, fallback);
-                            } catch {
-                                /* skip */
-                            }
-                        }
+                        // Concurrent fallback with pLimit — sequential
+                        // would 50× a single GraphQL hiccup into a
+                        // 15s+ stall on the FetchChangedFiles stage.
+                        // Same concurrency cap as the original
+                        // pullRequestManager `enrichFilesWithContent`.
+                        const limit = pLimit(30);
+                        await Promise.all(
+                            batch.map(({ file }) =>
+                                limit(async () => {
+                                    try {
+                                        const fallback =
+                                            await this.getRepositoryContentFile(
+                                                {
+                                                    organizationAndTeamData,
+                                                    repository,
+                                                    file,
+                                                    pullRequest,
+                                                },
+                                            );
+                                        if (fallback)
+                                            result.set(
+                                                file.filename,
+                                                fallback,
+                                            );
+                                    } catch {
+                                        /* skip */
+                                    }
+                                }),
+                            ),
+                        );
                     }
                 }
             }
         }
 
-        // 4. Files without usable blob sha — REST fallback only
+        // 4. Files without usable blob sha — REST fallback only.
+        //    Concurrent with pLimit, same rationale as the in-batch
+        //    catch above: avoid serializing N round-trips when GraphQL
+        //    isn't usable for these entries.
         if (pullRequest && restOnly.length > 0) {
-            for (const { file } of restOnly) {
-                try {
-                    const fallback = await this.getRepositoryContentFile({
-                        organizationAndTeamData,
-                        repository,
-                        file,
-                        pullRequest,
-                    });
-                    if (fallback) result.set(file.filename, fallback);
-                } catch {
-                    /* skip */
-                }
-            }
+            const limit = pLimit(30);
+            await Promise.all(
+                restOnly.map(({ file }) =>
+                    limit(async () => {
+                        try {
+                            const fallback =
+                                await this.getRepositoryContentFile({
+                                    organizationAndTeamData,
+                                    repository,
+                                    file,
+                                    pullRequest,
+                                });
+                            if (fallback) result.set(file.filename, fallback);
+                        } catch {
+                            /* skip */
+                        }
+                    }),
+                ),
+            );
         }
 
         return result;

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -4705,4 +4705,20 @@ ${copyPrompt}
 
         return copyPrompt;
     }
+
+    async getRepositoryContentBatch(
+        _params: any,
+    ): Promise<Map<string, any> | null> {
+        // Not implemented for GitLab — callers fall back to per-file
+        // `getRepositoryContentFile`.
+        return null;
+    }
+
+    async getUsersByUsername(
+        _params: any,
+    ): Promise<Map<string, any> | null> {
+        // Not implemented for GitLab — callers fall back to per-user
+        // `getUserByUsername`.
+        return null;
+    }
 }

--- a/libs/platformData/infrastructure/adapters/services/pullRequests.service.ts
+++ b/libs/platformData/infrastructure/adapters/services/pullRequests.service.ts
@@ -519,6 +519,24 @@ export class PullRequestsService implements IPullRequestsService {
             enrichedPullRequest.reviewers = foundReviewers;
         }
 
+        // Pre-flight user batch fetch: warms the Redis cache used by
+        // `getUserByUsername` in a single GraphQL call (GitHub only).
+        // The downstream extractUser/extractUsers (both in the update
+        // branch below and in initializeCodeReviewStructure via the
+        // initial branch) read from that cache, so this collapses up
+        // to 1+N+M parallel REST calls into 1 GraphQL request per save.
+        await this.prefetchUsersForExtraction(
+            [
+                enrichedPullRequest.user,
+                enrichedPullRequest.reviewers ??
+                    enrichedPullRequest.requested_reviewers,
+                enrichedPullRequest.assignees ??
+                    enrichedPullRequest.participants,
+            ],
+            organizationAndTeamData,
+            platformType,
+        );
+
         const existingPR =
             await this.pullRequestsRepository.findByNumberAndRepositoryName(
                 pullRequest?.number,
@@ -1179,6 +1197,76 @@ export class PullRequestsService implements IPullRequestsService {
                 },
             });
             return [];
+        }
+    }
+
+    /**
+     * Pre-flight: batch-fetch user data for all candidate user inputs
+     * (author + reviewers + assignees) via the platform's batch API
+     * (GitHub GraphQL today) and warm the `getUserByUsername` Redis
+     * cache. The per-user extractUser/extractUsers calls that follow
+     * then hit cache instead of fanning out N parallel REST round-trips.
+     *
+     * Opportunistic: silent no-op for non-GitHub platforms (the
+     * CodeManagementService wrapper returns null) and on any batch
+     * failure. The fallback path — per-user REST via extractUser — is
+     * always available.
+     */
+    private async prefetchUsersForExtraction(
+        inputs: Array<any | undefined>,
+        organizationAndTeamData: OrganizationAndTeamData,
+        platformType: PlatformType,
+    ): Promise<void> {
+        try {
+            const usernames = new Set<string>();
+
+            // Mirror the discriminator from extractUser: only users
+            // whose branch would call `getUserByUsername` are worth
+            // pre-fetching. Users with a valid email skip the lookup
+            // entirely and would just add noise to the batch.
+            const visit = (data: any) => {
+                if (!data) return;
+                const needsLookup =
+                    data?.role || (!data?.email && !data?.uniqueName);
+                if (!needsLookup) return;
+
+                const login =
+                    data?.login ||
+                    data?.username ||
+                    data?.nickname ||
+                    data?.descriptor ||
+                    '';
+                if (typeof login === 'string' && login.length > 0) {
+                    usernames.add(login);
+                }
+            };
+
+            for (const input of inputs) {
+                if (!input) continue;
+                if (Array.isArray(input)) {
+                    for (const u of input) visit(u);
+                } else {
+                    visit(input);
+                }
+            }
+
+            if (usernames.size === 0) return;
+
+            await this.codeManagement.getUsersByUsername(
+                {
+                    organizationAndTeamData,
+                    usernames: Array.from(usernames),
+                },
+                platformType,
+            );
+        } catch (err) {
+            this.logger.warn({
+                message:
+                    'User batch prefetch failed — falling back to per-user enrichment',
+                context: PullRequestsService.name,
+                error: err,
+                metadata: { organizationAndTeamData, platformType },
+            });
         }
     }
 

--- a/test/unit/platform/services/github.service.cache.spec.ts
+++ b/test/unit/platform/services/github.service.cache.spec.ts
@@ -353,7 +353,7 @@ describe('GithubService — cache layer (commit b7606bb5c)', () => {
             expect(cache.addToCache).toHaveBeenCalledWith(
                 expect.stringContaining(`:${fileWithSha.sha}:`),
                 fakeContentResponse,
-                15 * 60 * 1000,
+                24 * 60 * 60 * 1000,
             );
         });
 


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces significant performance improvements by optimizing API calls to GitHub and extending cache durations.

Key changes include:

*   **Batch Fetching for GitHub (GraphQL):**
    *   Implemented new `getRepositoryContentBatch` and `getUsersByUsername` methods in the `ICodeManagementService` interface.
    *   For GitHub, these methods leverage GraphQL to fetch multiple file contents or user details in a single request, significantly reducing the number of API calls compared to individual REST API calls. This is particularly beneficial for rate limit management (e.g., 1 GraphQL request for up to 50 files/users vs. 50 individual REST requests).
    *   Includes robust fallback mechanisms: if GraphQL batch fetching is not supported (e.g., for other platforms like GitLab, Bitbucket, Azure Repos, Forgejo, which return `null`), fails, or for specific file types (e.g., binary, oversized), the system gracefully falls back to the existing per-file or per-user REST API calls.
*   **Extended Cache TTLs:**
    *   Increased the cache Time-To-Live (TTL) for GitHub file content and user data (both positive and negative lookups) from minutes/hours to 24 hours. This is based on the immutability of Git blob SHAs for file content and the infrequent changes in user profiles, further reducing redundant API calls and improving overall performance.
*   **Integration:**
    *   The `PullRequestHandlerService` now attempts to use the new batch file content fetching for enriching files.
    *   The `PullRequestsService` performs a pre-flight batch user fetch to pre-warm the user cache, ensuring that subsequent individual user extractions hit the cache instead of making new API calls.
<!-- kody-pr-summary:end -->