### PR TITLE
fix(kody-rules): drop bitbucket Kody comments before rule-generator LLM

### DIFF
--- a/libs/code-review/infrastructure/adapters/services/__tests__/commentAnalysis.bot-filter.spec.ts
+++ b/libs/code-review/infrastructure/adapters/services/__tests__/commentAnalysis.bot-filter.spec.ts
@@ -1,0 +1,145 @@
+/**
+ * Regression tests for the bot-comment filter inside
+ * `CommentAnalysisService.processComments`. This filter is what stops
+ * the rule-generator LLM from learning from Kody's own past reviews of
+ * the same repository — a self-feedback loop that surfaced on
+ * 2026-05-20 when bitbucket onboarding kept producing the same
+ * generated rule run after run because Kody's prior bitbucket
+ * suggestions were leaking through the filter.
+ *
+ * Two visible signatures across providers, both have to be matched:
+ *   - `kody-codereview`    (github / gitlab / azure / forgejo)
+ *   - `kody|code-review`   (bitbucket — uses a visible chip because
+ *                           bitbucket's Atlassian Markdown escapes
+ *                           raw HTML comments, so the HTML-comment
+ *                           marker the other providers use is
+ *                           rendered as literal text on bitbucket
+ *                           and is unusable as a hidden marker)
+ *
+ * Pre-fix the filter only knew about the first form; bitbucket
+ * comments slipped through.
+ */
+import { CommentAnalysisService } from '../commentAnalysis.service';
+
+function makeService() {
+    // processComments is a pure sync transform that never touches the
+    // injected services — safe to wire with nulls and avoid mocking
+    // out the whole DI graph.
+    return new CommentAnalysisService(
+        null as any,
+        null as any,
+        null as any,
+    );
+}
+
+function longBody(prefix: string): string {
+    // The downstream length filter drops anything shorter than 100
+    // chars. Use a long-enough suffix so the only thing that can drop
+    // these fixtures is the bot filter under test.
+    return `${prefix}\n${'x'.repeat(200)}`;
+}
+
+describe('CommentAnalysisService.processComments — bot-comment filter', () => {
+    it('drops bitbucket Kody suggestions (kody|code-review chip)', () => {
+        const svc = makeService();
+
+        const out = svc.processComments([
+            {
+                pr: { pull_number: 1, repository: { language: 'typescript' } },
+                generalComments: [
+                    {
+                        id: 'human-1',
+                        body: longBody('Looks good overall, ship it.'),
+                        user: { id: 'u1', type: 'user' },
+                    },
+                    {
+                        id: 'kody-bb-1',
+                        body: longBody(
+                            '`kody|code-review` `kody_rules` `severity-level|high`\n\nForbidden temporary marker TODO_REMOVE_ME appears in src/legacy/cleanup.ts',
+                        ),
+                        user: { id: 'kody', type: 'user' },
+                    },
+                ],
+                reviewComments: [],
+                files: [{ filename: 'src/legacy/cleanup.ts' }],
+            },
+        ]);
+
+        // processComments returns a flat array of surviving comments
+        // (see the `.flatMap((pr) => pr.comments)` near the end of the
+        // method). Map to bodies for the assertions.
+        const allBodies = (out ?? []).map((c: any) => String(c?.body ?? ''));
+        expect(allBodies.some((b) => b.includes('Looks good overall'))).toBe(
+            true,
+        );
+        expect(
+            allBodies.some((b) => b.includes('kody|code-review')),
+        ).toBe(false);
+    });
+
+    it('drops github/gitlab/azure Kody comments (kody-codereview HTML marker)', () => {
+        const svc = makeService();
+
+        const out = svc.processComments([
+            {
+                pr: { pull_number: 1, repository: { language: 'typescript' } },
+                generalComments: [
+                    {
+                        id: 'human-2',
+                        body: longBody('Could you split the test fixture?'),
+                        user: { id: 'u2', type: 'user' },
+                    },
+                    {
+                        id: 'kody-gh-1',
+                        body: longBody(
+                            'Avoid forbidden marker TODO_REMOVE_ME here.\n\n<!-- kody-codereview -->&#8203;',
+                        ),
+                        user: { id: 'kody', type: 'user' },
+                    },
+                ],
+                reviewComments: [],
+                files: [{ filename: 'src/legacy/cleanup.ts' }],
+            },
+        ]);
+
+        const allBodies = (out ?? []).map((c: any) => String(c?.body ?? ''));
+        expect(allBodies.some((b) => b.includes('Could you split'))).toBe(
+            true,
+        );
+        expect(
+            allBodies.some((b) => b.includes('kody-codereview')),
+        ).toBe(false);
+    });
+
+    it('still drops comments whose `user.type` is "bot" regardless of body', () => {
+        const svc = makeService();
+
+        const out = svc.processComments([
+            {
+                pr: { pull_number: 1, repository: { language: 'typescript' } },
+                generalComments: [
+                    {
+                        id: 'dependabot-1',
+                        body: longBody('Bumps dependency from 1.0 to 1.1.'),
+                        user: { id: 'dependabot', type: 'bot' },
+                    },
+                    {
+                        id: 'human-3',
+                        body: longBody('Reviewer feedback: rename foo to bar.'),
+                        user: { id: 'u3', type: 'user' },
+                    },
+                ],
+                reviewComments: [],
+                files: [{ filename: 'src/foo.ts' }],
+            },
+        ]);
+
+        const allBodies = (out ?? []).map((c: any) => String(c?.body ?? ''));
+        expect(allBodies.some((b) => b.includes('Reviewer feedback'))).toBe(
+            true,
+        );
+        expect(allBodies.some((b) => b.includes('Bumps dependency'))).toBe(
+            false,
+        );
+    });
+});

