### PR TITLE
fix: passing structured outputs to llm

### DIFF
--- a/evals/structured-outputs/README.md
+++ b/evals/structured-outputs/README.md
@@ -1,0 +1,62 @@
+# Structured Outputs Repro
+
+Manual reproduction of the bug filed in the "self-hosted vLLM falls back to
+prompt-based JSON" issue: `@ai-sdk/openai-compatible` defaults to
+`supportsStructuredOutputs: false`, so the project's structured-output call
+sites (`review-structure-fallback` / `verify-structure-fallback` in
+`libs/code-review/infrastructure/agents/llm/agent-loop.ts`, and
+`dedup-suggestions` in `libs/code-review/pipeline/stages/agent-review.stage.ts`)
+send `response_format: { type: "json_object" }` without a schema. vLLM
+xgrammar (and the equivalent Structured Outputs path on Moonshot / OpenRouter
+/ OpenAI) is bypassed, the LLM falls back to prompt-injected schema
+extraction, and the generalist agent runs an order of magnitude slower.
+
+## Why this is not a `*.spec.ts`
+
+Jest's `testMatch` in `jest.config.ts` is
+`['**/*.spec.ts', '**/*.integration.spec.ts', '**/*.e2e-spec.ts']`. This file
+is named `repro.ts`, so it is invisible to `yarn test`. It is manually invoked
+during the fix work and parked here as a regression check.
+
+## Hermetic mode (default)
+
+Stubs `globalThis.fetch`, captures the outgoing chat-completions request body,
+and asserts that the project's structured-output factory produces a request
+with `response_format.type === "json_schema"`.
+
+```bash
+yarn repro:structured-outputs
+```
+
+Requires only `API_CRYPTO_KEY` (already in your `.env`; used to encrypt the
+dummy BYOK key). No network call.
+
+Expected today (broken state): exits 1, prints
+`response_format = {"type":"json_object"}`.
+
+Expected after the fix: exits 0, prints
+`response_format = {"type":"json_schema","json_schema":{...}}`.
+
+## Live mode
+
+Passes the captured request through to OpenRouter so we can verify the same
+contract against a real provider. Uses `moonshotai/kimi-k2-thinking` by
+default (set `REPRO_MODEL` to override).
+
+```bash
+yarn repro:structured-outputs --live
+```
+
+Requires `API_OPENROUTER_KEY` in addition to `API_CRYPTO_KEY`. Costs cents
+per run.
+
+## What the assertions mean
+
+1. **`getInternalModel` structured-output path emits native json_schema** —
+   the failing assertion today. Captures the request the SDK would send for
+   the `review-structure-fallback` / `dedup-suggestions` call sites.
+
+2. **agentic tool-loop path keeps response_format unset** — guardrail that
+   should keep passing both before and after the fix. The proposed fix is
+   scoped per-call (only the structured-output sites opt in), so the tool
+   loop must stay unchanged.

