### PR TITLE
chore: fixing branch version

### DIFF
--- a/libs/kodyRules/application/use-cases/find-rules-in-organization-by-filter.use-case.ts
+++ b/libs/kodyRules/application/use-cases/find-rules-in-organization-by-filter.use-case.ts
@@ -106,14 +106,14 @@ export class FindRulesInOrganizationByRuleFilterKodyRulesUseCase implements IUse
             }
 
             if (repositoryId && !directoryId) {
-                filteredRules = allRules.filter(
+                filteredRules = filteredRules.filter(
                     (rule) =>
                         rule.repositoryId === 'global' ||
                         (rule.repositoryId === repositoryId &&
                             !rule.directoryId),
                 );
             } else if (repositoryId && directoryId) {
-                filteredRules = allRules.filter(
+                filteredRules = filteredRules.filter(
                     (rule) =>
                         rule.repositoryId === 'global' ||
                         (rule.repositoryId === repositoryId &&


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Corrects the filtering logic in the `FindRulesInOrganizationByRuleFilterKodyRulesUseCase`. Previously, when filtering rules by `repositoryId` (with or without `directoryId`), the filter was incorrectly applied to the initial set of all rules (`allRules`). This change ensures that these filters are now applied to the already progressively filtered set of rules (`filteredRules`), ensuring cumulative and accurate filtering results.
<!-- kody-pr-summary:end -->