### PR TITLE
fix(agent-review): guard undefined agentResults before .map() access

### DIFF
--- a/libs/code-review/pipeline/stages/agent-review.stage.ts
+++ b/libs/code-review/pipeline/stages/agent-review.stage.ts
@@ -440,7 +440,7 @@ export class AgentReviewStage extends BasePipelineStage<CodeReviewPipelineContex
                 metadata: {
                     prNumber,
                     suggestionsCount: result.suggestions.length,
-                    agentResults: result.agentResults.map((r) => ({
+                    agentResults: (result.agentResults ?? []).map((r) => ({
                         agent: r.agentName,
                         category: r.agentCategory,
                         replicaIndex: r.agentReplicaIndex,
@@ -548,7 +548,7 @@ export class AgentReviewStage extends BasePipelineStage<CodeReviewPipelineContex
 
             // Collect suggestions discarded by severity filter and verify
             const allDiscarded: Partial<CodeSuggestion>[] = [];
-            for (const agentResult of result.agentResults) {
+            for (const agentResult of result.agentResults ?? []) {
                 if (agentResult.discardedBySeverity?.length) {
                     for (const s of agentResult.discardedBySeverity) {
                         allDiscarded.push({

--- a/test/unit/code-review/pipeline/stages/agent-review.stage.spec.ts
+++ b/test/unit/code-review/pipeline/stages/agent-review.stage.spec.ts
@@ -409,5 +409,46 @@ describe('AgentReviewStage', () => {
 
             expect(result.fileAnalysisResults).toEqual([]);
         });
+
+        it('should handle undefined agentResults without throwing', async () => {
+            mockOrchestrator.execute.mockResolvedValue({
+                suggestions: [
+                    {
+                        relevantFile: 'src/auth.ts',
+                        suggestionContent: 'Missing null check',
+                        label: 'bug',
+                        severity: 'high',
+                        relevantLinesStart: 10,
+                        relevantLinesEnd: 15,
+                    },
+                ],
+                agentResults: undefined,
+                totalDurationMs: 1000,
+            });
+
+            const context = createBaseContext({
+                changedFiles: [{ filename: 'src/auth.ts' } as any],
+                sandboxHandle: {
+                    remoteCommands: {
+                        grep: jest.fn(),
+                        read: jest.fn(),
+                        listDir: jest.fn(),
+                    },
+                    cleanup: jest.fn(),
+                    type: 'e2b' as const,
+                    sandboxId: 'mock-sandbox-id',
+                    repoDir: '/home/user/repo',
+                    run: jest.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 }),
+                    readFile: jest.fn().mockResolvedValue(''),
+                    writeFile: jest.fn().mockResolvedValue(undefined),
+                },
+            });
+
+            const result = await (stage as any).executeStage(context);
+
+            expect(result.fileAnalysisResults).toHaveLength(1);
+            expect(result.fileAnalysisResults[0].validSuggestionsToAnalyze).toHaveLength(1);
+        });
+
     });
 });


### PR DESCRIPTION
## Summary

Guard two unguarded `result.agentResults` accesses in `AgentReviewStage` that crash with `TypeError: Cannot read properties of undefined (reading 'map')` when the orchestrator result omits the field.

Although `OrchestratorOutput` declares `agentResults: ReviewAgentOutput[]`, runtime paths exist where the field is `undefined` rather than an empty array (e.g. generalist agent dispatch failures). The stage currently trusts the contract unconditionally at:

- **line 443**: `result.agentResults.map(...)` — logging metadata
- **line 551**: `for (const agentResult of result.agentResults)` — collecting discarded suggestions

## Changes

- Default to empty array: `(result.agentResults ?? [])` at both call sites
- Add regression test for `agentResults: undefined` orchestrator result

Fixes #1176