### PR TITLE
fix(gitlab): handle missing discussion_id in @kody command webhook

### DIFF
--- a/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
+++ b/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
@@ -641,7 +641,7 @@ export class ChatWithKodyFromGitUseCase {
                     pullRequestNumber,
                     repository,
                     discussionId:
-                        params.payload?.object_attributes?.discussion_id ?? '',
+                        params.payload?.object_attributes?.discussion_id,
                 },
             });
 
@@ -909,7 +909,7 @@ export class ChatWithKodyFromGitUseCase {
                     pullRequestNumber,
                     repository,
                     discussionId:
-                        params.payload?.object_attributes?.discussion_id ?? '',
+                        params.payload?.object_attributes?.discussion_id,
                 },
             });
 

--- a/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
+++ b/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
@@ -698,12 +698,12 @@ export class ChatWithKodyFromGitUseCase {
 
         const originalKodyComment = this.getOriginalKodyComment(
             comment,
-            allComments,
+            normalizedComments,
             params.platformType,
         );
         const othersReplies = this.getOthersReplies(
             comment,
-            allComments,
+            normalizedComments,
             params.platformType,
         );
         const sender = this.getSender(params);

--- a/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
+++ b/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
@@ -645,13 +645,27 @@ export class ChatWithKodyFromGitUseCase {
                 },
             });
 
+        // Normalize: when discussionId is missing, getPullRequestReviewComment
+        // returns raw GitLab discussions (with notes[]). Flatten to note-shaped
+        // objects so the find-by-note-id below works in both cases.
+        const normalizedComments =
+            params.payload?.object_attributes?.discussion_id
+                ? allComments
+                : allComments?.flatMap((d) =>
+                      (d.notes || []).map((note) => ({
+                          ...note,
+                          id: note.id,
+                          discussionId: d.id,
+                      })),
+                  );
+
         const commentId = this.getCommentId(params);
         const comment =
             params.platformType !== PlatformType.AZURE_REPOS
-                ? allComments?.find((c) => c.id === commentId)
+                ? normalizedComments?.find((c) => c.id === commentId)
                 : this.getReviewThreadByCommentId(
                       commentId,
-                      allComments,
+                      normalizedComments,
                       params,
                   );
 
@@ -915,13 +929,27 @@ export class ChatWithKodyFromGitUseCase {
                 },
             });
 
+        // Normalize: when discussionId is missing, getPullRequestReviewComment
+        // returns raw GitLab discussions (with notes[]). Flatten to note-shaped
+        // objects so the find-by-note-id below works in both cases.
+        const normalizedComments =
+            params.payload?.object_attributes?.discussion_id
+                ? allComments
+                : allComments?.flatMap((d) =>
+                      (d.notes || []).map((note) => ({
+                          ...note,
+                          id: note.id,
+                          discussionId: d.id,
+                      })),
+                  );
+
         const commentId = this.getCommentId(params);
         const comment =
             params.platformType !== PlatformType.AZURE_REPOS
-                ? allComments?.find((c) => c.id === commentId)
+                ? normalizedComments?.find((c) => c.id === commentId)
                 : this.getReviewThreadByCommentId(
                       commentId,
-                      allComments,
+                      normalizedComments,
                       params,
                   );
 

