### PR TITLE
fix: byok banner showing up with amazon bedrock

### DIFF
--- a/libs/organization/application/use-cases/organizationParameters/byok-config.util.ts
+++ b/libs/organization/application/use-cases/organizationParameters/byok-config.util.ts
@@ -1,0 +1,37 @@
+import { BYOKConfig, BYOKProvider } from '@kodus/kodus-common/llm';
+
+/**
+ * A single BYOK credential slot — the `main` (or `fallback`) block of a
+ * stored BYOK config.
+ */
+export type BYOKSlot = BYOKConfig['main'];
+
+/**
+ * Whether a BYOK credential slot carries the credentials it needs to run.
+ *
+ * Most providers authenticate with a single `apiKey` — Google Vertex
+ * stores its base64-encoded service-account JSON in that same field, so
+ * it is covered too. Amazon Bedrock is the exception: it has no `apiKey`
+ * and authenticates with either a bearer token (`awsBearerToken`) or
+ * static IAM credentials (`awsAccessKeyId` + `awsSecretAccessKey`).
+ *
+ * Keep in sync with the auth paths in `bedrockModelFromCredentials`
+ * (byok-to-vercel.ts) and the save-time validation in `encryptSlot`
+ * (create-or-update.use-case.ts).
+ */
+export function isByokSlotConfigured(
+    slot: Partial<BYOKSlot> | null | undefined,
+): boolean {
+    if (!slot) {
+        return false;
+    }
+
+    if (slot.provider === BYOKProvider.AMAZON_BEDROCK) {
+        return Boolean(
+            slot.awsBearerToken ||
+                (slot.awsAccessKeyId && slot.awsSecretAccessKey),
+        );
+    }
+
+    return Boolean(slot.apiKey);
+}

