### PR TITLE
fix: missing forgejo git settings entry

### DIFF
--- a/apps/web/src/app/(app)/settings/git/_constants/index.tsx
+++ b/apps/web/src/app/(app)/settings/git/_constants/index.tsx
@@ -2,6 +2,7 @@ import { SvgAzureRepos } from "@components/ui/icons/SvgAzureRepos";
 import { SvgBitbucket } from "@components/ui/icons/SvgBitbucket";
 import { SvgGithub } from "@components/ui/icons/SvgGithub";
 import { SvgGitlab } from "@components/ui/icons/SvgGitlab";
+import { SvgForgejo } from "@components/ui/icons/SvgForgejo";
 import { INTEGRATIONS_KEY } from "@enums";
 
 export const CODE_MANAGEMENT_PLATFORMS = {
@@ -20,6 +21,10 @@ export const CODE_MANAGEMENT_PLATFORMS = {
     [INTEGRATIONS_KEY.AZURE_REPOS]: {
         svg: SvgAzureRepos,
         platformName: "Azure Repos",
+    },
+    [INTEGRATIONS_KEY.FORGEJO]: {
+        svg: SvgForgejo,
+        platformName: "Forgejo",
     },
 } as const satisfies Partial<
     Record<


### PR DESCRIPTION
## Summary

Fixes: #1100 

## Test plan

I haven't had time to test this yet but, the enum and svg already exist, it was just missing an entry on this page.

but there might be more settings pages that are missing this too.

---

<!-- kody-pr-summary:start -->
Adds Forgejo as a recognized code management platform, making it available as a selectable option for Git integration in the application's settings. This includes importing its SVG icon and defining its platform name.
<!-- kody-pr-summary:end -->