### PR TITLE
fix(notifications): make ResendEmailProvider lazy so app boots without RESEND_API_KEY

### DIFF
--- a/libs/notifications/infrastructure/adapters/email-providers/resend-email.provider.spec.ts
+++ b/libs/notifications/infrastructure/adapters/email-providers/resend-email.provider.spec.ts
@@ -1,0 +1,54 @@
+import { ConfigService } from '@nestjs/config';
+import { Test } from '@nestjs/testing';
+
+import { ResendEmailProvider } from './resend-email.provider';
+
+describe('ResendEmailProvider', () => {
+    const buildProvider = async (configValues: Record<string, string | undefined>) => {
+        const moduleRef = await Test.createTestingModule({
+            providers: [
+                ResendEmailProvider,
+                {
+                    provide: ConfigService,
+                    useValue: {
+                        get: jest.fn(
+                            <T = string>(key: string): T | undefined =>
+                                configValues[key] as T | undefined,
+                        ),
+                        getOrThrow: jest.fn(<T = string>(key: string): T => {
+                            const v = configValues[key];
+                            if (v === undefined) {
+                                throw new Error(`Configuration key "${key}" does not exist`);
+                            }
+                            return v as T;
+                        }),
+                    },
+                },
+            ],
+        }).compile();
+
+        return moduleRef.get(ResendEmailProvider);
+    };
+
+    it('constructs without RESEND_API_KEY (app boots even on self-hosted without notifications configured)', async () => {
+        const provider = await buildProvider({});
+        expect(provider).toBeInstanceOf(ResendEmailProvider);
+    });
+
+    it('constructs with RESEND_API_KEY set', async () => {
+        const provider = await buildProvider({ RESEND_API_KEY: 're_test_key' });
+        expect(provider).toBeInstanceOf(ResendEmailProvider);
+    });
+
+    it('throws a clear error when send() is called without RESEND_API_KEY', async () => {
+        const provider = await buildProvider({});
+        await expect(
+            provider.send({
+                from: 'noreply@kodus.io',
+                to: 'user@example.com',
+                subject: 'Test',
+                html: '<p>Hi</p>',
+            }),
+        ).rejects.toThrow(/RESEND_API_KEY is not configured/);
+    });
+});

--- a/libs/notifications/infrastructure/adapters/email-providers/resend-email.provider.ts
+++ b/libs/notifications/infrastructure/adapters/email-providers/resend-email.provider.ts
@@ -1,26 +1,53 @@
+import { createLogger } from '@kodus/flow';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Resend } from 'resend';
 
-import { IEmailProvider } from './email-provider.contract';
+import { IEmailProvider, SendEmailPayload } from './email-provider.contract';
 
+/**
+ * Resend transport. Designed to be safe to instantiate without
+ * RESEND_API_KEY set so the app boots on self-hosted installs where
+ * notifications aren't configured. The first call to send() will
+ * throw with a clear error if the key is still missing.
+ *
+ * Cloud always has RESEND_API_KEY in production; self-hosted may or
+ * may not — both cases must boot.
+ */
 @Injectable()
 export class ResendEmailProvider implements IEmailProvider {
-    private readonly client: Resend;
+    private readonly logger = createLogger(ResendEmailProvider.name);
+    private client: Resend | null = null;
 
     constructor(private readonly configService: ConfigService) {
-        const apiKey = this.configService.getOrThrow<string>('RESEND_API_KEY');
-        this.client = new Resend(apiKey);
+        // Defer Resend instantiation to first send() — see class doc.
+        const apiKey = this.configService.get<string>('RESEND_API_KEY');
+        if (!apiKey) {
+            this.logger.warn({
+                message:
+                    'RESEND_API_KEY is not set — email sending is disabled. ' +
+                    'Set RESEND_API_KEY in your environment to enable.',
+                context: ResendEmailProvider.name,
+            });
+        }
     }
 
-    async send(input: {
-        from: string;
-        to: string;
-        subject: string;
-        html: string;
-        replyTo?: string;
-    }): Promise<{ id: string }> {
-        const result = await this.client.emails.send({
+    private getClient(): Resend {
+        if (!this.client) {
+            const apiKey = this.configService.get<string>('RESEND_API_KEY');
+            if (!apiKey) {
+                throw new Error(
+                    'Cannot send email: RESEND_API_KEY is not configured. ' +
+                        'Set it in your environment to enable notifications.',
+                );
+            }
+            this.client = new Resend(apiKey);
+        }
+        return this.client;
+    }
+
+    async send(input: SendEmailPayload): Promise<{ id: string }> {
+        const result = await this.getClient().emails.send({
             from: input.from,
             to: input.to,
             subject: input.subject,


### PR DESCRIPTION
## Summary

The `ResendEmailProvider` constructor called `configService.getOrThrow('RESEND_API_KEY')`, which brought down the entire Nest bootstrap for any self-hosted install that didn't configure Resend. Boot path crash:

\`\`\`
TypeError: Configuration key "RESEND_API_KEY" does not exist
    at ConfigService.getOrThrow
    at new ResendEmailProvider
\`\`\`

…before api/worker/webhooks could start. webhooks then cascaded with `NOT_FOUND - no queue 'workflow.jobs.code_review.queue'` because the worker never came up to declare the queues.

This PR makes the provider lazy, matching the pattern already used by `libs/common/email/services/resend.client.ts` and `SmtpEmailProvider`: the constructor only logs a warn when the key is missing; the Resend client is instantiated on first `send()` call. Customers without `RESEND_API_KEY` set get a clear runtime error when send is attempted, instead of an app-wide boot crash.

## Risk

Low. See full risk matrix in the commit body. TL;DR:

- Cloud (`RESEND_API_KEY` always set): **zero change**
- Self-hosted with Resend key: zero change
- Self-hosted with SMTP configured: not affected (uses `SmtpEmailProvider`)
- Self-hosted with no email config: **boots now** instead of crashing (the bug)

`EmailChannelAdapter.deliver()` is already wrapped in try/catch by `NotificationDispatcher`, so a runtime send failure marks the delivery as `FAILED` and continues — never crashes the worker.

## Tests

Adds `resend-email.provider.spec.ts` covering 3 scenarios:

1. Constructs without `RESEND_API_KEY` (the self-hosted-without-config case)
2. Constructs with the key set (existing happy path)
3. `send()` throws a clear error when called without the key

## Out of scope (follow-ups)

- Health check endpoint reporting "email: disabled" when key is missing
- Self-hosted notifications setup docs (already mentioned in `docs/_snippets/env-vars-generated.mdx` as reference, no narrative guide yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- kody-pr-summary:start -->
This pull request implements lazy initialization for the `ResendEmailProvider`.

Previously, the application would fail to boot if the `RESEND_API_KEY` environment variable was not set, as the `Resend` client was instantiated immediately in the provider's constructor.

With this change:
*   The `Resend` client is now instantiated only when the `send()` method is called for the first time.
*   The application can successfully boot even if `RESEND_API_KEY` is not configured. A warning will be logged at startup in this scenario.
*   If an attempt is made to send an email without `RESEND_API_KEY` being set, a clear error will be thrown at the point of the `send()` call, guiding the user to configure the key.

This ensures that self-hosted instances of the application can start without requiring email notification configuration, while still providing clear feedback if email sending is attempted without the necessary API key. New tests have been added to cover these scenarios.
<!-- kody-pr-summary:end -->