### PR TITLE
fix(byok): default temperature=1 for kimi-k2.6 (reasoning model rejects temp≠1)

### DIFF
--- a/apps/web/src/features/ee/byok/_data/curated-models.json
+++ b/apps/web/src/features/ee/byok/_data/curated-models.json
@@ -93,7 +93,7 @@
             "weaknesses": [],
             "apiKeyUrl": "https://platform.moonshot.ai/console/api-keys",
             "defaults": {
-                "temperature": 0,
+                "temperature": 1,
                 "maxOutputTokens": 16384,
                 "baseURL": "https://api.moonshot.ai/v1",
                 "reasoningEffort": "medium"


### PR DESCRIPTION
## Summary

- `apps/web/src/features/ee/byok/_data/curated-models.json` listed `kimi-k2.6` as a `recommended` tier model with `defaults.temperature: 0`.
- Moonshot's API rejects any temperature ≠ 1 for kimi-k2.6 (it's a reasoning/thinking model — same restriction as OpenAI o1 family).
- This patch updates the curated default to `temperature: 1` so the recommended-tier model is actually usable as-shipped.

## Proof of the API restriction

Verified directly against `api.moonshot.ai/v1` with a production API key:

\`\`\`text
=== kimi-k2.6 + temp=0 ===   HTTP 400
{"error":{"message":"invalid temperature: only 1 is allowed for this model","type":"invalid_request_error"}}

=== kimi-k2.6 + temp=1 ===   HTTP 200
{"id":"chatcmpl-...","model":"kimi-k2.6","choices":[{"message":{"content":"Hello! How can I help you today?","reasoning_content":"..."}}]}

=== kimi-k2.6 + temp=0.6 ===  HTTP 400
{"error":{"message":"invalid temperature: only 1 is allowed for this model"}}
\`\`\`

Note the `reasoning_content` field in the temp=1 response — confirms this is a reasoning model with the corresponding API constraint.

## Customer-impact path

1. Customer selects "Kimi K2.6 Coding" from the recommended tier in the BYOK catalog
2. Form pre-fills with `temperature: 0` from `defaults`
3. Customer saves → backend persists `BYOKConfig.main.temperature = 0`
4. At review time, the `PromptBuilderWithProviders` runtime override path (\`packages/kodus-common/src/llm/builder.ts:219\`) merges \`temperature: this.byokConfig.temperature\` into the LLM params — overriding every prompt's internal \`setTemperature(0)\` with the BYOK config value (which is also 0)
5. Moonshot returns 400 → review pipeline halts mid-flight (after posting the "Code Review Started!" placeholder, before posting findings)

## Workaround for existing customers (until this PR lands)

Have them edit their BYOK config and set temperature to 1 manually, or switch to a non-reasoning Kimi variant (e.g. `kimi-k2-0905-preview`) which accepts temperature=0.

## Test plan

- [ ] Open BYOK settings, select Kimi K2.6 Coding
- [ ] Verify the temperature field pre-fills with 1 (was 0)
- [ ] Save, trigger a code review, verify it completes (no 400 from Moonshot mid-pipeline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)