### PR TITLE
fix: conversation response

### DIFF
--- a/libs/agents/infrastructure/services/kodus-flow/conversation-response.util.spec.ts
+++ b/libs/agents/infrastructure/services/kodus-flow/conversation-response.util.spec.ts
@@ -1,0 +1,63 @@
+import {
+    CONVERSATION_FALLBACK_MESSAGE,
+    normalizeConversationResponse,
+} from './conversation-response.util';
+
+describe('normalizeConversationResponse', () => {
+    it('returns a plain string answer unchanged', () => {
+        expect(normalizeConversationResponse('Here is the answer')).toBe(
+            'Here is the answer',
+        );
+    });
+
+    it('trims surrounding whitespace', () => {
+        expect(normalizeConversationResponse('  hello  ')).toBe('hello');
+    });
+
+    it('unwraps a { content } envelope object', () => {
+        expect(normalizeConversationResponse({ content: 'real answer' })).toBe(
+            'real answer',
+        );
+    });
+
+    it('unwraps a JSON-string { content } envelope', () => {
+        expect(
+            normalizeConversationResponse('{"content":"real answer"}'),
+        ).toBe('real answer');
+    });
+
+    it('unwraps nested { content } envelopes', () => {
+        expect(
+            normalizeConversationResponse({
+                content: { content: 'deep answer' },
+            }),
+        ).toBe('deep answer');
+    });
+
+    it('returns null for an empty { content } envelope object', () => {
+        expect(normalizeConversationResponse({ content: '' })).toBeNull();
+    });
+
+    it('returns null for the {"content":""} JSON string the LLM echoes', () => {
+        expect(normalizeConversationResponse('{"content":""}')).toBeNull();
+    });
+
+    it('returns null for an empty or whitespace-only string', () => {
+        expect(normalizeConversationResponse('')).toBeNull();
+        expect(normalizeConversationResponse('   ')).toBeNull();
+    });
+
+    it('returns null for an empty object, null and undefined', () => {
+        expect(normalizeConversationResponse({})).toBeNull();
+        expect(normalizeConversationResponse(null)).toBeNull();
+        expect(normalizeConversationResponse(undefined)).toBeNull();
+    });
+
+    it('preserves a real JSON answer that is not a content envelope', () => {
+        expect(normalizeConversationResponse('{"foo":1}')).toBe('{"foo":1}');
+    });
+
+    it('exposes a non-empty fallback message', () => {
+        expect(CONVERSATION_FALLBACK_MESSAGE.trim().length).toBeGreaterThan(0);
+    });
+});

--- a/libs/agents/infrastructure/services/kodus-flow/conversation-response.util.ts
+++ b/libs/agents/infrastructure/services/kodus-flow/conversation-response.util.ts
@@ -1,0 +1,80 @@
+/**
+ * Shown to the user when the conversation agent produced nothing usable —
+ * better a clear message than a raw `{"content":""}` blob in a PR comment.
+ */
+export const CONVERSATION_FALLBACK_MESSAGE =
+    "I wasn't able to put together an answer for that. Could you rephrase " +
+    'your question or add a bit more context?';
+
+function isContentEnvelope(value: unknown): value is { content: unknown } {
+    return !!value && typeof value === 'object' && 'content' in value;
+}
+
+/**
+ * If `text` is a JSON object carrying a `content` key, return that
+ * `content` value so the caller can keep unwrapping. Returns `undefined`
+ * when `text` is not such an envelope — i.e. it is a real answer that
+ * merely happens to be (or start with) JSON.
+ */
+function unwrapJsonEnvelope(text: string): unknown | undefined {
+    if (!text.startsWith('{') || !text.endsWith('}')) {
+        return undefined;
+    }
+    try {
+        const parsed: unknown = JSON.parse(text);
+        if (isContentEnvelope(parsed)) {
+            return parsed.content;
+        }
+    } catch {
+        // Not JSON — a real answer that just happens to start with '{'.
+    }
+    return undefined;
+}
+
+/**
+ * Normalize whatever the conversation agent returned into the plain text
+ * to post back to the user.
+ *
+ * The result can arrive in several shapes:
+ *  - a plain string (the happy path)
+ *  - a `{ content: ... }` envelope object — the agent sometimes wraps its
+ *    answer instead of returning the bare string
+ *  - a JSON string that is itself such an envelope, e.g. `'{"content":""}'`
+ *    — the LLM echoing its response schema instead of answering
+ *  - nested combinations of the above
+ *
+ * @returns the unwrapped answer text, or `null` when there is no usable
+ * content (empty / blank / unknown shape) so the caller can surface a
+ * graceful fallback instead of posting garbage like `{"content":""}`.
+ */
+export function normalizeConversationResponse(raw: unknown): string | null {
+    let value: unknown = raw;
+
+    // Unwrap a few levels of { content } envelopes (object or JSON-string).
+    for (let depth = 0; depth < 4; depth++) {
+        if (typeof value === 'string') {
+            const trimmed = value.trim();
+            if (!trimmed) {
+                return null;
+            }
+
+            const inner = unwrapJsonEnvelope(trimmed);
+            if (inner !== undefined) {
+                value = inner;
+                continue;
+            }
+
+            return trimmed;
+        }
+
+        if (isContentEnvelope(value)) {
+            value = value.content;
+            continue;
+        }
+
+        // Unknown / non-string, non-envelope shape — nothing usable.
+        return null;
+    }
+
+    return null;
+}

