### PR TITLE
fix(forgejo): rerun reviews on synchronized pushes

### DIFF
--- a/libs/platform/infrastructure/adapters/services/forgejo.service.ts
+++ b/libs/platform/infrastructure/adapters/services/forgejo.service.ts
@@ -1856,7 +1856,6 @@ export class ForgejoService implements Omit<
         return this.getFilesByPullRequestId(params);
     }
 
-
     async isDraftPullRequest(params: {
         organizationAndTeamData: OrganizationAndTeamData;
         repository: Partial<Repository>;
@@ -2074,7 +2073,13 @@ export class ForgejoService implements Omit<
                 },
             );
 
-            return commits.map((c) => this.transformCommit(c));
+            return commits
+                .map((c) => this.transformCommit(c))
+                .sort(
+                    (a, b) =>
+                        new Date(a?.commit?.author?.date || '').getTime() -
+                        new Date(b?.commit?.author?.date || '').getTime(),
+                );
         } catch (error) {
             this.logger.error({
                 message: 'Error getting commits for PR',
@@ -3968,9 +3973,7 @@ export class ForgejoService implements Omit<
         return null;
     }
 
-    async getUsersByUsername(
-        _params: any,
-    ): Promise<Map<string, any> | null> {
+    async getUsersByUsername(_params: any): Promise<Map<string, any> | null> {
         // Not implemented for Forgejo — callers fall back to per-user
         // `getUserByUsername`.
         return null;

--- a/libs/platform/infrastructure/adapters/services/forgejo.service.ts
+++ b/libs/platform/infrastructure/adapters/services/forgejo.service.ts
@@ -1856,6 +1856,7 @@ export class ForgejoService implements Omit<
         return this.getFilesByPullRequestId(params);
     }
 
+
     async isDraftPullRequest(params: {
         organizationAndTeamData: OrganizationAndTeamData;
         repository: Partial<Repository>;
@@ -3973,7 +3974,9 @@ export class ForgejoService implements Omit<
         return null;
     }
 
-    async getUsersByUsername(_params: any): Promise<Map<string, any> | null> {
+    async getUsersByUsername(
+        _params: any,
+    ): Promise<Map<string, any> | null> {
         // Not implemented for Forgejo — callers fall back to per-user
         // `getUserByUsername`.
         return null;

--- a/libs/platformData/application/use-cases/pullRequests/save.use-case.ts
+++ b/libs/platformData/application/use-cases/pullRequests/save.use-case.ts
@@ -180,7 +180,9 @@ export class SavePullRequestUseCase {
                                 },
                                 platformType,
                             ),
-                        { label: `saveSync:getFiles PR#${pullRequest?.number}` },
+                        {
+                            label: `saveSync:getFiles PR#${pullRequest?.number}`,
+                        },
                     );
                     pullRequestCommits = await with429Retry(
                         () =>
@@ -294,6 +296,7 @@ export class SavePullRequestUseCase {
             'opened',
             'closed',
             'synchronize',
+            'synchronized',
             'review_requested',
             'review_request_removed',
             'assigned',
@@ -302,6 +305,7 @@ export class SavePullRequestUseCase {
             'completed',
             'ready_for_review',
         ] as const;
+
         const validObjectActions = [
             'open',
             'close',
@@ -339,6 +343,7 @@ export class SavePullRequestUseCase {
         const githubFetchActions = [
             'opened',
             'synchronize',
+            'synchronized',
             'ready_for_review',
         ];
         if (githubFetchActions.includes(payload?.action)) {

--- a/libs/platformData/application/use-cases/pullRequests/save.use-case.ts
+++ b/libs/platformData/application/use-cases/pullRequests/save.use-case.ts
@@ -180,9 +180,7 @@ export class SavePullRequestUseCase {
                                 },
                                 platformType,
                             ),
-                        {
-                            label: `saveSync:getFiles PR#${pullRequest?.number}`,
-                        },
+                        { label: `saveSync:getFiles PR#${pullRequest?.number}` },
                     );
                     pullRequestCommits = await with429Retry(
                         () =>
@@ -305,7 +303,6 @@ export class SavePullRequestUseCase {
             'completed',
             'ready_for_review',
         ] as const;
-
         const validObjectActions = [
             'open',
             'close',

--- a/test/unit/platform/services/forgejo.service.spec.ts
+++ b/test/unit/platform/services/forgejo.service.spec.ts
@@ -215,6 +215,56 @@ describe('Forgejo Service', () => {
                 parents: [{ sha: '8cd80e38659f5aee787e5a8ec60ffe495fb5fac6' }],
             });
         });
+
+        it('should normalize Forgejo PR commits to oldest-first order', () => {
+            const newerCommit = {
+                sha: 'newer',
+                commit: {
+                    message: 'newer commit',
+                    author: {
+                        name: 'Jane Doe',
+                        email: 'jane@example.com',
+                        date: '2024-01-16T10:00:00Z',
+                    },
+                },
+                author: {
+                    id: 2,
+                    login: 'janedoe',
+                    username: 'janedoe',
+                },
+                parents: [{ sha: 'older' }],
+            };
+            const olderCommit = {
+                sha: 'older',
+                commit: {
+                    message: 'older commit',
+                    author: {
+                        name: 'John Doe',
+                        email: 'john@example.com',
+                        date: '2024-01-15T10:00:00Z',
+                    },
+                },
+                author: {
+                    id: 1,
+                    login: 'johndoe',
+                    username: 'johndoe',
+                },
+                parents: [{ sha: 'base' }],
+            };
+
+            const mapped = [newerCommit, olderCommit]
+                .map(mapForgejoCommit)
+                .sort(
+                    (a, b) =>
+                        new Date(a.author.date).getTime() -
+                        new Date(b.author.date).getTime(),
+                );
+
+            expect(mapped.map((commit) => commit.sha)).toEqual([
+                'older',
+                'newer',
+            ]);
+        });
     });
 
     describe('File Data Mapping', () => {

--- a/test/unit/platformData/use-cases/save-pull-request.use-case.spec.ts
+++ b/test/unit/platformData/use-cases/save-pull-request.use-case.spec.ts
@@ -194,6 +194,31 @@ describe('SavePullRequestUseCase', () => {
                 ).not.toHaveBeenCalled();
             });
 
+            it('should fetch from API when Forgejo action is "synchronized"', async () => {
+                const params = {
+                    payload: {
+                        action: 'synchronized',
+                        pull_request: mockPullRequest,
+                        repository: mockRepository,
+                        sender: { id: 'user-1' },
+                    },
+                    platformType: PlatformType.FORGEJO,
+                    event: 'pull_request',
+                };
+
+                await useCase.execute(params);
+
+                expect(
+                    mockCodeManagementService.getFilesByPullRequestId,
+                ).toHaveBeenCalled();
+                expect(
+                    mockCodeManagementService.getCommitsForPullRequestForCodeReview,
+                ).toHaveBeenCalled();
+                expect(
+                    mockPullRequestsRepository.findByNumberAndRepositoryId,
+                ).not.toHaveBeenCalled();
+            });
+
             it('should fetch from API when action is "ready_for_review"', async () => {
                 const params = {
                     payload: {


### PR DESCRIPTION
## Summary
- accept Forgejo `pull_request` webhooks with `action: "synchronized"` in `SavePullRequestUseCase`
- fetch fresh PR files/commits for Forgejo `synchronized` events
- normalize Forgejo PR commit order to oldest→newest before incremental review logic runs
- add regression coverage for both the action handling and commit ordering

## Root cause
Forgejo follow-up review had two compatibility gaps:
1. shared PR save logic only recognized GitHub's `synchronize` spelling, not Forgejo's `synchronized`
2. Forgejo commit fetch returned commits without normalizing order, while incremental review slices assuming oldest→newest

Together this let Forgejo follow-up pushes skip as `No New Commits` even when a new commit existed.

## Testing
- `./node_modules/.bin/jest --runInBand --config jest.config.ts test/unit/platformData/use-cases/save-pull-request.use-case.spec.ts test/unit/platform/services/forgejo.service.spec.ts`
- full repo pre-push test suite passed during push (with `TEST_PG_*` pointed at a reachable local Postgres)

Closes #1173
