### PR TITLE
fix: three-layer protection against NaN dedup indices

### DIFF
--- a/libs/code-review/pipeline/stages/agent-review.stage.ts
+++ b/libs/code-review/pipeline/stages/agent-review.stage.ts
@@ -1525,11 +1525,19 @@ ${summaries}`,
             const result: Partial<CodeSuggestion>[] = [];
             const uniqueSuggestions: DedupTraceSuggestionSummary[] = [];
             const groupSummaries: DedupTraceGroupSummary[] = [];
+            const addedIndices = new Set<number>();
+            const classifiedIndices = new Set<number>();
+            const indexToResult = new Map<number, number>();
+
+            // Layer 1: Number.isInteger guard — NaN and non-integer floats rejected immediately
 
             // Add unique suggestions as-is
             for (const idx of unique) {
-                if (idx >= 0 && idx < suggestions.length) {
+                if (Number.isInteger(idx) && idx >= 0 && idx < suggestions.length) {
+                    indexToResult.set(idx, result.length);
                     result.push(suggestions[idx]);
+                    addedIndices.add(idx);
+                    classifiedIndices.add(idx);
                     uniqueSuggestions.push(
                         this.summarizeDedupSuggestion(suggestions[idx]),
                     );
@@ -1541,19 +1549,66 @@ ${summaries}`,
                 const keepIdx = group.keep;
                 const dupIndices = group.duplicates || [];
 
