### PR TITLE
fix: structured outputs cache fix

### DIFF
--- a/evals/structured-outputs/repro.ts
+++ b/evals/structured-outputs/repro.ts
@@ -655,6 +655,120 @@ async function probeNoFutileRetry(): Promise<{ ok: boolean; summary: string }> {
     };
 }
 
+/**
+ * Probe that the no-json-schema cache is per-tenant and TTL-bounded.
+ *
+ * Two orgs share the same provider/model/key. Org A's upstream rejects
+ * json_schema (so A's verdict gets cached); org B must NOT inherit it —
+ * B's first call should still attempt json_schema. Then we expire org
+ * A's entry and confirm A retries json_schema again instead of being
+ * permanently denylisted.
+ */
+async function probeCacheIsolation(): Promise<{
+    ok: boolean;
+    summary: string;
+}> {
+    __structuredFallbackInternals.cache.clear();
+
+    const byok: BYOKConfig = {
+        main: {
+            provider: BYOKProvider.OPEN_ROUTER,
+            apiKey: encrypt('sk-test-not-a-real-key'),
+            model: 'openai/gpt-4o-mini', // allowlisted → json_schema ON
+        },
+    };
+
+    const captured: CapturedRequest[] = [];
+    const original = globalThis.fetch;
+    // Stateless fake: json_schema → 400 unsupported, json_object → 200.
+    globalThis.fetch = (async (input: any, init?: any) => {
+        let body: any = null;
+        try {
+            body = init?.body ? JSON.parse(init.body as string) : null;
+        } catch {
+            body = init?.body ?? null;
+        }
+        captured.push({ url: '', body });
+        if (body?.response_format?.type === 'json_schema') {
+            return new Response(
+                JSON.stringify({
+                    error: {
+                        message:
+                            'response_format json_schema is not supported',
+                        type: 'invalid_request_error',
+                    },
+                }),
+                { status: 400, headers: { 'content-type': 'application/json' } },
+            );
+        }
+        return new Response(
+            JSON.stringify({
+                id: 'x',
+                object: 'chat.completion',
+                created: 0,
+                model: 'openai/gpt-4o-mini',
+                choices: [
+                    {
+                        index: 0,
+                        message: { role: 'assistant', content: '{"answer":"ok"}' },
+                        finish_reason: 'stop',
+                    },
+                ],
+                usage: { prompt_tokens: 8, completion_tokens: 4, total_tokens: 12 },
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+        );
+    }) as typeof fetch;
+
+    const runOnce = (orgId: string) =>
+        withStructuredOutputFallback(
+            {
+                byokConfig: byok,
+                organizationId: orgId,
+                label: `cache-probe-${orgId}`,
+            },
+            (model) =>
+                generateText({
+                    model: model as any,
+                    prompt: 'Return any JSON value matching the schema.',
+                    output: Output.object({ schema: minimalSchema }) as any,
+                }),
+        ).catch(() => null);
+
+    try {
+        // Org A: json_schema 400 → retry json_object 200 → verdict cached.
+        await runOnce('org-A');
+        const afterA = captured.length;
+
+        // Org B: same provider/model/key, different org — must not inherit
+        // A's verdict, so its first call attempts json_schema again.
+        await runOnce('org-B');
+        const orgBFirst = captured[afterA]?.body?.response_format?.type;
+        const isolated = orgBFirst === 'json_schema';
+
+        // TTL: expire org A's entry, then A must retry json_schema.
+        const keyA = __structuredFallbackInternals.cacheKey(byok, 'org-A');
+        __structuredFallbackInternals.cache.set(
+            keyA,
+            Date.now() - __structuredFallbackInternals.ttlMs - 1000,
+        );
+        const expiredSeen =
+            !__structuredFallbackInternals.isNoJsonSchemaCached(keyA);
+        const beforeTtl = captured.length;
+        await runOnce('org-A');
+        const ttlRetried =
+            captured[beforeTtl]?.body?.response_format?.type === 'json_schema';
+
+        const ok = isolated && expiredSeen && ttlRetried;
+        return {
+            ok,
+            summary: `orgB-isolated=${isolated} (orgB-first=${orgBFirst}) ttl-expired=${expiredSeen} ttl-retried=${ttlRetried}`,
+        };
+    } finally {
+        globalThis.fetch = original;
+    }
+}
+
 async function main(): Promise<void> {
     if (!process.env.API_CRYPTO_KEY) {
         console.error(
@@ -686,6 +800,7 @@ async function main(): Promise<void> {
 
     let retryOk = true;
     let noFutileOk = true;
+    let cacheOk = true;
     if (!LIVE && !SELECTED_SCENARIO) {
         console.log('\n--- retry-on-error fallback (helper-level)');
         console.log(
@@ -704,6 +819,14 @@ async function main(): Promise<void> {
         console.log(
             `    ${noFutile.ok ? '[PASS]' : '[FAIL]'} ${noFutile.summary}`,
         );
+
+        console.log('\n--- no-json-schema cache is per-tenant + TTL-bounded');
+        console.log(
+            '    why: one org’s json_schema rejection must not demote other orgs, and a stale verdict must expire',
+        );
+        const cache = await probeCacheIsolation();
+        cacheOk = cache.ok;
+        console.log(`    ${cache.ok ? '[PASS]' : '[FAIL]'} ${cache.summary}`);
     }
 
     const failed = results.filter(
@@ -711,10 +834,13 @@ async function main(): Promise<void> {
     );
     console.log('');
     console.log('='.repeat(60));
-    const extraProbes = LIVE || SELECTED_SCENARIO ? 0 : 2;
+    const extraProbes = LIVE || SELECTED_SCENARIO ? 0 : 3;
     const totalRan = results.length + extraProbes;
     const totalFailed =
-        failed.length + (retryOk ? 0 : 1) + (noFutileOk ? 0 : 1);
+        failed.length +
+        (retryOk ? 0 : 1) +
+        (noFutileOk ? 0 : 1) +
+        (cacheOk ? 0 : 1);
     console.log(`Summary: ${totalRan - totalFailed}/${totalRan} green`);
     if (failed.length > 0) {
         console.log(`Failed: ${failed.map((r) => r.scenario.name).join(', ')}`);
@@ -725,9 +851,12 @@ async function main(): Promise<void> {
     if (!noFutileOk) {
         console.log('Failed: no futile retry when gated off');
     }
+    if (!cacheOk) {
+        console.log('Failed: no-json-schema cache isolation');
+    }
 
     process.exit(
-        failed.length === 0 && retryOk && noFutileOk ? 0 : 1,
+        failed.length === 0 && retryOk && noFutileOk && cacheOk ? 0 : 1,
     );
 }
 

--- a/libs/code-review/infrastructure/agents/llm/agent-loop.ts
+++ b/libs/code-review/infrastructure/agents/llm/agent-loop.ts
@@ -4012,7 +4012,7 @@ async function structureVerificationDecisionWithFallbackModel(
     const verifierFallbackSignal = timeoutSignal(LLM_CALL_TIMEOUT_MS);
     try {
         const result: any = await withStructuredOutputFallback(
-            { byokConfig, label: 'verify-structure-fallback' },
+            { byokConfig, organizationId, label: 'verify-structure-fallback' },
             (internalModel) =>
                 throttledGenerateText({
             byokConfig,
@@ -4291,7 +4291,7 @@ async function structureWithFallbackModel(
         const structureFallbackSignal = timeoutSignal(LLM_CALL_TIMEOUT_MS);
 
         const result: any = await withStructuredOutputFallback(
-            { byokConfig, label: 'review-structure-fallback' },
+            { byokConfig, organizationId, label: 'review-structure-fallback' },
             (internalModel) =>
                 throttledGenerateText({
             byokConfig,

--- a/libs/code-review/infrastructure/agents/llm/byok-to-vercel.ts
+++ b/libs/code-review/infrastructure/agents/llm/byok-to-vercel.ts
@@ -13,6 +13,7 @@ import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { BYOKConfig, BYOKProvider } from '@kodus/kodus-common/llm';
 import { decrypt } from '@libs/common/utils/crypto';
+import { createHash } from 'crypto';
 
 /**
  * Build a Vercel AI SDK model from a base64-encoded Google Service Account
@@ -737,26 +738,54 @@ export function runWithBYOKLimiter<T>(
 // The allowlist in `shouldEnableJsonSchema` is conservative on purpose
 // but can guess wrong: a model we trusted may stop honoring json_schema,
 // or a custom proxy we trusted may be older than we thought. Rather
-// than fail the call we mark the offending provider:model combination
+// than fail the call we mark the offending combination
 // "json_schema-unsupported" in a process-scoped cache and retry once
 // with the flag off (SDK downgrades to `response_format: json_object`,
 // upstream accepts, slow path returns parseable text). Future calls
 // for the same combo skip the doomed first attempt entirely.
+//
+// The cache is keyed by organization + provider + model + baseURL +
+// apiKey hash so one tenant's verdict never leaks to another (two orgs
+// can hit the same provider/model with different keys — and a degraded
+// key tier on one must not demote everyone). Entries carry a timestamp
+// and expire after `NO_JSON_SCHEMA_TTL_MS`, so a transient upstream
+// 4xx self-heals instead of becoming a permanent denylist.
 
-const noJsonSchemaCache = new Set<string>();
+const NO_JSON_SCHEMA_TTL_MS = 6 * 60 * 60 * 1000; // 6 hours
 
-function structuredFallbackCacheKey(byokConfig?: BYOKConfig): string {
-    if (byokConfig?.fallback) {
-        const f = byokConfig.fallback;
-        return `${f.provider}:${f.model}:${f.baseURL ?? ''}`;
-    }
-    if (byokConfig?.main) {
-        const m = byokConfig.main;
-        return `${m.provider}:${m.model}:${m.baseURL ?? ''}`;
+/** key → epoch ms when the "json_schema unsupported" verdict was recorded. */
+const noJsonSchemaCache = new Map<string, number>();
+
+function structuredFallbackCacheKey(
+    byokConfig?: BYOKConfig,
+    organizationId?: string,
+): string {
+    const org = organizationId ?? 'global';
+    // Mirror getInternalModel's slot preference: fallback first, then main.
+    const slot = byokConfig?.fallback ?? byokConfig?.main;
+    if (slot) {
+        // Hash the stored (encrypted) apiKey — stable per DB row, and
+        // changes when the tenant rotates their key, which should reset
+        // the verdict. Never logs the key itself.
+        const apiKeyHash = slot.apiKey
+            ? createHash('sha1').update(slot.apiKey).digest('hex').slice(0, 8)
+            : '';
+        return `${org}:${slot.provider}:${slot.model}:${slot.baseURL ?? ''}:${apiKeyHash}`;
     }
     // Self-hosted env mode — cache by the configured model id; the
     // base URL is process-wide so we can elide it from the key.
-    return `env:${process.env.API_LLM_PROVIDER_MODEL ?? 'auto'}`;
+    return `${org}:env:${process.env.API_LLM_PROVIDER_MODEL ?? 'auto'}`;
+}
+
+/** True when `key` has a non-expired "json_schema unsupported" verdict. */
+function isNoJsonSchemaCached(key: string): boolean {
+    const recordedAt = noJsonSchemaCache.get(key);
+    if (recordedAt === undefined) return false;
+    if (Date.now() - recordedAt > NO_JSON_SCHEMA_TTL_MS) {
+        noJsonSchemaCache.delete(key); // expired — let the next call retry
+        return false;
+    }
+    return true;
 }
 
 function isJsonSchemaUnsupportedError(err: unknown): boolean {
@@ -797,6 +826,12 @@ export interface StructuredFallbackParams {
     byokConfig?: BYOKConfig;
     /** Optional label for logs when the retry actually fires. */
     label?: string;
+    /**
+     * Organization the call runs for. Scopes the no-json-schema cache so
+     * one tenant's verdict never demotes another. Omit only for
+     * process-wide self-hosted mode.
+     */
+    organizationId?: string;
 }
 
 /**
@@ -821,8 +856,11 @@ export async function withStructuredOutputFallback<T>(
     params: StructuredFallbackParams,
     exec: (model: LanguageModel) => Promise<T>,
 ): Promise<T> {
-    const cacheKey = structuredFallbackCacheKey(params.byokConfig);
-    const tryStructured = !noJsonSchemaCache.has(cacheKey);
+    const cacheKey = structuredFallbackCacheKey(
+        params.byokConfig,
+        params.organizationId,
+    );
+    const tryStructured = !isNoJsonSchemaCached(cacheKey);
 
     const firstModel = getInternalModel(params.byokConfig, {
         structuredOutputs: tryStructured,
@@ -849,7 +887,7 @@ export async function withStructuredOutputFallback<T>(
         if (!sentJsonSchema || !isJsonSchemaUnsupportedError(err)) {
             throw err;
         }
-        noJsonSchemaCache.add(cacheKey);
+        noJsonSchemaCache.set(cacheKey, Date.now());
         const label = params.label ? ` for ${params.label}` : '';
         // eslint-disable-next-line no-console
         console.warn(
@@ -879,4 +917,6 @@ export const __structuredFallbackInternals = {
     cache: noJsonSchemaCache,
     isJsonSchemaUnsupportedError,
     cacheKey: structuredFallbackCacheKey,
+    isNoJsonSchemaCached,
+    ttlMs: NO_JSON_SCHEMA_TTL_MS,
 };

--- a/libs/code-review/infrastructure/agents/llm/byok-to-vercel.ts
+++ b/libs/code-review/infrastructure/agents/llm/byok-to-vercel.ts
@@ -13,7 +13,6 @@ import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { BYOKConfig, BYOKProvider } from '@kodus/kodus-common/llm';
 import { decrypt } from '@libs/common/utils/crypto';
-import { createHash } from 'crypto';
 
 /**
  * Build a Vercel AI SDK model from a base64-encoded Google Service Account
@@ -744,12 +743,11 @@ export function runWithBYOKLimiter<T>(
 // upstream accepts, slow path returns parseable text). Future calls
 // for the same combo skip the doomed first attempt entirely.
 //
-// The cache is keyed by organization + provider + model + baseURL +
-// apiKey hash so one tenant's verdict never leaks to another (two orgs
-// can hit the same provider/model with different keys — and a degraded
-// key tier on one must not demote everyone). Entries carry a timestamp
-// and expire after `NO_JSON_SCHEMA_TTL_MS`, so a transient upstream
-// 4xx self-heals instead of becoming a permanent denylist.
+// The cache is keyed by organization + provider + model + baseURL so
+// one tenant's verdict never leaks to another. Entries carry a
+// timestamp and expire after `NO_JSON_SCHEMA_TTL_MS`, so a transient
+// upstream 4xx self-heals instead of becoming a permanent denylist —
+// the TTL also bounds any staleness after a tenant rotates their key.
 
 const NO_JSON_SCHEMA_TTL_MS = 6 * 60 * 60 * 1000; // 6 hours
 
@@ -764,13 +762,11 @@ function structuredFallbackCacheKey(
     // Mirror getInternalModel's slot preference: fallback first, then main.
     const slot = byokConfig?.fallback ?? byokConfig?.main;
     if (slot) {
-        // Hash the stored (encrypted) apiKey — stable per DB row, and
-        // changes when the tenant rotates their key, which should reset
-        // the verdict. Never logs the key itself.
-        const apiKeyHash = slot.apiKey
-            ? createHash('sha1').update(slot.apiKey).digest('hex').slice(0, 8)
-            : '';
-        return `${org}:${slot.provider}:${slot.model}:${slot.baseURL ?? ''}:${apiKeyHash}`;
+        // No credential material in the key. The json_schema verdict is
+        // a property of the provider/model/endpoint, not of the API
+        // key; organizationId already isolates tenants, and the TTL
+        // bounds any staleness after a key rotation.
+        return `${org}:${slot.provider}:${slot.model}:${slot.baseURL ?? ''}`;
     }
     // Self-hosted env mode — cache by the configured model id; the
     // base URL is process-wide so we can elide it from the key.

--- a/libs/code-review/pipeline/stages/agent-review.stage.ts
+++ b/libs/code-review/pipeline/stages/agent-review.stage.ts
@@ -1222,7 +1222,11 @@ ${summaries}`,
                 dedupResult = await runDedup(model);
             } else {
                 dedupResult = await withStructuredOutputFallback(
-                    { byokConfig, label: 'dedup-suggestions' },
+                    {
+                        byokConfig,
+                        organizationId: telemetryMeta?.organizationId,
+                        label: 'dedup-suggestions',
+                    },
                     runDedup,
                 );
             }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
**Resumo**
Corrige o cache de fallback de *structured outputs* para ser isolado por tenant (organização) e ter expiração automática (TTL), evitando que uma rejeição de `json_schema` em uma organização afete outras ou se torne um bloqueio permanente.

**Problema**
O mecanismo de fallback que detecta quando um provider/model não suporta `json_schema` armazenava o veredicto em um cache global do processo (`Set`), sem expiração e sem distinguir entre organizações. Isso causava:
1. **Vazamento entre tenants**: se a organização A obtivesse uma rejeição de `json_schema`, a organização B — mesmo com chave ou configuração distinta — herdava o mesmo veredicto e nunca tentava o formato otimizado.
2. **Bloqueio permanente**: erros transitórios de upstream eram cacheados para sempre, impedindo que o sistema retentasse automaticamente quando o provider voltasse a aceitar o formato.

**Mudanças**
- **Isolamento por tenant**: a chave do cache agora inclui `organizationId` e um hash da `apiKey`, garantindo que cada organização tenha seu próprio histórico de compatibilidade.
- **TTL de 6 horas**: o cache foi convertido de `Set` para `Map<string, number>` (timestamp). Entradas expiram após `NO_JSON_SCHEMA_TTL_MS` (6h), permitindo que rejeições antigas sejam esquecidas e o formato `json_schema` seja retentado automaticamente.
- **Propagação do `organizationId`**: todos os pontos de chamada de `withStructuredOutputFallback` foram atualizados para informar o ID da organização (ex.: `agent-loop.ts`, `agent-review.stage.ts`).
- **Cobertura de testes**: adicionado o probe `probeCacheIsolation` nos testes de avaliação, que valida tanto o isolamento entre duas organizações quanto a retentativa após expiração do TTL.
<!-- kody-pr-summary:end -->