### PR TITLE
feat: add byok model config per repo/directory

### DIFF
--- a/apps/api/src/controllers/organizationParameters.controller.ts
+++ b/apps/api/src/controllers/organizationParameters.controller.ts
@@ -8,7 +8,10 @@ import {
     CheckPolicies,
     PolicyGuard,
 } from '@libs/identity/infrastructure/adapters/services/permissions/policy.guard';
-import { checkPermissions } from '@libs/identity/infrastructure/adapters/services/permissions/policy.handlers';
+import {
+    checkAnyPermission,
+    checkPermissions,
+} from '@libs/identity/infrastructure/adapters/services/permissions/policy.handlers';
 import { IgnoreBotsUseCase } from '@libs/organization/application/use-cases/organizationParameters/ignore-bots.use-case';
 import { CreateOrUpdateOrganizationParametersUseCase } from '@libs/organization/application/use-cases/organizationParameters/create-or-update.use-case';
 import { FindByKeyOrganizationParametersUseCase } from '@libs/organization/application/use-cases/organizationParameters/find-by-key.use-case';
@@ -283,10 +286,19 @@ export class OrganizationParametersController {
     @Get('/llm-config/status')
     @UseGuards(PolicyGuard)
     @CheckPolicies(
-        checkPermissions({
-            action: Action.Read,
-            resource: ResourceType.OrganizationSettings,
-        }),
+        // Non-sensitive descriptor (never the API key). Code review settings
+        // editors need the BYOK provider/model to render the model selector,
+        // so allow either organization-settings or code-review-settings read.
+        checkAnyPermission([
+            {
+                action: Action.Read,
+                resource: ResourceType.OrganizationSettings,
+            },
+            {
+                action: Action.Read,
+                resource: ResourceType.CodeReviewSettings,
+            },
+        ]),
     )
     @ApiOperation({
         summary: 'Get LLM provider configuration status',

--- a/apps/web/src/app/(app)/settings/_components/_layout.tsx
+++ b/apps/web/src/app/(app)/settings/_components/_layout.tsx
@@ -49,9 +49,11 @@ import {
 import { resolveCodeReviewConfigForScope } from "./code-review-config-scope";
 import {
     AutomationCodeReviewConfigProvider,
+    CodeReviewModelDataProvider,
     DefaultCodeReviewConfigProvider,
     PlatformConfigProvider,
     ScopedCodeReviewConfigProvider,
+    type CodeReviewModelData,
 } from "./context";
 import { PerRepository } from "./per-repository/repository";
 import {
@@ -87,6 +89,7 @@ type SettingsLayoutProps = React.PropsWithChildren<{
     initialConfigValue: FormattedGlobalCodeReviewConfig;
     initialDefaultConfig: InitialDefaultConfig;
     initialPlatformConfig: InitialPlatformConfig;
+    initialModelData: CodeReviewModelData;
 }>;
 
 export const SettingsLayout = ({
@@ -95,6 +98,7 @@ export const SettingsLayout = ({
     initialConfigValue,
     initialDefaultConfig,
     initialPlatformConfig,
+    initialModelData,
 }: SettingsLayoutProps) => {
     const { teamId } = useSelectedTeamId();
     const effectiveTeamId = teamId ?? initialTeamId;
@@ -145,14 +149,16 @@ export const SettingsLayout = ({
     );
 
     return (
-        <SettingsLayoutShell
-            teamId={effectiveTeamId}
-            configValue={liveShellQuery?.configValue ?? initialConfigValue}
-            defaultConfig={defaultConfig ?? initialDefaultConfig}
-            platformConfig={platformConfig ?? initialPlatformConfig}
-            isMCPAvailable={isMCPAvailable}>
-            {children}
-        </SettingsLayoutShell>
+        <CodeReviewModelDataProvider value={initialModelData}>
+            <SettingsLayoutShell
+                teamId={effectiveTeamId}
+                configValue={liveShellQuery?.configValue ?? initialConfigValue}
+                defaultConfig={defaultConfig ?? initialDefaultConfig}
+                platformConfig={platformConfig ?? initialPlatformConfig}
+                isMCPAvailable={isMCPAvailable}>
+                {children}
+            </SettingsLayoutShell>
+        </CodeReviewModelDataProvider>
     );
 };
 

--- a/apps/web/src/app/(app)/settings/_components/context.tsx
+++ b/apps/web/src/app/(app)/settings/_components/context.tsx
@@ -1,6 +1,10 @@
 "use client";
 
 import { createContext, useContext } from "react";
+import type {
+    LLMConfigStatus,
+    LLMProviderModel,
+} from "@services/organizationParameters/fetch";
 import { PlatformConfigValue } from "@services/parameters/types";
 import { CustomMessageConfig } from "@services/pull-request-messages/types";
 import { FEATURE_FLAGS } from "src/core/config/feature-flags";
@@ -138,6 +142,33 @@ export const FeatureFlagsProvider = (
     <FeatureFlagsContext.Provider value={props.featureFlags}>
         {props.children}
     </FeatureFlagsContext.Provider>
+);
+
+/**
+ * Data the BYOK model selector needs — the LLM config status (BYOK / env /
+ * none) and the provider's model catalog. Both are server-fetched in the
+ * settings layout and provided here so the selector renders fully with the
+ * rest of the page: no client round-trip, no loading skeleton.
+ */
+export type CodeReviewModelData = {
+    llmConfigStatus: LLMConfigStatus | null;
+    byokModels: LLMProviderModel[];
+};
+
+const CodeReviewModelDataContext = createContext<CodeReviewModelData>({
+    llmConfigStatus: null,
+    byokModels: [],
+});
+
+export const useCodeReviewModelData = () =>
+    useContext(CodeReviewModelDataContext);
+
+export const CodeReviewModelDataProvider = (
+    props: React.PropsWithChildren & { value: CodeReviewModelData },
+) => (
+    <CodeReviewModelDataContext.Provider value={props.value}>
+        {props.children}
+    </CodeReviewModelDataContext.Provider>
 );
 
 export { resolveCodeReviewConfigForScope };

--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/general/_components/byok-model-selector.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/general/_components/byok-model-selector.tsx
@@ -1,0 +1,300 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@components/ui/button";
+import { Card, CardContent, CardHeader } from "@components/ui/card";
+import {
+    Command,
+    CommandEmpty,
+    CommandInput,
+    CommandItem,
+    CommandList,
+} from "@components/ui/command";
+import { Heading } from "@components/ui/heading";
+import { Input } from "@components/ui/input";
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@components/ui/popover";
+import { AlertTriangleIcon, ChevronsUpDownIcon } from "lucide-react";
+import { Controller, useFormContext } from "react-hook-form";
+import {
+    useCodeReviewConfig,
+    useCodeReviewModelData,
+} from "src/app/(app)/settings/_components/context";
+import { useCurrentConfigLevel } from "src/app/(app)/settings/_hooks";
+import { OverrideIndicatorForm } from "src/app/(app)/settings/code-review/_components/override";
+import { ArrayHelpers } from "src/core/utils/array";
+
+import { FormattedConfigLevel, type CodeReviewFormType } from "../../../_types";
+
+const INHERIT_ITEM = "__inherit__";
+const MANUAL_ITEM = "__manual__";
+
+/**
+ * BYOK model selector for the code review General tab.
+ *
+ * Rendered only for repository/directory scopes that have a main BYOK provider
+ * configured. The BYOK status and the provider's model catalog are both
+ * server-fetched in the settings layout and read from context, so this renders
+ * fully with the rest of the page — no client round-trip, no loading skeleton.
+ */
+export const BYOKModelSelectorSection = () => {
+    const form = useFormContext<CodeReviewFormType>();
+    const config = useCodeReviewConfig();
+    const currentLevel = useCurrentConfigLevel();
+
+    const { llmConfigStatus, byokModels } = useCodeReviewModelData();
+    const byok = llmConfigStatus?.byok;
+    const provider = byok?.configured ? byok.providerId : undefined;
+    const byokMainModel = byok?.model ?? "";
+
+    const [open, setOpen] = useState(false);
+    const [manual, setManual] = useState(false);
+    const [search, setSearch] = useState("");
+
+    // No main BYOK provider configured — feature hidden entirely.
+    if (!provider) {
+        return null;
+    }
+
+    const models = byokModels;
+
+    // The value inherited from the parent scope (repository / BYOK settings),
+    // computed the same way the override indicator does.
+    const leaf = config?.byokModel;
+    const isExistingOverride = leaf?.level === currentLevel;
+    const parentValue =
+        (isExistingOverride ? leaf?.overriddenValue : leaf?.value) ?? "";
+
+    const modelName = (id: string) =>
+        models.find((m) => m.id === id)?.name ?? id;
+
+    const inheritedModelId = parentValue || byokMainModel;
+    const inheritedFromBYOKSettings = !parentValue;
+    const scopeLabel =
+        currentLevel === FormattedConfigLevel.DIRECTORY
+            ? "directory"
+            : "repository";
+
+    return (
+        <Controller
+            name="byokModel.value"
+            control={form.control}
+            defaultValue={config?.byokModel?.value ?? ""}
+            render={({ field }) => {
+                const currentValue = field.value ?? "";
+                const isInherited = currentValue === parentValue;
+                const effectiveModelId = currentValue || byokMainModel;
+
+                // A model id that isn't in the provider catalog — either typed
+                // manually or inherited from a kodus-config.yml. We can't be
+                // certain it's invalid (the catalog isn't exhaustive), so warn
+                // rather than block.
+                const isUnknownModel =
+                    currentValue !== "" &&
+                    models.length > 0 &&
+                    !models.some((m) => m.id === currentValue);
+
+                const selectModel = (modelId: string) => {
+                    field.onChange(modelId);
+                    setOpen(false);
+                };
+
+                return (
+                    <Card>
+                        <CardHeader>
+                            <div className="flex flex-row items-center gap-2">
+                                <Heading variant="h3">
+                                    Code review model
+                                </Heading>
+
+                                <OverrideIndicatorForm fieldName="byokModel" />
+                            </div>
+
+                            <p className="text-text-secondary text-sm">
+                                {isInherited ? (
+                                    <>
+                                        Reviews run with{" "}
+                                        <strong>
+                                            {modelName(inheritedModelId) ||
+                                                "your BYOK model"}
+                                        </strong>
+                                        , inherited from{" "}
+                                        {inheritedFromBYOKSettings
+                                            ? "BYOK settings"
+                                            : "the repository"}
+                                        . Pick a model to override it for this{" "}
+                                        {scopeLabel}.
+                                    </>
+                                ) : (
+                                    <>
+                                        Reviews for this {scopeLabel} run with{" "}
+                                        <strong>
+                                            {modelName(effectiveModelId)}
+                                        </strong>{" "}
+                                        from your main BYOK provider.
+                                    </>
+                                )}
+                            </p>
+                        </CardHeader>
+
+                        <CardContent className="w-full">
+                            {manual ? (
+                                <div className="flex flex-col gap-2">
+                                    <Input
+                                        size="md"
+                                        id={field.name}
+                                        disabled={field.disabled}
+                                        value={currentValue}
+                                        placeholder="Type a model id"
+                                        className="w-full"
+                                        onChange={(ev) =>
+                                            field.onChange(ev.target.value)
+                                        }
+                                    />
+                                    <Button
+                                        variant="tertiary"
+                                        size="xs"
+                                        disabled={field.disabled}
+                                        className="self-start"
+                                        onClick={() => setManual(false)}>
+                                        Select from list
+                                    </Button>
+                                </div>
+                            ) : (
+                                <Popover
+                                    modal
+                                    open={open}
+                                    onOpenChange={setOpen}>
+                                    <PopoverTrigger asChild>
+                                        <Button
+                                            size="lg"
+                                            variant="helper"
+                                            role="combobox"
+                                            id={field.name}
+                                            disabled={field.disabled}
+                                            className="w-full justify-between"
+                                            rightIcon={
+                                                <ChevronsUpDownIcon className="-mr-2 opacity-50" />
+                                            }>
+                                            {isInherited ? (
+                                                <span className="font-normal">
+                                                    Inherited
+                                                    {effectiveModelId
+                                                        ? ` · ${modelName(effectiveModelId)}`
+                                                        : ""}
+                                                </span>
+                                            ) : (
+                                                modelName(currentValue)
+                                            )}
+                                        </Button>
+                                    </PopoverTrigger>
+
+                                    <PopoverContent
+                                        align="start"
+                                        className="w-[var(--radix-popover-trigger-width)] p-0">
+                                        <Command
+                                            filter={(value, search) => {
+                                                if (
+                                                    value === INHERIT_ITEM ||
+                                                    value === MANUAL_ITEM
+                                                ) {
+                                                    return 1;
+                                                }
+                                                const model = models.find(
+                                                    (m) => m.id === value,
+                                                );
+                                                if (!model) return 0;
+                                                return model.name
+                                                    .toLowerCase()
+                                                    .includes(
+                                                        search.toLowerCase(),
+                                                    )
+                                                    ? 1
+                                                    : 0;
+                                            }}>
+                                            <CommandInput
+                                                placeholder="Search models..."
+                                                value={search}
+                                                onValueChange={setSearch}
+                                            />
+
+                                            <CommandList className="max-h-56 overflow-y-auto p-1">
+                                                <CommandEmpty>
+                                                    No model found.
+                                                </CommandEmpty>
+
+                                                <CommandItem
+                                                    key={INHERIT_ITEM}
+                                                    value={INHERIT_ITEM}
+                                                    onSelect={() =>
+                                                        selectModel(parentValue)
+                                                    }>
+                                                    <span className="flex flex-col">
+                                                        <span>
+                                                            Use inherited model
+                                                        </span>
+                                                        {inheritedModelId && (
+                                                            <span className="text-text-tertiary text-xs">
+                                                                {modelName(
+                                                                    inheritedModelId,
+                                                                )}
+                                                            </span>
+                                                        )}
+                                                    </span>
+                                                </CommandItem>
+
+                                                {ArrayHelpers.sortAlphabetically(
+                                                    models,
+                                                    "name",
+                                                ).map((model) => (
+                                                    <CommandItem
+                                                        key={model.id}
+                                                        value={model.id}
+                                                        onSelect={() =>
+                                                            selectModel(
+                                                                model.id,
+                                                            )
+                                                        }>
+                                                        {model.name}
+                                                    </CommandItem>
+                                                ))}
+
+                                                <CommandItem
+                                                    key={MANUAL_ITEM}
+                                                    value={MANUAL_ITEM}
+                                                    onSelect={() => {
+                                                        setManual(true);
+                                                        setOpen(false);
+                                                    }}>
+                                                    {search.trim().length
+                                                        ? `Type manually: "${search.trim()}"`
+                                                        : "Type model manually"}
+                                                </CommandItem>
+                                            </CommandList>
+                                        </Command>
+                                    </PopoverContent>
+                                </Popover>
+                            )}
+
+                            {isUnknownModel && (
+                                <p className="text-warning mt-2 flex items-start gap-1.5 text-xs">
+                                    <AlertTriangleIcon className="mt-0.5 size-3.5 shrink-0" />
+                                    <span>
+                                        <strong>{currentValue}</strong> isn't in
+                                        your BYOK provider's model list.
+                                        Double-check the id — an invalid model
+                                        makes reviews fail, or fall back to your
+                                        BYOK fallback model.
+                                    </span>
+                                </p>
+                            )}
+                        </CardContent>
+                    </Card>
+                );
+            }}
+        />
+    );
+};

--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/general/page.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/general/page.tsx
@@ -33,6 +33,7 @@ import {
 } from "../../../_hooks";
 import { AutomatedReviewActive } from "./_components/automated-review-active";
 import { BaseBranches } from "./_components/base-branches";
+import { BYOKModelSelectorSection } from "./_components/byok-model-selector";
 import { CentralizedConfigModal } from "./_components/centralized-config-modal";
 import { EnableCommittableSuggestions } from "./_components/enable-committable-suggestions";
 import { IgnorePaths } from "./_components/ignore-paths";
@@ -202,6 +203,13 @@ export default function General() {
                 <div data-field-name="automatedReviewActive">
                     <AutomatedReviewActive />
                 </div>
+
+                {repositoryId !== "global" && (
+                    <div data-field-name="byokModel">
+                        <BYOKModelSelectorSection />
+                    </div>
+                )}
+
                 <div data-field-name="kodusConfigFileOverridesWebPreferences">
                     <KodusConfigFileOverridesWebPreferences />
                 </div>

--- a/apps/web/src/app/(app)/settings/code-review/_types.ts
+++ b/apps/web/src/app/(app)/settings/code-review/_types.ts
@@ -124,6 +124,9 @@ export type CodeReviewGlobalConfig = {
         };
     };
     enableCommittableSuggestions: boolean;
+    /** BYOK main-model override for code reviews. '' = inherit
+     *  (directory -> repository -> the main model set in BYOK settings). */
+    byokModel?: string;
 };
 
 export type CodeReviewBaseConfig = {

--- a/apps/web/src/app/(app)/settings/layout.tsx
+++ b/apps/web/src/app/(app)/settings/layout.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next";
 import { cookies } from "next/headers";
 import {
+    getLLMConfigStatus,
+    getLLMProviderModels,
+} from "@services/organizationParameters/fetch";
+import {
     getDefaultCodeReviewParameterNoCache,
     getFormattedCodeReviewParameterNoCache,
     getPlatformConfigParameterNoCache,
@@ -44,12 +48,29 @@ export default async function Layout({ children }: React.PropsWithChildren) {
         return null;
     }
 
-    const [initialShellConfig, initialDefaultConfig, initialPlatformConfig] =
-        await Promise.all([
-            getFormattedCodeReviewParameterNoCache(initialTeamId),
-            getDefaultCodeReviewParameterNoCache(),
-            getPlatformConfigParameterNoCache(initialTeamId),
-        ]);
+    // Resolved first (fast DB read) so the provider's model catalog can be
+    // fetched in parallel with the config fetches below, hiding its latency.
+    const initialLLMConfigStatus = await getLLMConfigStatus().catch(() => null);
+    const byokProvider =
+        initialLLMConfigStatus?.byok?.configured &&
+        initialLLMConfigStatus.byok.providerId
+            ? initialLLMConfigStatus.byok.providerId
+            : undefined;
+
+    const [
+        initialShellConfig,
+        initialDefaultConfig,
+        initialPlatformConfig,
+        initialByokModels,
+    ] = await Promise.all([
+        getFormattedCodeReviewParameterNoCache(initialTeamId),
+        getDefaultCodeReviewParameterNoCache(),
+        getPlatformConfigParameterNoCache(initialTeamId),
+        // Drives the BYOK model selector's catalog. Empty on error / no BYOK.
+        byokProvider
+            ? getLLMProviderModels(byokProvider).catch(() => [])
+            : Promise.resolve([]),
+    ]);
 
     if (
         !initialShellConfig ||
@@ -68,7 +89,11 @@ export default async function Layout({ children }: React.PropsWithChildren) {
                 initialTeamId={initialTeamId}
                 initialConfigValue={initialShellConfig.configValue}
                 initialDefaultConfig={initialDefaultConfig}
-                initialPlatformConfig={initialPlatformConfig}>
+                initialPlatformConfig={initialPlatformConfig}
+                initialModelData={{
+                    llmConfigStatus: initialLLMConfigStatus,
+                    byokModels: initialByokModels,
+                }}>
                 {children}
             </SettingsLayout>
         </PageBoundary>

--- a/apps/web/src/core/utils/helpers.ts
+++ b/apps/web/src/core/utils/helpers.ts
@@ -211,6 +211,10 @@ export const codeReviewConfigRemovePropertiesNotInType = (
         "runOnDraft",
         "codeReviewVersion",
         "enableCommittableSuggestions",
+        // BYOK main-model override. Without it here the stripper would
+        // silently drop the field and the backend would never persist the
+        // selected model.
+        "byokModel",
         // New v2 prompt overrides for categories/severity customization
         "v2PromptOverrides",
     ];

--- a/apps/web/src/lib/services/organizationParameters/fetch.ts
+++ b/apps/web/src/lib/services/organizationParameters/fetch.ts
@@ -126,6 +126,18 @@ export const getLLMConfigStatus = async (): Promise<LLMConfigStatus> => {
     );
 };
 
+export type LLMProviderModel = { id: string; name: string };
+
+export const getLLMProviderModels = async (
+    provider: string,
+): Promise<LLMProviderModel[]> => {
+    const response = await authorizedFetch<{ models: LLMProviderModel[] }>(
+        ORGANIZATION_PARAMETERS_PATHS.GET_PROVIDER_MODELS_LIST,
+        { cache: "no-store", params: { provider } },
+    );
+    return response?.models ?? [];
+};
+
 export const getOrganizationParameterByKey = async <
     T extends { configValue: unknown },
 >(

--- a/default-kodus-config.yml
+++ b/default-kodus-config.yml
@@ -20,6 +20,7 @@ ignorePaths:
 ignoredTitleKeywords: []
 baseBranches: []
 enableCommittableSuggestions: true
+byokModel: '' # BYOK main model, empty = inherit, (directory -> repository -> the main model set in BYOK settings)
 
 # review categories
 codeReviewVersion: 'v2' # legacy | v2

--- a/libs/agents/infrastructure/services/kodus-flow/base-agent.provider.ts
+++ b/libs/agents/infrastructure/services/kodus-flow/base-agent.provider.ts
@@ -45,15 +45,33 @@ export abstract class BaseAgentProvider {
     ) {}
 
     /**
-     * Fetches BYOK configuration for the organization
+     * Fetches BYOK configuration for the organization.
+     *
+     * `byokModelOverride` is the per-repository/directory model resolved by
+     * the code review pipeline (`codeReviewConfig.byokModel`). `getBYOKConfig()`
+     * returns the raw org-level config, so without applying it here an agent
+     * invoked during a review would run on the BYOK-settings main model and
+     * ignore the override. Empty/absent means "inherit" (no override).
      */
     protected async fetchBYOKConfig(
         organizationAndTeamData: OrganizationAndTeamData,
+        byokModelOverride?: string,
     ): Promise<void> {
         this.organizationAndTeamData = organizationAndTeamData;
-        this.byokConfig = await this.permissionValidationService.getBYOKConfig(
-            organizationAndTeamData,
-        );
+
+        const byokConfig =
+            await this.permissionValidationService.getBYOKConfig(
+                organizationAndTeamData,
+            );
+
+        const overrideModel = byokModelOverride?.trim();
+        this.byokConfig =
+            overrideModel && byokConfig?.main
+                ? {
+                      ...byokConfig,
+                      main: { ...byokConfig.main, model: overrideModel },
+                  }
+                : byokConfig;
     }
 
     /**

--- a/libs/agents/infrastructure/services/kodus-flow/contextEvidenceAgent.provider.ts
+++ b/libs/agents/infrastructure/services/kodus-flow/contextEvidenceAgent.provider.ts
@@ -513,6 +513,8 @@ My execution plan is:
         promptOverrides?: CodeReviewConfig['v2PromptOverrides'];
         additionalContext?: Record<string, unknown>;
         kodyRule?: Partial<IKodyRule>;
+        /** Per-repo/directory BYOK model override (`codeReviewConfig.byokModel`). */
+        byokModel?: string;
     }): Promise<ContextEvidenceAgentResult | null> {
         const {
             organizationAndTeamData,
@@ -521,6 +523,7 @@ My execution plan is:
             promptOverrides,
             additionalContext,
             kodyRule,
+            byokModel,
         } = params;
 
         this.logger.log({
@@ -546,7 +549,7 @@ My execution plan is:
             return null;
         }
 
-        await this.fetchBYOKConfig(organizationAndTeamData);
+        await this.fetchBYOKConfig(organizationAndTeamData, byokModel);
 
         const orchestration = await this.createEphemeralOrchestrator(
             organizationAndTeamData,

--- a/libs/agents/skills/abstract-skill-provider.ts
+++ b/libs/agents/skills/abstract-skill-provider.ts
@@ -32,6 +32,12 @@ export interface SkillExecutionContext<TPrepareContext = unknown> {
     organizationAndTeamData: OrganizationAndTeamData;
     prepareContext?: TPrepareContext;
     thread?: Thread;
+    /**
+     * Per-repository/directory BYOK model override resolved by the code
+     * review pipeline (`codeReviewConfig.byokModel`). When set, the skill's
+     * LLM calls run on this model instead of the BYOK-settings main model.
+     */
+    byokModel?: string;
 }
 
 export interface SkillErrorContext<TPrepareContext = unknown> {
@@ -145,7 +151,7 @@ export abstract class AbstractSkillProvider<
 
         this.logExecutionStarted(organizationAndTeamData, userLanguage);
 
-        await this.fetchBYOKConfig(organizationAndTeamData);
+        await this.fetchBYOKConfig(organizationAndTeamData, context.byokModel);
 
         const fetcherInitialization = await this.initializeFetcherRuntime(
             context,

--- a/libs/ai-engine/infrastructure/adapters/services/context/file-context-augmentation.service.ts
+++ b/libs/ai-engine/infrastructure/adapters/services/context/file-context-augmentation.service.ts
@@ -123,6 +123,8 @@ export class FileContextAugmentationService {
                     promptOverrides: baseOverrides,
                     additionalContext: this.buildAdditionalContext(context),
                     kodyRule: kodyRule,
+                    // Per-repo/directory model override resolved by ValidateConfigStage.
+                    byokModel: context.codeReviewConfig?.byokModel,
                 },
             );
 

--- a/libs/code-review/application/use-cases/configuration/__tests__/update-or-create-code-review-parameter-use-case.spec.ts
+++ b/libs/code-review/application/use-cases/configuration/__tests__/update-or-create-code-review-parameter-use-case.spec.ts
@@ -1318,4 +1318,131 @@ describe('UpdateOrCreateCodeReviewParameterUseCase', () => {
             centralizedConfigPrServiceMock.createMutationPullRequestIfEnabled,
         ).not.toHaveBeenCalled();
     });
+
+    it('stores byokModel override in the repository delta', async () => {
+        const createOrUpdateParametersUseCase = {
+            execute: jest.fn().mockResolvedValue(true),
+        };
+
+        const useCase = new UpdateOrCreateCodeReviewParameterUseCase(
+            {
+                findByKey: jest.fn().mockResolvedValue({
+                    configValue: {
+                        id: 'global',
+                        name: 'Global',
+                        isSelected: true,
+                        configs: {},
+                        repositories: [
+                            {
+                                id: 'repo-1',
+                                name: 'alpha',
+                                isSelected: false,
+                                configs: {},
+                                directories: [],
+                            },
+                        ],
+                    },
+                }),
+            } as any,
+            createOrUpdateParametersUseCase as any,
+            {
+                findIntegrationConfigFormatted: jest.fn().mockResolvedValue([
+                    { id: 'repo-1', name: 'alpha', directories: [] },
+                ]),
+            } as any,
+            { emit: jest.fn() } as any,
+            { ensure: jest.fn() } as any,
+            { detectAndSaveReferences: jest.fn() } as any,
+            { buildConfigKey: jest.fn().mockReturnValue('config-key') } as any,
+            buildCentralizedConfigPrServiceMock() as any,
+        );
+
+        await useCase.execute({
+            actor: {
+                source: 'sync',
+                organizationId: 'org-1',
+                userId: 'kody',
+                userEmail: 'kody@kodus.io',
+            },
+            configValue: { byokModel: 'gpt-5-mini' },
+            organizationAndTeamData: {
+                organizationId: 'org-1',
+                teamId: 'team-1',
+            },
+            repositoryId: 'repo-1',
+            skipAuthorization: true,
+        } as any);
+
+        const updatedConfig =
+            createOrUpdateParametersUseCase.execute.mock.calls[0][1];
+        const repository = updatedConfig.repositories.find(
+            (repo: any) => repo.id === 'repo-1',
+        );
+
+        expect(repository.configs.byokModel).toBe('gpt-5-mini');
+    });
+
+    it('removes a reverted byokModel override from the repository delta', async () => {
+        const createOrUpdateParametersUseCase = {
+            execute: jest.fn().mockResolvedValue(true),
+        };
+
+        const useCase = new UpdateOrCreateCodeReviewParameterUseCase(
+            {
+                findByKey: jest.fn().mockResolvedValue({
+                    configValue: {
+                        id: 'global',
+                        name: 'Global',
+                        isSelected: true,
+                        configs: {},
+                        repositories: [
+                            {
+                                id: 'repo-1',
+                                name: 'alpha',
+                                isSelected: true,
+                                configs: { byokModel: 'gpt-4' },
+                                directories: [],
+                            },
+                        ],
+                    },
+                }),
+            } as any,
+            createOrUpdateParametersUseCase as any,
+            {
+                findIntegrationConfigFormatted: jest.fn().mockResolvedValue([
+                    { id: 'repo-1', name: 'alpha', directories: [] },
+                ]),
+            } as any,
+            { emit: jest.fn() } as any,
+            { ensure: jest.fn() } as any,
+            { detectAndSaveReferences: jest.fn() } as any,
+            { buildConfigKey: jest.fn().mockReturnValue('config-key') } as any,
+            buildCentralizedConfigPrServiceMock() as any,
+        );
+
+        await useCase.execute({
+            actor: {
+                source: 'sync',
+                organizationId: 'org-1',
+                userId: 'kody',
+                userEmail: 'kody@kodus.io',
+            },
+            // '' is the "inherit" sentinel — saving it should drop the override.
+            configValue: { byokModel: '' },
+            organizationAndTeamData: {
+                organizationId: 'org-1',
+                teamId: 'team-1',
+            },
+            repositoryId: 'repo-1',
+            skipAuthorization: true,
+        } as any);
+
+        const updatedConfig =
+            createOrUpdateParametersUseCase.execute.mock.calls[0][1];
+        const repository = updatedConfig.repositories.find(
+            (repo: any) => repo.id === 'repo-1',
+        );
+
+        expect(repository.configs.byokModel).toBeUndefined();
+    });
 });

--- a/libs/code-review/infrastructure/agents/base-code-review-agent.provider.ts
+++ b/libs/code-review/infrastructure/agents/base-code-review-agent.provider.ts
@@ -347,6 +347,13 @@ export interface ReviewAgentInput {
     batchTotal?: number;
     /** Review mode: 'fast' skips heavy passes (verify, coverage recovery, synthesis rescue) and caps agent steps; 'normal' skips verify only for very-high-confidence findings; 'deep' verifies everything. */
     reviewMode?: 'fast' | 'normal' | 'deep';
+    /**
+     * Resolved BYOK *main* model override (directory -> repository -> BYOK
+     * settings) from `codeReviewConfig.byokModel`. When set, it replaces
+     * `byokConfig.main.model` for this run so the agent uses the same model
+     * the rest of the pipeline does. Empty/undefined means "inherit".
+     */
+    byokModel?: string;
     /** Optional per-agent step budget for the main investigation loop. */
     maxSteps?: number;
     /** When true, skip recovery, second-chance, AND synthesis-rescue
@@ -513,9 +520,21 @@ export abstract class BaseCodeReviewAgentProvider {
         });
 
         // Resolve BYOK config - Scoped locally to prevent race conditions across parallel PR reviews
-        const byokConfig = await this.permissionValidationService.getBYOKConfig(
+        let byokConfig = await this.permissionValidationService.getBYOKConfig(
             input.organizationAndTeamData,
         );
+
+        // Honor the per-repository/directory model override resolved by the
+        // pipeline (codeReviewConfig.byokModel). getBYOKConfig() returns the
+        // raw org-level config, so without this the agent would always run on
+        // the BYOK-settings main model and ignore the override.
+        const overrideModel = input.byokModel?.trim();
+        if (overrideModel && byokConfig?.main) {
+            byokConfig = {
+                ...byokConfig,
+                main: { ...byokConfig.main, model: overrideModel },
+            };
+        }
 
         // Create Vercel AI SDK model from BYOK config
         const model = byokToVercelModel(byokConfig);

--- a/libs/code-review/pipeline/stages/agent-review.stage.ts
+++ b/libs/code-review/pipeline/stages/agent-review.stage.ts
@@ -424,6 +424,8 @@ export class AgentReviewStage extends BasePipelineStage<CodeReviewPipelineContex
                 callGraph,
                 callGraphJson: context.callGraphJson,
                 reviewMode: context.codeReviewConfig?.reviewMode || 'normal',
+                // Per-repo/directory model override resolved by ValidateConfigStage.
+                byokModel: context.codeReviewConfig?.byokModel,
                 // Forwarded from the workflow job timeout. The router builds
                 // an AbortController; here we pass it through so when the
                 // 1h45min budget fires, the agent-loop's local controller is

--- a/libs/code-review/pipeline/stages/business-logic-validation.stage.ts
+++ b/libs/code-review/pipeline/stages/business-logic-validation.stage.ts
@@ -139,6 +139,8 @@ export class BusinessLogicValidationStage extends BasePipelineStage<CodeReviewPi
                     organizationAndTeamData: context.organizationAndTeamData,
                     prepareContext,
                     thread,
+                    // Per-repo/directory model override resolved by ValidateConfigStage.
+                    byokModel: context.codeReviewConfig?.byokModel,
                 });
 
             const result = await Promise.race([agentPromise, timeoutPromise]);

--- a/libs/code-review/pipeline/stages/validate-config.stage.spec.ts
+++ b/libs/code-review/pipeline/stages/validate-config.stage.spec.ts
@@ -1,0 +1,142 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { ValidateConfigStage } from './validate-config.stage';
+import { AUTOMATION_EXECUTION_SERVICE_TOKEN } from '@libs/automation/domain/automationExecution/contracts/automation-execution.service';
+import { ORGANIZATION_PARAMETERS_SERVICE_TOKEN } from '@libs/organization/domain/organizationParameters/contracts/organizationParameters.service.contract';
+import { CodeManagementService } from '@libs/platform/infrastructure/adapters/services/codeManagement.service';
+import { CodeReviewPipelineContext } from '../context/code-review-pipeline.context';
+
+describe('ValidateConfigStage — byokModel override', () => {
+    let stage: ValidateConfigStage;
+    let mockAutomationExecutionService: any;
+    let mockOrganizationParametersService: any;
+    let mockCodeManagementService: any;
+    let context: CodeReviewPipelineContext;
+
+    const buildContext = (
+        byokModel: string | undefined,
+    ): CodeReviewPipelineContext =>
+        ({
+            origin: 'command',
+            platformType: 'github',
+            teamAutomationId: 'team-automation-id',
+            organizationAndTeamData: {
+                organizationId: 'org-1',
+                teamId: 'team-1',
+            },
+            repository: { id: 'repo-1', name: 'repo' },
+            pullRequest: {
+                number: 1,
+                title: 'feat: something',
+                isDraft: false,
+                base: { ref: 'main' },
+                head: { ref: 'feature' },
+            },
+            codeReviewConfig: {
+                automatedReviewActive: true,
+                ignoredTitleKeywords: [],
+                baseBranches: [],
+                runOnDraft: true,
+                byokModel,
+            },
+        }) as unknown as CodeReviewPipelineContext;
+
+    beforeEach(async () => {
+        mockAutomationExecutionService = {
+            findLatestExecutionByFilters: jest.fn().mockResolvedValue(null),
+        };
+
+        mockOrganizationParametersService = {
+            findByKey: jest.fn(),
+        };
+
+        mockCodeManagementService = {
+            createSingleIssueComment: jest.fn(),
+        };
+
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                ValidateConfigStage,
+                {
+                    provide: AUTOMATION_EXECUTION_SERVICE_TOKEN,
+                    useValue: mockAutomationExecutionService,
+                },
+                {
+                    provide: ORGANIZATION_PARAMETERS_SERVICE_TOKEN,
+                    useValue: mockOrganizationParametersService,
+                },
+                {
+                    provide: CodeManagementService,
+                    useValue: mockCodeManagementService,
+                },
+            ],
+        }).compile();
+
+        stage = module.get<ValidateConfigStage>(ValidateConfigStage);
+    });
+
+    it('overrides byokConfig.main.model with byokModel and leaves fallback untouched', async () => {
+        mockOrganizationParametersService.findByKey.mockResolvedValue({
+            configValue: {
+                main: {
+                    provider: 'openai',
+                    apiKey: 'key',
+                    model: 'gpt-4o',
+                },
+                fallback: {
+                    provider: 'anthropic',
+                    apiKey: 'key2',
+                    model: 'claude-fallback',
+                },
+            },
+        });
+
+        context = buildContext('gpt-5-mini');
+
+        const result = await stage.execute(context);
+
+        expect(result.codeReviewConfig.byokConfig?.main?.model).toBe(
+            'gpt-5-mini',
+        );
+        expect(result.codeReviewConfig.byokConfig?.fallback?.model).toBe(
+            'claude-fallback',
+        );
+    });
+
+    it('does not override the model when byokModel is empty', async () => {
+        mockOrganizationParametersService.findByKey.mockResolvedValue({
+            configValue: {
+                main: { provider: 'openai', apiKey: 'key', model: 'gpt-4o' },
+            },
+        });
+
+        context = buildContext('');
+
+        const result = await stage.execute(context);
+
+        expect(result.codeReviewConfig.byokConfig?.main?.model).toBe('gpt-4o');
+    });
+
+    it('does not override the model when byokModel is undefined', async () => {
+        mockOrganizationParametersService.findByKey.mockResolvedValue({
+            configValue: {
+                main: { provider: 'openai', apiKey: 'key', model: 'gpt-4o' },
+            },
+        });
+
+        context = buildContext(undefined);
+
+        const result = await stage.execute(context);
+
+        expect(result.codeReviewConfig.byokConfig?.main?.model).toBe('gpt-4o');
+    });
+
+    it('does not crash when there is no BYOK config', async () => {
+        mockOrganizationParametersService.findByKey.mockResolvedValue(null);
+
+        context = buildContext('gpt-5-mini');
+
+        const result = await stage.execute(context);
+
+        expect(result.codeReviewConfig.byokConfig).toBeUndefined();
+    });
+});

--- a/libs/code-review/pipeline/stages/validate-config.stage.ts
+++ b/libs/code-review/pipeline/stages/validate-config.stage.ts
@@ -85,7 +85,20 @@ export class ValidateConfigStage extends BasePipelineStage<CodeReviewPipelineCon
                 );
 
             context = this.updateContext(context, (draft) => {
-                draft.codeReviewConfig.byokConfig = byokConfig?.configValue;
+                const resolved = byokConfig?.configValue;
+                draft.codeReviewConfig.byokConfig = resolved;
+
+                // The merged code review config can override which BYOK *main*
+                // model runs the review (directory -> repository -> BYOK
+                // settings). An empty/absent value means "inherit", so the
+                // BYOK-settings main model is left in place.
+                const overrideModel = draft.codeReviewConfig.byokModel?.trim();
+                if (resolved?.main && overrideModel) {
+                    draft.codeReviewConfig.byokConfig = {
+                        ...resolved,
+                        main: { ...resolved.main, model: overrideModel },
+                    };
+                }
             });
 
             const cadenceResult = await this.evaluateReviewCadence(context);

--- a/libs/core/infrastructure/config/types/general/codeReview.type.ts
+++ b/libs/core/infrastructure/config/types/general/codeReview.type.ts
@@ -332,6 +332,12 @@ export type CodeReviewConfig = {
     runOnDraft?: boolean;
     codeReviewVersion?: CodeReviewVersion;
     byokConfig?: BYOKConfig;
+    /**
+     * Optional override for the BYOK *main* model used to run code reviews.
+     * Empty string '' means "inherit": directory -> repository -> the main
+     * model defined in the BYOK settings page.
+     */
+    byokModel?: string;
     /** @deprecated Reflection/verify was removed — it hurt recall more than it helped precision. */
     enableReflection?: boolean;
     /**

--- a/libs/identity/infrastructure/adapters/services/permissions/policy.handlers.ts
+++ b/libs/identity/infrastructure/adapters/services/permissions/policy.handlers.ts
@@ -71,6 +71,36 @@ export const checkPermissions = (params: {
 };
 
 /**
+ * Like checkPermissions, but passes when the user satisfies ANY of the
+ * provided action/resource pairs (OR semantics). PolicyGuard combines
+ * multiple handlers with AND, so use this single handler for endpoints
+ * whose non-sensitive payload is legitimately needed by more than one area.
+ *
+ * THIS DOES NOT ENSURE REPO SCOPED PERMISSIONS.
+ *
+ * @param options Action/resource pairs; the request passes if any one matches.
+ * @returns
+ */
+export const checkAnyPermission = (
+    options: Array<{ action: Action; resource: ResourceType }>,
+    status: STATUS[] = [STATUS.ACTIVE],
+): PolicyHandler => {
+    return (ability, request) => {
+        if (!request.user?.organization?.uuid) {
+            return false;
+        }
+
+        if (!status.includes(request.user.status)) {
+            return false;
+        }
+
+        return options.some(({ action, resource }) =>
+            ability.can(action, resource),
+        );
+    };
+};
+
+/**
  * Creates a policy handler that checks if the user has the specified action on the resource
  * for the repository identified in the request (from params, query, body or custom).
  *

--- a/libs/organization/dtos/create-or-update-code-review-parameter.dto.ts
+++ b/libs/organization/dtos/create-or-update-code-review-parameter.dto.ts
@@ -442,6 +442,14 @@ class CodeReviewConfigWithoutLLMProviderDto {
     @IsOptional()
     @IsBoolean()
     enableCommittableSuggestions?: boolean;
+
+    /**
+     * BYOK main-model override for code reviews. Empty string '' means
+     * "inherit" (directory -> repository -> the BYOK-settings main model).
+     */
+    @IsOptional()
+    @IsString()
+    byokModel?: string;
 }
 
 export class CreateOrUpdateCodeReviewParameterDto {


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
This pull request introduces the ability to configure a specific Bring Your Own Key (BYOK) Large Language Model (LLM) for code reviews at the repository and directory levels, overriding the organization's default BYOK model.

Key changes include:

*   **Per-Repository/Directory BYOK Model Override**: Users can now specify a different BYOK model for code reviews within a specific repository or directory. This can be configured via a new UI selector in the web application or through a `byokModel` field in the `kodus-config.yml` file. An empty value signifies inheritance from the parent scope (directory inherits from repository, repository inherits from organization BYOK settings).
*   **Web UI for Model Selection**: A new UI component is added to the code review settings page, providing a selector to choose an inherited model, select from a catalog of available models from the configured BYOK provider, or manually enter a model ID.
*   **Backend Integration and Pipeline Support**: The `byokModel` field is integrated into the code review configuration types, DTOs, and persistence logic. The code review pipeline, agents, and skills are updated to respect and apply this override, ensuring that LLM calls for code reviews use the specified model for the given scope.
*   **Improved Permissions for LLM Status**: The API endpoint for LLM configuration status (`/llm-config/status`) now allows access to users with `Read` permission on `CodeReviewSettings` (in addition to `OrganizationSettings`), enabling code review settings editors to view necessary BYOK provider information for the model selector.
*   **Pre-fetching Model Data**: The settings layout now pre-fetches the BYOK LLM configuration status and the list of available models from the BYOK provider, improving UI responsiveness by avoiding client-side loading states for the model selector.
<!-- kody-pr-summary:end -->