--- a/libs/organization/application/use-cases/organizationParameters/get-llm-config-status.use-case.spec.ts
+++ b/libs/organization/application/use-cases/organizationParameters/get-llm-config-status.use-case.spec.ts
@@ -1,0 +1,122 @@
+import { BYOKProvider } from '@kodus/kodus-common/llm';
+
+// Keep the env-LLM branch deterministic: these tests exercise the BYOK
+// detection logic, so env is always "not configured" here.
+jest.mock('@libs/code-review/infrastructure/agents/llm/env-llm-config', () => ({
+    describeEnvLLMConfig: jest.fn(() => ({ configured: false })),
+}));
+
+import { GetLLMConfigStatusUseCase } from './get-llm-config-status.use-case';
+
+describe('GetLLMConfigStatusUseCase', () => {
+    const orgAndTeam = { organizationId: 'org-1', teamId: 'team-1' };
+
+    const buildUseCase = (configValue: unknown) => {
+        const organizationParametersService = {
+            findByKey: jest
+                .fn()
+                .mockResolvedValue(
+                    configValue === undefined ? null : { configValue },
+                ),
+        };
+        return new GetLLMConfigStatusUseCase(
+            organizationParametersService as any,
+        );
+    };
+
+    describe('Amazon Bedrock BYOK', () => {
+        it('reports byok configured when the bearer token is set (no apiKey)', async () => {
+            const useCase = buildUseCase({
+                main: {
+                    provider: BYOKProvider.AMAZON_BEDROCK,
+                    model: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+                    awsBearerToken: 'enc(ABSK-token)',
+                    awsRegion: 'us-east-1',
+                },
+            });
+
+            const result = await useCase.execute(orgAndTeam as any);
+
+            expect(result.byok.configured).toBe(true);
+            expect(result.byok.providerId).toBe(BYOKProvider.AMAZON_BEDROCK);
+            expect(result.byok.model).toBe(
+                'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+            );
+            expect(result.source).toBe('byok');
+        });
+
+        it('reports byok configured when IAM credentials are set (no apiKey)', async () => {
+            const useCase = buildUseCase({
+                main: {
+                    provider: BYOKProvider.AMAZON_BEDROCK,
+                    model: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+                    awsAccessKeyId: 'enc(AKIA-id)',
+                    awsSecretAccessKey: 'enc(secret)',
+                    awsRegion: 'us-east-1',
+                },
+            });
+
+            const result = await useCase.execute(orgAndTeam as any);
+
+            expect(result.byok.configured).toBe(true);
+            expect(result.source).toBe('byok');
+        });
+
+        it('reports byok NOT configured when no AWS credentials are present', async () => {
+            const useCase = buildUseCase({
+                main: {
+                    provider: BYOKProvider.AMAZON_BEDROCK,
+                    model: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+                    awsRegion: 'us-east-1',
+                },
+            });
+
+            const result = await useCase.execute(orgAndTeam as any);
+
+            expect(result.byok.configured).toBe(false);
+            expect(result.source).toBe('none');
+        });
+
+        it('reports byok NOT configured when only the access key id is present (missing secret)', async () => {
+            const useCase = buildUseCase({
+                main: {
+                    provider: BYOKProvider.AMAZON_BEDROCK,
+                    model: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+                    awsAccessKeyId: 'enc(AKIA-id)',
+                    awsRegion: 'us-east-1',
+                },
+            });
+
+            const result = await useCase.execute(orgAndTeam as any);
+
+            expect(result.byok.configured).toBe(false);
+        });
+    });
+
+    describe('non-Bedrock providers (regression)', () => {
+        it('reports byok configured when apiKey is set', async () => {
+            const useCase = buildUseCase({
+                main: {
+                    provider: BYOKProvider.ANTHROPIC,
+                    model: 'claude-sonnet-4-5-20250929',
+                    apiKey: 'enc(sk-ant)',
+                },
+            });
+
+            const result = await useCase.execute(orgAndTeam as any);
+
+            expect(result.byok.configured).toBe(true);
+            expect(result.byok.providerId).toBe(BYOKProvider.ANTHROPIC);
+            expect(result.source).toBe('byok');
+        });
+
+        it('reports byok NOT configured when no BYOK parameter exists', async () => {
+            const useCase = buildUseCase(undefined);
+
+            const result = await useCase.execute(orgAndTeam as any);
+
+            expect(result.byok.configured).toBe(false);
+            expect(result.source).toBe('none');
+        });
+    });
+});

--- a/libs/organization/application/use-cases/organizationParameters/get-llm-config-status.use-case.ts
+++ b/libs/organization/application/use-cases/organizationParameters/get-llm-config-status.use-case.ts
@@ -11,6 +11,8 @@ import {
 } from '@libs/organization/domain/organizationParameters/contracts/organizationParameters.service.contract';
 import { Inject, Injectable } from '@nestjs/common';
 
+import { isByokSlotConfigured, type BYOKSlot } from './byok-config.util';
+
 export type LLMConfigSource = 'byok' | 'env' | 'none';
 
 export interface LLMConfigStatus {
@@ -47,24 +49,21 @@ export class GetLLMConfigStatusUseCase implements IUseCase {
             )
             .catch(() => null);
 
-        const byokMain =
-            (parameter?.configValue as
-                | {
-                      main?: {
-                          apiKey?: string;
-                          model?: string;
-                          provider?: string;
-                          baseURL?: string;
-                      };
-                  }
-                | undefined)?.main;
+        const byokMain = (
+            parameter?.configValue as
+                | { main?: Partial<BYOKSlot> }
+                | undefined
+        )?.main;
 
-        const byok = byokMain?.apiKey
+        // Provider-aware: most providers gate on `apiKey`, but Amazon
+        // Bedrock authenticates with `awsBearerToken` / IAM credentials
+        // and never sets `apiKey`. See `isByokSlotConfigured`.
+        const byok = isByokSlotConfigured(byokMain)
             ? {
                   configured: true,
-                  model: byokMain.model,
-                  providerId: byokMain.provider,
-                  baseUrl: byokMain.baseURL,
+                  model: byokMain?.model,
+                  providerId: byokMain?.provider,
+                  baseUrl: byokMain?.baseURL,
               }
             : { configured: false };
 


### PR DESCRIPTION
fixes #1138

---

<!-- kody-pr-summary:start -->
This pull request addresses an issue where the Bring Your Own Key (BYOK) banner was incorrectly displayed or not displayed for Amazon Bedrock configurations.

The core problem was that the system's logic for determining if BYOK was configured only checked for the presence of an `apiKey`. Amazon Bedrock, however, authenticates using either an `awsBearerToken` or a combination of `awsAccessKeyId` and `awsSecretAccessKey`, and does not use an `apiKey`.

To fix this, the following changes were implemented:

1.  **Introduced `isByokSlotConfigured` utility function**: A new utility function was added to `byok-config.util.ts` that intelligently checks for the presence of required credentials based on the BYOK provider. For Amazon Bedrock, it verifies if either `awsBearerToken` or both `awsAccessKeyId` and `awsSecretAccessKey` are present. For all other providers, it continues to check for `apiKey`.
2.  **Integrated provider-aware logic**: The `GetLLMConfigStatusUseCase` was updated to use the new `isByokSlotConfigured` function. This ensures that the BYOK configuration status is accurately determined for Amazon Bedrock, preventing the banner from showing up when Bedrock is not fully configured or from being absent when it is.
3.  **Added comprehensive test cases**: New tests were added to `get-llm-config-status.use-case.spec.ts` specifically for Amazon Bedrock, covering scenarios where `awsBearerToken` is set, IAM credentials are set, and cases where credentials are incomplete or missing. Regression tests for other providers were also included to ensure existing functionality remains intact.

This change ensures that the BYOK banner and related UI elements accurately reflect the configuration status for Amazon Bedrock, aligning with its unique authentication requirements.
<!-- kody-pr-summary:end -->