### PR TITLE
feat(benchmark): add Azure DevOps platform support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,6 +151,7 @@ evals/investigation/evals/
 
 scripts/pr-creator/accounts.json
 scripts/pr-creator/prs.json
+scripts/pr-creator/prs-azure.json
 scripts/pr-creator/package-lock.json
 scripts/pr-creator/node_modules
 .spectral-report.json

--- a/scripts/benchmark/benchmark-create.sh
+++ b/scripts/benchmark/benchmark-create.sh
@@ -3,21 +3,44 @@
 # Step 1: Create benchmark PRs
 #
 # Usage:
-#   ./benchmark-create.sh <name> [TOTAL_PRS]
+#   ./benchmark-create.sh <name> [TOTAL_PRS] [--platform=github|azure]
 #
 # Examples:
-#   ./benchmark-create.sh sonnet-v1 20
+#   ./benchmark-create.sh sonnet-v1 20                       # GitHub (default)
 #   ./benchmark-create.sh kimi-baseline 50
-#   ./benchmark-create.sh test-run        # default: 20 PRs
+#   ./benchmark-create.sh azure-run 5 --platform=azure       # Azure DevOps
+#
+# Platforms:
+#   github (default) — uses gh auth token + scripts/pr-creator/prs.json
+#   azure            — uses AZURE_DEVOPS_TOKEN + scripts/pr-creator/prs-azure.json
+#                      (generate it first with migrate-prs-to-azure.mjs)
 #
 set -euo pipefail
 
+# Parse optional --platform flag from any position
+PLATFORM="github"
+POS_ARGS=()
+for arg in "$@"; do
+  case "$arg" in
+    --platform=*) PLATFORM="${arg#*=}" ;;
+    *)            POS_ARGS+=("$arg") ;;
+  esac
+done
+# Reset positional args (safe under set -u when POS_ARGS is empty)
+set -- ${POS_ARGS[@]+"${POS_ARGS[@]}"}
+
+if [ "$PLATFORM" != "github" ] && [ "$PLATFORM" != "azure" ]; then
+  echo "ERROR: --platform must be 'github' or 'azure' (got: '$PLATFORM')"
+  exit 1
+fi
+
 if [ -z "${1:-}" ]; then
-  echo "Usage: ./benchmark-create.sh <name> [TOTAL_PRS]"
+  echo "Usage: ./benchmark-create.sh <name> [TOTAL_PRS] [--platform=github|azure]"
   echo ""
   echo "Examples:"
-  echo "  ./benchmark-create.sh sonnet-v1 20"
+  echo "  ./benchmark-create.sh sonnet-v1 20                       # GitHub (default)"
   echo "  ./benchmark-create.sh kimi-baseline"
+  echo "  ./benchmark-create.sh azure-run 5 --platform=azure       # Azure DevOps"
   echo ""
   # List existing runs
   RUNS_DIR="$(cd "$(dirname "$0")" && pwd)/runs"
@@ -166,16 +189,39 @@ done
 # Pass TOTAL_PRS so we only bump the branches that will actually be used —
 # bumping every branch in prs.json fires synchronize webhooks on orphan PRs
 # from previous runs and triggers spurious reviews.
-if [ "${SKIP_BUMP_HEADS:-0}" != "1" ]; then
+#
+# Azure DevOps doesn't enforce the same cap, and bump-benchmark-heads.sh
+# is GitHub-API only, so we always skip on the azure path.
+if [ "$PLATFORM" = "azure" ]; then
+  echo "▸ Skipping HEAD bump (azure platform — N/A)"
+elif [ "${SKIP_BUMP_HEADS:-0}" != "1" ]; then
   TOTAL_PRS="$TOTAL_PRS" "$(cd "$(dirname "$0")" && pwd)/bump-benchmark-heads.sh"
 else
   echo "▸ Skipping HEAD bump (SKIP_BUMP_HEADS=1)"
 fi
 
 # Create PRs
-echo "▸ Creating $TOTAL_PRS PRs..."
+echo "▸ Creating $TOTAL_PRS PRs on $PLATFORM..."
 cd "$REPO_DIR/scripts/pr-creator"
