### PR TITLE
fix: lost first review after repo onboarding

### DIFF
--- a/libs/automation/application/use-cases/teamAutomation/updateOrCreateTeamAutomationUseCase.ts
+++ b/libs/automation/application/use-cases/teamAutomation/updateOrCreateTeamAutomationUseCase.ts
@@ -45,13 +45,16 @@ export class UpdateOrCreateTeamAutomationUseCase implements IUseCase {
             team: { uuid: teamAutomations.teamId },
         });
 
-        if (!oldTeamAutomation) {
-            this.setupNewAutomations(
+        // `find` always resolves to an array, so a fresh team yields `[]`.
+        // Treat an empty (or missing) result as "no automations yet" so it
+        // still flows into `setupNewAutomations`, as the falsy check intended.
+        if (!oldTeamAutomation?.length) {
+            await this.setupNewAutomations(
                 teamAutomations.automations,
                 organizationAndTeamData,
             );
         } else {
-            this.updateOrCreateAutomations(
+            await this.updateOrCreateAutomations(
                 teamAutomations,
                 oldTeamAutomation,
                 organizationAndTeamData,
@@ -68,19 +71,22 @@ export class UpdateOrCreateTeamAutomationUseCase implements IUseCase {
         };
     }
 
-    private setupNewAutomations(
+    private async setupNewAutomations(
         automations: TeamAutomationsDto['automations'],
         organizationAndTeamData: any,
     ) {
+        // Awaited so the team_automation rows are committed before `execute`
+        // returns. Callers (registerRepo -> ActiveCodeReviewAutomationUseCase)
+        // depend on those rows existing to flip the automation to active.
         for (const automation of automations) {
-            this.executeAutomation.setupStrategy(
+            await this.executeAutomation.setupStrategy(
                 automation?.automationType,
                 organizationAndTeamData,
             );
         }
     }
 
-    private updateOrCreateAutomations(
+    private async updateOrCreateAutomations(
         teamAutomations: TeamAutomationsDto,
         oldTeamAutomation: any[],
         organizationAndTeamData: any,
@@ -91,7 +97,7 @@ export class UpdateOrCreateTeamAutomationUseCase implements IUseCase {
             );
 
             if (existingAutomation) {
-                this.teamAutomationService.update(
+                await this.teamAutomationService.update(
                     { uuid: existingAutomation.uuid },
                     {
                         uuid: existingAutomation.uuid,
@@ -101,7 +107,7 @@ export class UpdateOrCreateTeamAutomationUseCase implements IUseCase {
                     },
                 );
             } else if (automation.status) {
-                this.executeAutomation.setupStrategy(
+                await this.executeAutomation.setupStrategy(
                     automation.automationType,
                     organizationAndTeamData,
                 );

--- a/libs/automation/application/use-cases/teamAutomation/updateOrCreateTeamAutomationUseCase.ts
+++ b/libs/automation/application/use-cases/teamAutomation/updateOrCreateTeamAutomationUseCase.ts
@@ -91,9 +91,18 @@ export class UpdateOrCreateTeamAutomationUseCase implements IUseCase {
         oldTeamAutomation: any[],
         organizationAndTeamData: any,
     ) {
+        // Index by automation uuid so the lookup below is O(1). `set` only when
+        // absent keeps the first-match semantics of the previous `.find()`.
+        const existingByAutomationUuid = new Map<string, any>();
+        for (const old of oldTeamAutomation) {
+            if (!existingByAutomationUuid.has(old.automation.uuid)) {
+                existingByAutomationUuid.set(old.automation.uuid, old);
+            }
+        }
+
         for (const automation of teamAutomations.automations) {
-            const existingAutomation = oldTeamAutomation.find(
-                (old) => old.automation.uuid === automation.automationUuid,
+            const existingAutomation = existingByAutomationUuid.get(
+                automation.automationUuid,
             );
 
             if (existingAutomation) {

--- a/libs/platform/application/services/webhook-context.service.spec.ts
+++ b/libs/platform/application/services/webhook-context.service.spec.ts
@@ -247,4 +247,73 @@ describe('WebhookContextService', () => {
             );
         });
     });
+
+    describe('observability', () => {
+        it('logs a warning when a connected repository has no active code review automation', async () => {
+            const config = buildConfig('org-uuid', 'team-uuid');
+            integrationConfigServiceMock.findIntegrationConfigWithTeams.mockResolvedValue(
+                [config],
+            );
+            // Integration config exists, but no ACTIVE team automation — the
+            // silent-drop window (e.g. webhook right after onboarding).
+            teamAutomationServiceMock.find.mockResolvedValue([]);
+            const warnSpy = jest
+                .spyOn((service as any).logger, 'warn')
+                .mockImplementation(() => undefined);
+
+            const result = await service.getContext(PlatformType.GITHUB, '123');
+
+            expect(result).toBeNull();
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            expect(warnSpy.mock.calls[0][0]).toEqual(
+                expect.objectContaining({
+                    message: expect.stringContaining(
+                        'no team has an active code review automation',
+                    ),
+                    metadata: expect.objectContaining({
+                        repositoryId: '123',
+                        candidateTeamIds: ['team-uuid'],
+                    }),
+                }),
+            );
+        });
+
+        it('logs a warning when no code review automation is registered in the system', async () => {
+            const config = buildConfig('org-uuid', 'team-uuid');
+            integrationConfigServiceMock.findIntegrationConfigWithTeams.mockResolvedValue(
+                [config],
+            );
+            automationServiceMock.find.mockResolvedValue([]);
+            const warnSpy = jest
+                .spyOn((service as any).logger, 'warn')
+                .mockImplementation(() => undefined);
+
+            const result = await service.getContext(PlatformType.GITHUB, '123');
+
+            expect(result).toBeNull();
+            expect(warnSpy).toHaveBeenCalledTimes(1);
+            expect(warnSpy.mock.calls[0][0]).toEqual(
+                expect.objectContaining({
+                    message: expect.stringContaining(
+                        'no code review automation is registered',
+                    ),
+                }),
+            );
+        });
+
+        it('does not warn when an active automation context is resolved', async () => {
+            const config = buildConfig('org-uuid', 'team-uuid');
+            integrationConfigServiceMock.findIntegrationConfigWithTeams.mockResolvedValue(
+                [config],
+            );
+            const warnSpy = jest
+                .spyOn((service as any).logger, 'warn')
+                .mockImplementation(() => undefined);
+
+            const result = await service.getContext(PlatformType.GITHUB, '123');
+
+            expect(result).not.toBeNull();
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/libs/platform/application/services/webhook-context.service.ts
+++ b/libs/platform/application/services/webhook-context.service.ts
@@ -1,3 +1,4 @@
+import { createLogger } from '@kodus/flow';
 import { Inject, Injectable } from '@nestjs/common';
 import {
     IIntegrationConfigService,
@@ -28,6 +29,8 @@ export type WebhookDisambiguator = {
 
 @Injectable()
 export class WebhookContextService {
+    private readonly logger = createLogger(WebhookContextService.name);
+
     constructor(
         @Inject(INTEGRATION_CONFIG_SERVICE_TOKEN)
         private readonly integrationConfigService: IIntegrationConfigService,
@@ -67,13 +70,25 @@ export class WebhookContextService {
         const automation = automations?.[0];
 
         if (!automation) {
+            // The repository is connected but no code review automation exists
+            // in the system at all — a setup/seed problem, not a per-team one.
+            this.logger.warn({
+                message:
+                    'Webhook ignored: no code review automation is registered in the system',
+                context: WebhookContextService.name,
+                metadata: { platformType, repositoryId },
+            });
             return null;
         }
+
+        const candidateTeamIds: string[] = [];
 
         for (const config of candidates) {
             if (!config?.team?.organization?.uuid || !config?.team?.uuid) {
                 continue;
             }
+
+            candidateTeamIds.push(config.team.uuid);
 
             const teamAutomations = await this.teamAutomationService.find({
                 automation: { uuid: automation.uuid },
@@ -91,6 +106,18 @@ export class WebhookContextService {
                 };
             }
         }
+
+        // The repository is connected (integration configs were found) but no
+        // candidate team has an ACTIVE code review automation. This is the
+        // silent-drop path — e.g. a webhook arriving right after onboarding
+        // before the team_automation row is active. Log it so the gap is
+        // observable instead of vanishing without a trace.
+        this.logger.warn({
+            message:
+                'Webhook ignored: repository is connected but no team has an active code review automation',
+            context: WebhookContextService.name,
+            metadata: { platformType, repositoryId, candidateTeamIds },
+        });
 
         return null;
     }

--- a/test/integration/automation/team-automation-onboarding-race.spec.ts
+++ b/test/integration/automation/team-automation-onboarding-race.spec.ts
@@ -1,0 +1,217 @@
+/**
+ * Regression test — onboarding "team_automation" race.
+ *
+ * `POST /code-management/repositories` (registerRepo) runs this sequence,
+ * see create-repositories.ts:101-109:
+ *
+ *   1. ActiveCodeManagementTeamAutomationsUseCase.execute(teamId)
+ *        -> UpdateOrCreateTeamAutomationUseCase.execute(...)
+ *             -> executeAutomation.setupStrategy(...)   // registers the row, status:false
+ *   2. ActiveCodeReviewAutomationUseCase.execute(teamId, automations)
+ *        -> flips that row to status:true
+ *
+ * The bug: UpdateOrCreateTeamAutomationUseCase did NOT await setupStrategy, so
+ * step 2 could run its find() before the row from step 1 was committed. When
+ * that happened the row stayed status:false and every webhook for that team was
+ * silently dropped by WebhookContextService (which queries status:true).
+ *
+ * These tests reproduce the race deterministically by giving register() a
+ * realistic latency: with the missing await the row lands too late and stays
+ * inactive; with the fix the whole chain is awaited and the row is active by
+ * the time step 2 runs.
+ */
+import { ActiveCodeManagementTeamAutomationsUseCase } from '@libs/automation/application/use-cases/teamAutomation/active-code-manegement-automations.use-case';
+import { ActiveCodeReviewAutomationUseCase } from '@libs/automation/application/use-cases/teamAutomation/active-code-review-automation.use-case';
+import { UpdateOrCreateTeamAutomationUseCase } from '@libs/automation/application/use-cases/teamAutomation/updateOrCreateTeamAutomationUseCase';
+import { UpdateTeamAutomationStatusUseCase } from '@libs/automation/application/use-cases/teamAutomation/updateTeamAutomationStatusUseCase';
+import { AutomationType } from '@libs/automation/domain/automation/enum/automation-type';
+
+const REGISTER_DELAY_MS = 40;
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+type TeamAutomationRow = {
+    uuid: string;
+    status: boolean;
+    team: { uuid: string };
+    automation: { uuid: string };
+};
+
+const CODE_REVIEW_AUTOMATION = {
+    uuid: 'automation-code-review',
+    automationType: AutomationType.AUTOMATION_CODE_REVIEW,
+    status: true,
+};
+
+/**
+ * In-memory stand-in for TeamAutomationService. `register` deliberately takes
+ * REGISTER_DELAY_MS to model the INSERT round-trip — that latency is exactly
+ * what the missing `await` used to skip over.
+ */
+const createTeamAutomationServiceFake = () => {
+    const store: TeamAutomationRow[] = [];
+    let sequence = 0;
+
+    return {
+        store,
+        find: jest.fn(async (filter: any = {}) => {
+            return store.filter((row) => {
+                if (filter?.team?.uuid && row.team.uuid !== filter.team.uuid) {
+                    return false;
+                }
+                if (
+                    filter?.automation?.uuid &&
+                    row.automation.uuid !== filter.automation.uuid
+                ) {
+                    return false;
+                }
+                if (
+                    filter?.status !== undefined &&
+                    row.status !== filter.status
+                ) {
+                    return false;
+                }
+                return true;
+            });
+        }),
+        register: jest.fn(async (teamAutomation: any) => {
+            await delay(REGISTER_DELAY_MS);
+            const row: TeamAutomationRow = {
+                uuid: `team-automation-${++sequence}`,
+                status: teamAutomation.status,
+                team: teamAutomation.team,
+                automation: teamAutomation.automation,
+            };
+            store.push(row);
+            return row;
+        }),
+        update: jest.fn(async (filter: any, data: any) => {
+            const row = store.find((r) => r.uuid === filter?.uuid);
+            if (row && data?.status !== undefined) {
+                row.status = data.status;
+            }
+            return row;
+        }),
+    };
+};
+
+/**
+ * Wires the real use cases that registerRepo chains together, backed by the
+ * in-memory team automation store.
+ */
+const createOnboardingHarness = () => {
+    const teamAutomationService = createTeamAutomationServiceFake();
+
+    // Mirrors AutomationCodeReviewService.setup(): registers the team
+    // automation row with status:false. Activation to true happens later,
+    // in ActiveCodeReviewAutomationUseCase.
+    const executeAutomation = {
+        setupStrategy: jest.fn(
+            async (_automationType: string, payload: any) => {
+                await teamAutomationService.register({
+                    status: false,
+                    automation: { uuid: CODE_REVIEW_AUTOMATION.uuid },
+                    team: { uuid: payload.teamId },
+                });
+            },
+        ),
+    };
+
+    const automationService = {
+        find: jest.fn(async () => [CODE_REVIEW_AUTOMATION]),
+    };
+
+    const profileConfigService = {
+        findOne: jest.fn(async () => null),
+    };
+
+    const request = {
+        user: { organization: { uuid: 'org-1' } },
+    } as any;
+
+    const updateTeamAutomationStatusUseCase =
+        new UpdateTeamAutomationStatusUseCase(
+            teamAutomationService as any,
+            request,
+        );
+
+    const updateOrCreateTeamAutomationUseCase =
+        new UpdateOrCreateTeamAutomationUseCase(
+            teamAutomationService as any,
+            executeAutomation as any,
+            profileConfigService as any,
+            request,
+        );
+
+    const activeCodeManagementUseCase =
+        new ActiveCodeManagementTeamAutomationsUseCase(
+            updateOrCreateTeamAutomationUseCase,
+            automationService as any,
+            {} as any,
+            {} as any,
+            request,
+        );
+
+    const activeCodeReviewUseCase = new ActiveCodeReviewAutomationUseCase(
+        updateTeamAutomationStatusUseCase,
+        teamAutomationService as any,
+        request,
+    );
+
+    return {
+        teamAutomationService,
+        executeAutomation,
+        updateOrCreateTeamAutomationUseCase,
+        activeCodeManagementUseCase,
+        activeCodeReviewUseCase,
+    };
+};
+
+describe('Team automation onboarding race', () => {
+    it('registers the code review automation as ACTIVE after the registerRepo onboarding sequence', async () => {
+        const harness = createOnboardingHarness();
+        const teamId = 'team-1';
+
+        // Reproduces create-repositories.ts:101-109 exactly.
+        const codeManagementTeamAutomations =
+            await harness.activeCodeManagementUseCase.execute(teamId);
+        await harness.activeCodeReviewUseCase.execute(
+            teamId,
+            codeManagementTeamAutomations as any,
+        );
+
+        // Let any un-awaited register() settle before asserting, so a failure
+        // reads as "row exists but status:false" rather than "row missing".
+        await delay(REGISTER_DELAY_MS + 20);
+
+        const rows = harness.teamAutomationService.store;
+        expect(rows).toHaveLength(1);
+        expect(rows[0].automation.uuid).toBe(CODE_REVIEW_AUTOMATION.uuid);
+        // The bug: ActiveCodeReviewAutomationUseCase ran its find() before the
+        // un-awaited register() committed, so the row was never flipped to true
+        // and every webhook for this team is dropped by WebhookContextService.
+        expect(rows[0].status).toBe(true);
+    });
+
+    it('does not resolve UpdateOrCreateTeamAutomationUseCase.execute() until setupStrategy has finished', async () => {
+        const harness = createOnboardingHarness();
+
+        await harness.updateOrCreateTeamAutomationUseCase.execute({
+            teamId: 'team-1',
+            automations: [
+                {
+                    automationUuid: CODE_REVIEW_AUTOMATION.uuid,
+                    automationType: CODE_REVIEW_AUTOMATION.automationType,
+                    status: true,
+                },
+            ],
+        } as any);
+
+        // With the missing await, execute() resolves while register() is still
+        // in flight and the row has not landed yet.
+        expect(harness.teamAutomationService.store).toHaveLength(1);
+
+        // Settle the (formerly un-awaited) register() so it doesn't leak.
+        await delay(REGISTER_DELAY_MS + 20);
+    });
+});


### PR DESCRIPTION
fixes #1145

---

<!-- kody-pr-summary:start -->
This pull request addresses a race condition during repository onboarding that could lead to code review automations remaining inactive, causing webhooks to be silently ignored.

The changes include:

1.  **Fixing Asynchronous Operations:** The `UpdateOrCreateTeamAutomationUseCase` now correctly `await`s database write operations (such as setting up new automations and updating existing ones). This ensures that `team_automation` rows are committed to the database before subsequent steps attempt to activate them, preventing a race condition where the automation status might not be flipped to active.
2.  **Enhancing Observability:** The `WebhookContextService` now logs warning messages when incoming webhooks are ignored due to either no code review automation being registered in the system or no active code review automation being found for a connected repository. This provides crucial visibility into previously silent failures, making it easier to diagnose issues during onboarding or with automation setup.
3.  **Adding Integration Tests:** A new integration test has been added to deterministically reproduce and verify the fix for the onboarding race condition, ensuring that code review automations are reliably activated after the repository onboarding sequence.

These changes ensure that newly onboarded repositories will have their code review automations correctly activated, preventing the loss of initial code reviews and improving the diagnosability of webhook processing issues.
<!-- kody-pr-summary:end -->