--- a/evals/structured-outputs/repro.ts
+++ b/evals/structured-outputs/repro.ts
@@ -1,0 +1,366 @@
+/**
+ * Manual reproduction: @ai-sdk/openai-compatible does not set
+ * `supportsStructuredOutputs: true`, so calls that use
+ * `generateText({ output: Output.object(...) })` (and `generateObject`)
+ * end up sending `response_format: { type: "json_object" }` to the LLM
+ * — vLLM's xgrammar (and the equivalent strict json_schema mode on
+ * Moonshot / OpenRouter / OpenAI) is bypassed, and the model falls
+ * back to prompt-injected schema extraction.
+ *
+ * The relevant production call sites — `review-structure-fallback`
+ * and `verify-structure-fallback` in
+ * libs/code-review/infrastructure/agents/llm/agent-loop.ts, plus
+ * `dedup-suggestions` in libs/code-review/pipeline/stages/agent-review.stage.ts
+ * — all build their model via `getInternalModel(byokConfig)` or
+ * `byokToVercelModel(byokConfig)`, so we exercise the same factory here.
+ *
+ * Run:
+ *   yarn repro:structured-outputs                          # hermetic OpenRouter
+ *   yarn repro:structured-outputs --live                   # real OpenRouter / Kimi
+ *   yarn repro:structured-outputs --provider google        # hermetic Gemini
+ *   yarn repro:structured-outputs --provider google --live # real Gemini
+ *
+ * Today this script EXITS 1 for `--provider openrouter`: captured body shows
+ *   response_format = { type: "json_object" }
+ * After the fix it should EXIT 0 with
+ *   response_format = { type: "json_schema", json_schema: { name, schema, strict } }
+ *
+ * For `--provider google` it should EXIT 0 today AND after the fix —
+ * `@ai-sdk/google` always emits `generationConfig.responseSchema`, so the
+ * structured-output contract is honoured natively without any flag.
+ *
+ * This file is intentionally NOT named `*.spec.ts`, so Jest's
+ * `testMatch` in jest.config.ts ignores it and `yarn test` does not
+ * pick it up.
+ */
+
+import 'dotenv/config';
+
+import {
+    generateText,
+    Output,
+    jsonSchema,
+    type LanguageModel,
+} from 'ai';
+
+import {
+    byokToVercelModel,
+    getInternalModel,
+} from '@/code-review/infrastructure/agents/llm/byok-to-vercel';
+import { encrypt } from '@/common/utils/crypto';
+import { BYOKConfig, BYOKProvider } from '@kodus/kodus-common/llm';
+
+type ProviderChoice = 'openrouter' | 'google';
+
+function parseProvider(): ProviderChoice {
+    const idx = process.argv.indexOf('--provider');
+    if (idx === -1) return 'openrouter';
+    const value = process.argv[idx + 1];
+    if (value === 'openrouter' || value === 'google') return value;
+    console.error(
+        `[repro] Unknown --provider value: ${value}. Use openrouter|google.`,
+    );
+    process.exit(2);
+}
+
+const LIVE = process.argv.includes('--live');
+const PROVIDER = parseProvider();
+
+const DEFAULT_MODEL: Record<ProviderChoice, string> = {
+    openrouter: 'moonshotai/kimi-k2-thinking',
+    google: 'gemini-2.5-flash',
+};
+const MODEL_ID = process.env.REPRO_MODEL ?? DEFAULT_MODEL[PROVIDER];
+
+function buildByokConfig(apiKey: string): BYOKConfig {
+    if (PROVIDER === 'openrouter') {
+        return {
+            main: {
+                provider: BYOKProvider.OPEN_ROUTER,
+                apiKey: encrypt(apiKey),
+                model: MODEL_ID,
+            },
+        };
+    }
+    return {
+        main: {
+            provider: BYOKProvider.GOOGLE_GEMINI,
+            apiKey: encrypt(apiKey),
+            model: MODEL_ID,
+        },
+    };
+}
+
+const minimalSchema = jsonSchema({
+    type: 'object',
+    additionalProperties: false,
+    properties: { answer: { type: 'string' } },
+    required: ['answer'],
+} as any);
+
+function fakeResponseFor(provider: ProviderChoice): {
+    body: string;
+    headers: Record<string, string>;
+} {
+    if (provider === 'openrouter') {
+        return {
+            body: JSON.stringify({
+                id: 'chatcmpl-fake',
+                object: 'chat.completion',
+                created: Math.floor(Date.now() / 1000),
+                model: MODEL_ID,
+                choices: [
+                    {
+                        index: 0,
+                        message: {
+                            role: 'assistant',
+                            content: '{"answer":"ok"}',
+                        },
+                        finish_reason: 'stop',
+                    },
+                ],
+                usage: {
+                    prompt_tokens: 8,
+                    completion_tokens: 4,
+                    total_tokens: 12,
+                },
+            }),
+            headers: { 'content-type': 'application/json' },
+        };
+    }
+    return {
+        body: JSON.stringify({
+            candidates: [
+                {
+                    content: {
+                        role: 'model',
+                        parts: [{ text: '{"answer":"ok"}' }],
+                    },
+                    finishReason: 'STOP',
+                    index: 0,
+                },
+            ],
+            usageMetadata: {
+                promptTokenCount: 8,
+                candidatesTokenCount: 4,
+                totalTokenCount: 12,
+            },
+        }),
+        headers: { 'content-type': 'application/json' },
+    };
+}
+
+interface CapturedRequest {
+    url: string;
+    body: any;
+}
+
+function installInterceptingFetch(): {
+    captured: CapturedRequest[];
+    restore: () => void;
+} {
+    const original = globalThis.fetch;
+    const captured: CapturedRequest[] = [];
+    const fake = fakeResponseFor(PROVIDER);
+
+    globalThis.fetch = (async (input: any, init?: any) => {
+        const url =
+            typeof input === 'string'
+                ? input
+                : input instanceof URL
+                  ? input.toString()
+                  : (input?.url ?? '');
+        let body: any = null;
+        try {
+            body = init?.body ? JSON.parse(init.body as string) : null;
+        } catch {
+            body = init?.body ?? null;
+        }
+        captured.push({ url, body });
+
+        if (LIVE) {
+            return original(input as any, init);
+        }
+        return new Response(fake.body, {
+            status: 200,
+            headers: fake.headers,
+        });
+    }) as typeof fetch;
+
+    return {
+        captured,
+        restore: () => {
+            globalThis.fetch = original;
+        },
+    };
+}
+
+async function probeStructuredOutput(
+    model: LanguageModel,
+): Promise<CapturedRequest | null> {
+    const { captured, restore } = installInterceptingFetch();
+    try {
+        await generateText({
+            model: model as any,
+            prompt: 'Return any JSON value matching the schema.',
+            output: Output.object({ schema: minimalSchema }) as any,
+        }).catch((err) => {
+            console.warn(
+                `[repro] generateText threw (continuing): ${String(
+                    (err as any)?.message ?? err,
+                )}`,
+            );
+        });
+    } finally {
+        restore();
+    }
+    return captured[0] ?? null;
+}
+
+function assert(name: string, cond: boolean, detail: string): boolean {
+    console.log(`${cond ? '[PASS]' : '[FAIL]'} ${name} — ${detail}`);
+    return cond;
+}
+
+function checkStructuredOutputBody(
+    provider: ProviderChoice,
+    body: any,
+): { ok: boolean; summary: string } {
+    if (provider === 'openrouter') {
+        const rf = body?.response_format;
+        const ok =
+            rf?.type === 'json_schema' && rf?.json_schema?.schema != null;
+        return {
+            ok,
+            summary: `response_format = ${JSON.stringify(rf ?? null)}`,
+        };
+    }
+    const gc = body?.generationConfig;
+    const ok =
+        gc?.responseMimeType === 'application/json' &&
+        gc?.responseSchema != null;
+    return {
+        ok,
+        summary: `generationConfig.responseMimeType=${JSON.stringify(
+            gc?.responseMimeType ?? null,
+        )} generationConfig.responseSchema=${
+            gc?.responseSchema ? '<set>' : 'null'
+        }`,
+    };
+}
+
+function apiKeyFromEnv(provider: ProviderChoice): string | undefined {
+    return provider === 'openrouter'
+        ? process.env.API_OPENROUTER_KEY
+        : (process.env.API_GOOGLE_AI_API_KEY ??
+              process.env.GOOGLE_GENERATIVE_AI_API_KEY);
+}
+
+async function main(): Promise<void> {
+    if (!process.env.API_CRYPTO_KEY) {
+        console.error(
+            '[repro] API_CRYPTO_KEY is required (used to encrypt the BYOK apiKey).',
+        );
+        process.exit(2);
+    }
+    const apiKey = LIVE ? apiKeyFromEnv(PROVIDER) : 'sk-test-not-a-real-key';
+    if (LIVE && !apiKey) {
+        const envName =
+            PROVIDER === 'openrouter'
+                ? 'API_OPENROUTER_KEY'
+                : 'API_GOOGLE_AI_API_KEY';
+        console.error(`[repro] --live --provider ${PROVIDER} requires ${envName}.`);
+        process.exit(2);
+    }
+
+    const byok = buildByokConfig(apiKey as string);
+
+    console.log(
+        `[repro] mode=${LIVE ? 'live' : 'hermetic'} provider=${PROVIDER} model=${MODEL_ID}`,
+    );
+    console.log(
+        '[repro] Probing structured-output path (mirrors review-structure-fallback).',
+    );
+
+    // Mirror agent-loop.ts:4011 / 4288 and agent-review.stage.ts:1145
+    // after the fix — those call sites pass { structuredOutputs: true }
+    // so the cheap fallback model emits native json_schema.
+    const internalModel = getInternalModel(byok, { structuredOutputs: true });
+    if (!internalModel) {
+        console.error('[repro] getInternalModel returned null.');
+        process.exit(2);
+    }
+
+    const captured = await probeStructuredOutput(internalModel);
+    if (!captured) {
+        console.error('[repro] No outgoing request was captured.');
+        process.exit(2);
+    }
+
+    console.log('[repro] Outgoing URL:', captured.url);
+    const check = checkStructuredOutputBody(PROVIDER, captured.body);
+    console.log('[repro]', check.summary);
+
+    const expectation =
+        PROVIDER === 'openrouter'
+            ? 'expected response_format.type === "json_schema" with a populated json_schema.schema so vLLM xgrammar / OpenAI Structured Outputs constrains the response (the current SDK default emits "json_object" without a schema, which vLLM cannot constrain)'
+            : 'expected generationConfig.responseMimeType === "application/json" and a populated responseSchema — @ai-sdk/google handles this natively without any flag';
+
+    const passedPrimary = assert(
+        `getInternalModel structured-output path (${PROVIDER}) emits native schema`,
+        check.ok,
+        expectation,
+    );
+
+    // Bonus: confirm the agentic tool-loop path is NOT emitting a
+    // structured-output schema (today and after the fix). The proposed
+    // fix is scoped per-call so the tool loop stays unchanged.
+    console.log(
+        '\n[repro] Probing agentic tool-loop path (no Output.object).',
+    );
+    const mainModel = byokToVercelModel(byok, 'main');
+    const { captured: capturedTool, restore } = installInterceptingFetch();
+    try {
+        await generateText({
+            model: mainModel as any,
+            prompt: 'Say hi.',
+        }).catch((err) =>
+            console.warn(
+                `[repro] tool-loop probe threw (continuing): ${String(
+                    (err as any)?.message ?? err,
+                )}`,
+            ),
+        );
+    } finally {
+        restore();
+    }
+    const toolBody = capturedTool[0]?.body;
+    if (PROVIDER === 'openrouter') {
+        console.log(
+            '[repro] tool-loop response_format =',
+            JSON.stringify(toolBody?.response_format ?? null),
+        );
+    } else {
+        console.log(
+            '[repro] tool-loop generationConfig.responseSchema =',
+            toolBody?.generationConfig?.responseSchema ? '<set>' : 'null',
+        );
+    }
+    const toolOk =
+        PROVIDER === 'openrouter'
+            ? toolBody?.response_format == null ||
+              toolBody?.response_format?.type !== 'json_schema'
+            : toolBody?.generationConfig?.responseSchema == null;
+    const passedTool = assert(
+        'agentic tool-loop path keeps structured-output schema unset',
+        toolOk,
+        'must stay unchanged so existing tool-call behaviour is not regressed by the structured-output fix',
+    );
+
+    process.exit(passedPrimary && passedTool ? 0 : 1);
+}
+
+main().catch((err) => {
+    console.error('[repro] crashed:', err);
+    process.exit(2);
+});

