### PR TITLE
fix(memory): adding filter to list only memories in check out modal

### DIFF
--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/kody-rules/_components/_page.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/kody-rules/_components/_page.tsx
@@ -673,6 +673,7 @@ const KodyRulesPageContent = () => {
         () =>
             pendingRules.filter(
                 (rule) =>
+                    getRuleType(rule) === KodyRulesType.MEMORY &&
                     rule.requestType === KodyRuleRequestType.MEMORY_UPDATE,
             ),
         [pendingRules],
@@ -682,6 +683,7 @@ const KodyRulesPageContent = () => {
         () =>
             pendingRules.filter(
                 (rule) =>
+                    getRuleType(rule) === KodyRulesType.MEMORY &&
                     rule.requestType !== KodyRuleRequestType.MEMORY_UPDATE,
             ),
         [pendingRules],


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
Added a filter to ensure that only Kody rules of type `MEMORY` are included when processing or displaying pending rules. This applies to both rules related to `MEMORY_UPDATE` and other memory-related rules, ensuring that lists of pending rules are correctly scoped to memory-specific entries.
<!-- kody-pr-summary:end -->