### PR TITLE
fix(code-review): Fix to the formula that defines file chunk division

### DIFF
--- a/libs/code-review/infrastructure/agents/base-code-review-agent.provider.ts
+++ b/libs/code-review/infrastructure/agents/base-code-review-agent.provider.ts
@@ -92,13 +92,36 @@ function estimateDiffTokens(files: FileChange[]): number {
 }
 
 /**
+ * Total non-diff overhead in tokens: static (system prompt + tool schemas)
+ * plus dynamic (callGraph + coverage list + PR context). Reused by both
+ * estimatePromptTokens and the per-chunk budget calc so the split decision
+ * and chunk sizing can't drift — when they did, a ~2% prompt overflow
+ * still produced a chunker that packed every file into one chunk because
+ * the chunk budget subtracted only the static part.
+ */
+function estimateNonDiffOverheadTokens(input: {
+    changedFiles?: FileChange[];
+    callGraph?: string;
+    prTitle?: string;
+    prBody?: string;
+}): number {
+    const callGraphChars = (input.callGraph || '').length;
+    const prBodyChars = Math.min((input.prBody || '').length, 500);
+    const prContextChars =
+        300 + (input.prTitle || '').length + prBodyChars;
+    const coverageListChars = (input.changedFiles?.length || 0) * 80;
+    const totalChars =
+        callGraphChars +
+        prContextChars +
+        coverageListChars +
+        PROMPT_STATIC_OVERHEAD_CHARS;
+    return Math.ceil(totalChars / CHARS_PER_TOKEN);
+}
+
+/**
  * Estimate of the full input token count for the first LLM call:
  * diff content + callGraph + PR context + per-file coverage lines +
  * static overhead (system prompt + tool schemas).
- *
- * Matches what the model actually receives, unlike estimateDiffTokens
- * which only counted patches and consistently underestimated by ~100K
- * tokens on large PRs.
  */
 function estimatePromptTokens(input: {
     changedFiles?: FileChange[];
@@ -122,17 +145,8 @@ function estimatePromptTokens(input: {
         }
         return sum + diff.length;
     }, 0);
-    const callGraphChars = (input.callGraph || '').length;
-    const prContextChars =
-        300 + (input.prTitle || '').length + (input.prBody || '').length;
-    const coverageListChars = (input.changedFiles?.length || 0) * 80;
-    const totalChars =
-        diffChars +
-        callGraphChars +
-        prContextChars +
-        coverageListChars +
-        PROMPT_STATIC_OVERHEAD_CHARS;
-    return Math.ceil(totalChars / CHARS_PER_TOKEN);
+    const diffTokens = Math.ceil(diffChars / CHARS_PER_TOKEN);
+    return diffTokens + estimateNonDiffOverheadTokens(input);
 }
 
 function normalizeFilenameForTier(filename?: string): string {
@@ -609,13 +623,17 @@ export abstract class BaseCodeReviewAgentProvider {
             estimatedPromptTokens > promptBudget &&
             input.changedFiles.length > 1
         ) {
-            // Per-chunk diff budget: prompt budget minus the static
-            // overhead every chunk pays again (system + tool schemas +
-            // callGraph). Prevents chunks from individually blowing
-            // through the window once their own overhead is added back.
-            const overheadTokens = Math.ceil(
-                PROMPT_STATIC_OVERHEAD_CHARS / CHARS_PER_TOKEN,
-            );
+            // Per-chunk diff budget: prompt budget minus the FULL non-diff
+            // overhead every chunk pays again (static system prompt + tool
+            // schemas, callGraph, coverage list, PR context). Previously we
+            // only subtracted the static piece, so chunkDiffBudget was too
+            // generous: a PR whose diffs alone fit in the budget but whose
+            // total prompt overflowed by ~2% produced 1 chunk containing
+            // every file, tripping the recursion guard and killing the
+            // review. Aligning this with estimatePromptTokens (which uses
+            // the same helper for the split decision) keeps the two ends
+            // from drifting.
+            const overheadTokens = estimateNonDiffOverheadTokens(input);
             const chunkDiffBudget = Math.max(
                 promptBudget - overheadTokens,
                 Math.floor(contextWindow * 0.3),

--- a/test/unit/code-review/agents/base-code-review-agent.recursion.spec.ts
+++ b/test/unit/code-review/agents/base-code-review-agent.recursion.spec.ts
@@ -207,6 +207,67 @@ function makeSmallInput(): ReviewAgentInput {
 }
 
 /**
+ * Marginal-overflow scenario. Diffs sum to ~93k tokens, comfortably under
+ * the legacy chunkDiffBudget of 94.5k (which only subtracted the static
+ * overhead) so the chunker packed every file into ONE chunk and the
+ * recursion guard killed the review. With the fix the chunk budget also
+ * subtracts the dynamic overhead (callGraph + coverage list + PR
+ * context), drops to ~92k, and the chunker correctly produces two chunks.
+ *
+ * Numbers: 3 files × 124_000 chars (≈31k tokens each) + 10_000-char
+ * callGraph. estimatePromptTokens ≈ 111k tokens (> promptBudget 110k →
+ * gate fires).
+ */
+function makeMarginalOverflowInput(): ReviewAgentInput {
+    return {
+        ...BASE_INPUT_FIELDS,
+        changedFiles: [
+            makeFile('src/a.ts', 124_000),
+            makeFile('src/b.ts', 124_000),
+            makeFile('src/c.ts', 124_000),
+        ],
+        callGraph: 'x'.repeat(10_000),
+    } as ReviewAgentInput;
+}
+
+/**
+ * Real-world replay using the exact numbers captured in the prod
+ * observability trace that surfaced this bug:
+ *   - 77 changed files (post aggressive filter; we use 'deep' mode here
+ *     to skip that branch and feed the chunker the same shape directly)
+ *   - average diff per file 4_800 chars (~1_200 tokens)
+ *   - callGraph 10_938 chars (~2_734 tokens)
+ *   - contextWindow 200_000, promptBudget 110_000
+ *
+ * Expected accounting (post-fix):
+ *   diff total          ≈ 92_400 tokens
+ *   + static overhead   = 15_500
+ *   + callGraph         = 2_734
+ *   + coverage list     = 1_540  (77 × 80 / 4)
+ *   + PR context        =    25  (post user-tweak with MIN(500))
+ *   ────────────────────────────
+ *   estimatedPrompt     ≈ 112_200 tokens  > 110_000 → gate fires
+ *
+ *   chunkDiffBudget OLD = 110_000 − 15_500 = 94_500
+ *     → 92_400 ≤ 94_500 → 1 chunk → guard throws (the bug)
+ *   chunkDiffBudget NEW = 110_000 − 19_800 = 90_200
+ *     → 92_400 > 90_200 → 2+ chunks → review proceeds (the fix)
+ */
+function makeProdReplayInput(): ReviewAgentInput {
+    const FILES = 77;
+    const CHARS_PER_FILE = 4_800;
+    const CALLGRAPH_CHARS = 10_938;
+    const files = Array.from({ length: FILES }, (_, i) =>
+        makeFile(`src/file_${i}.ts`, CHARS_PER_FILE),
+    );
+    return {
+        ...BASE_INPUT_FIELDS,
+        changedFiles: files,
+        callGraph: 'x'.repeat(CALLGRAPH_CHARS),
+    } as ReviewAgentInput;
+}
+
+/**
  * Wrap agent.execute() with a counter + hard cap so a runaway recursion
  * cannot hang the test runner. The cap throw is caught by executeChunked's
  * per-batch try/catch and absorbed into an empty result — exactly what
@@ -310,6 +371,37 @@ describe('BaseCodeReviewAgentProvider — recursion bug + proposed fixes', () =>
             const result = await agent.execute(makeSmallInput());
             expect(result).toBeDefined();
             expect(getCount()).toBe(1);
+        });
+    });
+
+    describe('Marginal-overflow scenario — dynamic overhead pushes prompt 2% over budget', () => {
+        it('splits diffs that fit under the static-only budget but overflow the full prompt — no false-positive guard trip', async () => {
+            const { getCount } = setupExecuteSpy(agent);
+            const result = await agent.execute(makeMarginalOverflowInput());
+            // 2 chunks → root + 2 per-batch executes = 3 calls.
+            // Pre-fix this returned 1 chunk and threw
+            // AGENT_PROMPT_OVERHEAD_EXCEEDS_BUDGET on the second pass.
+            expect(result).toBeDefined();
+            expect(getCount()).toBeGreaterThanOrEqual(3);
+        });
+
+        it('does NOT throw AGENT_PROMPT_OVERHEAD_EXCEEDS_BUDGET on the marginal scenario', async () => {
+            setupExecuteSpy(agent);
+            await expect(
+                agent.execute(makeMarginalOverflowInput()),
+            ).resolves.toBeDefined();
+        });
+
+        // Higher-fidelity regression test using the exact numbers from
+        // the prod incident trace (77 files × ~4_800 chars, 10_938-char
+        // callGraph). Verifies the fix against the real shape, not just
+        // a constructed minimal case.
+        it('replays prod trace shape — 77 files + 10_938-char callGraph + 200k window → split, not abort', async () => {
+            const { getCount } = setupExecuteSpy(agent);
+            const result = await agent.execute(makeProdReplayInput());
+            expect(result).toBeDefined();
+            // Root execute + at least 2 batch executes
+            expect(getCount()).toBeGreaterThanOrEqual(3);
         });
     });
 });


### PR DESCRIPTION
Closes #1158

---

<!-- kody-pr-summary:start -->
This pull request addresses a critical bug in the LLM prompt token estimation and chunking system that caused large pull requests to fail.

Previously, the system's chunking logic, which splits large diffs into manageable parts for the LLM, only accounted for *static* overhead (like system prompts and tool schemas) when calculating the available token budget for file diffs within each chunk. It overlooked *dynamic* overhead components such as the call graph, PR title/body, and file coverage list.

This led to a scenario where:
1.  The *total* estimated prompt tokens (including all dynamic overhead) would exceed the LLM's context window.
2.  However, the *per-chunk diff budget* (which only subtracted static overhead) would incorrectly appear large enough to fit all file diffs.
3.  As a result, the chunking system would erroneously pack all files into a single, oversized chunk.
4.  This oversized chunk would then trigger a recursion guard, causing the code review process to abort with an "AGENT_PROMPT_OVERHEAD_EXCEEDS_BUDGET" error.

The changes implement the following:
*   **Introduced `estimateNonDiffOverheadTokens`:** A new helper function to consistently calculate *all* non-diff overhead, encompassing both static (system prompt, tool schemas) and dynamic (call graph, PR title/body, coverage list) components. The PR body length in this calculation is now capped at 500 characters to prevent excessive length from skewing estimates.
*   **Unified Overhead Calculation:** The `estimateNonDiffOverheadTokens` function is now used in both the overall prompt token estimation (`estimatePromptTokens`) and, crucially, in the per-chunk diff budget calculation within the chunking logic.

This ensures that the `chunkDiffBudget` accurately reflects the true available token space for diffs in each chunk. By aligning these calculations, the system now correctly identifies when files need to be split into multiple chunks, preventing false-positive recursion guard trips and allowing large pull requests to be reviewed successfully.

New unit tests, including a "marginal overflow" scenario and a "production replay" scenario based on real-world data, have been added to validate the fix against the specific conditions that previously caused the bug.
<!-- kody-pr-summary:end -->