### PR TITLE
fix(menu): adding guard in routes

### DIFF
--- a/apps/api/src/controllers/codeReviewSettingLog.controller.ts
+++ b/apps/api/src/controllers/codeReviewSettingLog.controller.ts
@@ -1,4 +1,5 @@
 import { Body, Controller, Get, Post, Query, UseGuards } from '@nestjs/common';
+import { EnterpriseTierGuard } from '@libs/ee/license/guards/enterprise-tier.guard';
 import {
     Action,
     ResourceType,
@@ -25,6 +26,7 @@ import { CodeReviewSettingsLogResponseDto } from '../dtos/code-review-settings-l
 
 @ApiTags('Code Review Logs')
 @ApiStandardResponses()
+@UseGuards(EnterpriseTierGuard)
 @Controller('user-log')
 export class CodeReviewSettingLogController {
     constructor(

--- a/apps/api/src/controllers/ssoConfig.controller.ts
+++ b/apps/api/src/controllers/ssoConfig.controller.ts
@@ -1,4 +1,5 @@
 import { UserRequest } from '@libs/core/infrastructure/config/types/http/user-request.type';
+import { EnterpriseTierGuard } from '@libs/ee/license/guards/enterprise-tier.guard';
 import {
     ISSOConfigService,
     SSO_CONFIG_SERVICE_TOKEN,
@@ -46,6 +47,7 @@ import { ApiObjectResponseDto } from '../dtos/api-response.dto';
 @ApiTags('SSO Config')
 @ApiBearerAuth('jwt')
 @ApiStandardResponses()
+@UseGuards(EnterpriseTierGuard)
 @Controller('sso-config')
 export class SSOConfigController {
     constructor(

--- a/apps/web/src/features/ee/byok/_utils.ts
+++ b/apps/web/src/features/ee/byok/_utils.ts
@@ -31,19 +31,24 @@ export const isBYOKSubscriptionPlan = (license: OrganizationLicense) => {
 };
 
 export const isEnterprisePlan = (license: OrganizationLicense): boolean => {
-    if (
-        license.subscriptionStatus === "self-hosted" ||
-        license.subscriptionStatus === "licensed-self-hosted"
-    ) {
-        return true;
+    // Mirror of `isEnterpriseTierAllowed` in
+    // `libs/ee/license/tier/enterprise-tier-policy.ts` — keep aligned.
+    // CE self-hosted (no key) is modeled here as
+    // `{ valid: true, subscriptionStatus: "self-hosted" }` and falls
+    // into the `default` branch.
+    if (!license.valid) return false;
+
+    switch (license.subscriptionStatus) {
+        case "active":
+        case "licensed-self-hosted": {
+            const plan = license.planType ?? "";
+            return plan.startsWith("enterprise_") || plan === "enterprise";
+        }
+        case "trial":
+            return true;
+        default:
+            return false;
     }
-    if (license.subscriptionStatus === "trial") {
-        return true;
-    }
-    if (license.subscriptionStatus !== "active") {
-        return false;
-    }
-    return license.planType?.startsWith("enterprise") ?? false;
 };
 
 export const shouldShowBYOKMissingKeyTopbar = (params: {

--- a/apps/web/src/features/ee/sso/page.tsx
+++ b/apps/web/src/features/ee/sso/page.tsx
@@ -1,10 +1,28 @@
+import { redirect } from "next/navigation";
 import { getSSOConfig } from "@services/ssoConfig/fetch";
 import { auth } from "src/core/config/auth";
+import { getGlobalSelectedTeamId } from "src/core/utils/get-global-selected-team-id";
+import { isEnterprisePlan } from "src/features/ee/byok/_utils";
+import { validateOrganizationLicense } from "src/features/ee/subscription/_services/billing/fetch";
 import { SSOConfig, SSOProtocol } from "src/lib/auth/types";
 
 import { ClientSsoOrganizationSettingsPage } from "./_page-component";
 
 export default async function SsoOrganizationSettingsPage() {
+    const teamId = await getGlobalSelectedTeamId();
+    const license = await validateOrganizationLicense({ teamId }).catch(
+        () => null,
+    );
+
+    // SSO is enterprise-only (trials get a preview). Mirrors the sidebar
+    // visibility in app/(app)/organization/_components/sidebar.tsx — the
+    // menu hides the link, this guard blocks direct URL access.
+    const isTrial = license?.subscriptionStatus === "trial";
+    const isEnterprise = license ? isEnterprisePlan(license) : false;
+    if (!isEnterprise && !isTrial) {
+        redirect("/organization/general");
+    }
+
     const jwtPayload = await auth();
     const email = jwtPayload?.user?.email ?? "";
 

--- a/apps/web/src/features/ee/user-logs/page.tsx
+++ b/apps/web/src/features/ee/user-logs/page.tsx
@@ -1,5 +1,24 @@
+import { redirect } from "next/navigation";
+import { getGlobalSelectedTeamId } from "src/core/utils/get-global-selected-team-id";
+import { isEnterprisePlan } from "src/features/ee/byok/_utils";
+import { validateOrganizationLicense } from "src/features/ee/subscription/_services/billing/fetch";
+
 import { UserLogsPageClient } from "./_components/page.client";
 
 export default async function UserLogsPage() {
+    const teamId = await getGlobalSelectedTeamId();
+    const license = await validateOrganizationLicense({ teamId }).catch(
+        () => null,
+    );
+
+    // Activity logs is enterprise-only (trials get a preview). Mirrors the
+    // dropdown visibility in core/layout/navbar/_components/user-nav.tsx —
+    // the menu hides the link, this guard blocks direct URL access.
+    const isTrial = license?.subscriptionStatus === "trial";
+    const isEnterprise = license ? isEnterprisePlan(license) : false;
+    if (!isEnterprise && !isTrial) {
+        redirect("/");
+    }
+
     return <UserLogsPageClient />;
 }

--- a/libs/ee/codeReviewSettingsLog/codeReviewSettingsLog.module.ts
+++ b/libs/ee/codeReviewSettingsLog/codeReviewSettingsLog.module.ts
@@ -2,6 +2,7 @@ import { Module, forwardRef } from '@nestjs/common';
 import { MongooseModule } from '@nestjs/mongoose';
 
 import { ContextResolutionModule } from '@libs/core/context-resolution/context-resolution.module';
+import { LicenseModule } from '@libs/ee/license/license.module';
 import { PermissionValidationModule } from '@libs/ee/shared/permission-validation.module';
 import { PermissionsModule } from '@libs/identity/modules/permissions.module';
 import { FindCodeReviewSettingsLogsUseCase } from './application/use-cases/find-code-review-settings-logs.use-case';
@@ -38,6 +39,7 @@ import { AuditLogListener } from './listeners/audit-log.listener';
         forwardRef(() => PermissionValidationModule),
         ContextResolutionModule,
         forwardRef(() => PermissionsModule),
+        LicenseModule,
     ],
     providers: [
         {

--- a/libs/ee/license/guards/enterprise-tier.guard.ts
+++ b/libs/ee/license/guards/enterprise-tier.guard.ts
@@ -1,0 +1,93 @@
+import {
+    CanActivate,
+    ExecutionContext,
+    ForbiddenException,
+    Inject,
+    Injectable,
+    Logger,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { Request } from 'express';
+
+import { IS_PUBLIC_KEY } from '@libs/identity/infrastructure/adapters/services/auth/public.decorator';
+
+import {
+    ILicenseService,
+    LICENSE_SERVICE_TOKEN,
+} from '../interfaces/license.interface';
+import { isEnterpriseTierAllowed } from '../tier/enterprise-tier-policy';
+
+/**
+ * Rejects enterprise-only endpoints (SSO config, user activity logs)
+ * for orgs outside the supported tier. Mirrors the frontend shell
+ * gates (sidebar visibility + page-level redirects) so a user with a
+ * JWT can't bypass the UI and hit the API directly.
+ *
+ * Skips `@Public()` handlers — they have no JWT to derive an org from
+ * (e.g. the unauthenticated `/user-log/status-change` callback).
+ */
+@Injectable()
+export class EnterpriseTierGuard implements CanActivate {
+    private readonly logger = new Logger(EnterpriseTierGuard.name);
+
+    constructor(
+        @Inject(LICENSE_SERVICE_TOKEN)
+        private readonly licenseService: ILicenseService,
+        private readonly reflector: Reflector,
+    ) {}
+
+    async canActivate(context: ExecutionContext): Promise<boolean> {
+        const isPublic = this.reflector.getAllAndOverride<boolean>(
+            IS_PUBLIC_KEY,
+            [context.getHandler(), context.getClass()],
+        );
+        if (isPublic) return true;
+
+        const req = context.switchToHttp().getRequest<
+            Request & {
+                user?: {
+                    organizationId?: string;
+                    organization?: { uuid?: string };
+                };
+            }
+        >();
+
+        // `UserEntity` exposes the org as `organization: { uuid }` —
+        // matches the resolution used by `CockpitTierGuard`.
+        const organizationId =
+            req.user?.organizationId ?? req.user?.organization?.uuid;
+
+        if (!organizationId) {
+            throw new ForbiddenException(
+                'enterprise tier: organizationId missing from request',
+            );
+        }
+
+        try {
+            // Tier is an org-level property; teamId is irrelevant here
+            // (it only matters for per-seat license assignment). Match
+            // the cockpit guard call shape.
+            const license =
+                await this.licenseService.validateOrganizationLicense({
+                    organizationId,
+                });
+            if (!isEnterpriseTierAllowed(license)) {
+                throw new ForbiddenException(
+                    'enterprise tier: organization is not on a supported plan',
+                );
+            }
+            return true;
+        } catch (err) {
+            if (err instanceof ForbiddenException) throw err;
+            this.logger.warn(
+                `license validation failed for org ${organizationId}: ${
+                    err instanceof Error ? err.message : String(err)
+                }`,
+            );
+            // Fail-closed: if we can't validate, don't leak data.
+            throw new ForbiddenException(
+                'enterprise tier: license validation unavailable',
+            );
+        }
+    }
+}

--- a/libs/ee/license/license.module.ts
+++ b/libs/ee/license/license.module.ts
@@ -7,6 +7,7 @@ import { forwardRef, Module } from '@nestjs/common';
 
 import { TeamModule } from '@libs/organization/modules/team.module';
 
+import { EnterpriseTierGuard } from './guards/enterprise-tier.guard';
 import { LICENSE_SERVICE_TOKEN } from './interfaces/license.interface';
 import { LicenseService } from './license.service';
 import { SelfHostedLicenseService } from './self-hosted-license.service';
@@ -35,12 +36,14 @@ import { environment } from '@libs/ee/configs/environment';
             inject: [LicenseService, SelfHostedLicenseService],
         },
         AutoAssignLicenseUseCase,
+        EnterpriseTierGuard,
     ],
     exports: [
         LicenseService,
         SelfHostedLicenseService,
         LICENSE_SERVICE_TOKEN,
         AutoAssignLicenseUseCase,
+        EnterpriseTierGuard,
     ],
 })
 export class LicenseModule {}

--- a/libs/ee/license/tier/enterprise-tier-policy.ts
+++ b/libs/ee/license/tier/enterprise-tier-policy.ts
@@ -1,0 +1,40 @@
+import {
+    OrganizationLicenseValidationResult,
+    SubscriptionStatus,
+} from '../interfaces/license.interface';
+
+/**
+ * Enterprise tier policy — single source of truth for "who can access
+ * enterprise-only features" (SSO config, user activity logs). Keep the
+ * frontend copy in `apps/web/src/features/ee/byok/_utils.ts`
+ * (`isEnterprisePlan`) aligned with this when the rule changes.
+ *
+ * Allowed:
+ *   - self-hosted (any) — historically full feature set
+ *   - licensed self-hosted (any)
+ *   - trial (treated as enterprise preview)
+ *   - cloud paid (active) on enterprise plans
+ *
+ * Blocked:
+ *   - canceled / expired / payment_failed
+ *   - cloud paid (active) on non-enterprise plans
+ *   - invalid licenses
+ */
+export function isEnterpriseTierAllowed(
+    license: OrganizationLicenseValidationResult | null | undefined,
+): boolean {
+    if (!license) return false;
+
+    switch (license.subscriptionStatus) {
+        case SubscriptionStatus.SELF_HOSTED:
+        case SubscriptionStatus.LICENSED_SELF_HOSTED:
+        case SubscriptionStatus.TRIAL:
+            return true;
+        case SubscriptionStatus.ACTIVE: {
+            const plan = license.planType ?? '';
+            return plan.startsWith('enterprise');
+        }
+        default:
+            return false;
+    }
+}

--- a/libs/ee/license/tier/enterprise-tier-policy.ts
+++ b/libs/ee/license/tier/enterprise-tier-policy.ts
@@ -10,30 +10,32 @@ import {
  * (`isEnterprisePlan`) aligned with this when the rule changes.
  *
  * Allowed:
- *   - self-hosted (any) — historically full feature set
- *   - licensed self-hosted (any)
+ *   - cloud paid (`active`) on enterprise plans
+ *   - licensed self-hosted with `plan: enterprise*` in the signed JWT
  *   - trial (treated as enterprise preview)
- *   - cloud paid (active) on enterprise plans
  *
  * Blocked:
- *   - canceled / expired / payment_failed
- *   - cloud paid (active) on non-enterprise plans
- *   - invalid licenses
+ *   - invalid / canceled / expired / payment_failed
+ *   - CE self-hosted (no key) — `validateOrganizationLicense` returns
+ *     `{ valid: false }`, caught by the early short-circuit
+ *   - cloud paid on non-enterprise plans
+ *   - licensed self-hosted with a non-enterprise `plan` in the JWT
  */
 export function isEnterpriseTierAllowed(
     license: OrganizationLicenseValidationResult | null | undefined,
 ): boolean {
-    if (!license) return false;
+    if (!license || !license.valid) return false;
+    const plan = license.planType ?? '';
+    const isEnterprise =
+        plan.startsWith('enterprise_') || plan === 'enterprise';
 
     switch (license.subscriptionStatus) {
-        case SubscriptionStatus.SELF_HOSTED:
+        case SubscriptionStatus.ACTIVE:
+            return isEnterprise;
         case SubscriptionStatus.LICENSED_SELF_HOSTED:
+            return isEnterprise;
         case SubscriptionStatus.TRIAL:
             return true;
-        case SubscriptionStatus.ACTIVE: {
-            const plan = license.planType ?? '';
-            return plan.startsWith('enterprise');
-        }
         default:
             return false;
     }

--- a/libs/ee/sso/sso.module.ts
+++ b/libs/ee/sso/sso.module.ts
@@ -1,4 +1,5 @@
 import { EmailModule } from '@libs/common/email/email.module';
+import { LicenseModule } from '@libs/ee/license/license.module';
 import { AuthModule } from '@libs/identity/modules/auth.module';
 import { forwardRef, Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
@@ -22,6 +23,7 @@ import { NotificationModule } from '@libs/notifications/modules/notification.mod
         TypeOrmModule.forFeature([SSOConfigModel, SSOTestSessionModel]),
         AuthModule,
         EmailModule,
+        LicenseModule,
         forwardRef(() => NotificationModule),
     ],
     providers: [


### PR DESCRIPTION
Closes #1102

---

<!-- kody-pr-summary:start -->
This pull request introduces comprehensive access control for enterprise-only features, specifically SSO configuration and user activity logs, by implementing guards at both the API and UI levels.

Key changes include:

*   **API Protection**: A new `EnterpriseTierGuard` has been implemented and applied to the `CodeReviewSettingLogController` and `SSOConfigController`. This guard ensures that API endpoints for code review setting logs and SSO configuration are only accessible to organizations on an allowed enterprise plan (including trials and self-hosted instances).
*   **UI Protection**: Server-side guards have been added to the web application's SSO configuration page (`/features/ee/sso/page.tsx`) and User Logs page (`/features/ee/user-logs/page.tsx`). These guards validate the organization's license and redirect users if their organization is not on an enterprise plan or a trial, preventing direct URL access to these restricted pages.
*   **Centralized Policy**: A new `isEnterpriseTierAllowed` function defines the precise business logic for determining which license types and subscription statuses qualify for enterprise feature access, ensuring consistent enforcement across the application.
<!-- kody-pr-summary:end -->