--- a/libs/code-review/infrastructure/agents/llm/agent-loop.ts
+++ b/libs/code-review/infrastructure/agents/llm/agent-loop.ts
@@ -4008,7 +4008,9 @@ async function structureVerificationDecisionWithFallbackModel(
     };
 } | null> {
     try {
-        const internalModel = getInternalModel(byokConfig);
+        const internalModel = getInternalModel(byokConfig, {
+            structuredOutputs: true,
+        });
         const verifierFallbackSignal = timeoutSignal(LLM_CALL_TIMEOUT_MS);
 
         if (!internalModel) {
@@ -4285,7 +4287,9 @@ async function structureWithFallbackModel(
                 { type: 'null' as const },
             ],
         };
-        const internalModel = getInternalModel(byokConfig);
+        const internalModel = getInternalModel(byokConfig, {
+            structuredOutputs: true,
+        });
         const structureFallbackSignal = timeoutSignal(LLM_CALL_TIMEOUT_MS);
 
         if (!internalModel) {

--- a/libs/code-review/infrastructure/agents/llm/byok-to-vercel.ts
+++ b/libs/code-review/infrastructure/agents/llm/byok-to-vercel.ts
@@ -135,10 +135,25 @@ const DEFAULT_MODEL = {
  * - OPEN_ROUTER → @ai-sdk/openai-compatible (OpenRouter is OpenAI-compatible)
  * - OPENAI_COMPATIBLE → @ai-sdk/openai-compatible
  * - NOVITA → @ai-sdk/openai-compatible
+ *
+ * `options.structuredOutputs` opts the OpenAI-compatible branches into
+ * `response_format: { type: "json_schema", json_schema: { schema, strict } }`
+ * by setting `supportsStructuredOutputs: true` on the provider. Scope this
+ * per-call to `generateObject` / `generateText({ output: Output.object })`
+ * sites — leaving it off keeps the agentic tool-call loop on the unchanged
+ * `json_object` (or absent) `response_format` path. Native SDKs
+ * (`@ai-sdk/openai`, `@ai-sdk/anthropic`, `@ai-sdk/google`,
+ * `@ai-sdk/google-vertex`, `@ai-sdk/amazon-bedrock`) handle structured
+ * outputs natively without any flag and are not affected by this option.
  */
+export type ByokModelOptions = {
+    structuredOutputs?: boolean;
+};
+
 export function byokToVercelModel(
     byokConfig?: BYOKConfig,
     role: 'main' | 'fallback' = 'main',
+    options: ByokModelOptions = {},
 ): LanguageModel {
     const config =
         role === 'fallback' ? byokConfig?.fallback : byokConfig?.main;
@@ -221,6 +236,8 @@ export function byokToVercelModel(
                     // api.openai.com to match the legacy v2 getChatGPT
                     // behavior when no custom endpoint is configured.
                     baseURL: openaiBaseURL || 'https://api.openai.com/v1',
+                    supportsStructuredOutputs:
+                        options.structuredOutputs === true,
                 })(envMode);
             }
             // self-hosted mode declared but no usable env key — fall through
@@ -264,6 +281,7 @@ export function byokToVercelModel(
                 name: 'open-router',
                 apiKey,
                 baseURL: baseURL || 'https://openrouter.ai/api/v1',
+                supportsStructuredOutputs: options.structuredOutputs === true,
             })(model);
 
         case BYOKProvider.OPENAI_COMPATIBLE:
@@ -271,6 +289,7 @@ export function byokToVercelModel(
                 name: 'openai-compatible',
                 apiKey,
                 baseURL: baseURL || '',
+                supportsStructuredOutputs: options.structuredOutputs === true,
             })(model);
 
         case BYOKProvider.NOVITA:
@@ -278,6 +297,7 @@ export function byokToVercelModel(
                 name: 'novita',
                 apiKey,
                 baseURL: baseURL || 'https://api.novita.ai/v3/openai',
+                supportsStructuredOutputs: options.structuredOutputs === true,
             })(model);
 
         case BYOKProvider.GOOGLE_VERTEX: {
@@ -306,6 +326,7 @@ export function byokToVercelModel(
                 name: String(provider),
                 apiKey,
                 baseURL: baseURL || '',
+                supportsStructuredOutputs: options.structuredOutputs === true,
             })(model);
     }
 }
