### PR TITLE
fix(gitlab): implement requestChangesPullRequest for GitLab

### DIFF
--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -25,6 +25,7 @@ import {
     PullRequestState,
 } from '@libs/core/domain/enums';
 import {
+    CommentResult,
     Repository,
     ReviewComment,
 } from '@libs/core/infrastructure/config/types/general/codeReview.type';
@@ -95,7 +96,6 @@ export class GitlabService implements Omit<
     | 'getAuthenticationOAuthToken'
     | 'getCommitsByReleaseMode'
     | 'getDataForCalculateDeployFrequency'
-    | 'requestChangesPullRequest'
 > {
     private readonly logger = createLogger(GitlabService.name);
 
@@ -3318,6 +3318,89 @@ export class GitlabService implements Omit<
             });
             return null;
         }
+    }
+
+    async requestChangesPullRequest(params: {
+        organizationAndTeamData: OrganizationAndTeamData;
+        prNumber: number;
+        repository: { id: string; name: string };
+        criticalComments: CommentResult[];
+    }) {
+        try {
+            const {
+                organizationAndTeamData,
+                prNumber,
+                repository,
+                criticalComments,
+            } = params;
+
+            const gitlabAuthDetail = await this.getAuthDetails(
+                organizationAndTeamData,
+            );
+
+            const gitlabAPI = this.instanceGitlabApi(gitlabAuthDetail);
+
+            // Unapprove MR if previously approved
+            // On GitLab CE this may fail with 403 (Premium-only feature)
+            try {
+                await gitlabAPI.MergeRequestApprovals.unapprove(
+                    repository.id,
+                    prNumber,
+                );
+            } catch (unapproveError) {
+                this.logger.warn({
+                    message: `Could not unapprove MR #${prNumber} (may require GitLab Premium)`,
+                    context: GitlabService.name,
+                    serviceName: 'GitlabService requestChangesPullRequest',
+                    error: unapproveError,
+                    metadata: params,
+                });
+            }
+
+            const listOfCriticalIssues = this.getListOfCriticalIssues(
+                criticalComments,
+            );
+
+            const requestChangeBodyTitle =
+                '# Found critical issues please review the requested changes';
+
+            const formattedBody =
+                `${requestChangeBodyTitle}\n\n${listOfCriticalIssues}`.trim();
+
+            await gitlabAPI.MergeRequestDiscussions.create(
+                repository.id,
+                prNumber,
+                formattedBody,
+            );
+
+            this.logger.log({
+                message: `Requested changes on MR #${prNumber} with ${criticalComments.length} critical issues`,
+                context: GitlabService.name,
+                serviceName: 'GitlabService requestChangesPullRequest',
+                metadata: params,
+            });
+        } catch (error) {
+            this.logger.error({
+                message: `Error requesting changes on MR #${params.prNumber}`,
+                context: GitlabService.name,
+                serviceName: 'GitlabService requestChangesPullRequest',
+                error: error,
+                metadata: params,
+            });
+            throw error;
+        }
+    }
+
+    private getListOfCriticalIssues(
+        criticalComments: CommentResult[],
+    ): string {
+        return criticalComments
+            .map((comment) => {
+                const summary =
+                    comment.comment?.suggestion?.oneSentenceSummary ?? '';
+                return `- ${summary}`;
+            })
+            .join('\n');
     }
 
     async getAllCommentsInPullRequest(params: {


### PR DESCRIPTION
## Summary

- Implement `requestChangesPullRequest` in `GitlabService` — the only provider missing this method, which caused `TypeError` in `RequestChangesOrApproveStage` when Kody detects critical bugs
- Unapprove MR (with graceful fallback for GitLab CE where this is Premium-only) + post discussion comment with critical issues summary

Closes #1198

## Changelog routing

| Prefix | Public changelog |
|--------|-----------------|
| `fix:` | **Bug fixes** section |

## Test plan

- [x] Verified `requestChangesPullRequest` removed from `Omit<>` type
- [x] Verified method signature matches `ICodeManagementService` interface
- [x] Verified CE risk handled: `unapprove()` wrapped in try/catch with warning log
- [x] Verified `getListOfCriticalIssues` produces correct markdown format
- [ ] Manual test on GitLab EE: trigger critical review → verify MR is unapproved + comment posted
- [ ] Manual test on GitLab CE: trigger critical review → verify comment posted despite unapprove 403

## Notes for the reviewer

**GitLab has no `REQUEST_CHANGES` review event** like GitHub. The equivalent is:
1. `MergeRequestApprovals.unapprove()` — revoke any existing approval
2. `MergeRequestDiscussions.create()` — post a comment summarizing critical issues

**CE license risk**: `unapprove()` requires GitLab Premium. On CE it returns 403. This is handled gracefully — the comment is still posted even if unapprove fails.