-                if (keepIdx < 0 || keepIdx >= suggestions.length) {
+                if (!Number.isInteger(keepIdx) || keepIdx < 0 || keepIdx >= suggestions.length) {
+                    // Layer 2: keep is invalid — preserve valid duplicates as independent results
+                    for (const dupIdx of dupIndices) {
+                        classifiedIndices.add(dupIdx);
+                        if (Number.isInteger(dupIdx) && dupIdx >= 0 && dupIdx < suggestions.length && !addedIndices.has(dupIdx)) {
+                            indexToResult.set(dupIdx, result.length);
+                            result.push(suggestions[dupIdx]);
+                            addedIndices.add(dupIdx);
+                            uniqueSuggestions.push(
+                                this.summarizeDedupSuggestion(suggestions[dupIdx]),
+                            );
+                        }
+                    }
+                    continue;
+                }
+
+                // Skip if this keep was already added (malformed groups with overlapping indices)
+                if (addedIndices.has(keepIdx)) {
+                    // Merge duplicate locations into the already-added suggestion
+                    const existingIdx = indexToResult.get(keepIdx);
+                    if (existingIdx !== undefined) {
+                        const locations: string[] = [];
+                        for (const dupIdx of dupIndices) {
+                            if (Number.isInteger(dupIdx) && dupIdx >= 0 && dupIdx < suggestions.length) {
+                                classifiedIndices.add(dupIdx);
+                                const dup = suggestions[dupIdx];
+                                const loc = `${dup.relevantFile}:${dup.relevantLinesStart}-${dup.relevantLinesEnd}`;
+                                const keptLoc = `${suggestions[keepIdx].relevantFile}:${suggestions[keepIdx].relevantLinesStart}-${suggestions[keepIdx].relevantLinesEnd}`;
+                                if (loc !== keptLoc) {
+                                    locations.push(loc);
+                                }
+                            }
+                        }
+                        if (locations.length > 0) {
+                            const existing = result[existingIdx];
+                            const locList = locations.map((l) => `- \`${l}\``).join('\n');
+                            existing.suggestionContent = `${existing.suggestionContent}\n\n**Also found in:**\n${locList}`;
+                        }
+                    } else {
+                        for (const dupIdx of dupIndices) {
+                            if (Number.isInteger(dupIdx) && dupIdx >= 0 && dupIdx < suggestions.length) {
+                                classifiedIndices.add(dupIdx);
+                            }
+                        }
+                    }
                     continue;
                 }
 
                 const kept = { ...suggestions[keepIdx] };
+                addedIndices.add(keepIdx);
+                classifiedIndices.add(keepIdx);
                 const duplicateSummaries: DedupTraceSuggestionSummary[] = [];
 
                 // Collect locations from duplicates that are in DIFFERENT locations
                 const otherLocations: string[] = [];
                 for (const dupIdx of dupIndices) {
-                    if (dupIdx < 0 || dupIdx >= suggestions.length) {
+                    if (!Number.isInteger(dupIdx) || dupIdx < 0 || dupIdx >= suggestions.length) {
                         continue;
                     }
+                    classifiedIndices.add(dupIdx);
                     const dup = suggestions[dupIdx];
                     duplicateSummaries.push(this.summarizeDedupSuggestion(dup));
                     const dupLocation = `${dup.relevantFile}:${dup.relevantLinesStart}-${dup.relevantLinesEnd}`;
@@ -1581,7 +1636,20 @@ ${summaries}`,
                     keep: this.summarizeDedupSuggestion(kept),
                     duplicates: duplicateSummaries,
                 });
+                indexToResult.set(keepIdx, result.length);
                 result.push(kept);
+            }
+
+            // Layer 3: Safety net — add any suggestions not classified by dedup
+            // (neither in unique nor in any group's keep/duplicates). This handles
+            // malformed LLM output that omits some indices entirely.
+            for (let i = 0; i < suggestions.length; i++) {
+                if (!classifiedIndices.has(i)) {
+                    result.push(suggestions[i]);
+                    uniqueSuggestions.push(
+                        this.summarizeDedupSuggestion(suggestions[i]),
+                    );
+                }
             }
 
             const totalRemoved = suggestions.length - result.length;

--- a/test/unit/code-review/pipeline/stages/agent-review.stage.spec.ts
+++ b/test/unit/code-review/pipeline/stages/agent-review.stage.spec.ts
@@ -9,6 +9,26 @@ import { CodeReviewPipelineContext } from '@/code-review/pipeline/context/code-r
 import { PlatformType } from '@/core/domain/enums';
 import { CodeReviewVersion } from '@/core/domain/enums/code-review.enum';
 
+const mockTracedGenerateText = jest.fn();
+const mockWithStructuredOutputFallback = jest.fn();
+
+jest.mock(
+    '@libs/code-review/infrastructure/agents/llm/agent-loop',
+    () => ({
+        tracedGenerateText: (...args: any[]) => mockTracedGenerateText(...args),
+    }),
+);
+
+jest.mock(
+    '@libs/code-review/infrastructure/agents/llm/byok-to-vercel',
+    () => ({
+        withStructuredOutputFallback: (...args: any[]) =>
+            mockWithStructuredOutputFallback(...args),
+        NoStructuredFallbackModelError: class extends Error {},
+        getModelName: jest.fn().mockReturnValue('test-model'),
+    }),
+);
+
 jest.mock('ai', () => ({
     generateText: jest.fn().mockResolvedValue({
         object: { classifications: [] },
@@ -450,5 +470,333 @@ describe('AgentReviewStage', () => {
             expect(result.fileAnalysisResults[0].validSuggestionsToAnalyze).toHaveLength(1);
         });
 
+    });
+
+    describe('deduplicateSuggestions - NaN index handling (three-layer protection)', () => {
+        const makeSuggestions = (count: number) =>
+            Array.from({ length: count }, (_, i) => ({
+                relevantFile: `src/file-${i}.ts`,
+                suggestionContent: `Suggestion ${i}`,
+                label: 'bug',
+                severity: 'high',
+                relevantLinesStart: i * 10,
+                relevantLinesEnd: i * 10 + 5,
+                oneSentenceSummary: `Summary ${i}`,
+            }));
+
+        beforeEach(() => {
+            mockTracedGenerateText.mockReset();
+            mockWithStructuredOutputFallback.mockReset();
+        });
+
+        it('Layer 1: should reject NaN keep index', async () => {
+            const suggestions = makeSuggestions(4);
+
+            mockTracedGenerateText.mockResolvedValue({
+                object: {
+                    groups: [{ keep: NaN, duplicates: [1, 2] }],
+                    unique: [0],
+                },
+                usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+            });
+
+            const origKey = process.env.API_GOOGLE_AI_API_KEY;
+            process.env.API_GOOGLE_AI_API_KEY = 'test-key';
+
+            try {
+                const result = await (stage as any).deduplicateSuggestions(
+                    suggestions,
+                    42,
+                );
+
+                // Layer 1: NaN keep rejected → Layer 2: valid dups (1, 2) preserved
+                // Layer 3: unclassified suggestion 3 also preserved
+                // unique[0] + dup 1 + dup 2 + unclassified 3 = 4
+                expect(result.suggestions).toHaveLength(4);
+                for (const s of result.suggestions) {
+                    expect(s.relevantFile).toBeDefined();
+                    expect(s.suggestionContent).not.toContain('undefined');
+                }
+            } finally {
+                if (origKey === undefined) {
+                    delete process.env.API_GOOGLE_AI_API_KEY;
+                } else {
+                    process.env.API_GOOGLE_AI_API_KEY = origKey;
+                }
+            }
+        });
+
+        it('Layer 2: should preserve valid duplicates when keep is invalid', async () => {
+            const suggestions = makeSuggestions(3);
+
+            mockTracedGenerateText.mockResolvedValue({
+                object: {
+                    groups: [{ keep: NaN, duplicates: [0, 2] }],
+                    unique: [],
+                },
+                usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+            });
+
+            const origKey = process.env.API_GOOGLE_AI_API_KEY;
+            process.env.API_GOOGLE_AI_API_KEY = 'test-key';
+
+            try {
+                const result = await (stage as any).deduplicateSuggestions(
+                    suggestions,
+                    42,
+                );
+
+                // keep=NaN → invalid, dup 0 and 2 preserved via Layer 2
+                // suggestion 1 unclassified → preserved via Layer 3
+                expect(result.suggestions).toHaveLength(3);
+                const filenames = result.suggestions.map(
+                    (s: any) => s.relevantFile,
+                );
+                expect(filenames).toContain('src/file-0.ts');
+                expect(filenames).toContain('src/file-1.ts');
+                expect(filenames).toContain('src/file-2.ts');
+            } finally {
+                if (origKey === undefined) {
+                    delete process.env.API_GOOGLE_AI_API_KEY;
+                } else {
+                    process.env.API_GOOGLE_AI_API_KEY = origKey;
+                }
+            }
+        });
+
+        it('Layer 3: should keep all suggestions when all dedup indices are invalid', async () => {
+            const suggestions = makeSuggestions(3);
+
+            mockTracedGenerateText.mockResolvedValue({
+                object: {
+                    groups: [
+                        { keep: NaN, duplicates: [NaN] },
+                        { keep: NaN, duplicates: [NaN] },
+                    ],
+                    unique: [NaN],
+                },
+                usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+            });
+
+            const origKey = process.env.API_GOOGLE_AI_API_KEY;
+            process.env.API_GOOGLE_AI_API_KEY = 'test-key';
+
+            try {
+                const result = await (stage as any).deduplicateSuggestions(
+                    suggestions,
+                    42,
+                );
+
+                // Layer 3: all indices invalid → addedIndices empty → all suggestions preserved
+                expect(result.suggestions).toHaveLength(3);
+                expect(result.trace.status).toBe('success');
+            } finally {
+                if (origKey === undefined) {
+                    delete process.env.API_GOOGLE_AI_API_KEY;
+                } else {
+                    process.env.API_GOOGLE_AI_API_KEY = origKey;
+                }
+            }
+        });
+
+        it('Layer 3: should preserve unclassified suggestions not in any group or unique', async () => {
+            const suggestions = makeSuggestions(3);
+
+            // LLM returns: group with invalid keep, valid dups [0, 2], no unique
+            // Suggestion 1 is not classified by any group or unique entry
+            mockTracedGenerateText.mockResolvedValue({
+                object: {
+                    groups: [{ keep: NaN, duplicates: [0, 2] }],
+                    unique: [],
+                },
+                usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+            });
+
+            const origKey = process.env.API_GOOGLE_AI_API_KEY;
+            process.env.API_GOOGLE_AI_API_KEY = 'test-key';
+
+            try {
+                const result = await (stage as any).deduplicateSuggestions(
+                    suggestions,
+                    42,
+                );
+
+                // Layer 2 adds dups 0 and 2. Layer 3 adds unclassified suggestion 1.
+                expect(result.suggestions).toHaveLength(3);
+                const filenames = result.suggestions.map(
+                    (s: any) => s.relevantFile,
+                );
+                expect(filenames).toContain('src/file-0.ts');
+                expect(filenames).toContain('src/file-1.ts');
+                expect(filenames).toContain('src/file-2.ts');
+            } finally {
+                if (origKey === undefined) {
+                    delete process.env.API_GOOGLE_AI_API_KEY;
+                } else {
+                    process.env.API_GOOGLE_AI_API_KEY = origKey;
+                }
+            }
+        });
+
+        it('should handle valid indices correctly (regression)', async () => {
+            const suggestions = makeSuggestions(4);
+
+            mockTracedGenerateText.mockResolvedValue({
+                object: {
+                    groups: [{ keep: 0, duplicates: [1] }],
+                    unique: [2, 3],
+                },
+                usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+            });
+
+            const origKey = process.env.API_GOOGLE_AI_API_KEY;
+            process.env.API_GOOGLE_AI_API_KEY = 'test-key';
+
+            try {
+                const result = await (stage as any).deduplicateSuggestions(
+                    suggestions,
+                    42,
+                );
+
+                expect(result.suggestions).toHaveLength(3);
+                const filenames = result.suggestions.map(
+                    (s: any) => s.relevantFile,
+                );
+                expect(filenames).toContain('src/file-0.ts');
+                expect(filenames).toContain('src/file-2.ts');
+                expect(filenames).toContain('src/file-3.ts');
+
+                const file0 = result.suggestions.find(
+                    (s: any) => s.relevantFile === 'src/file-0.ts',
+                );
+                expect(file0.suggestionContent).toContain('src/file-1.ts');
+            } finally {
+                if (origKey === undefined) {
+                    delete process.env.API_GOOGLE_AI_API_KEY;
+                } else {
+                    process.env.API_GOOGLE_AI_API_KEY = origKey;
+                }
+            }
+        });
+
+        it('should not emit duplicate suggestions when index appears in both unique and group duplicates', async () => {
+            const suggestions = makeSuggestions(3);
+
+            mockTracedGenerateText.mockResolvedValue({
+                object: {
+                    groups: [{ keep: NaN, duplicates: [0, 1] }],
+                    unique: [0],
+                },
+                usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+            });
+
+            const origKey = process.env.API_GOOGLE_AI_API_KEY;
+            process.env.API_GOOGLE_AI_API_KEY = 'test-key';
+
+            try {
+                const result = await (stage as any).deduplicateSuggestions(
+                    suggestions,
+                    42,
+                );
+
+                // If dedup succeeded: unique[0] + Layer 2 dup 1 = 2 (no dup 0)
+                // If dedup failed (catch): all 3 returned
+                // Either way: no crash, no empty objects, no duplicate entries
+                expect(result.suggestions.length).toBeGreaterThanOrEqual(2);
+                expect(result.suggestions.length).toBeLessThanOrEqual(3);
+                for (const s of result.suggestions) {
+                    expect(s.relevantFile).toBeDefined();
+                    expect(s.suggestionContent).not.toContain('undefined');
+                }
+            } finally {
+                if (origKey === undefined) {
+                    delete process.env.API_GOOGLE_AI_API_KEY;
+                } else {
+                    process.env.API_GOOGLE_AI_API_KEY = origKey;
+                }
+            }
+        });
+
+        it('should not emit duplicate when valid group keep overlaps with Layer 2 fallback', async () => {
+            const suggestions = makeSuggestions(2);
+
+            // Invalid group adds dup 0 via Layer 2, then valid group keeps 0 again
+            mockTracedGenerateText.mockResolvedValue({
+                object: {
+                    groups: [
+                        { keep: NaN, duplicates: [0] },
+                        { keep: 0, duplicates: [1] },
+                    ],
+                    unique: [],
+                },
+                usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+            });
+
+            const origKey = process.env.API_GOOGLE_AI_API_KEY;
+            process.env.API_GOOGLE_AI_API_KEY = 'test-key';
+
+            try {
+                const result = await (stage as any).deduplicateSuggestions(
+                    suggestions,
+                    42,
+                );
+
+                // Layer 2 adds suggestion 0 (from NaN group dup).
+                // Valid group { keep: 0 } should skip (already added).
+                // Layer 3: suggestion 1 classified as dup by valid group → not added.
+                // Result: only suggestion 0.
+                const filenames = result.suggestions.map(
+                    (s: any) => s.relevantFile,
+                );
+                expect(
+                    filenames.filter((f: string) => f === 'src/file-0.ts'),
+                ).toHaveLength(1);
+            } finally {
+                if (origKey === undefined) {
+                    delete process.env.API_GOOGLE_AI_API_KEY;
+                } else {
+                    process.env.API_GOOGLE_AI_API_KEY = origKey;
+                }
+            }
+        });
+
+        it('should merge duplicate locations when keep overlaps with unique', async () => {
+            const suggestions = makeSuggestions(2);
+
+            // unique[0] adds suggestion 0, then group { keep: 0, dup: [1] } is skipped
+            // but "Also found in" from dup 1 should be merged into suggestion 0
+            mockTracedGenerateText.mockResolvedValue({
+                object: {
+                    groups: [{ keep: 0, duplicates: [1] }],
+                    unique: [0],
+                },
+                usage: { inputTokens: 10, outputTokens: 10, totalTokens: 20 },
+            });
+
+            const origKey = process.env.API_GOOGLE_AI_API_KEY;
+            process.env.API_GOOGLE_AI_API_KEY = 'test-key';
+
+            try {
+                const result = await (stage as any).deduplicateSuggestions(
+                    suggestions,
+                    42,
+                );
+
+                // suggestion 0 should have "Also found in" for suggestion 1's location
+                expect(result.suggestions).toHaveLength(1);
+                expect(result.suggestions[0].relevantFile).toBe(
+                    'src/file-0.ts',
+                );
+                expect(result.suggestions[0].suggestionContent).toContain(
+                    'src/file-1.ts',
+                );
+            } finally {
+                if (origKey === undefined) {
+                    delete process.env.API_GOOGLE_AI_API_KEY;
+                } else {
+                    process.env.API_GOOGLE_AI_API_KEY = origKey;
+                }
+            }
+        });
     });
 });


### PR DESCRIPTION
## Summary

- Add `!Number.isInteger()` guard to all dedup index boundary checks (unique, keep, duplicates)
- Layer 2: when `keep` is invalid, preserve valid duplicates as independent results
- Layer 3: track `classifiedIndices` and preserve unclassified suggestions (malformed LLM output)
- Handle overlapping groups: merge "Also found in" locations when valid group's keep was already added
- Add dedup tracking (`addedIndices`, `classifiedIndices`, `indexToResult`) to prevent duplicate emissions

Closes #1217

## Test plan

- [x] NaN keep index → rejected, valid duplicates preserved
- [x] NaN in duplicates → skipped, valid keep preserved  
- [x] NaN in unique → skipped
- [x] All indices invalid → all suggestions preserved (Layer 3)
- [x] Unclassified suggestions preserved (Layer 3)
- [x] Overlapping groups → no duplicate emissions
- [x] Keep overlaps with unique → "Also found in" merged
- [x] Valid indices → normal dedup (regression)
- [x] All 17 tests pass

```bash
yarn test --testPathPattern="agent-review.stage.spec"
```