### PR TITLE
fix: self hosted not showing invite data

### DIFF
--- a/apps/web/src/core/utils/clipboard.ts
+++ b/apps/web/src/core/utils/clipboard.ts
@@ -1,3 +1,58 @@
+/**
+ * Copy text to the clipboard.
+ *
+ * `navigator.clipboard` only exists in a *secure context* (HTTPS, or
+ * `localhost`). Self-hosted instances are routinely served over plain
+ * HTTP on an internal address, where the Clipboard API is absent — so we
+ * fall back to the legacy `document.execCommand("copy")` path.
+ *
+ * @returns `true` when the copy succeeded, `false` otherwise. Callers
+ * should surface failure to the user instead of assuming success.
+ */
 export const ClipboardHelpers = {
-    copyTextToClipboard: (text: string) => navigator.clipboard.writeText(text),
+    copyTextToClipboard: async (text: string): Promise<boolean> => {
+        const clipboard = (globalThis as { navigator?: Navigator }).navigator
+            ?.clipboard;
+
+        if (clipboard?.writeText) {
+            try {
+                await clipboard.writeText(text);
+                return true;
+            } catch {
+                // Permission denied or insecure context — fall through.
+            }
+        }
+
+        return legacyCopy(text);
+    },
 };
+
+/**
+ * Pre-Clipboard-API copy: drop the text into an off-screen <textarea>,
+ * select it, and run `execCommand("copy")`. Works in insecure contexts.
+ */
+function legacyCopy(text: string): boolean {
+    const doc = (globalThis as { document?: Document }).document;
+    if (!doc?.body) {
+        return false;
+    }
+
+    try {
+        const textarea = doc.createElement("textarea");
+        textarea.value = text;
+        textarea.setAttribute("readonly", "");
+        // Keep it out of view and avoid scroll/zoom jumps on mobile.
+        textarea.style.position = "fixed";
+        textarea.style.top = "0";
+        textarea.style.left = "0";
+        textarea.style.opacity = "0";
+
+        doc.body.appendChild(textarea);
+        textarea.select();
+        const ok = doc.execCommand("copy");
+        doc.body.removeChild(textarea);
+        return ok;
+    } catch {
+        return false;
+    }
+}

