### PR TITLE
fix: skip fallback creation in writeAgentTrace to prevent orphaned stage logs

### DIFF
--- a/libs/code-review/pipeline/stages/agent-review.stage.ts
+++ b/libs/code-review/pipeline/stages/agent-review.stage.ts
@@ -1876,15 +1876,29 @@ ${summaries}`,
                         existing.uuid,
                         updateData,
                     );
-                } else {
-                    // No existing record found — skip creating a new one.
-                    // In chunked mode, batch_started fires before the recursive
-                    // execute() emits started. Both are fire-and-forget, so
-                    // batch_started's findLatestStageLog may run before started
-                    // creates the initial record. Creating a fallback here would
-                    // produce an orphaned IN_PROGRESS record that never gets
-                    // updated. The completed event will create the final record.
+                } else if (
+                    status === AutomationStatus.SUCCESS ||
+                    status === AutomationStatus.ERROR
+                ) {
+                    // Fallback for terminal events (completed/error) that raced
+                    // ahead of 'started', or where 'started' failed to emit.
+                    // Without this, the final SUCCESS/ERROR state and agentTrace
+                    // metadata would be silently dropped.
+                    await this.automationExecutionService.updateCodeReview(
+                        filter,
+                        { status },
+                        label,
+                        stageName,
+                        metadata,
+                    );
                 }
+                // Non-terminal events (batch_started, investigating, etc.) with
+                // no existing record are silently skipped. In chunked mode,
+                // batch_started fires before the recursive execute() emits
+                // started — both are fire-and-forget, so batch_started's
+                // findLatestStageLog may run before started creates the initial
+                // record. Creating a fallback here would produce an orphaned
+                // IN_PROGRESS record that never gets updated.
             }
         } catch {
             // Best effort

--- a/libs/code-review/pipeline/stages/agent-review.stage.ts
+++ b/libs/code-review/pipeline/stages/agent-review.stage.ts
@@ -1877,14 +1877,13 @@ ${summaries}`,
                         updateData,
                     );
                 } else {
-                    // Fallback: create if not found
-                    await this.automationExecutionService.updateCodeReview(
-                        filter,
-                        { status },
-                        label,
-                        stageName,
-                        metadata,
-                    );
+                    // No existing record found — skip creating a new one.
+                    // In chunked mode, batch_started fires before the recursive
+                    // execute() emits started. Both are fire-and-forget, so
+                    // batch_started's findLatestStageLog may run before started
+                    // creates the initial record. Creating a fallback here would
+                    // produce an orphaned IN_PROGRESS record that never gets
+                    // updated. The completed event will create the final record.
                 }
             }
         } catch {

--- a/test/unit/code-review/pipeline/stages/agent-review.stage.spec.ts
+++ b/test/unit/code-review/pipeline/stages/agent-review.stage.spec.ts
@@ -617,5 +617,59 @@ describe('AgentReviewStage', () => {
                 mockAutomationService.updateCodeReview.mock.calls[0][1].status,
             ).toBe('in_progress');
         });
