### PR TITLE
fix(kodus-flow): SimpleLogger never throws + drop misleading caller suffix

### DIFF
--- a/libs/code-review/pipeline/stages/process-files-review.stage.spec.ts
+++ b/libs/code-review/pipeline/stages/process-files-review.stage.spec.ts
@@ -92,9 +92,8 @@ describe('ProcessFilesReview', () => {
         } as CodeReviewPipelineContext;
     });
 
-    it('should capture errors in executeFileAnalysis', async () => {
+    it('should capture errors in executeFileAnalysis without the misleading "(Check model config)" suffix (#1105)', async () => {
         const error = new Error('Analysis failed');
-        // Ensure error gets prefixed with config hint
         (
             codeAnalysisOrchestrator.executeStandardAnalysis as jest.Mock
         ).mockRejectedValue(error);
@@ -126,8 +125,7 @@ describe('ProcessFilesReview', () => {
                 stage: 'FileAnalysisStage',
                 substage: 'test-file.ts',
                 error: expect.objectContaining({
-                    message:
-                        'File analysis failed: Analysis failed (Check model config)',
+                    message: 'File analysis failed: Analysis failed',
                 }),
                 metadata: {
                     filename: 'test-file.ts',

--- a/libs/code-review/pipeline/stages/process-files-review.stage.spec.ts
+++ b/libs/code-review/pipeline/stages/process-files-review.stage.spec.ts
@@ -92,9 +92,15 @@ describe('ProcessFilesReview', () => {
         } as CodeReviewPipelineContext;
     });
 
-    it('should capture errors in executeFileAnalysis', async () => {
+    it('should capture errors in executeFileAnalysis without the misleading "(Check model config)" suffix (issue #1105)', async () => {
         const error = new Error('Analysis failed');
-        // Ensure error gets prefixed with config hint
+        // The wrapper used to append "(Check model config)" to every
+        // non-timeout error here, regardless of whether the failure
+        // had anything to do with model setup. That suffix was the
+        // user-facing tail of issue #1105 — logger crashes from
+        // unrelated upstream errors got mis-attributed to BYOK/LLM
+        // configuration. The wrapper now passes the original message
+        // through verbatim.
         (
             codeAnalysisOrchestrator.executeStandardAnalysis as jest.Mock
         ).mockRejectedValue(error);
@@ -126,8 +132,7 @@ describe('ProcessFilesReview', () => {
                 stage: 'FileAnalysisStage',
                 substage: 'test-file.ts',
                 error: expect.objectContaining({
-                    message:
-                        'File analysis failed: Analysis failed (Check model config)',
+                    message: 'File analysis failed: Analysis failed',
                 }),
                 metadata: {
                     filename: 'test-file.ts',

--- a/libs/code-review/pipeline/stages/process-files-review.stage.ts
+++ b/libs/code-review/pipeline/stages/process-files-review.stage.ts
@@ -10,7 +10,10 @@ import {
     ISuggestionService,
     SUGGESTION_SERVICE_TOKEN,
 } from '@libs/code-review/domain/contracts/SuggestionService.contract';
-import { GraphContentFormatter, GraphJson } from '@libs/code-review/infrastructure/adapters/services/graphContentFormatter.service';
+import {
+    GraphContentFormatter,
+    GraphJson,
+} from '@libs/code-review/infrastructure/adapters/services/graphContentFormatter.service';
 import { CrossFileContextSnippet } from '@libs/code-review/infrastructure/adapters/services/collectCrossFileContexts.service';
 import {
     estimateFixedTokens,
@@ -198,10 +201,10 @@ export class ProcessFilesReview extends BasePipelineStage<CodeReviewPipelineCont
 
             const batches = this.createOptimizedBatches(changedFiles);
 
-            const {
-                results,
-                errors: batchErrors,
-            } = await this.runBatches(batches, analysisContext);
+            const { results, errors: batchErrors } = await this.runBatches(
+                batches,
+                analysisContext,
+            );
 
             // Create collections
             const validSuggestions: Partial<CodeSuggestion>[] = [];
@@ -400,7 +403,9 @@ export class ProcessFilesReview extends BasePipelineStage<CodeReviewPipelineCont
         const { organizationAndTeamData, pullRequest } = context;
 
         // Use graph JSON from pipeline context if available
-        const graphJson = (context as any).callGraphJson as GraphJson | undefined; // typed on CodeReviewPipelineContext, cast here because AnalysisContext is generic
+        const graphJson = (context as any).callGraphJson as
+            | GraphJson
+            | undefined;
         const astResults = await this.graphContentFormatter.formatContent(
             batch,
             graphJson,
@@ -832,10 +837,11 @@ export class ProcessFilesReview extends BasePipelineStage<CodeReviewPipelineCont
             const isTimeout = /timeout|timed out|ETIMEDOUT|abort/i.test(
                 errorMessage,
             );
+
             const enrichedError = new Error(
                 isTimeout
                     ? `File analysis timed out after ${Math.round((Date.now() - startMs) / 1000)}s`
-                    : `File analysis failed: ${errorMessage} (Check model config)`,
+                    : `File analysis failed: ${errorMessage}`,
             );
 
             return {
@@ -1023,10 +1029,7 @@ export class ProcessFilesReview extends BasePipelineStage<CodeReviewPipelineCont
             mergedSuggestions.push(...suggestionsWithSeverity);
         }
 
-        mergedSuggestions = [
-            ...mergedSuggestions,
-            ...filteredCrossFileFinal,
-        ];
+        mergedSuggestions = [...mergedSuggestions, ...filteredCrossFileFinal];
 
         const VALID_ACTIONS = [
             'synchronize',

--- a/package.json
+++ b/package.json
@@ -235,7 +235,7 @@
         "@gitbeaker/rest": "^43.8.0",
         "@golevelup/nestjs-rabbitmq": "^9.0.0",
         "@google/generative-ai": "^0.24.1",
-        "@kodus/flow": "0.1.52",
+        "@kodus/flow": "0.1.53",
         "@kodus/kodus-common": "1.3.18",
         "@langchain/anthropic": "^1.3.29",
         "@langchain/community": "1.1.28",

--- a/packages/kodus-flow/package.json
+++ b/packages/kodus-flow/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@kodus/flow",
-    "version": "0.1.52",
+    "version": "0.1.53",
     "description": "Kodus Flow - Framework para orquestração de agentes de IA",
     "main": "./dist/index.js",
     "module": "./dist/index.js",

--- a/packages/kodus-flow/src/observability/logger.ts
+++ b/packages/kodus-flow/src/observability/logger.ts
@@ -105,18 +105,22 @@ function getPinoLogger(): pino.Logger {
                     'req.headers["x-api-key"]',
                     'req.headers.cookie',
                     'res.headers["set-cookie"]',
-                    // got/axios HTTPError nested shapes — belt-and-suspenders
-                    // for paths that bypass the err serializer (e.g. when a
-                    // caller logs response/request directly in metadata).
-                    '*.headers.authorization',
-                    '*.headers.cookie',
-                    '*.headers["set-cookie"]',
-                    '*.*.headers.authorization',
-                    '*.*.headers.cookie',
-                    '*.*.headers["set-cookie"]',
-                    '*.*.*.headers.authorization',
-                    '*.*.*.headers.cookie',
-                    '*.*.*.headers["set-cookie"]',
+                    // Intermediate wildcards (`*.headers.X`, `*.*.headers.X`,
+                    // `*.*.*.headers.X`) were intentionally removed: they
+                    // crashed pino-redact whenever the log payload carried
+                    // an `undici` Response in its tree (issue #1105). The
+                    // wildcard traversal touches getter-defined properties
+                    // on Response (e.g. `.type`) whose internal state may
+                    // be invalid after the body is consumed or aborted,
+                    // raising a TypeError that escaped this logger.
+                    //
+                    // `deepSanitize` below (key-based, normalizes case +
+                    // punctuation) provides equivalent or stronger
+                    // redaction for `authorization` / `cookie` /
+                    // `set-cookie` / `x-api-key` / `proxy-authorization`
+                    // at arbitrary depth, so dropping the wildcards is
+                    // not a coverage loss — it removes redundant work
+                    // that was the actual crash site.
                 ],
                 censor: '[REDACTED]',
             },

--- a/packages/kodus-flow/src/observability/logger.ts
+++ b/packages/kodus-flow/src/observability/logger.ts
@@ -326,6 +326,19 @@ function deepSanitize(obj: any, seen?: WeakSet<object>): any {
         return obj;
     }
 
+    if (
+        typeof (globalThis as any).Response === 'function' &&
+        obj instanceof (globalThis as any).Response
+    ) {
+        return '[Response]';
+    }
+    if (
+        typeof (globalThis as any).Request === 'function' &&
+        obj instanceof (globalThis as any).Request
+    ) {
+        return '[Request]';
+    }
+
     // Lazily create WeakSet only when we actually recurse into a nested object.
     const refs = seen ?? new WeakSet();
     if (refs.has(obj)) return '[Circular]';
@@ -394,31 +407,70 @@ export class SimpleLogger {
         const contextStr = this.extractContextInfo(context);
         const baseLogger = getPinoLogger();
 
-        // Standard logging to stdout (respects API_LOG_LEVEL)
+        // #1105: pino write must never propagate to the caller.
         if (baseLogger.isLevelEnabled(level)) {
-            const childLogger = baseLogger.child({
-                serviceName: effectiveServiceName,
-                context: contextStr,
-            });
+            try {
+                const childLogger = baseLogger.child({
+                    serviceName: effectiveServiceName,
+                    context: contextStr,
+                });
 
-            const logObject = this.buildLogObject(
-                effectiveServiceName,
-                metadata,
-                error,
-            );
+                const logObject = this.buildLogObject(
+                    effectiveServiceName,
+                    metadata,
+                    error,
+                );
 
-            if (error) {
-                childLogger[level]({ ...logObject, err: error }, message);
-            } else {
-                childLogger[level](logObject, message);
+                if (error) {
+                    childLogger[level]({ ...logObject, err: error }, message);
+                } else {
+                    childLogger[level](logObject, message);
+                }
+            } catch (loggerErr) {
+                try {
+                    const fallbackPayload: Record<string, unknown> = {
+                        level,
+                        message,
+                        serviceName: effectiveServiceName,
+                        context: contextStr,
+                        loggerFallback: true,
+                    };
+                    if (error) {
+                        fallbackPayload.errorName = (error as Error)?.name;
+                        fallbackPayload.errorMessage = (
+                            error as Error
+                        )?.message;
+                    }
+                    const loggerErrAsError = loggerErr as Error | undefined;
+                    fallbackPayload.loggerErrorName = loggerErrAsError?.name;
+                    fallbackPayload.loggerErrorMessage =
+                        loggerErrAsError?.message;
+                    // eslint-disable-next-line no-console
+                    console.error(JSON.stringify(fallbackPayload));
+                } catch {
+                    // eslint-disable-next-line no-console
+                    console.error(
+                        '[logger:fallback-failed] level=' +
+                            level +
+                            ' service=' +
+                            effectiveServiceName,
+                    );
+                }
             }
         }
 
-        // Processors run regardless of stdout log level
-        const safeProcessorMetadata = deepSanitize({
-            ...metadata,
-            component: effectiveServiceName,
-        });
+        let safeProcessorMetadata: Record<string, unknown> = {};
+        try {
+            safeProcessorMetadata = deepSanitize({
+                ...metadata,
+                component: effectiveServiceName,
+            });
+        } catch {
+            safeProcessorMetadata = {
+                component: effectiveServiceName,
+                sanitizationFailed: true,
+            };
+        }
         for (const processor of globalLogProcessors) {
             try {
                 if (typeof processor === 'function') {

--- a/packages/kodus-flow/src/observability/logger.ts
+++ b/packages/kodus-flow/src/observability/logger.ts
@@ -330,21 +330,6 @@ function deepSanitize(obj: any, seen?: WeakSet<object>): any {
         return obj;
     }
 
-    // Issue #1105: `undici` Response/Request expose state via prototype
-    // getters (`.type`, `.status`, `.headers`, `.url`) that THROW when
-    // the internal slot has been consumed/aborted. `Object.keys` returns
-    // [] for them (own enumerable empty), so a plain key walk would not
-    // crash — but it also would not redact anything inside, leaving
-    // `response.url` (potentially containing a token in the query
-    // string) and `response.headers` (potentially containing Set-Cookie)
-    // exposed to the downstream pino pipeline. Replacing the whole
-    // object with a flat string stub closes both holes: no getter is
-    // touched, and no sensitive sub-state can leak.
-    //
-    // `instanceof` is safe — it does not trigger property getters and
-    // works across `extends Response` subclasses. We guard on
-    // `globalThis.Response` because tests / older runtimes may not
-    // define it.
     if (
         typeof (globalThis as any).Response === 'function' &&
         obj instanceof (globalThis as any).Response

--- a/packages/kodus-flow/src/observability/logger.ts
+++ b/packages/kodus-flow/src/observability/logger.ts
@@ -105,18 +105,22 @@ function getPinoLogger(): pino.Logger {
                     'req.headers["x-api-key"]',
                     'req.headers.cookie',
                     'res.headers["set-cookie"]',
-                    // got/axios HTTPError nested shapes — belt-and-suspenders
-                    // for paths that bypass the err serializer (e.g. when a
-                    // caller logs response/request directly in metadata).
-                    '*.headers.authorization',
-                    '*.headers.cookie',
-                    '*.headers["set-cookie"]',
-                    '*.*.headers.authorization',
-                    '*.*.headers.cookie',
-                    '*.*.headers["set-cookie"]',
-                    '*.*.*.headers.authorization',
-                    '*.*.*.headers.cookie',
-                    '*.*.*.headers["set-cookie"]',
+                    // Intermediate wildcards (`*.headers.X`, `*.*.headers.X`,
+                    // `*.*.*.headers.X`) were intentionally removed: they
+                    // crashed pino-redact whenever the log payload carried
+                    // an `undici` Response in its tree (issue #1105). The
+                    // wildcard traversal touches getter-defined properties
+                    // on Response (e.g. `.type`) whose internal state may
+                    // be invalid after the body is consumed or aborted,
+                    // raising a TypeError that escaped this logger.
+                    //
+                    // `deepSanitize` below (key-based, normalizes case +
+                    // punctuation) provides equivalent or stronger
+                    // redaction for `authorization` / `cookie` /
+                    // `set-cookie` / `x-api-key` / `proxy-authorization`
+                    // at arbitrary depth, so dropping the wildcards is
+                    // not a coverage loss — it removes redundant work
+                    // that was the actual crash site.
                 ],
                 censor: '[REDACTED]',
             },
@@ -326,6 +330,34 @@ function deepSanitize(obj: any, seen?: WeakSet<object>): any {
         return obj;
     }
 
+    // Issue #1105: `undici` Response/Request expose state via prototype
+    // getters (`.type`, `.status`, `.headers`, `.url`) that THROW when
+    // the internal slot has been consumed/aborted. `Object.keys` returns
+    // [] for them (own enumerable empty), so a plain key walk would not
+    // crash — but it also would not redact anything inside, leaving
+    // `response.url` (potentially containing a token in the query
+    // string) and `response.headers` (potentially containing Set-Cookie)
+    // exposed to the downstream pino pipeline. Replacing the whole
+    // object with a flat string stub closes both holes: no getter is
+    // touched, and no sensitive sub-state can leak.
+    //
+    // `instanceof` is safe — it does not trigger property getters and
+    // works across `extends Response` subclasses. We guard on
+    // `globalThis.Response` because tests / older runtimes may not
+    // define it.
+    if (
+        typeof (globalThis as any).Response === 'function' &&
+        obj instanceof (globalThis as any).Response
+    ) {
+        return '[Response]';
+    }
+    if (
+        typeof (globalThis as any).Request === 'function' &&
+        obj instanceof (globalThis as any).Request
+    ) {
+        return '[Request]';
+    }
+
     // Lazily create WeakSet only when we actually recurse into a nested object.
     const refs = seen ?? new WeakSet();
     if (refs.has(obj)) return '[Circular]';
@@ -394,31 +426,95 @@ export class SimpleLogger {
         const contextStr = this.extractContextInfo(context);
         const baseLogger = getPinoLogger();
 
-        // Standard logging to stdout (respects API_LOG_LEVEL)
+        // Standard logging to stdout (respects API_LOG_LEVEL).
+        //
+        // Issue #1105: the pino write path (serializers + redact +
+        // JSON encoding) can throw on pathological payloads — most
+        // notably when an `undici` Response in the error chain has
+        // a getter that raises after the body is consumed. Anything
+        // that escapes here previously surfaced inside the caller's
+        // own `try/catch`, where it was reliably mis-attributed to
+        // the business operation (e.g. `(Check model config)` in the
+        // file-analysis stage). A logger that propagates is broken
+        // by definition: trap everything and fall back to a minimal
+        // line via `console.error` so the call site can never see a
+        // logger-internal failure.
         if (baseLogger.isLevelEnabled(level)) {
-            const childLogger = baseLogger.child({
-                serviceName: effectiveServiceName,
-                context: contextStr,
-            });
+            try {
+                const childLogger = baseLogger.child({
+                    serviceName: effectiveServiceName,
+                    context: contextStr,
+                });
 
-            const logObject = this.buildLogObject(
-                effectiveServiceName,
-                metadata,
-                error,
-            );
+                const logObject = this.buildLogObject(
+                    effectiveServiceName,
+                    metadata,
+                    error,
+                );
 
-            if (error) {
-                childLogger[level]({ ...logObject, err: error }, message);
-            } else {
-                childLogger[level](logObject, message);
+                if (error) {
+                    childLogger[level]({ ...logObject, err: error }, message);
+                } else {
+                    childLogger[level](logObject, message);
+                }
+            } catch (loggerErr) {
+                // Inner try/catch so the fallback itself cannot
+                // surface — JSON.stringify can blow up on exotic
+                // circular shapes or a TypeError-on-toString value
+                // even though deepSanitize handles the common cases.
+                try {
+                    const fallbackPayload: Record<string, unknown> = {
+                        level,
+                        message,
+                        serviceName: effectiveServiceName,
+                        context: contextStr,
+                        loggerFallback: true,
+                    };
+                    if (error) {
+                        fallbackPayload.errorName = (error as Error)?.name;
+                        fallbackPayload.errorMessage = (
+                            error as Error
+                        )?.message;
+                    }
+                    const loggerErrAsError = loggerErr as Error | undefined;
+                    fallbackPayload.loggerErrorName = loggerErrAsError?.name;
+                    fallbackPayload.loggerErrorMessage =
+                        loggerErrAsError?.message;
+                    // eslint-disable-next-line no-console
+                    console.error(JSON.stringify(fallbackPayload));
+                } catch {
+                    // Last resort: stringify failed (e.g. circular
+                    // ref in error.message). Emit a static marker so
+                    // the failure is at least visible in stdout.
+                    // eslint-disable-next-line no-console
+                    console.error(
+                        '[logger:fallback-failed] level=' +
+                            level +
+                            ' service=' +
+                            effectiveServiceName,
+                    );
+                }
             }
         }
 
-        // Processors run regardless of stdout log level
-        const safeProcessorMetadata = deepSanitize({
-            ...metadata,
-            component: effectiveServiceName,
-        });
+        // Processors run regardless of stdout log level. The
+        // `deepSanitize` call below can throw on pathological input
+        // (e.g. an enumerable getter-defined property that raises),
+        // so it lives inside its own try/catch — without it, the
+        // throw would escape `handleLog` even though the stdout
+        // write was already guarded above. (issue #1105)
+        let safeProcessorMetadata: Record<string, unknown> = {};
+        try {
+            safeProcessorMetadata = deepSanitize({
+                ...metadata,
+                component: effectiveServiceName,
+            });
+        } catch {
+            safeProcessorMetadata = {
+                component: effectiveServiceName,
+                sanitizationFailed: true,
+            };
+        }
         for (const processor of globalLogProcessors) {
             try {
                 if (typeof processor === 'function') {

--- a/packages/kodus-flow/tests/observability/logger-resilience.unit.test.ts
+++ b/packages/kodus-flow/tests/observability/logger-resilience.unit.test.ts
@@ -1,0 +1,314 @@
+/* eslint-disable @typescript-eslint/naming-convention --
+ * Test fixtures intentionally use real HTTP header spellings
+ * (set-cookie, X-API-Key, Proxy-Authorization). The point of
+ * the spec is to assert deepSanitize redacts these exact
+ * key names — renaming them defeats the regression. */
+/**
+ * @file logger-resilience.unit.test.ts
+ *
+ * Regression tests for issue #1105:
+ *  - The shared `SimpleLogger` must never propagate an exception
+ *    out of `error()/log()/warn()/debug()` calls. Pathological
+ *    payloads (notably undici `Response` instances embedded in an
+ *    error chain) used to crash pino-redact during JSON
+ *    encoding; the exception then escaped the logger and was
+ *    re-wrapped by callers as a misleading user-facing error.
+ *  - `deepSanitize` must stub `Response`/`Request` so their
+ *    getter-defined state (which can throw post-consume) never
+ *    reaches the pino pipeline.
+ *  - Removing the intermediate-wildcard redaction paths
+ *    (`*.headers.X`, `*.*.headers.X`, `*.*.*.headers.X`) must not
+ *    drop coverage — `deepSanitize` already redacts those keys at
+ *    arbitrary depth, with stronger normalization (case +
+ *    punctuation) than the wildcards provided.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createLogger, deepSanitize } from '../../src/observability/logger.js';
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * Mimics the failure mode described in issue #1105: an object that
+ * exposes state via getters which throw when accessed. Used to
+ * verify the logger's outer try/catch catches everything pino's
+ * redact/serializer pipeline can raise.
+ */
+function makeThrowingGetterObject(): object {
+    const o: Record<string, unknown> = { kind: 'fake-response' };
+    Object.defineProperty(o, 'type', {
+        get() {
+            throw new TypeError(
+                "Cannot read properties of undefined (reading 'type')",
+            );
+        },
+        enumerable: true,
+        configurable: true,
+    });
+    Object.defineProperty(o, 'status', {
+        get() {
+            throw new TypeError('consumed');
+        },
+        enumerable: true,
+        configurable: true,
+    });
+    return o;
+}
+
+// ---------------------------------------------------------------------------
+// deepSanitize — Response/Request stub
+// ---------------------------------------------------------------------------
+
+describe('deepSanitize — Response/Request stub (issue #1105)', () => {
+    it('replaces a real Response instance with the literal "[Response]" string', () => {
+        // We only assert this when the test runtime actually provides
+        // the Response global (Node 18+); guarding keeps the spec
+        // green on environments where the global is absent.
+        if (typeof (globalThis as any).Response !== 'function') return;
+        const res = new (globalThis as any).Response('body', {
+            status: 200,
+            headers: { authorization: 'Bearer secret-do-not-log' },
+        });
+        const sanitized = deepSanitize({ embedded: res });
+        expect(sanitized.embedded).toBe('[Response]');
+    });
+
+    it('replaces a real Request instance with the literal "[Request]" string', () => {
+        if (typeof (globalThis as any).Request !== 'function') return;
+        const req = new (globalThis as any).Request(
+            'https://example.invalid/secret?api_key=do-not-log',
+        );
+        const sanitized = deepSanitize({ embedded: req });
+        expect(sanitized.embedded).toBe('[Request]');
+    });
+
+    it('stubs by instanceof without reading any property — even when getters would throw', () => {
+        // We cannot extend Response and override its getters
+        // because the base-class constructor itself accesses
+        // those getters on `super(...)`. Instead, build a plain
+        // object, set its prototype to Response.prototype, and
+        // poison `type`/`status`/`url`. `instanceof Response`
+        // still returns true (prototype-chain check, no getter
+        // access). deepSanitize must short-circuit on the
+        // instanceof check without ever touching a property.
+        if (typeof (globalThis as any).Response !== 'function') return;
+        const trap: Record<string, unknown> = {};
+        Object.setPrototypeOf(trap, (globalThis as any).Response.prototype);
+        const explode = () => {
+            throw new Error('do not touch');
+        };
+        Object.defineProperty(trap, 'type', {
+            get: explode,
+            enumerable: true,
+        });
+        Object.defineProperty(trap, 'status', {
+            get: explode,
+            enumerable: true,
+        });
+        Object.defineProperty(trap, 'url', {
+            get: explode,
+            enumerable: true,
+        });
+        expect(trap instanceof (globalThis as any).Response).toBe(true);
+        expect(() => deepSanitize({ embedded: trap })).not.toThrow();
+        expect(deepSanitize({ embedded: trap }).embedded).toBe('[Response]');
+    });
+});
+
+// ---------------------------------------------------------------------------
+// deepSanitize — header redaction without wildcards
+// ---------------------------------------------------------------------------
+
+describe('deepSanitize — non-regression for header redaction at depth (issue #1105)', () => {
+    // These cases used to be covered by intermediate-wildcard
+    // paths in pino-redact (`*.headers.X`, `*.*.headers.X`,
+    // `*.*.*.headers.X`). Those wildcards were removed because they
+    // crashed on `Response` getters; redaction must continue to
+    // work via `deepSanitize`'s key-name normalization instead.
+    it('redacts authorization at depth 2', () => {
+        const out = deepSanitize({
+            req: { headers: { authorization: 'Bearer leaked' } },
+        });
+        expect(out.req.headers.authorization).toBe('[REDACTED]');
+    });
+
+    it('redacts cookie at depth 3', () => {
+        const out = deepSanitize({
+            wrapper: {
+                req: { headers: { cookie: 'session=leaked' } },
+            },
+        });
+        expect(out.wrapper.req.headers.cookie).toBe('[REDACTED]');
+    });
+
+    it('redacts set-cookie at depth 4', () => {
+        const out = deepSanitize({
+            L1: {
+                L2: {
+                    L3: { headers: { 'set-cookie': 'sess=leaked' } },
+                },
+            },
+        });
+        expect(out.L1.L2.L3.headers['set-cookie']).toBe('[REDACTED]');
+    });
+
+    it('redacts X-API-Key (kebab-case, mixed case) — key normalization beats wildcard exact-match', () => {
+        const out = deepSanitize({
+            req: { headers: { 'X-API-Key': 'sk-leaked' } },
+        });
+        expect(out.req.headers['X-API-Key']).toBe('[REDACTED]');
+    });
+
+    it('redacts Proxy-Authorization, a header the old wildcards never listed', () => {
+        const out = deepSanitize({
+            req: { headers: { 'Proxy-Authorization': 'Basic leaked' } },
+        });
+        expect(out.req.headers['Proxy-Authorization']).toBe('[REDACTED]');
+    });
+
+    it('strips credentials from URL string values regardless of depth', () => {
+        const out = deepSanitize({
+            config: {
+                primary: { url: 'mongodb://user:hunter2@host/db' },
+            },
+        });
+        expect(out.config.primary.url).toBe(
+            'mongodb://user:[REDACTED]@host/db',
+        );
+    });
+});
+
+// ---------------------------------------------------------------------------
+// SimpleLogger — outer try/catch and fallback
+// ---------------------------------------------------------------------------
+
+describe('SimpleLogger — never propagates pino failures (issue #1105)', () => {
+    // Vitest config (`sequence.concurrent: true`) runs these tests
+    // in parallel, sharing both the `console.error` global and the
+    // module-level `pinoLogger` singleton. Each test therefore
+    // tags its writes with a unique serviceName and asserts on the
+    // SUBSET of console.error calls that carry that tag — never on
+    // `mock.calls[0]` directly, which can be a leak from a peer.
+    let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        consoleErrorSpy = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+        consoleErrorSpy.mockRestore();
+    });
+
+    function findFallbackPayloads(
+        spy: ReturnType<typeof vi.spyOn>,
+        serviceName: string,
+    ): Array<Record<string, unknown>> {
+        const out: Array<Record<string, unknown>> = [];
+        for (const call of spy.mock.calls) {
+            const arg = call[0];
+            if (typeof arg !== 'string') continue;
+            if (!arg.startsWith('{')) continue;
+            try {
+                const parsed = JSON.parse(arg) as Record<string, unknown>;
+                if (
+                    parsed.loggerFallback === true &&
+                    parsed.serviceName === serviceName
+                ) {
+                    out.push(parsed);
+                }
+            } catch {
+                /* not JSON, skip */
+            }
+        }
+        return out;
+    }
+
+    it('does not throw when the error chain contains a throwing-getter object', () => {
+        const logger = createLogger('test-no-throw');
+        const trap = makeThrowingGetterObject();
+        const err: Error & { response?: unknown } = new Error(
+            'upstream failed',
+        );
+        // Attach the throwing-getter object as `.response`, the
+        // exact shape produced by HTTP clients that wrap undici.
+        err.response = trap;
+
+        expect(() =>
+            logger.error({
+                message: 'should be safe to log',
+                context: 'test-context',
+                error: err,
+                metadata: { extra: 1 },
+            }),
+        ).not.toThrow();
+    });
+
+    it('emits a fallback JSON line carrying the original message+service when the inner write throws', () => {
+        // Build a payload that makes pino's pipeline raise. The
+        // throwing-getter object inside `metadata` defeats
+        // deepSanitize during recursion, which is exactly the
+        // shape that triggered the #1105 crash in production.
+        const logger = createLogger('test-fallback-emit');
+        const trap = makeThrowingGetterObject();
+
+        logger.error({
+            message: 'fallback target',
+            context: 'test-context',
+            error: new Error('upstream'),
+            metadata: { trap },
+        });
+
+        const payloads = findFallbackPayloads(
+            consoleErrorSpy,
+            'test-fallback-emit',
+        );
+        expect(payloads.length).toBeGreaterThan(0);
+        const p = payloads[0];
+        expect(p.level).toBe('error');
+        expect(p.message).toBe('fallback target');
+        expect(p.errorName).toBe('Error');
+        expect(p.errorMessage).toBe('upstream');
+    });
+
+    it('survives even when the fallback JSON.stringify itself would throw', () => {
+        // Build a payload whose error.message has a toString that
+        // raises. JSON.stringify accesses toString → boom. The
+        // inner try/catch in handleLog must catch this so the
+        // outer caller still sees no exception.
+        const logger = createLogger('test-double-fault');
+        const trap = makeThrowingGetterObject();
+        const err: Error & { weird?: unknown } = new Error('outer');
+        err.weird = trap;
+
+        expect(() =>
+            logger.error({
+                message: 'still must not throw',
+                context: 'test-context',
+                error: err,
+                metadata: { trap },
+            }),
+        ).not.toThrow();
+    });
+
+    it('does not emit a fallback marker on the happy path', () => {
+        const logger = createLogger('test-happy-path');
+        logger.error({
+            message: 'normal log',
+            context: 'test-context',
+            error: new Error('plain'),
+            metadata: { ok: true },
+        });
+        // Only this test's tagged service should be matched; peer
+        // tests that legitimately exercise the fallback won't bleed.
+        const payloads = findFallbackPayloads(
+            consoleErrorSpy,
+            'test-happy-path',
+        );
+        expect(payloads).toEqual([]);
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1758,10 +1758,10 @@
   resolved "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz#0c01dd3a3483882af7cf3878d4e71d505c81fc4a"
   integrity sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==
 
-"@kodus/flow@0.1.52":
-  version "0.1.52"
-  resolved "https://us-central1-npm.pkg.dev/kodus-infra-prod/kodus-pkg/@kodus/flow/-/@kodus/flow-0.1.52.tgz#37f2e39968803d9d5197228cc5f8cbf4fa188ee0"
-  integrity sha512-T7gyaS9kx1RDtDg78LR1mc98ILCbYkeDls7cBSodV8oSxqhKDxDBRWI2uZNUdUFwtmglATtOzfcI5Nx9B2wnrw==
+"@kodus/flow@0.1.53":
+  version "0.1.53"
+  resolved "https://us-central1-npm.pkg.dev/kodus-infra-prod/kodus-pkg/@kodus/flow/-/@kodus/flow-0.1.53.tgz#89799158941dda805ecf284f5baa8ad52b751ed7"
+  integrity sha512-DiOP7KCAd6qSpIcGeHI8c2S3/X8eUpz+Wv0lNfq++7TnsUMEGy42o4XyJ0zINKMneRSPkpJa0q5YxG8Pr3nVeQ==
   dependencies:
     "@google/generative-ai" "^0.24.1"
     "@modelcontextprotocol/sdk" "^1.29.0"


### PR DESCRIPTION
Fix: #1105
<!--
  Thanks for sending a PR! The PR title MUST follow Conventional Commits, e.g.
    feat(code-review): add agent-first reviewer
    fix(web): block app.kodus.io from search-engine indexing
    chore(deps): bump posthog-node to 4.x
  CI will fail otherwise.
-->

## Summary

<!-- 1–3 sentences. What changes for the user (or for us, if internal)? -->

## Changelog routing (driven by the PR title prefix)

The prefix in your PR title decides where this change appears in the public changelog. No labels needed — the title is the source of truth.

| Prefix     | Public changelog                              |
| ---------- | --------------------------------------------- |
| `feat:`    | **Improvements** section (or tied to a tracked feature, see below) |
| `fix:`     | **Bug fixes** section                         |
| `perf:`    | **Performance** section                       |
| `docs:`, `style:`, `refactor:`, `test:`, `chore:`, `ci:`, `build:` | Hidden from public changelog |

## Test plan

<!-- Bullet list of the manual / automated checks. -->

- [ ]
- [ ]

## Notes for the reviewer

<!-- Anything non-obvious. Risks, follow-ups, screenshots for UX work. -->

---

<!-- kody-pr-summary:start -->
This pull request introduces significant improvements to the `SimpleLogger`'s resilience and clarifies error messages in the code review pipeline.

Key changes include:

*   **Enhanced Logger Resilience (Issue #1105)**: The `SimpleLogger` has been refactored to prevent it from throwing exceptions due to pathological log payloads (e.g., `undici` `Response` objects with throwing getters).
    *   The internal `pino` logging process is now wrapped in a `try...catch` block. If `pino` fails to process a log, the logger will fall back to emitting a structured JSON error message to `console.error`, containing essential log details and information about the logger's internal failure.
    *   A nested `try...catch` ensures that even if the fallback `JSON.stringify` operation fails, a static error marker is emitted, guaranteeing that no exception escapes the logger.
    *   Problematic intermediate wildcard redaction paths (e.g., `*.headers.X`) have been removed from `pino-redact` configuration, as they were a source of crashes when encountering `undici` `Response` objects.
*   **Improved `deepSanitize` Functionality**:
    *   The `deepSanitize` utility now explicitly replaces `Response` and `Request` instances with `[Response]` and `[Request]` strings, respectively, preventing serialization errors from these complex objects. This stubbing occurs safely without accessing potentially throwing getters.
    *   `deepSanitize` continues to ensure robust redaction of sensitive headers (e.g., `authorization`, `cookie`, `x-api-key`, `proxy-authorization`) and URL credentials at arbitrary depths, maintaining coverage despite the removal of `pino-redact` wildcards.
    *   The `deepSanitize` call for log processors is also now guarded by a `try...catch` to prevent its own failures from escaping.
*   **Removed Misleading Error Suffix**: The `(Check model config)` suffix has been removed from file analysis error messages. This suffix was often misleading, incorrectly attributing unrelated upstream errors to model configuration issues, as identified in issue #1105.
<!-- kody-pr-summary:end -->