@@ -358,15 +379,16 @@ export function getModelName(byokConfig?: BYOKConfig): string {
  */
 export function getInternalModel(
     byokConfig?: BYOKConfig,
+    options: ByokModelOptions = {},
 ): LanguageModel | null {
     const envMode = process.env.API_LLM_PROVIDER_MODEL ?? 'auto';
 
     // If BYOK is configured, use the client's fallback or main model
     if (byokConfig?.fallback) {
-        return byokToVercelModel(byokConfig, 'fallback');
+        return byokToVercelModel(byokConfig, 'fallback', options);
     }
     if (byokConfig?.main) {
-        return byokToVercelModel(byokConfig, 'main');
+        return byokToVercelModel(byokConfig, 'main', options);
     }
 
     // Self-hosted mode: match byokToVercelModel's provider selection so
@@ -409,6 +431,7 @@ export function getInternalModel(
                 name: 'self-hosted',
                 apiKey: openaiKey,
                 baseURL: openaiBaseURL || 'https://api.openai.com/v1',
+                supportsStructuredOutputs: options.structuredOutputs === true,
             })(envMode);
         }
 

--- a/libs/code-review/pipeline/stages/agent-review.stage.ts
+++ b/libs/code-review/pipeline/stages/agent-review.stage.ts
@@ -1142,7 +1142,7 @@ export class AgentReviewStage extends BasePipelineStage<CodeReviewPipelineContex
             const { getInternalModel } = await import(
                 '@libs/code-review/infrastructure/agents/llm/byok-to-vercel'
             );