--- a/libs/code-review/infrastructure/adapters/services/commentAnalysis.service.ts
+++ b/libs/code-review/infrastructure/adapters/services/commentAnalysis.service.ts
@@ -604,12 +604,34 @@ export class CommentAnalysisService {
                             !comment?.user?.type ||
                             comment?.user?.type?.toLowerCase() !== 'bot',
                     )
-                    ?.filter(
-                        (comment) =>
-                            !comment?.body
-                                ?.toLowerCase()
-                                ?.includes('kody-codereview'),
-                    )
+                    ?.filter((comment) => {
+                        // Drop comments authored by Kody itself — otherwise
+                        // the rule-generator LLM learns from Kody's own past
+                        // reviews and creates duplicate rules on subsequent
+                        // onboardings (self-feedback loop). Two visible
+                        // signatures across providers, both have to match:
+                        //   - `kody-codereview`  → github / gitlab / azure /
+                        //     forgejo emit this in the HTML-comment marker
+                        //     they suffix to every Kody comment. The marker
+                        //     is invisible in those renderers.
+                        //   - `kody|code-review` → bitbucket cloud emits
+                        //     this as a visible chip at the start of every
+                        //     Kody suggestion (bitbucket's Atlassian
+                        //     Markdown escapes raw HTML, so the HTML-comment
+                        //     marker is unusable there — see
+                        //     bitbucket.service.ts:213). Before this filter
+                        //     was widened, bitbucket Kody comments slipped
+                        //     through and the onboarding rule generator
+                        //     was effectively learning from itself —
+                        //     symptom is generated rules that exactly
+                        //     paraphrase Kody's own prior reviews of the
+                        //     same repo.
+                        const body = comment?.body?.toLowerCase() ?? '';
+                        return (
+                            !body.includes('kody-codereview') &&
+                            !body.includes('kody|code-review')
+                        );
+                    })
                     ?.filter((comment) => comment?.body?.length > 100);
 
                 let finalComments = filteredComments;

--- a/libs/code-review/infrastructure/adapters/services/commentAnalysis.service.ts
+++ b/libs/code-review/infrastructure/adapters/services/commentAnalysis.service.ts
@@ -10,6 +10,7 @@ import { Injectable } from '@nestjs/common';
 import { v4 } from 'uuid';
 
 import { SUPPORTED_LANGUAGES } from '@libs/code-review/domain/contracts/SupportedLanguages';
