### PR TITLE
fix(gitlab): fallback to /changes endpoint for GitLab < 15.7

### DIFF
--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -1731,12 +1731,29 @@ export class GitlabService implements Omit<
         projectId: string,
         merge_number: number,
     ): Promise<any> {
-        const files = await gitlab.MergeRequests.allDiffs(
-            projectId,
-            merge_number,
-        );
+        try {
+            const files = await gitlab.MergeRequests.allDiffs(
+                projectId,
+                merge_number,
+            );
 
-        return files;
+            return files;
+        } catch (error) {
+            if (
+                error?.cause?.response?.status === 404 ||
+                error?.status === 404
+            ) {
+                // Fallback for GitLab < 15.7 where /diffs endpoint doesn't exist
+                const mr = await gitlab.MergeRequests.showChanges(
+                    projectId,
+                    merge_number,
+                );
+
+                return mr.changes || [];
+            }
+
+            throw error;
+        }
     }
 
     async countChangesInMergeRequest(
@@ -1903,10 +1920,27 @@ export class GitlabService implements Omit<
 
         // 4. Get the MR diffs to filter out files that came from merge commits
         // MergeRequests.allDiffs only returns files that belong to the MR (relative to target branch)
-        const mrDiffs = await gitlabAPI.MergeRequests.allDiffs(
-            repository.id,
-            prNumber,
-        );
+        // Fallback to showChanges for GitLab < 15.7 where /diffs endpoint doesn't exist
+        let mrDiffs: Array<{ new_path: string }>;
+        try {
+            mrDiffs = await gitlabAPI.MergeRequests.allDiffs(
+                repository.id,
+                prNumber,
+            );
+        } catch (error) {
+            if (
+                error?.cause?.response?.status === 404 ||
+                error?.status === 404
+            ) {
+                const mr = await gitlabAPI.MergeRequests.showChanges(
+                    repository.id,
+                    prNumber,
+                );
+                mrDiffs = mr.changes || [];
+            } else {
+                throw error;
+            }
+        }
 
         const mrFileNames = new Set(mrDiffs.map((f) => f.new_path));
 

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -1747,6 +1747,7 @@ export class GitlabService implements Omit<
                 const mr = await gitlab.MergeRequests.showChanges(
                     projectId,
                     merge_number,
+                    { accessRawDiffs: true },
                 );
 
                 return mr.changes || [];
@@ -1935,6 +1936,7 @@ export class GitlabService implements Omit<
                 const mr = await gitlabAPI.MergeRequests.showChanges(
                     repository.id,
                     prNumber,
+                    { accessRawDiffs: true },
                 );
                 mrDiffs = mr.changes || [];
             } else {


### PR DESCRIPTION
## Summary

- Add try/catch around `MergeRequests.allDiffs()` calls to gracefully fall back to `MergeRequests.showChanges()` on 404, enabling code review for self-hosted GitLab instances running versions older than 15.7

Closes #1187

## Changelog routing

| Prefix | Public changelog |
|--------|-----------------|
| `fix:` | **Bug fixes** section |

## Test plan

- [x] Verified both call sites (`getPullRequestFiles` at line ~1734, `getMergeRequestData` at line ~1923) are patched
- [x] Confirmed `MergeRequestDiffSchema` and `CommitDiffSchema` share the same fields used downstream (`diff`, `new_path`, `old_path`)
- [ ] Manual test against a GitLab 13.x/14.x instance (requires self-hosted environment)

## Notes for the reviewer

**Why this fix:** `allDiffs()` calls `GET /merge_requests/:id/diffs` (introduced in GitLab 15.7). Older GitLab only has `GET /merge_requests/:id/changes` (`showChanges()`). The response schemas are compatible — both return arrays with `diff`, `new_path`, `old_path`, `new_file`, `renamed_file`, `deleted_file`.

**Error detection:** Uses `error?.cause?.response?.status === 404 || error?.status === 404` to cover both gitbeaker's nested error format and direct status access.

**Trade-off:** `showChanges()` emits a `process.emitWarning` deprecation notice in gitbeaker v43 on GitLab >= 15.7. This only triggers on the 404 fallback path, so it won't affect normal operation.