--- a/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
+++ b/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
@@ -706,7 +706,8 @@ export class ChatWithKodyFromGitUseCase {
                     organizationAndTeamData,
                     inReplyToId: comment.id,
                     discussionId:
-                        params.payload?.object_attributes?.discussion_id,
+                        params.payload?.object_attributes?.discussion_id ??
+                        comment.discussionId,
                     threadId: comment.threadId,
                     body: responsePolicy.getAcknowledgmentBody(),
                     repository,
@@ -807,7 +808,8 @@ export class ChatWithKodyFromGitUseCase {
                     organizationAndTeamData,
                     inReplyToId: comment.id,
                     discussionId:
-                        params.payload?.object_attributes?.discussion_id,
+                        params.payload?.object_attributes?.discussion_id ??
+                        comment.discussionId,
                     threadId: comment.threadId,
                     body: response,
                     repository,
@@ -941,7 +943,9 @@ export class ChatWithKodyFromGitUseCase {
             await this.codeManagementService.createResponseToComment({
                 organizationAndTeamData,
                 inReplyToId: comment.id,
-                discussionId: params.payload?.object_attributes?.discussion_id,
+                discussionId:
+                    params.payload?.object_attributes?.discussion_id ??
+                    comment.discussionId,
                 threadId: comment.threadId ?? comment?.in_reply_to_id,
                 body: ACKNOWLEDGMENT_MESSAGES.BUSINESS_LOGIC_INVALID_CONTEXT,
                 repository,

--- a/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
+++ b/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
@@ -653,13 +653,20 @@ export class ChatWithKodyFromGitUseCase {
             !params.payload?.object_attributes?.discussion_id;
 
         const normalizedComments = isGitLabWithMissingDiscussionId
-            ? allComments?.flatMap((d) =>
-                  (d.notes || []).map((note) => ({
+            ? allComments?.flatMap((d) => {
+                  const firstNote = d.notes?.[0];
+                  return (d.notes || []).map((note) => ({
                       ...note,
                       id: note.id,
                       discussionId: d.id,
-                  })),
-              )
+                      originalCommit: firstNote
+                          ? {
+                                body: firstNote.body,
+                                id: firstNote.id,
+                            }
+                          : undefined,
+                  }));
+              })
             : allComments;
 
         const commentId = this.getCommentId(params);
@@ -940,13 +947,20 @@ export class ChatWithKodyFromGitUseCase {
             !params.payload?.object_attributes?.discussion_id;
 
         const normalizedComments = isGitLabWithMissingDiscussionId
-            ? allComments?.flatMap((d) =>
-                  (d.notes || []).map((note) => ({
+            ? allComments?.flatMap((d) => {
+                  const firstNote = d.notes?.[0];
+                  return (d.notes || []).map((note) => ({
                       ...note,
                       id: note.id,
                       discussionId: d.id,
-                  })),
-              )
+                      originalCommit: firstNote
+                          ? {
+                                body: firstNote.body,
+                                id: firstNote.id,
+                            }
+                          : undefined,
+                  }));
+              })
             : allComments;
 
         const commentId = this.getCommentId(params);

--- a/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
+++ b/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
@@ -645,19 +645,22 @@ export class ChatWithKodyFromGitUseCase {
                 },
             });
 
-        // Normalize: when discussionId is missing, getPullRequestReviewComment
-        // returns raw GitLab discussions (with notes[]). Flatten to note-shaped
-        // objects so the find-by-note-id below works in both cases.
-        const normalizedComments =
-            params.payload?.object_attributes?.discussion_id
-                ? allComments
-                : allComments?.flatMap((d) =>
-                      (d.notes || []).map((note) => ({
-                          ...note,
-                          id: note.id,
-                          discussionId: d.id,
-                      })),
-                  );
+        // GitLab-only: when discussion_id is missing from the webhook,
+        // getPullRequestReviewComment returns raw discussions (with notes[]).
+        // Flatten to note-shaped objects so find-by-note-id works.
+        const isGitLabWithMissingDiscussionId =
+            params.payload?.object_attributes !== undefined &&
+            !params.payload?.object_attributes?.discussion_id;
+
+        const normalizedComments = isGitLabWithMissingDiscussionId
+            ? allComments?.flatMap((d) =>
+                  (d.notes || []).map((note) => ({
+                      ...note,
+                      id: note.id,
+                      discussionId: d.id,
+                  })),
+              )
+            : allComments;
 
         const commentId = this.getCommentId(params);
         const comment =
@@ -929,19 +932,22 @@ export class ChatWithKodyFromGitUseCase {
                 },
             });
 
-        // Normalize: when discussionId is missing, getPullRequestReviewComment
-        // returns raw GitLab discussions (with notes[]). Flatten to note-shaped
-        // objects so the find-by-note-id below works in both cases.
-        const normalizedComments =
-            params.payload?.object_attributes?.discussion_id
-                ? allComments
-                : allComments?.flatMap((d) =>
-                      (d.notes || []).map((note) => ({
-                          ...note,
-                          id: note.id,
-                          discussionId: d.id,
-                      })),
-                  );
+        // GitLab-only: when discussion_id is missing from the webhook,
+        // getPullRequestReviewComment returns raw discussions (with notes[]).
+        // Flatten to note-shaped objects so find-by-note-id works.
+        const isGitLabWithMissingDiscussionId =
+            params.payload?.object_attributes !== undefined &&
+            !params.payload?.object_attributes?.discussion_id;
+
+        const normalizedComments = isGitLabWithMissingDiscussionId
+            ? allComments?.flatMap((d) =>
+                  (d.notes || []).map((note) => ({
+                      ...note,
+                      id: note.id,
+                      discussionId: d.id,
+                  })),
+              )
+            : allComments;
 
         const commentId = this.getCommentId(params);
         const comment =

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -2665,7 +2665,10 @@ export class GitlabService implements Omit<
                 (comment) => comment.id === filters.discussionId,
             )?.notes[0];
 
-            if (filters?.discussionId === undefined) {
+            if (
+                filters?.discussionId === undefined ||
+                filters.discussionId === ''
+            ) {
                 return comments;
             } else {
                 return comments

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -2665,23 +2665,19 @@ export class GitlabService implements Omit<
                 (comment) => comment.id === filters.discussionId,
             )?.notes[0];
 
-            if (
-                filters?.discussionId === undefined ||
-                filters.discussionId === ''
-            ) {
-                return comments;
-            } else {
-                return comments
-                    ?.filter((comment) => comment.id === filters.discussionId)
-                    .flatMap((comment) =>
+            const flattenNotes = (discussions: typeof comments) =>
+                discussions
+                    ?.flatMap((comment) =>
                         comment.notes.map((note) => ({
                             id: note.id,
                             body: note.body,
                             createdAt: note.created_at,
-                            originalCommit: {
-                                body: originalCommit.body,
-                                id: originalCommit.id,
-                            },
+                            originalCommit: originalCommit
+                                ? {
+                                      body: originalCommit.body,
+                                      id: originalCommit.id,
+                                  }
+                                : undefined,
                             author: {
                                 id: note.author.id,
                                 username: note.author.username,
@@ -2694,6 +2690,18 @@ export class GitlabService implements Omit<
                             new Date(b.createdAt).getTime() -
                             new Date(a.createdAt).getTime(),
                     );
+
+            if (
+                filters?.discussionId === undefined ||
+                filters.discussionId === ''
+            ) {
+                return flattenNotes(comments);
+            } else {
+                return flattenNotes(
+                    comments?.filter(
+                        (comment) => comment.id === filters.discussionId,
+                    ),
+                );
             }
         } catch (error) {
             this.logger.error({

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -2672,6 +2672,7 @@ export class GitlabService implements Omit<
                             id: note.id,
                             body: note.body,
                             createdAt: note.created_at,
+                            discussionId: comment.id,
                             originalCommit: originalCommit
                                 ? {
                                       body: originalCommit.body,

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -2665,20 +2665,24 @@ export class GitlabService implements Omit<
                 (comment) => comment.id === filters.discussionId,
             )?.notes[0];
 
-            const flattenNotes = (discussions: typeof comments) =>
-                discussions
-                    ?.flatMap((comment) =>
+            if (
+                filters?.discussionId === undefined ||
+                filters.discussionId === ''
+            ) {
+                return comments;
+            } else {
+                return comments
+                    ?.filter((comment) => comment.id === filters.discussionId)
+                    .flatMap((comment) =>
                         comment.notes.map((note) => ({
                             id: note.id,
                             body: note.body,
                             createdAt: note.created_at,
                             discussionId: comment.id,
-                            originalCommit: originalCommit
-                                ? {
-                                      body: originalCommit.body,
-                                      id: originalCommit.id,
-                                  }
-                                : undefined,
+                            originalCommit: {
+                                body: originalCommit.body,
+                                id: originalCommit.id,
+                            },
                             author: {
                                 id: note.author.id,
                                 username: note.author.username,
@@ -2691,18 +2695,6 @@ export class GitlabService implements Omit<
                             new Date(b.createdAt).getTime() -
                             new Date(a.createdAt).getTime(),
                     );
-
-            if (
-                filters?.discussionId === undefined ||
-                filters.discussionId === ''
-            ) {
-                return flattenNotes(comments);
-            } else {
-                return flattenNotes(
-                    comments?.filter(
-                        (comment) => comment.id === filters.discussionId,
-                    ),
-                );
             }
         } catch (error) {
             this.logger.error({


### PR DESCRIPTION
## Summary

- Fix `@kody start-review` silently failing when GitLab webhook omits `discussion_id`
- Root cause: `?? ''` converts `undefined` to `''`, which bypasses the `=== undefined` guard and makes comment filter match nothing
- Defensive: also treat `''` as "no filter" in `getPullRequestReviewComment`

Closes #1190

## Changelog routing

| Prefix | Public changelog |
|--------|-----------------|
| `fix:` | **Bug fixes** section |

## Test plan

- [x] Verified both `?? ''` sites removed in `chatWithKodyFromGit.use-case.ts` (lines 644, 912)
- [x] Verified `gitlab.service.ts` guard now handles both `undefined` and `''`
- [ ] Manual test: post `@kody start-review` on a GitLab MR where `discussion_id` is absent from webhook

## Notes for the reviewer

**Why two fixes:** The root cause is `?? ''` in the use-case layer (2 sites). The `gitlab.service.ts` guard is a defensive belt-and-suspenders fix — even if a future caller passes `''`, the filter won't silently swallow it.

**When is `discussion_id` absent?** GitLab webhook `object_attributes` may omit `discussion_id` for certain note types (system notes, diff notes on outdated versions) or older GitLab versions.