--- a/apps/web/src/features/ee/subscription/@admins/_components/columns.tsx
+++ b/apps/web/src/features/ee/subscription/@admins/_components/columns.tsx
@@ -309,6 +309,7 @@ export const columns: ColumnDef<MembersSetup>[] = [
         header: "Actions",
         meta: { align: "right" },
         cell: ({ row }) => {
+            const { userId } = useAuth();
             const canEdit = usePermission(
                 Action.Update,
                 ResourceType.UserSettings,
@@ -317,6 +318,7 @@ export const columns: ColumnDef<MembersSetup>[] = [
                 Action.Delete,
                 ResourceType.UserSettings,
             );
+            const isSelf = row.original.userId === userId;
 
             const approveUserAction = async () => {
                 try {
@@ -387,39 +389,65 @@ export const columns: ColumnDef<MembersSetup>[] = [
                                 leftIcon={<CopyIcon />}
                                 disabled={!canEdit}
                                 onClick={async () => {
-                                    await ClipboardHelpers.copyTextToClipboard(
-                                        `${window.location.origin}/invite/${row.original.userId}`,
-                                    );
+                                    const inviteLink = `${window.location.origin}/invite/${row.original.userId}`;
+                                    const copied =
+                                        await ClipboardHelpers.copyTextToClipboard(
+                                            inviteLink,
+                                        );
 
-                                    toast({
-                                        variant: "info",
-                                        title: "Copied to clipboard the invite link",
-                                        description: (
-                                            <span className="text-text-secondary">
-                                                for user with email{" "}
-                                                <span className="text-text-primary">
-                                                    {row.original.email}
-                                                </span>
-                                            </span>
-                                        ),
-                                    });
+                                    toast(
+                                        copied
+                                            ? {
+                                                  variant: "info",
+                                                  title: "Copied to clipboard the invite link",
+                                                  description: (
+                                                      <span className="text-text-secondary">
+                                                          for user with email{" "}
+                                                          <span className="text-text-primary">
+                                                              {
+                                                                  row.original
+                                                                      .email
+                                                              }
+                                                          </span>
+                                                      </span>
+                                                  ),
+                                              }
+                                            : {
+                                                  variant: "danger",
+                                                  title: "Couldn't copy the invite link",
+                                                  description: (
+                                                      <span className="text-text-secondary">
+                                                          Copy it manually:{" "}
+                                                          <span className="text-text-primary">
+                                                              {inviteLink}
+                                                          </span>
+                                                      </span>
+                                                  ),
+                                              },
+                                    );
                                 }}>
                                 Copy invite link
                             </DropdownMenuItem>
 
-                            <DropdownMenuSeparator />
+                            {!isSelf && (
+                                <>
+                                    <DropdownMenuSeparator />
 
-                            <DropdownMenuItem
-                                className="text-danger"
-                                leftIcon={<TrashIcon />}
-                                disabled={!canDelete}
-                                onClick={() =>
-                                    magicModal.show(() => (
-                                        <DeleteModal member={row.original} />
-                                    ))
-                                }>
-                                Delete
-                            </DropdownMenuItem>
+                                    <DropdownMenuItem
+                                        className="text-danger"
+                                        leftIcon={<TrashIcon />}
+                                        disabled={!canDelete}
+                                        onClick={() =>
+                                            magicModal.show(() => (
+                                                <DeleteModal
+                                                    member={row.original}
+                                                />
+                                            ))
+                                        }>
+                                        Delete
+                                    </DropdownMenuItem>
+                                </>
+                            )}
                         </DropdownMenuContent>
                     </DropdownMenu>
                 </div>

--- a/apps/web/src/features/ee/subscription/layout.tsx
+++ b/apps/web/src/features/ee/subscription/layout.tsx
@@ -89,6 +89,23 @@ export default function SubscriptionLayout({
                                                 setQuery(e.target.value)
                                             }
                                         />
+
+                                        {selectedTab === tabs.admins && (
+                                            <Button
+                                                size="md"
+                                                variant="helper"
+                                                leftIcon={<PlusIcon />}
+                                                disabled={!canCreate}
+                                                onClick={() => {
+                                                    magicModal.show(() => (
+                                                        <InviteModal
+                                                            teamId={teamId}
+                                                        />
+                                                    ));
+                                                }}>
+                                                Invite member
+                                            </Button>
+                                        )}
                                     </div>
                                 </div>
                             </TabsList>

--- a/libs/organization/application/use-cases/teamMembers/delete.use-case.spec.ts
+++ b/libs/organization/application/use-cases/teamMembers/delete.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { ForbiddenException } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
 import { Test, TestingModule } from '@nestjs/testing';
 
@@ -150,5 +151,78 @@ describe('DeleteTeamMembersUseCase — org.member_removed emit', () => {
         expect(teamMembers.deleteMembers).toHaveBeenCalled();
         // Still cascaded to user delete (single-team removal).
         expect(deleteUser.execute).toHaveBeenCalledWith('user-1');
+    });
+});
+
+describe('DeleteTeamMembersUseCase — self-deletion guard', () => {
+    const buildMember = (memberUuid: string, userUuid: string) => ({
+        uuid: memberUuid,
+        user: {
+            uuid: userUuid,
+            name: 'Member',
+            email: `${userUuid}@acme.com`,
+        },
+        team: { uuid: 'team-1', name: 'Engineering' },
+        organization: { uuid: 'org-1', name: 'Acme Inc' },
+    });
+
+    const build = async (requestUserUuid: string) => {
+        const teamMembers = {
+            findOne: jest.fn(),
+            findManyByUser: jest.fn().mockResolvedValue([]),
+            countByUser: jest.fn().mockResolvedValue(1),
+            deleteMembers: jest.fn().mockResolvedValue(undefined),
+        };
+        const deleteUser = { execute: jest.fn().mockResolvedValue(undefined) };
+        const notify = { emit: jest.fn().mockResolvedValue(undefined) };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                DeleteTeamMembersUseCase,
+                { provide: TEAM_MEMBERS_SERVICE_TOKEN, useValue: teamMembers },
+                { provide: DeleteUserUseCase, useValue: deleteUser },
+                { provide: NotificationService, useValue: notify },
+                {
+                    provide: REQUEST,
+                    useValue: {
+                        user: {
+                            uuid: requestUserUuid,
+                            email: `${requestUserUuid}@acme.com`,
+                            organization: { uuid: 'org-1', name: 'Acme Inc' },
+                        },
+                    },
+                },
+            ],
+        }).compile();
+
+        return {
+            useCase: module.get(DeleteTeamMembersUseCase),
+            teamMembers,
+            deleteUser,
+        };
+    };
+
+    it('throws and deletes nothing when a user removes their own account', async () => {
+        const { useCase, teamMembers, deleteUser } = await build('user-self');
+        teamMembers.findOne.mockResolvedValue(
+            buildMember('member-self', 'user-self'),
+        );
+
+        await expect(useCase.execute('member-self')).rejects.toBeInstanceOf(
+            ForbiddenException,
+        );
+
+        expect(teamMembers.deleteMembers).not.toHaveBeenCalled();
+        expect(deleteUser.execute).not.toHaveBeenCalled();
+    });
+
+    it('still removes a different member', async () => {
+        const { useCase, teamMembers } = await build('user-self');
+        const target = buildMember('member-2', 'user-2');
+        teamMembers.findOne.mockResolvedValue(target);
+
+        await useCase.execute('member-2');
+
+        expect(teamMembers.deleteMembers).toHaveBeenCalledWith([target]);
     });
 });

--- a/libs/organization/application/use-cases/teamMembers/delete.use-case.ts
+++ b/libs/organization/application/use-cases/teamMembers/delete.use-case.ts
@@ -1,5 +1,5 @@
 import { createLogger } from '@kodus/flow';
-import { Inject, Injectable } from '@nestjs/common';
+import { ForbiddenException, Inject, Injectable } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
 
 import { DeleteUserUseCase } from '@libs/identity/application/use-cases/user/delete.use-case';
@@ -41,6 +41,16 @@ export class DeleteTeamMembersUseCase implements IUseCase {
         removeAll: boolean = false,
     ): Promise<string[] | void> {
         const memberToRemove = await this.teamMembersService.findOne({ uuid });
+
+        // A user must not be able to remove their own account: it would
+        // orphan the org and, for a single-team user, cascade into
+        // deleting their own User entity via `deleteUserUseCase` below.
+        if (
+            memberToRemove?.user?.uuid &&
+            memberToRemove.user.uuid === this.request.user?.uuid
+        ) {
+            throw new ForbiddenException('You cannot remove your own account');
+        }
 
         const teamMembersRelated = await this.teamMembersService.findManyByUser(
             memberToRemove.user.uuid,


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces several enhancements and fixes related to member management and clipboard functionality, particularly benefiting self-hosted instances:

1.  **Improved Clipboard Copy Functionality**: The `copyTextToClipboard` utility has been enhanced to provide a robust fallback mechanism. It now first attempts to use the modern `navigator.clipboard.writeText` API and, if that fails (e.g., in insecure contexts common in self-hosted environments), it falls back to the legacy `document.execCommand("copy")` method.
2.  **Enhanced User Feedback for Invite Link Copy**: The "Copy invite link" action in the admin panel now provides more informative toast notifications. It confirms successful copying or, in case of failure, alerts the user and displays the invite link for manual copying.
3.  **Prevented Self-Deletion of Member Accounts**:
    *   **Backend**: A new guard has been implemented in the `DeleteTeamMembersUseCase` to prevent users from deleting their own team member accounts, throwing a `ForbiddenException` if such an attempt is made.
    *   **Frontend**: The "Delete" action button for a member is now hidden in the UI if the member corresponds to the currently logged-in user, preventing them from attempting to delete their own account.
4.  **Added "Invite Member" Button**: A dedicated "Invite member" button has been added to the subscription/admin layout when the "Admins" tab is active, providing a more direct and accessible way to invite new team members.
<!-- kody-pr-summary:end -->