--- a/libs/agents/infrastructure/services/kodus-flow/conversationAgent.ts
+++ b/libs/agents/infrastructure/services/kodus-flow/conversationAgent.ts
@@ -22,6 +22,10 @@ import { ObservabilityService } from '@libs/core/log/observability.service';
 import { MCPManagerService } from '@libs/mcp-server/services/mcp-manager.service';
 import { SandboxInstance } from '@libs/sandbox/domain/contracts/sandbox.provider';
 import { BaseAgentProvider } from './base-agent.provider';
+import {
+    CONVERSATION_FALLBACK_MESSAGE,
+    normalizeConversationResponse,
+} from './conversation-response.util';
 import { buildNativeToolConfigs } from './native-tools.factory';
 
 @Injectable()
@@ -247,9 +251,24 @@ export class ConversationAgentProvider extends BaseAgentProvider {
                 },
             });
 
-            return typeof result.result === 'string'
-                ? result.result
-                : JSON.stringify(result.result);
+            const response = normalizeConversationResponse(result.result);
+
+            if (response === null) {
+                this.logger.warn({
+                    message: 'Conversation agent produced no usable response',
+                    context: ConversationAgentProvider.name,
+                    serviceName: ConversationAgentProvider.name,
+                    metadata: {
+                        organizationAndTeamData,
+                        thread,
+                        rawResult: result.result,
+                        rawResultType: typeof result.result,
+                    },
+                });
+                return CONVERSATION_FALLBACK_MESSAGE;
+            }
+
+            return response;
         } catch (error) {
             this.logger.error({
                 message: 'Error during conversation agent execution',


### PR DESCRIPTION
fixes #1142

---

<!-- kody-pr-summary:start -->
This pull request introduces a robust mechanism to normalize and handle responses from the conversation agent, significantly improving user experience and system reliability.

Previously, the agent's raw output was returned directly, which could result in unhelpful or malformed responses (e.g., `{"content":""}` or empty strings) being displayed to the user.

This change implements a new utility, `normalizeConversationResponse`, which:
- **Extracts the actual answer** from various formats, including plain strings, `{ content: "..." }` objects, and JSON strings representing such objects (even when nested).
- **Trims surrounding whitespace** from responses.
- **Returns a user-friendly fallback message** (`CONVERSATION_FALLBACK_MESSAGE`) when the agent produces no usable content (e.g., empty, blank, or unrecognized response formats).
- **Logs a warning** when the agent's output cannot be normalized into a usable response, aiding in debugging.

This ensures that users always receive clear, concise, and relevant answers, or a helpful message when the agent is unable to formulate a response.
<!-- kody-pr-summary:end -->