-RESULT=$(GITHUB_TOKEN=$(gh auth token) TOTAL_PRS=$TOTAL_PRS node create-test-prs.mjs 2>&1)
+if [ "$PLATFORM" = "azure" ]; then
+  if [ -z "${AZURE_DEVOPS_TOKEN:-}" ]; then
+    echo "ERROR: AZURE_DEVOPS_TOKEN must be set for --platform=azure"
+    exit 1
+  fi
+  if [ ! -f "$REPO_DIR/scripts/pr-creator/prs-azure.json" ]; then
+    echo "ERROR: scripts/pr-creator/prs-azure.json not found."
+    echo "Generate it first:"
+    echo "  node scripts/benchmark/migrate-prs-to-azure.mjs \\"
+    echo "    --azure-org=<org> --azure-project=<project>"
+    exit 1
+  fi
+  RESULT=$(AZURE_DEVOPS_TOKEN="$AZURE_DEVOPS_TOKEN" \
+           PR_CONFIG=prs-azure.json \
+           TOTAL_PRS=$TOTAL_PRS \
+           node create-test-prs.mjs 2>&1)
+else
+  RESULT=$(GITHUB_TOKEN=$(gh auth token) TOTAL_PRS=$TOTAL_PRS node create-test-prs.mjs 2>&1)
+fi
 CREATED=$(printf '%s\n' "$RESULT" | sed -n 's/.*Total: \([0-9][0-9]*\).*/\1/p' | tail -n 1)
 echo "$RESULT" | grep "✅" || true
 echo "$RESULT" | grep "❌" || true

