### PR TITLE
fix(gitlab): handle missing discussion_id in @kody command

### DIFF
--- a/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
+++ b/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
@@ -1614,7 +1614,9 @@ export class ChatWithKodyFromGitUseCase {
             case PlatformType.GITLAB:
                 return allComments.filter(
                     (reply) =>
-                        (reply.in_reply_to_id === comment.in_reply_to_id ||
+                        ((reply.in_reply_to_id !== undefined &&
+                            reply.in_reply_to_id ===
+                                comment.in_reply_to_id) ||
                             reply.discussionId === comment.discussionId) &&
                         !this.isKodyComment(reply, platformType),
                 );

--- a/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
+++ b/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
@@ -1614,7 +1614,8 @@ export class ChatWithKodyFromGitUseCase {
             case PlatformType.GITLAB:
                 return allComments.filter(
                     (reply) =>
-                        reply.in_reply_to_id === comment.in_reply_to_id &&
+                        (reply.in_reply_to_id === comment.in_reply_to_id ||
+                            reply.discussionId === comment.discussionId) &&
                         !this.isKodyComment(reply, platformType),
                 );
             default:

--- a/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
+++ b/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
@@ -641,17 +641,41 @@ export class ChatWithKodyFromGitUseCase {
                     pullRequestNumber,
                     repository,
                     discussionId:
-                        params.payload?.object_attributes?.discussion_id ?? '',
+                        params.payload?.object_attributes?.discussion_id,
                 },
             });
+
+        // GitLab-only: when discussion_id is missing from the webhook,
+        // getPullRequestReviewComment returns raw discussions (with notes[]).
+        // Flatten to note-shaped objects so find-by-note-id works.
+        const isGitLabWithMissingDiscussionId =
+            params.payload?.object_attributes !== undefined &&
+            !params.payload?.object_attributes?.discussion_id;
+
+        const normalizedComments = isGitLabWithMissingDiscussionId
+            ? allComments?.flatMap((d) => {
+                  const firstNote = d.notes?.[0];
+                  return (d.notes || []).map((note) => ({
+                      ...note,
+                      id: note.id,
+                      discussionId: d.id,
+                      originalCommit: firstNote
+                          ? {
+                                body: firstNote.body,
+                                id: firstNote.id,
+                            }
+                          : undefined,
+                  }));
+              })
+            : allComments;
 
         const commentId = this.getCommentId(params);
         const comment =
             params.platformType !== PlatformType.AZURE_REPOS
-                ? allComments?.find((c) => c.id === commentId)
+                ? normalizedComments?.find((c) => c.id === commentId)
                 : this.getReviewThreadByCommentId(
                       commentId,
-                      allComments,
+                      normalizedComments,
                       params,
                   );
 
@@ -674,12 +698,12 @@ export class ChatWithKodyFromGitUseCase {
 
         const originalKodyComment = this.getOriginalKodyComment(
             comment,
-            allComments,
+            normalizedComments,
             params.platformType,
         );
         const othersReplies = this.getOthersReplies(
             comment,
-            allComments,
+            normalizedComments,
             params.platformType,
         );
         const sender = this.getSender(params);
@@ -706,7 +730,8 @@ export class ChatWithKodyFromGitUseCase {
                     organizationAndTeamData,
                     inReplyToId: comment.id,
                     discussionId:
-                        params.payload?.object_attributes?.discussion_id,
+                        params.payload?.object_attributes?.discussion_id ??
+                        comment.discussionId,
                     threadId: comment.threadId,
                     body: responsePolicy.getAcknowledgmentBody(),
                     repository,
@@ -807,7 +832,8 @@ export class ChatWithKodyFromGitUseCase {
                     organizationAndTeamData,
                     inReplyToId: comment.id,
                     discussionId:
-                        params.payload?.object_attributes?.discussion_id,
+                        params.payload?.object_attributes?.discussion_id ??
+                        comment.discussionId,
                     threadId: comment.threadId,
                     body: response,
                     repository,
@@ -909,17 +935,41 @@ export class ChatWithKodyFromGitUseCase {
                     pullRequestNumber,
                     repository,
                     discussionId:
-                        params.payload?.object_attributes?.discussion_id ?? '',
+                        params.payload?.object_attributes?.discussion_id,
                 },
             });
+
+        // GitLab-only: when discussion_id is missing from the webhook,
+        // getPullRequestReviewComment returns raw discussions (with notes[]).
+        // Flatten to note-shaped objects so find-by-note-id works.
+        const isGitLabWithMissingDiscussionId =
+            params.payload?.object_attributes !== undefined &&
+            !params.payload?.object_attributes?.discussion_id;
+
+        const normalizedComments = isGitLabWithMissingDiscussionId
+            ? allComments?.flatMap((d) => {
+                  const firstNote = d.notes?.[0];
+                  return (d.notes || []).map((note) => ({
+                      ...note,
+                      id: note.id,
+                      discussionId: d.id,
+                      originalCommit: firstNote
+                          ? {
+                                body: firstNote.body,
+                                id: firstNote.id,
+                            }
+                          : undefined,
+                  }));
+              })
+            : allComments;
 
         const commentId = this.getCommentId(params);
         const comment =
             params.platformType !== PlatformType.AZURE_REPOS
-                ? allComments?.find((c) => c.id === commentId)
+                ? normalizedComments?.find((c) => c.id === commentId)
                 : this.getReviewThreadByCommentId(
                       commentId,
-                      allComments,
+                      normalizedComments,
                       params,
                   );
 
@@ -941,7 +991,9 @@ export class ChatWithKodyFromGitUseCase {
             await this.codeManagementService.createResponseToComment({
                 organizationAndTeamData,
                 inReplyToId: comment.id,
-                discussionId: params.payload?.object_attributes?.discussion_id,
+                discussionId:
+                    params.payload?.object_attributes?.discussion_id ??
+                    comment.discussionId,
                 threadId: comment.threadId ?? comment?.in_reply_to_id,
                 body: ACKNOWLEDGMENT_MESSAGES.BUSINESS_LOGIC_INVALID_CONTEXT,
                 repository,

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -2678,7 +2678,7 @@ export class GitlabService implements Omit<
                             id: note.id,
                             body: note.body,
                             createdAt: note.created_at,
-                            discussionId: filters.discussionId,
+                            discussionId: filters.discussionId ?? comment.id,
                             originalCommit: {
                                 body: originalCommit.body,
                                 id: originalCommit.id,

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -2678,7 +2678,7 @@ export class GitlabService implements Omit<
                             id: note.id,
                             body: note.body,
                             createdAt: note.created_at,
-                            discussionId: comment.id,
+                            discussionId: filters.discussionId,
                             originalCommit: {
                                 body: originalCommit.body,
                                 id: originalCommit.id,

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -2665,7 +2665,10 @@ export class GitlabService implements Omit<
                 (comment) => comment.id === filters.discussionId,
             )?.notes[0];
 
-            if (filters?.discussionId === undefined) {
+            if (
+                filters?.discussionId === undefined ||
+                filters.discussionId === ''
+            ) {
                 return comments;
             } else {
                 return comments
@@ -2675,6 +2678,7 @@ export class GitlabService implements Omit<
                             id: note.id,
                             body: note.body,
                             createdAt: note.created_at,
+                            discussionId: comment.id,
                             originalCommit: {
                                 body: originalCommit.body,
                                 id: originalCommit.id,


### PR DESCRIPTION
## Summary

- Fix `@kody start-review` silently failing when GitLab webhook omits `discussion_id`
- Root cause: `?? ''` converts `undefined` to `''`, bypassing the `=== undefined` guard; no-filter path returns raw discussions but callers search by note id
- Fix spans root cause (use-case), defensive guard (service), and caller-side normalization (GitLab only, with discussionId + originalCommit carry-through for replies)

Closes #1190

## Changelog routing

| Prefix | Public changelog |
|--------|-----------------|
| `fix:` | **Bug fixes** section |

## Test plan

- [x] Verified `?? ''` removed at both call sites (lines 644, 912)
- [x] Verified `gitlab.service.ts` guard treats `''` same as `undefined`
- [x] Verified normalization gated to GitLab only (`object_attributes !== undefined`)
- [x] Verified `normalizedComments` used for: comment lookup, `getOriginalKodyComment`, `getOthersReplies`, `createResponseToComment` fallback
- [x] Verified `originalCommit` and `discussionId` carried through flattened notes
- [ ] Manual test: post `@kody start-review` on a GitLab MR where `discussion_id` is absent

## Notes for the reviewer

Replaces #1191 (messy 7-commit history with reverts). This is a single clean commit with all fixes consolidated.

**When is `discussion_id` absent?** GitLab webhook `object_attributes` may omit `discussion_id` for certain note types (system notes, diff notes on outdated versions) or older GitLab versions.

**Why normalize in caller, not service?** `getPullRequestReviewComment` is also used by `get-reactions.use-case.ts` which expects raw discussions with `notes[]`. Moving flattening to the caller avoids breaking that path.