### PR TITLE
fix(gitlab): fallback mapAction to top-level action for Note Hooks

### DIFF
--- a/libs/common/utils/webhooks/gitlab.ts
+++ b/libs/common/utils/webhooks/gitlab.ts
@@ -126,13 +126,18 @@ export class GitlabMappedPlatform implements IMappedPlatform {
             return null;
         }
 
-        switch (params?.payload?.object_attributes?.action) {
+        const action =
+            params?.payload?.object_attributes?.action ??
+            params?.payload?.action ??
+            params?.payload?.event_type;
+
+        switch (action) {
             case 'open':
                 return MappedAction.OPENED;
             case 'update':
                 return MappedAction.UPDATED;
             default:
-                return params?.payload?.object_attributes?.action;
+                return action;
         }
     }
 }


### PR DESCRIPTION
## Summary

- Fix `@kody start-review` silently failing on GitLab 13.x because `mapAction()` only reads `object_attributes.action` which doesn't exist in Note Hook payloads
- Add fallback chain: `object_attributes.action` → `payload.action` → `payload.event_type`

## Root Cause

PR #1204 fixed the webhook handler layer to accept Note Hooks without `action`. But the handler sets `action: 'synchronize'` at the top level of the payload, while `mapAction()` in `GitlabMappedPlatform` only reads `object_attributes.action`. For Note Hooks, `object_attributes` is comment data (no `action` field), so `mapAction()` returns `undefined` and the CODE_REVIEW job silently skips.

## Changelog routing

| Prefix | Public changelog |
|--------|-----------------|
| `fix:` | **Bug fixes** section |

## Test plan

- [x] Verified `mapAction` fallback chain handles all cases
- [ ] Manual test on GitLab 13.x: `@kody start-review` → verify review triggers end-to-end

## Notes for the reviewer

Complements #1204. That PR fixed the "entry" (webhook handler accepting Note Hooks). This PR fixes the "exit" (mapAction reading the action from the right location).