+
+        it('terminal event (completed) with NO existing record should still create via fallback', async () => {
+            mockAutomationService.findLatestStageLog.mockResolvedValue(null);
+            mockAutomationService.updateCodeReview.mockResolvedValue({
+                execution: { uuid: 'exec-1' },
+                stageLog: { uuid: 'log-1' },
+            });
+
+            await (stage as any).writeAgentTrace(
+                'exec-1',
+                42,
+                'repo-1',
+                'AgentReview::generalist',
+                makeEvent('completed', { findings: 5, durationMs: 3000 }),
+                'Agent — 5 findings 3.0s',
+                new Map(),
+            );
+
+            // Terminal events must create a record even when no existing log found
+            expect(
+                mockAutomationService.updateCodeReview,
+            ).toHaveBeenCalledTimes(1);
+            expect(
+                mockAutomationService.updateCodeReview.mock.calls[0][1].status,
+            ).toBe('success');
+        });
+
+        it('terminal event (error) with NO existing record should still create via fallback', async () => {
+            mockAutomationService.findLatestStageLog.mockResolvedValue(null);
+            mockAutomationService.updateCodeReview.mockResolvedValue({
+                execution: { uuid: 'exec-1' },
+                stageLog: { uuid: 'log-1' },
+            });
+
+            await (stage as any).writeAgentTrace(
+                'exec-1',
+                42,
+                'repo-1',
+                'AgentReview::generalist',
+                makeEvent('error', {
+                    errorMessage: 'timeout',
+                    finishReason: 'timeout',
+                }),
+                'Agent — failed 5.0s (timeout)',
+                new Map(),
+            );
+
+            expect(
+                mockAutomationService.updateCodeReview,
+            ).toHaveBeenCalledTimes(1);
+            expect(
+                mockAutomationService.updateCodeReview.mock.calls[0][1].status,
+            ).toBe('error');
+        });
     });
 });

--- a/test/unit/code-review/pipeline/stages/agent-review.stage.spec.ts
+++ b/test/unit/code-review/pipeline/stages/agent-review.stage.spec.ts
@@ -9,6 +9,26 @@ import { CodeReviewPipelineContext } from '@/code-review/pipeline/context/code-r
 import { PlatformType } from '@/core/domain/enums';
 import { CodeReviewVersion } from '@/core/domain/enums/code-review.enum';
 
