### PR TITLE
fix(gitlab): handle missing action in Note Hook for GitLab 13.x

### DIFF
--- a/libs/common/utils/webhooks/gitlab.ts
+++ b/libs/common/utils/webhooks/gitlab.ts
@@ -126,13 +126,18 @@ export class GitlabMappedPlatform implements IMappedPlatform {
             return null;
         }
 
-        switch (params?.payload?.object_attributes?.action) {
+        const action =
+            params?.payload?.object_attributes?.action ??
+            params?.payload?.action ??
+            params?.payload?.event_type;
+
+        switch (action) {
             case 'open':
                 return MappedAction.OPENED;
             case 'update':
                 return MappedAction.UPDATED;
             default:
-                return params?.payload?.object_attributes?.action;
+                return action;
         }
     }
 }

--- a/libs/platform/infrastructure/webhooks/gitlab/gitlabPullRequest.handler.ts
+++ b/libs/platform/infrastructure/webhooks/gitlab/gitlabPullRequest.handler.ts
@@ -458,8 +458,15 @@ export class GitLabMergeRequestHandler implements IWebhookEventHandler {
         );
 
         try {
-            // Verify if the action is create
-            if (payload?.object_attributes?.action === 'create') {
+            // Note Hook fires only on new comments. GitLab 13.x omits
+            // the action field, so treat missing action as 'create'.
+            // Gate on noteable_type to ignore issue/snippet/commit notes.
+            if (
+                payload?.object_attributes?.noteable_type ===
+                    'MergeRequest' &&
+                (!payload?.object_attributes?.action ||
+                    payload?.object_attributes?.action === 'create')
+            ) {
                 const comment = mappedPlatform.mapComment({ payload });
                 if (!comment || !comment.body) {
                     this.logger.debug({


### PR DESCRIPTION
## Summary

- Fix `@kody` commands silently ignored on GitLab 13.x Note Hook payloads that omit `object_attributes.action`
- Gate on `noteable_type === 'MergeRequest'` to ignore issue/snippet/commit notes on all GitLab versions

Closes #1200

## Changelog routing

| Prefix | Public changelog |
|--------|-----------------|
| `fix:` | **Bug fixes** section |

## Test plan

- [x] Verified from real GitLab 13.12 webhook payload that `noteable_type: "MergeRequest"` exists
- [ ] Manual test on GitLab 13.x: post `@kody start-review` on MR → verify review triggers
- [ ] Manual test on GitLab 13.x: post `@kody` on issue → verify it's ignored
- [ ] Manual test on GitLab 14.x+: verify no regression

## Known limitation

On GitLab < 16.11, `object_attributes.action` is absent for both created and edited comments. This fix treats missing `action` as `create`, so editing an existing MR comment containing `@kody` will trigger a duplicate review. This is a rare edge case and non-destructive — the alternative (ignoring missing action) means `@kody` is completely unresponsive on GitLab 13.x-16.10.

## Notes for the reviewer

GitLab 13.x Note Hook omits `object_attributes.action`. GitLab 14.x+ includes it as `"create"`. The `noteable_type` check ensures only MR notes enter the handler, regardless of GitLab version.