### PR TITLE
fix(env-schema): API_KODUS_SERVICE_MCP_MANAGER should point to compose service, not localhost

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -689,8 +689,14 @@ API_MCP_SERVER_ENABLED=false
 
 # Address of the kodus-mcp-manager service (sibling container).
 # kodus-ai calls this URL to provision MCP servers per organization.
+# In docker-compose self-hosted installs, the worker and mcp-manager run
+# in sibling containers — `localhost` inside the worker resolves to the
+# worker itself, not to the mcp-manager, and pipeline stages that call
+# `MCPManagerService.getConnections()` 400 with ECONNREFUSED. Always use
+# the compose service name (`kodus-mcp-manager`) so the request reaches
+# the right container.
 # (type: url)
-API_KODUS_SERVICE_MCP_MANAGER=localhost:3101
+API_KODUS_SERVICE_MCP_MANAGER=http://kodus-mcp-manager:3101
 
 # Public URL where MCP clients (e.g. Cursor/Claude Desktop) connect to
 # consume MCP tools exposed by kodus-ai itself.

--- a/.env.schema
+++ b/.env.schema
@@ -999,9 +999,15 @@ API_MCP_SERVER_ENABLED=false
 
 # Address of the kodus-mcp-manager service (sibling container).
 # kodus-ai calls this URL to provision MCP servers per organization.
+# In docker-compose self-hosted installs, the worker and mcp-manager run
+# in sibling containers — `localhost` inside the worker resolves to the
+# worker itself, not to the mcp-manager, and pipeline stages that call
+# `MCPManagerService.getConnections()` 400 with ECONNREFUSED. Always use
+# the compose service name (`kodus-mcp-manager`) so the request reaches
+# the right container.
 # @type=url
-# kodus: audience=both installer-default="http://localhost:3101"
-API_KODUS_SERVICE_MCP_MANAGER=localhost:3101
+# kodus: audience=both installer-default="http://kodus-mcp-manager:3101"
+API_KODUS_SERVICE_MCP_MANAGER=http://kodus-mcp-manager:3101
 
 # Public URL where MCP clients (e.g. Cursor/Claude Desktop) connect to
 # consume MCP tools exposed by kodus-ai itself.

--- a/docs/_snippets/env-vars-generated.mdx
+++ b/docs/_snippets/env-vars-generated.mdx
@@ -296,7 +296,7 @@
 | `WEB_ANALYTICS_SECRET` | – | secret | 🏢 ☁️ Cloud |  |
 | `WEB_PORT_ANALYTICS` | – | port | 🏢 ☁️ Cloud |  |
 | `API_MCP_SERVER_ENABLED` | – | boolean | ⚙️ Both | Enables the MCP integration in kodus-ai (calls into the MCP Manager service). When false, MCP-related code paths are skipped entirely. |
-| `API_KODUS_SERVICE_MCP_MANAGER` | – | url | ⚙️ Both | Address of the kodus-mcp-manager service (sibling container). kodus-ai calls this URL to provision MCP servers per organization. |
+| `API_KODUS_SERVICE_MCP_MANAGER` | – | url | ⚙️ Both | Address of the kodus-mcp-manager service (sibling container). kodus-ai calls this URL to provision MCP servers per organization. In docker-compose self-hosted installs, the worker and mcp-manager run in sibling containers — `localhost` inside the worker resolves to the worker itself, not to the mcp-manager, and pipeline stages that call `MCPManagerService.getConnections()` 400 with ECONNREFUSED. Always use the compose service name (`kodus-mcp-manager`) so the request reaches the right container. |
 | `API_KODUS_MCP_SERVER_URL` | – | url | ⚙️ Both | Public URL where MCP clients (e.g. Cursor/Claude Desktop) connect to consume MCP tools exposed by kodus-ai itself. |
 | `API_MCP_MANAGER_LOG_LEVEL` | – | enum(error,warn,info,debug) | 🏠 Self-hosted | Log verbosity for the MCP Manager container. |
 | `API_MCP_MANAGER_PORT` | – | port | 🏠 Self-hosted |  |


### PR DESCRIPTION
## Summary

- `.env.schema` `installer-default` for `API_KODUS_SERVICE_MCP_MANAGER` was `http://localhost:3101`. The env-sync workflow propagates that into `kodus-installer/.env.example`, which every self-hosted customer copies into their `.env`.
- Inside the `worker` container, `localhost` resolves to the worker itself, not to the `kodus-mcp-manager` sibling container. `MCPManagerService.getConnections()` therefore 400s with `ECONNREFUSED 127.0.0.1:3101`.
- Updated both the value and the `installer-default` directive so the next env-sync run regenerates a working `.env.example`.

## Customer impact

Every fresh self-hosted tenant that follows the documented setup hits this. Symptom from the worker log:

\`\`\`
AxiosError: connect ECONNREFUSED 127.0.0.1:3101
    at AxiosMCPManagerService.get (mcpManager.axios.ts:21)
    at MCPManagerService.getConnections (mcp-manager.service.ts:182)
    at BusinessLogicValidationStage.getConnectedTaskManagementMcps (business-logic-validation.stage.ts:394)
\`\`\`

Pipeline halts after Kody posts the \"Code Review Started!\" placeholder — no findings, no \"Complete!\" notification, customer sees the bot hang forever.

## Why this default existed

Likely a copy-paste from a local-dev setup (no Docker) early in the project. The rest of the MCP-manager-related vars in the same schema already use the correct service name:

- \`WEB_HOSTNAME_MCP_MANAGER=kodus-mcp-manager\`
- \`GLOBAL_MCP_MANAGER_CONTAINER_NAME=kodus-mcp-manager\`

And both \`kodus-installer\` docs already document the correct value:

- \`kodus-installer/.claude/skills/kodus-install/SKILL.md:120\` → \`e.g. http://kodus-mcp-manager:3101\`
- \`kodus-installer/railway/nginx/RAILWAY_TEMPLATE.md:78\` → \`http://mcp-manager.railway.internal:3101\`

Only the schema default was wrong.

## How this was found

A self-hosted smoke test exercised the full review flow from fresh signup → \`@kody review\` and tripped on the MCP manager call. The temporary patch was to edit \`.env\` on the running droplet and restart the worker; this PR moves the fix upstream so new installs don't hit it.

## Workaround for existing self-hosted customers (until env-sync re-runs)

\`\`\`bash
sed -i 's|^API_KODUS_SERVICE_MCP_MANAGER=.*|API_KODUS_SERVICE_MCP_MANAGER=http://kodus-mcp-manager:3101|' .env
docker compose up -d --no-deps worker api
\`\`\`

## Test plan

- [ ] Trigger env-sync workflow (or wait for next scheduled run)
- [ ] Verify \`kodus-installer/.env.example\` regenerates with \`http://kodus-mcp-manager:3101\`
- [ ] Fresh self-hosted install completes a code review end-to-end (Kody posts \"Complete!\" after \"Started!\")

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- kody-pr-summary:start -->
Updated the documentation for the `API_KODUS_SERVICE_MCP_MANAGER` environment variable. The description now clarifies that in docker-compose self-hosted installations, this variable should always point to the compose service name (`kodus-mcp-manager`) rather than `localhost`. This change addresses an issue where using `localhost` inside the worker container would cause it to attempt to connect to itself, leading to connection refused errors when trying to reach the `kodus-mcp-manager` service.
<!-- kody-pr-summary:end -->