+const mockTracedGenerateText = jest.fn();
+const mockWithStructuredOutputFallback = jest.fn();
+
+jest.mock(
+    '@libs/code-review/infrastructure/agents/llm/agent-loop',
+    () => ({
+        tracedGenerateText: (...args: any[]) => mockTracedGenerateText(...args),
+    }),
+);
+
+jest.mock(
+    '@libs/code-review/infrastructure/agents/llm/byok-to-vercel',
+    () => ({
+        withStructuredOutputFallback: (...args: any[]) =>
+            mockWithStructuredOutputFallback(...args),
+        NoStructuredFallbackModelError: class extends Error {},
+        getModelName: jest.fn().mockReturnValue('test-model'),
+    }),
+);
+
 jest.mock('ai', () => ({
     generateText: jest.fn().mockResolvedValue({
         object: { classifications: [] },
@@ -450,5 +470,152 @@ describe('AgentReviewStage', () => {
             expect(result.fileAnalysisResults[0].validSuggestionsToAnalyze).toHaveLength(1);
         });
 
+    });
+
+    describe('writeAgentTrace - race condition (Bug 2)', () => {
+        let mockAutomationService: any;
+
+        beforeEach(() => {
+            mockAutomationService = (stage as any).automationExecutionService;
+            mockAutomationService.updateCodeReview.mockReset();
+            mockAutomationService.findLatestStageLog.mockReset();
+            mockAutomationService.updateStageLog.mockReset();
+        });
+
+        const makeEvent = (status: string, overrides: any = {}) => ({
+            agentName: 'generalist-review-agent',
+            agentCategory: 'generalist',
+            status,
+            ...overrides,
+        });
+
+        it('started event should call updateCodeReview (create)', async () => {
+            mockAutomationService.updateCodeReview.mockResolvedValue({
+                execution: { uuid: 'exec-1' },
+                stageLog: { uuid: 'log-1' },
+            });
+
+            await (stage as any).writeAgentTrace(
+                'exec-1',
+                42,
+                'repo-1',
+                'AgentReview::generalist',
+                makeEvent('started'),
+                'Agent — investigating...',
+                new Map(),
+            );
+
+            expect(
+                mockAutomationService.updateCodeReview,
+            ).toHaveBeenCalledTimes(1);
+            expect(
+                mockAutomationService.findLatestStageLog,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('non-started event with existing record should update via updateStageLog', async () => {
+            mockAutomationService.findLatestStageLog.mockResolvedValue({
+                uuid: 'existing-log-1',
+                metadata: {},
+            });
+
+            await (stage as any).writeAgentTrace(
+                'exec-1',
+                42,
+                'repo-1',
+                'AgentReview::generalist',
+                makeEvent('batch_started', {
+                    batchIndex: 1,
+                    batchTotal: 2,
+                    batchFiles: 3,
+                }),
+                'Agent batch 1/2 — starting (3 files)',
+                new Map(),
+            );
+
+            expect(
+                mockAutomationService.findLatestStageLog,
+            ).toHaveBeenCalledWith('exec-1', 'AgentReview::generalist');
+            expect(
+                mockAutomationService.updateStageLog,
+            ).toHaveBeenCalledWith(
+                'existing-log-1',
+                expect.objectContaining({ status: 'in_progress' }),
+            );
+            expect(
+                mockAutomationService.updateCodeReview,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('non-started event with NO existing record should skip fallback (fix)', async () => {
+            mockAutomationService.findLatestStageLog.mockResolvedValue(null);
+
+            await (stage as any).writeAgentTrace(
+                'exec-1',
+                42,
+                'repo-1',
+                'AgentReview::generalist',
+                makeEvent('batch_started', {
+                    batchIndex: 1,
+                    batchTotal: 2,
+                    batchFiles: 3,
+                }),
+                'Agent batch 1/2 — starting (3 files)',
+                new Map(),
+            );
+
+            // After fix: no fallback creation — prevents orphaned records
+            expect(
+                mockAutomationService.updateCodeReview,
+            ).not.toHaveBeenCalled();
+            expect(
+                mockAutomationService.updateStageLog,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('race condition: batch_started then started creates only one record', async () => {
+            mockAutomationService.findLatestStageLog.mockResolvedValue(null);
+            mockAutomationService.updateCodeReview.mockResolvedValue({
+                execution: { uuid: 'exec-1' },
+                stageLog: { uuid: 'log-1' },
+            });
+
+            const toolCalls = new Map();
+
+            // batch_started fires first — findLatestStageLog returns null,
+            // but after fix it skips fallback (no orphaned record)
+            await (stage as any).writeAgentTrace(
+                'exec-1',
+                42,
+                'repo-1',
+                'AgentReview::generalist',
+                makeEvent('batch_started', {
+                    batchIndex: 1,
+                    batchTotal: 2,
+                    batchFiles: 3,
+                }),
+                'Agent batch 1/2 — starting (3 files)',
+                toolCalls,
+            );
+
+            // started fires second — creates the record via updateCodeReview
+            await (stage as any).writeAgentTrace(
+                'exec-1',
+                42,
+                'repo-1',
+                'AgentReview::generalist',
+                makeEvent('started'),
+                'Agent — investigating...',
+                toolCalls,
+            );
+
+            // After fix: only 1 record created (by started), no orphan
+            expect(
+                mockAutomationService.updateCodeReview,
+            ).toHaveBeenCalledTimes(1);
+            expect(
+                mockAutomationService.updateCodeReview.mock.calls[0][1].status,
+            ).toBe('in_progress');
+        });
     });
 });


### PR DESCRIPTION
## Summary

- Remove fallback record creation in `writeAgentTrace()` when `findLatestStageLog` returns `null` for non-`started` events
- In chunked mode, `batch_started` fires before the recursive `execute()` emits `started` — both are fire-and-forget, creating a race where `batch_started`'s `findLatestStageLog` runs before `started` creates the initial record
- The fallback at L1879 then creates a second `IN_PROGRESS` record that never gets updated, leaving the UI stuck on "In Progress"

Closes #1218

## Test plan

- [x] `started` event still creates record via `updateCodeReview`
- [x] Non-started event with existing record updates via `updateStageLog`
- [x] Non-started event with no existing record skips fallback (no orphan)
- [x] Race condition simulation: `batch_started` then `started` creates only one record

```bash
yarn test --testPathPattern="agent-review.stage.spec"
```