-            model = getInternalModel(byokConfig);
+            model = getInternalModel(byokConfig, { structuredOutputs: true });
         }
 
         if (!model) {

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
         "eval:memory:quality:prepare": "cd evals/promptfoo/memory-quality && node convert-memory-quality-dataset.js",
         "eval:memory:quality": "cd evals/promptfoo/memory-quality && bash ./run-memory-quality-eval.sh",
         "eval:memory:quality:light": "cd evals/promptfoo/memory-quality && bash ./run-memory-quality-eval.sh --limit=3 --no-cache",
+        "repro:structured-outputs": "ts-node -r tsconfig-paths/register evals/structured-outputs/repro.ts",
         "typeorm": "TS_NODE_PROJECT=tsconfig.json ts-node -r tsconfig-paths/register ./node_modules/typeorm/cli",
         "migration:generate": "f() { API_PG_DB_HOST=localhost yarn typeorm migration:generate -p -d libs/core/infrastructure/database/typeorm/ormconfig.ts \"libs/core/infrastructure/database/typeorm/migrations/$@\"; }; f",
         "migration:run": "API_PG_DB_HOST=localhost yarn typeorm migration:run -d libs/core/infrastructure/database/typeorm/ormconfig.ts",


### PR DESCRIPTION
closes #1122 

<!-- kody-pr-summary:start -->
This pull request addresses an issue where structured output calls to OpenAI-compatible LLM providers (such as OpenRouter or self-hosted vLLM) were not leveraging native JSON schema enforcement. Previously, the `@ai-sdk/openai-compatible` adapter defaulted `supportsStructuredOutputs` to `false`, causing these calls to send `response_format: { type: "json_object" }` without a schema. This forced LLMs to fall back to slower and less reliable prompt-injected schema extraction.

The changes implement the following:

1.  **Enable Native Structured Outputs:** A new `structuredOutputs: true` option has been introduced to the `byokToVercelModel` and `getInternalModel` functions. When this option is set, OpenAI-compatible providers are configured with `supportsStructuredOutputs: true`, allowing them to send `response_format: { type: "json_schema", json_schema: { schema, strict } }` for structured output requests.
2.  **Targeted Application:** The `structuredOutputs: true` option is explicitly applied to specific call sites that require strict structured outputs:
    *   `structureVerificationDecisionWithFallbackModel` in `agent-loop.ts`
    *   `structureWithFallbackModel` in `agent-loop.ts`
    *   The `dedup-suggestions` logic in `agent-review.stage.ts`
3.  **Preserve Existing Behavior:** The change is opt-in per-call, ensuring that other LLM interactions, such as agentic tool-loops, remain unaffected and continue to use their existing `response_format` behavior without unintended schema enforcement.
4.  **Verification Script:** A new manual reproduction script (`evals/structured-outputs/repro.ts`) and its corresponding `README.md` have been added. This script verifies that structured output calls correctly send the native `json_schema` format for OpenAI-compatible providers and that non-structured calls remain unchanged.

This fix ensures that structured output operations benefit from native JSON schema enforcement, leading to improved performance and reliability.
<!-- kody-pr-summary:end -->