### PR TITLE
fix(gitlab): handle missing action field in Note Hook for GitLab 13.x

### DIFF
--- a/libs/platform/infrastructure/webhooks/gitlab/gitlabPullRequest.handler.ts
+++ b/libs/platform/infrastructure/webhooks/gitlab/gitlabPullRequest.handler.ts
@@ -458,8 +458,12 @@ export class GitLabMergeRequestHandler implements IWebhookEventHandler {
         );
 
         try {
-            // Verify if the action is create
-            if (payload?.object_attributes?.action === 'create') {
+            // Note Hook fires only on new comments. GitLab 13.x omits
+            // the action field, so treat missing action as 'create'.
+            if (
+                !payload?.object_attributes?.action ||
+                payload?.object_attributes?.action === 'create'
+            ) {
                 const comment = mappedPlatform.mapComment({ payload });
                 if (!comment || !comment.body) {
                     this.logger.debug({

--- a/libs/platform/infrastructure/webhooks/gitlab/gitlabPullRequest.handler.ts
+++ b/libs/platform/infrastructure/webhooks/gitlab/gitlabPullRequest.handler.ts
@@ -459,13 +459,13 @@ export class GitLabMergeRequestHandler implements IWebhookEventHandler {
 
         try {
             // Note Hook fires only on new comments. GitLab 13.x omits
-            // the action field, so treat missing action as 'create',
-            // but only for MR notes (not issue/snippet/commit comments).
+            // the action field, so treat missing action as 'create'.
+            // Gate on noteable_type to ignore issue/snippet/commit notes.
             if (
-                (!payload?.object_attributes?.action &&
-                    payload?.object_attributes?.noteable_type ===
-                        'MergeRequest') ||
-                payload?.object_attributes?.action === 'create'
+                payload?.object_attributes?.noteable_type ===
+                    'MergeRequest' &&
+                (!payload?.object_attributes?.action ||
+                    payload?.object_attributes?.action === 'create')
             ) {
                 const comment = mappedPlatform.mapComment({ payload });
                 if (!comment || !comment.body) {

--- a/libs/platform/infrastructure/webhooks/gitlab/gitlabPullRequest.handler.ts
+++ b/libs/platform/infrastructure/webhooks/gitlab/gitlabPullRequest.handler.ts
@@ -459,9 +459,12 @@ export class GitLabMergeRequestHandler implements IWebhookEventHandler {
 
         try {
             // Note Hook fires only on new comments. GitLab 13.x omits
-            // the action field, so treat missing action as 'create'.
+            // the action field, so treat missing action as 'create',
+            // but only for MR notes (not issue/snippet/commit comments).
             if (
-                !payload?.object_attributes?.action ||
+                (!payload?.object_attributes?.action &&
+                    payload?.object_attributes?.noteable_type ===
+                        'MergeRequest') ||
                 payload?.object_attributes?.action === 'create'
             ) {
                 const comment = mappedPlatform.mapComment({ payload });


### PR DESCRIPTION
## Summary

- Fix `@kody` commands silently ignored on GitLab 13.x Note Hook payloads that omit `object_attributes.action`
- Treat missing `action` as `'create'` since Note Hooks only fire on new comments

Closes #1200

## Changelog routing

| Prefix | Public changelog |
|--------|-----------------|
| `fix:` | **Bug fixes** section |

## Test plan

- [x] Verified only line 462 changed — other `action` checks (merge, close, update) are MR Hook events and unaffected
- [ ] Manual test on GitLab 13.x: post `@kody start-review` → verify review triggers
- [ ] Manual test on GitLab 14.x+: verify no regression

## Notes for the reviewer

GitLab 14.x+ Note Hook includes `object_attributes.action: "create"`. GitLab 13.x omits it entirely. The `!action || action === 'create'` pattern handles both. Since Note Hooks only fire on comment creation, the `action` gate is redundant — this fix simply makes it backwards-compatible.