--- a/scripts/benchmark/import-repos-to-azure.sh
+++ b/scripts/benchmark/import-repos-to-azure.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+#
+# import-repos-to-azure.sh
+#
+# Mirrors the 5 benchmark fork repos from GitHub to Azure DevOps,
+# preserving every branch, tag, and SHA (byte-for-byte via --mirror).
+#
+# Idempotent: if the Azure repo already exists, the script skips the
+# create step and just pushes/refreshes the mirror.
+#
+# Requires:
+#   - az CLI + azure-devops extension
+#   - git
+#   - AZURE_DEVOPS_TOKEN env var (PAT with Code read/write + PR read/write)
+#
+# Usage:
+#   AZURE_ORG=myorg AZURE_PROJECT=ai-code-review-benchmark \
+#   AZURE_DEVOPS_TOKEN=<pat> \
+#     ./scripts/benchmark/import-repos-to-azure.sh
+#
+#   Optional:
+#     GITHUB_OWNER=Wellington01            (default)
+#     WORKDIR=./tmp/benchmark-import       (default; cloned mirrors live here)
+#     SKIP_VALIDATE=1                      (skip SHA spot-check after push)
+#
+# Does NOT touch the GitHub source repos. Read-only on GitHub side.
+
+set -euo pipefail
+
+# ---------- args / env ----------
+
+AZURE_ORG="${AZURE_ORG:-}"
+AZURE_PROJECT="${AZURE_PROJECT:-}"
+GITHUB_OWNER="${GITHUB_OWNER:-Wellington01}"
+WORKDIR="${WORKDIR:-./tmp/benchmark-import}"
+SKIP_VALIDATE="${SKIP_VALIDATE:-0}"
+
+if [ -z "$AZURE_ORG" ] || [ -z "$AZURE_PROJECT" ]; then
+    echo "ERROR: AZURE_ORG and AZURE_PROJECT are required."
+    echo ""
+    echo "Example:"
+    echo "  AZURE_ORG=myorg AZURE_PROJECT=ai-code-review-benchmark \\"
+    echo "    AZURE_DEVOPS_TOKEN=<pat> $0"
+    exit 1
+fi
+
+if [ -z "${AZURE_DEVOPS_TOKEN:-}" ]; then
+    echo "ERROR: AZURE_DEVOPS_TOKEN env var is required (PAT with Code+PR write)."
+    exit 1
+fi
+
+# Tell az CLI to use the PAT non-interactively
+export AZURE_DEVOPS_EXT_PAT="$AZURE_DEVOPS_TOKEN"
+# Pre-compute the Authorization header git will send on push
+AZ_AUTH_HEADER="Authorization: Basic $(printf ':%s' "$AZURE_DEVOPS_TOKEN" | base64 | tr -d '\n')"
+
+REPOS=(
+    "sentry-greptile"
+    "grafana-greptile"
+    "discourse-greptile"
+    "cal.com-greptile"
+    "keycloak-greptile"
+)
+
+AZURE_BASE="https://dev.azure.com/${AZURE_ORG}/${AZURE_PROJECT}/_git"
+
+mkdir -p "$WORKDIR"
+echo "🪜  Workdir: $WORKDIR"
+echo "🪜  Azure target: $AZURE_BASE"
+echo ""
+
+# ---------- prerequisites ----------
+
+command -v az >/dev/null || {
+    echo "ERROR: az CLI not installed. brew install azure-cli"; exit 1;
+}
+az extension show --name azure-devops >/dev/null 2>&1 || {
+    echo "Installing azure-devops extension..."
+    az extension add --name azure-devops
+}
+command -v git >/dev/null || { echo "ERROR: git missing"; exit 1; }
+
+# Configure default org/project for az (silences --organization on every call)
+az devops configure --defaults \
+    organization="https://dev.azure.com/${AZURE_ORG}" \
+    project="${AZURE_PROJECT}" >/dev/null
+
+echo "✅ az CLI ready (org=$AZURE_ORG, project=$AZURE_PROJECT)"
+echo ""
+
+# ---------- per-repo ----------
+
+for REPO in "${REPOS[@]}"; do
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+    echo "📦  $REPO"
+    echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+    GH_URL="https://github.com/${GITHUB_OWNER}/${REPO}.git"
+    AZ_URL="${AZURE_BASE}/${REPO}"
+    LOCAL_MIRROR="${WORKDIR}/${REPO}.git"
+
+    # 1. Mirror clone (or refresh if already cloned)
+    if [ -d "$LOCAL_MIRROR" ]; then
+        echo "  ↻  Refreshing existing mirror..."
+        git -C "$LOCAL_MIRROR" remote update --prune >/dev/null 2>&1
+    else
+        echo "  ⬇️  Cloning --mirror from GitHub..."
+        git clone --mirror "$GH_URL" "$LOCAL_MIRROR" >/dev/null 2>&1
+    fi
+
+    # 2. Ensure Azure repo exists (idempotent)
+    if az repos show --repository "$REPO" >/dev/null 2>&1; then
+        echo "  ℹ️   Azure repo exists — will refresh"
+    else
+        echo "  ✨  Creating Azure repo..."
+        az repos create --name "$REPO" >/dev/null
+    fi
+
+    # 3. Push branches and tags to Azure (PAT via http.extraheader)
+    # Avoid --mirror because it tries to push refs/pull/* and refs/notes/*
+    # which Azure DevOps blocks ("can only be performed by the system").
+    # Explicit refspec covers what we need (all branches + all tags), with
+    # --force so retries work if something already exists.
+    echo "  ⬆️   Pushing branches+tags to Azure..."
+    git -C "$LOCAL_MIRROR" remote remove azure >/dev/null 2>&1 || true
+    git -C "$LOCAL_MIRROR" remote add azure "$AZ_URL"
+    git -C "$LOCAL_MIRROR" \
+        -c "http.extraheader=$AZ_AUTH_HEADER" \
+        push --force azure \
+            'refs/heads/*:refs/heads/*' \
+            'refs/tags/*:refs/tags/*' 2>&1 | tail -5
+
+    # 4. Validate SHA preservation (spot-check first branch from prs.json)
+    if [ "$SKIP_VALIDATE" != "1" ]; then
+        # Pick one branch this repo uses in prs.json
+        SAMPLE_BRANCH=$(node -e "
+            const p = require('./scripts/pr-creator/prs.json');
+            const match = p.prs.find(pr => pr.repo.endsWith('/${REPO}'));
+            console.log(match ? match.head : '');
+        " 2>/dev/null || echo "")
+
+        if [ -n "$SAMPLE_BRANCH" ]; then
+            GH_SHA=$(git -C "$LOCAL_MIRROR" rev-parse "refs/heads/${SAMPLE_BRANCH}" 2>/dev/null || echo "missing")
+            AZ_SHA=$(az repos ref list --repository "$REPO" --filter "heads/${SAMPLE_BRANCH}" \
+                --query "[0].objectId" -o tsv 2>/dev/null || echo "missing")
+
+            if [ "$GH_SHA" = "$AZ_SHA" ] && [ "$GH_SHA" != "missing" ]; then
+                echo "  ✅ SHA match on '${SAMPLE_BRANCH}': ${GH_SHA:0:12}"
+            else
+                echo "  ⚠️  SHA mismatch on '${SAMPLE_BRANCH}':"
+                echo "       GitHub: ${GH_SHA}"
+                echo "       Azure:  ${AZ_SHA}"
+            fi
+        fi
+    fi
+
+    echo ""
+done
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "✅ Done. ${#REPOS[@]} repos mirrored to ${AZURE_BASE}/<repo>"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "Next:"
+echo "  1. Connect the Azure DevOps integration in the benchmark Kodus account"
+echo "  2. Generate prs-azure.json:"
+echo "       node scripts/benchmark/migrate-prs-to-azure.mjs \\"
+echo "         --azure-org=${AZURE_ORG} --azure-project=${AZURE_PROJECT}"
+echo "  3. Run benchmark-create.sh --platform=azure 5"

--- a/scripts/benchmark/migrate-prs-to-azure.mjs
+++ b/scripts/benchmark/migrate-prs-to-azure.mjs
@@ -1,0 +1,103 @@
+#!/usr/bin/env node
+/**
+ * migrate-prs-to-azure.mjs
+ *
+ * Reads scripts/pr-creator/prs.json (GitHub form) and writes
+ * scripts/pr-creator/prs-azure.json (Azure DevOps form).
+ *
+ * Only the `repo` field changes. Branches (head, base), titles,
+ * source_url metadata and golden_comments are preserved verbatim —
+ * the golden judging is text-only, so the Azure run reuses the same
+ * ground truth.
+ *
+ * Usage:
+ *   node scripts/benchmark/migrate-prs-to-azure.mjs \
+ *     --azure-org=<org> --azure-project=<project>
+ *
+ * Optional:
+ *   --in=<path>   default: scripts/pr-creator/prs.json
+ *   --out=<path>  default: scripts/pr-creator/prs-azure.json
+ *
+ * Does NOT touch the GitHub prs.json. Pure read-then-write to a new file.
+ */
+
+import { readFileSync, writeFileSync } from 'node:fs';
+
+// ---------- args ----------
+
+const args = Object.fromEntries(
+    process.argv
+        .slice(2)
+        .filter((a) => a.startsWith('--'))
+        .map((a) => {
+            const [k, v] = a.replace(/^--/, '').split('=');
+            return [k, v ?? true];
+        }),
+);
+
+const AZURE_ORG = args['azure-org'];
+const AZURE_PROJECT = args['azure-project'];
+const IN_PATH = args['in'] ?? 'scripts/pr-creator/prs.json';
+const OUT_PATH = args['out'] ?? 'scripts/pr-creator/prs-azure.json';
+
+if (!AZURE_ORG || !AZURE_PROJECT) {
+    console.error(
+        'ERROR: --azure-org and --azure-project are required.\n\n' +
+            'Example:\n' +
+            '  node scripts/benchmark/migrate-prs-to-azure.mjs \\\n' +
+            '    --azure-org=myorg --azure-project=ai-code-review-benchmark',
+    );
+    process.exit(1);
+}
+
+// ---------- read ----------
+
+const src = JSON.parse(readFileSync(IN_PATH, 'utf8'));
+if (!src?.prs?.length) {
+    console.error(`ERROR: ${IN_PATH} has no .prs array.`);
+    process.exit(1);
+}
+
+// ---------- map ----------
+
+/**
+ * GitHub repo string -> Azure repo path.
+ * GitHub form: "<owner>/<repo>"      e.g. "Wellington01/sentry-greptile"
+ * Azure form:  "<org>/<project>/<repo>" e.g. "kodus/ai-code-review-benchmark/sentry-greptile"
+ *
+ * The `<repo>` segment is preserved (import script keeps the same name).
+ */
+function toAzureRepo(githubRepo) {
+    const segments = githubRepo.split('/').filter(Boolean);
+    const repoName = segments[segments.length - 1];
+    if (!repoName) {
+        throw new Error(`Cannot extract repo name from "${githubRepo}"`);
+    }
+    return `${AZURE_ORG}/${AZURE_PROJECT}/${repoName}`;
+}
+
+const out = {
+    ...src,
+    prs: src.prs.map((pr) => ({
+        ...pr,
+        repo: toAzureRepo(pr.repo),
+        platform: 'azuredevops',
+    })),
+};
+
+// ---------- write ----------
+
+writeFileSync(OUT_PATH, JSON.stringify(out, null, 4) + '\n');
+
+const byRepo = out.prs.reduce((acc, pr) => {
+    acc[pr.repo] = (acc[pr.repo] || 0) + 1;
+    return acc;
+}, {});
+
+console.log(`✅ Wrote ${out.prs.length} PRs to ${OUT_PATH}`);
+console.log('   Per repo:');
+for (const [repo, count] of Object.entries(byRepo)) {
+    console.log(`     ${repo}: ${count}`);
+}
+console.log('');
+console.log('Next: benchmark-create.sh --platform=azure <N>');

--- a/scripts/pr-creator/create-test-prs.mjs
+++ b/scripts/pr-creator/create-test-prs.mjs
@@ -369,11 +369,91 @@ async function loadTargetedPRs() {
 }
 
 /**
+ * Azure DevOps variant: pr.repo is "<org>/<project>/<repoName>".
+ * Abandon any active PR with the same sourceRef, then create a new one.
+ */
+async function closeAndCreateAzurePR(pr, token) {
+    const segments = pr.repo.split('/').filter(Boolean);
+    if (segments.length < 3) {
+        console.error(`   ❌ Azure repo must be "<org>/<project>/<repo>": ${pr.repo}`);
+        return null;
+    }
+    const [org, project, repoName] = segments.slice(-3);
+    const apiBase = `https://dev.azure.com/${org}/${project}/_apis/git/repositories/${encodeURIComponent(repoName)}`;
+    const headers = {
+        'Authorization': getAzureAuthHeader(token),
+        'Content-Type': 'application/json',
+    };
+
+    try {
+        const sourceRef = `refs/heads/${pr.head}`;
+        const listUrl =
+            `${apiBase}/pullrequests?searchCriteria.status=active` +
+            `&searchCriteria.sourceRefName=${encodeURIComponent(sourceRef)}` +
+            `&api-version=6.0`;
+        const listResp = await fetch(listUrl, { headers });
+        if (listResp.ok) {
+            const data = await listResp.json();
+            for (const existing of data?.value ?? []) {
+                console.log(`   🗑️  Abandoning existing PR !${existing.pullRequestId}`);
+                await fetch(
+                    `${apiBase}/pullrequests/${existing.pullRequestId}?api-version=6.0`,
+                    {
+                        method: 'PATCH',
+                        headers,
+                        body: JSON.stringify({ status: 'abandoned' }),
+                    },
+                );
+                await new Promise((r) => setTimeout(r, 500));
+            }
+        }
+    } catch (e) {
+        console.warn(`   ⚠️  Failed to close existing Azure PRs: ${e.message}`);
+    }
+
+    const title = pr.title || `${pr.head} → ${pr.base}`;
+    console.log(`📝 Creating PR for ${pr.repo}: ${pr.head} → ${pr.base}`);
+
+    try {
+        const response = await fetch(`${apiBase}/pullrequests?api-version=6.0`, {
+            method: 'POST',
+            headers,
+            body: JSON.stringify({
+                title,
+                description: `Test PR: ${pr.head} → ${pr.base}`,
+                sourceRefName: `refs/heads/${pr.head}`,
+                targetRefName: `refs/heads/${pr.base}`,
+            }),
+        });
+        if (!response.ok) {
+            const err = await response.text();
+            console.error(`   ❌ Failed: ${err}`);
+            return null;
+        }
+        const data = await response.json();
+        const prUrl =
+            data?._links?.web?.href ||
+            `https://dev.azure.com/${org}/${project}/_git/${repoName}/pullrequest/${data.pullRequestId}`;
+        console.log(`   ✅ PR created: ${prUrl}`);
+        await new Promise((r) => setTimeout(r, 1500));
+        return prUrl;
+    } catch (e) {
+        console.error(`   ❌ Error: ${e.message}`);
+        return null;
+    }
+}
+
+/**
  * Close existing PR for a specific head branch, then create a new one.
  */
 async function closeAndCreatePR(pr, token) {
-    const [owner, name] = pr.repo.split('/');
     const platform = pr.platform || 'github';
+
+    if (platform === 'azuredevops') {
+        return await closeAndCreateAzurePR(pr, token);
+    }
+
+    const [owner, name] = pr.repo.split('/');
 
     // Close existing PR with same head branch
     try {
@@ -466,12 +546,13 @@ async function runTargeted(targetedPRs) {
     }
     console.log(`🎯 Targeted mode: ${targetedPRs.length} PR(s) to create${limit ? ` (limit: ${limit})` : ''}\n`);
 
-    // Detect platform and get token
-    const token = CONFIG.githubToken || process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
-    if (!token) {
-        console.error('❌ GITHUB_TOKEN required for targeted PRs');
-        process.exit(1);
-    }
+    const tokensByPlatform = {
+        github:
+            CONFIG.githubToken ||
+            process.env.GITHUB_TOKEN ||
+            process.env.GH_TOKEN,
+        azuredevops: CONFIG.azureDevOpsToken,
+    };
 
     const createdPRs = [];
     for (const pr of targetedPRs) {
@@ -479,7 +560,15 @@ async function runTargeted(targetedPRs) {
             console.warn(`   ⚠️  Skipping invalid PR config: ${JSON.stringify(pr)}`);
             continue;
         }
-        const url = await closeAndCreatePR(pr, token);
+        const platform = pr.platform || 'github';
+        const prToken = tokensByPlatform[platform];
+        if (!prToken) {
+            console.error(
+                `   ❌ Missing token for platform '${platform}' — skipping ${pr.repo}`,
+            );
+            continue;
+        }
+        const url = await closeAndCreatePR(pr, prToken);
         if (url) createdPRs.push(url);
     }
 


### PR DESCRIPTION
Mirror the 5 GitHub fork repos to Azure Repos and let the benchmark pipeline target either platform via --platform=github|azure (default github). Goldens are platform-agnostic (judging is text-only), so the same prs.json drives both runs after a repo-field rewrite.

- import-repos-to-azure.sh: idempotent `git clone --mirror` → `az repos create` → explicit-refspec push. Azure DevOps blocks `refs/pull/*` on `--mirror`, so we push only `refs/heads/*` and `refs/tags/*`. PAT travels via http.extraheader (never in the remote URL). SHA spot-check after push.
- migrate-prs-to-azure.mjs: rewrites `repo` from "<owner>/<name>" to "<azure-org>/<project>/<name>" and tags each entry with `platform: "azuredevops"`. Output (prs-azure.json) is gitignored, same convention as prs.json.
- create-test-prs.mjs (targeted mode): new closeAndCreateAzurePR() — abandons active PRs on the same sourceRef, POSTs a new one via `_apis/git/repositories/<repo>/pullrequests`. Tokens are now resolved by `pr.platform` instead of being hardcoded to GITHUB_TOKEN.
- benchmark-create.sh: accepts `--platform=github|azure`; on azure switches PR_CONFIG to prs-azure.json and skips bump-benchmark-heads (the head_sha cap is GitHub-only).

Validated end-to-end with a 5-PR smoke against
wellingtonsantana0015/ai-code-review-benchmark: webhooks delivered to Kodus in <6s of creation and all five reviews finished ("Kody Review Finished" / success).

Out of scope (follow-up): benchmark-create.sh still calls `gh api` for the close-existing-PRs step and manifest builder. They no-op on the azure path but should be replaced with Azure REST equivalents before running larger Azure benchmarks.

---

<!-- kody-pr-summary:start -->
This pull request introduces comprehensive support for running benchmarks on Azure DevOps, alongside the existing GitHub platform.

Key changes include:
- **Platform Selection for Benchmark Creation:** The `benchmark-create.sh` script now accepts a `--platform` argument (`github` or `azure`) to specify where benchmark pull requests should be created.
- **Azure DevOps Repository Mirroring:** A new script, `import-repos-to-azure.sh`, is added to mirror benchmark repositories from GitHub to Azure DevOps, ensuring all branches, tags, and SHAs are preserved.
- **Azure DevOps PR Configuration Conversion:** A new utility, `migrate-prs-to-azure.mjs`, is introduced to convert existing GitHub-style PR configurations (`prs.json`) into an Azure DevOps-compatible format (`prs-azure.json`), adapting repository paths and platform identifiers.
- **Azure DevOps Pull Request Creation:** The core PR creation script (`create-test-prs.mjs`) has been extended with a new function (`closeAndCreateAzurePR`) to interact with the Azure DevOps API, enabling the creation and management of pull requests on Azure DevOps. This includes abandoning existing active PRs for a given source branch before creating new ones.
- **Platform-Specific Token Handling:** The PR creation logic now supports different authentication tokens for GitHub (`GITHUB_TOKEN`) and Azure DevOps (`AZURE_DEVOPS_TOKEN`).
- **Updated Documentation and Examples:** Usage instructions for `benchmark-create.sh` have been updated to reflect the new `--platform` option and provide Azure DevOps examples.
- **Git Ignore Update:** The `.gitignore` file is updated to include `prs-azure.json`, ensuring the generated Azure-specific PR configuration file is not committed.

These changes enable users to set up and execute AI code review benchmarks within an Azure DevOps environment, leveraging existing benchmark definitions and infrastructure.
<!-- kody-pr-summary:end -->