+import { isKodyAuthoredBody } from '@libs/common/utils/kody-identifiers';
 import {
     CategorizedComment,
     UncategorizedComment,
@@ -604,34 +605,18 @@ export class CommentAnalysisService {
                             !comment?.user?.type ||
                             comment?.user?.type?.toLowerCase() !== 'bot',
                     )
-                    ?.filter((comment) => {
+                    ?.filter(
                         // Drop comments authored by Kody itself — otherwise
-                        // the rule-generator LLM learns from Kody's own past
-                        // reviews and creates duplicate rules on subsequent
-                        // onboardings (self-feedback loop). Two visible
-                        // signatures across providers, both have to match:
-                        //   - `kody-codereview`  → github / gitlab / azure /
-                        //     forgejo emit this in the HTML-comment marker
-                        //     they suffix to every Kody comment. The marker
-                        //     is invisible in those renderers.
-                        //   - `kody|code-review` → bitbucket cloud emits
-                        //     this as a visible chip at the start of every
-                        //     Kody suggestion (bitbucket's Atlassian
-                        //     Markdown escapes raw HTML, so the HTML-comment
-                        //     marker is unusable there — see
-                        //     bitbucket.service.ts:213). Before this filter
-                        //     was widened, bitbucket Kody comments slipped
-                        //     through and the onboarding rule generator
-                        //     was effectively learning from itself —
-                        //     symptom is generated rules that exactly
-                        //     paraphrase Kody's own prior reviews of the
-                        //     same repo.
-                        const body = comment?.body?.toLowerCase() ?? '';
-                        return (
-                            !body.includes('kody-codereview') &&
-                            !body.includes('kody|code-review')
-                        );
-                    })
+                        // the rule-generator LLM learns from Kody's own
+                        // past reviews and creates duplicate rules on
+                        // subsequent onboardings (self-feedback loop).
+                        // Both provider signatures are checked centrally
+                        // via `isKodyAuthoredBody` — see
+                        // `libs/common/utils/kody-identifiers.ts` for why
+                        // bitbucket needs a different marker form than
+                        // github / gitlab / azure / forgejo.
+                        (comment) => !isKodyAuthoredBody(comment?.body),
+                    )
                     ?.filter((comment) => comment?.body?.length > 100);
 
                 let finalComments = filteredComments;

--- a/libs/common/utils/kody-identifiers.ts
+++ b/libs/common/utils/kody-identifiers.ts
@@ -1,0 +1,43 @@
+/**
+ * Signatures Kody injects at the end (or, on bitbucket, the start) of
+ * every comment it posts. Used by:
+ *
+ *   - Per-provider comment emitters
+ *     (`github.service.ts`, `gitlab.service.ts`, `azureRepos.service.ts`,
+ *      `forgejo.service.ts`, `bitbucket.service.ts`,
+ *      `chatWithKodyFromGit.use-case.ts`, `commentManager.service.ts`)
+ *     append the right marker to each Kody comment.
+ *
+ *   - Read-side filters that need to recognize "this comment was
+ *     written by Kody, don't treat it as human signal":
+ *     `commentAnalysis.service.ts` (rule-generator input filter),
+ *     `validate-prerequisites.stage.ts` (skip re-review on standing
+ *     PRs), etc.
+ *
+ * Two distinct values because bitbucket cloud's Atlassian Markdown
+ * escapes raw HTML (it would render `<!-- kody-codereview -->` as
+ * visible text), so the HTML-comment marker the other providers
+ * suffix to each comment is unusable on bitbucket. Bitbucket gets a
+ * visible chip at the start of each comment instead.
+ */
+export const KODY_IDENTIFIERS = {
+    LOGIN_KEYWORDS: ['kody', 'kodus'],
+    MARKDOWN_IDENTIFIERS: {
+        DEFAULT: 'kody-codereview',
+        BITBUCKET: 'kody|code-review',
+    },
+} as const;
+
+/**
+ * True when the given comment body looks like one Kody itself
+ * authored. Checks BOTH provider signatures so callers don't have to
+ * special-case bitbucket. Case-insensitive on the body to match what
+ * the existing filter sites have always done.
+ */
+export function isKodyAuthoredBody(body: string | undefined | null): boolean {
+    const lower = (body ?? '').toLowerCase();
+    return (
+        lower.includes(KODY_IDENTIFIERS.MARKDOWN_IDENTIFIERS.DEFAULT) ||
+        lower.includes(KODY_IDENTIFIERS.MARKDOWN_IDENTIFIERS.BITBUCKET)
+    );
+}

--- a/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
+++ b/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
@@ -13,6 +13,10 @@ import {
     buildPrKey,
 } from '@libs/sandbox/domain/contracts/sandbox-lease-manager.contract';
 import { CreateSandboxParams } from '@libs/sandbox/domain/contracts/sandbox.provider';
+// Shared with libs/code-review/.../commentAnalysis.service.ts so the
+// read-side filter that drops Kody's own past comments stays in sync
+// with what every provider emitter actually writes.
+import { KODY_IDENTIFIERS } from '@libs/common/utils/kody-identifiers';
 
 import { PlatformResponsePolicyFactory } from './policies/platform-response.policy';
 
@@ -21,14 +25,6 @@ const KODY_COMMANDS = {
     BUSINESS_LOGIC_VALIDATION: '@kody -v business-logic',
     KODY_MENTION: '@kody',
     KODUS_MENTION: '@kodus',
-} as const;
-
-const KODY_IDENTIFIERS = {
-    LOGIN_KEYWORDS: ['kody', 'kodus'],
-    MARKDOWN_IDENTIFIERS: {
-        DEFAULT: 'kody-codereview',
-        BITBUCKET: 'kody|code-review',
-    },
 } as const;
 
 const ACKNOWLEDGMENT_MESSAGES = {


### PR DESCRIPTION
## Summary

- `CommentAnalysisService.processComments` filters Kody's own past comments by looking for `kody-codereview` in the body — works for github / gitlab / azure / forgejo (which suffix every Kody comment with `<!-- kody-codereview -->&#8203;`, hidden by their markdown renderers) but **NOT for bitbucket cloud**, whose Atlassian Markdown escapes raw HTML and would render `<!-- kody-codereview -->` as literal visible text.
- Bitbucket uses a visible chip at the start of every Kody suggestion instead: `` `kody|code-review` `kody_rules` `severity-level|high` ``. The chip is what's defined as the BITBUCKET signature in `chatWithKodyFromGit.use-case.ts:30` and emitted in `bitbucket.service.ts:213`.
- Because the filter only matched the hyphen form, every bitbucket Kody comment slipped through. The downstream LLM then treated Kody's own past suggestions as legitimate human review signal and generated rules that paraphrased its own prior reviews of the same repository — a **self-feedback loop**.

## How it was observed

Validating the `kody-rules-create-and-apply` E2E scenario on bitbucket on 2026-05-20: every fresh test tenant onboarded with an auto-generated rule **"Avoid Committing Temporary or Forbidden Markers"** whose text was reverse-engineered from Kody's prior `"Forbidden temporary marker TODO_REMOVE_ME ..."` suggestions on the test repo. That generated rule then competed with a user-created test rule on the same identifier — 2 of 3 stability runs flaked because the suggestion attribution was non-deterministic between the two.

The behavior also affects **real customers** who onboard a bitbucket repo with prior Kody review history — they get auto-generated rules that simply restate things Kody already said.

## Change

`libs/code-review/infrastructure/adapters/services/commentAnalysis.service.ts`: widen the bot-comment filter inside `processComments` to recognize both `kody-codereview` and `kody|code-review`. Adds a comment block linking the platform-specific marker emission sites so the next person who renames the signature finds this filter.

Adds `libs/code-review/infrastructure/adapters/services/__tests__/commentAnalysis.bot-filter.spec.ts` — 3 cases:
- bitbucket Kody suggestion (chip) is dropped
- github/gitlab/azure/forgejo Kody comment (HTML marker) is dropped
- regular `user.type === 'bot'` filter still works for non-Kody bots (dependabot, etc.)

Negative-test confirmed: reverting the production change makes the bitbucket case fail.

## Test plan

- [x] Unit: new `commentAnalysis.bot-filter.spec.ts` passes 3/3
- [x] Negative test: reverting the production change → 1/3 fails (bitbucket case)
- [ ] Manual: re-run the `kody-rules-create-and-apply × cloud × bitbucket` scenario after this lands; the historical contamination on the QA test repo still exists for ~3 months (the `dateFilter` window in `generateKodyRules`), so the user rule will keep competing with the existing `[active/generated] Avoid Committing Temporary or Forbidden Markers` until that's pruned. New onboardings start clean.

## Related

E2E test infra needs a complementary change to use a unique marker per run so the scenario isn't dependent on no competing generated rule existing — tracked in `chore/quality-gates`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

<!-- kody-pr-summary:start -->
This pull request fixes a self-feedback loop issue where Kody's rule-generator LLM was inadvertently learning from Kody's own past code review suggestions, specifically on Bitbucket.

Previously, the `CommentAnalysisService`'s bot-comment filter, which prevents Kody's own comments from being used for rule generation, only recognized the `kody-codereview` HTML marker used by platforms like GitHub, GitLab, and Azure. Bitbucket, however, uses a visible `kody|code-review` chip in its suggestions due to its Atlassian Markdown escaping HTML comments. This difference caused Kody's Bitbucket suggestions to bypass the filter, leading to the generation of duplicate or paraphrased rules based on Kody's prior output.

This change updates the `CommentAnalysisService` to correctly identify and filter out Kody's comments from Bitbucket by checking for the `kody|code-review` signature in addition to the existing `kody-codereview` marker. This ensures that the rule-generator LLM learns exclusively from human feedback, preventing Kody's own suggestions from influencing future rule generation.

New regression tests have been added to validate the correct filtering of both Bitbucket (`kody|code-review`) and other provider (`kody-codereview`) Kody comments, as well as general bot comments.
<!-- kody-pr-summary:end -->