### PR TITLE
test(e2e): stop per-scenario webhook churn that drops PR-open events

### DIFF
--- a/tests/e2e/lib/onboarding.ts
+++ b/tests/e2e/lib/onboarding.ts
@@ -230,6 +230,7 @@ export async function registerRepo(
     target: TargetContext,
     provider: Provider,
     session: KodusSession,
+    opts?: { forceRecreate?: boolean },
 ): Promise<ProviderRepoRef> {
     const repoRef = await provider.repoRef();
     // Key on apiBaseUrl (not target.target) so each hermetic mock server
@@ -238,7 +239,14 @@ export async function registerRepo(
     // registration. Real runs share one apiBaseUrl, where organizationId
     // disambiguates tenants.
     const cacheKey = `${target.apiBaseUrl}:${provider.name}:${session.organizationId}:${repoRef.full_name}`;
-    const cached = registeredRepoCache.get(cacheKey);
+    // forceRecreate bypasses the cache: onboarding-webhook-registration
+    // deletes the repo's webhook on purpose and then asserts registerRepo
+    // recreated it, so it MUST hit the real POST (the cache exists exactly
+    // to skip that POST's webhook churn, which would otherwise leave the
+    // just-deleted hook gone and fail that scenario's assertion).
+    const cached = opts?.forceRecreate
+        ? undefined
+        : registeredRepoCache.get(cacheKey);
     if (cached) {
         log.info(
             `Repo ${cached.full_name} already registered this run — reusing (skips webhook-churning re-POST)`,

--- a/tests/e2e/lib/onboarding.ts
+++ b/tests/e2e/lib/onboarding.ts
@@ -212,12 +212,39 @@ export async function registerIntegration(
     }
 }
 
+// Within a single matrix run a tenant's repo only needs to be registered
+// ONCE. Re-POSTing /code-management/repositories on every scenario makes
+// Kodus delete+recreate that repo's GitHub webhook each time (see
+// github.service.ts createPullRequestWebhook: it lists → deletes → creates
+// the hook with the same URL). That recreate opens a brief blind spot: a
+// PR opened right then fires its `opened` event at the about-to-be-deleted
+// hook, and GitHub never redelivers it to the new one — so the review
+// never starts and the scenario times out waiting for a heartbeat that can
+// no longer come. Caching the registration per (target, provider, org,
+// repo) means only the FIRST scenario per tenant pays the webhook churn;
+// every later scenario reuses the stable hook. (The first scenario's lone
+// churn completes before it opens its PR, so the new hook is already live.)
+const registeredRepoCache = new Map<string, ProviderRepoRef>();
+
 export async function registerRepo(
     target: TargetContext,
     provider: Provider,
     session: KodusSession,
 ): Promise<ProviderRepoRef> {
     const repoRef = await provider.repoRef();
+    // Key on apiBaseUrl (not target.target) so each hermetic mock server
+    // — every integration test spins a fresh one on a unique localhost
+    // port — gets its own cache slot and never reuses a prior test's
+    // registration. Real runs share one apiBaseUrl, where organizationId
+    // disambiguates tenants.
+    const cacheKey = `${target.apiBaseUrl}:${provider.name}:${session.organizationId}:${repoRef.full_name}`;
+    const cached = registeredRepoCache.get(cacheKey);
+    if (cached) {
+        log.info(
+            `Repo ${cached.full_name} already registered this run — reusing (skips webhook-churning re-POST)`,
+        );
+        return cached;
+    }
     log.info(`Looking up ${repoRef.full_name} in available repos`);
     const listResp = await http<{
         data: Array<{
@@ -324,6 +351,7 @@ export async function registerRepo(
         full_name: found.full_name ?? repoRef.full_name,
     };
     log.ok(`Repo ${normalized.full_name} registered`);
+    registeredRepoCache.set(cacheKey, normalized);
     return normalized;
 }
 

--- a/tests/e2e/lib/runner.ts
+++ b/tests/e2e/lib/runner.ts
@@ -349,8 +349,8 @@ export async function runMatrix(opts: RunOptions): Promise<RunOutcome> {
                         login: (creds) => login(target, creds),
                         registerIntegration: (session) =>
                             registerIntegration(target, provider, session),
-                        registerRepo: (session) =>
-                            registerRepo(target, provider, session),
+                        registerRepo: (session, repoOpts) =>
+                            registerRepo(target, provider, session, repoOpts),
                         finishOnboarding: (session, repo) =>
                             finishOnboarding(target, session, repo),
                     },

--- a/tests/e2e/lib/types.ts
+++ b/tests/e2e/lib/types.ts
@@ -194,7 +194,10 @@ export interface RunContext {
     kodus: {
         login: (creds: TenantCredentials) => Promise<KodusSession>;
         registerIntegration: (session: KodusSession) => Promise<void>;
-        registerRepo: (session: KodusSession) => Promise<ProviderRepoRef>;
+        registerRepo: (
+            session: KodusSession,
+            opts?: { forceRecreate?: boolean },
+        ) => Promise<ProviderRepoRef>;
         finishOnboarding: (
             session: KodusSession,
             repo: ProviderRepoRef,

--- a/tests/e2e/scenarios/onboarding-webhook-registration.ts
+++ b/tests/e2e/scenarios/onboarding-webhook-registration.ts
@@ -73,7 +73,13 @@ export const onboardingWebhookRegistration: Scenario = {
         }
 
         await ctx.kodus.registerIntegration(session);
-        const repo = await ctx.kodus.registerRepo(session);
+        // forceRecreate: this scenario just deleted the repo's webhook in
+        // the pre-clean above and asserts registerRepo recreated it, so it
+        // must bypass the per-run registration cache (which otherwise skips
+        // the POST that re-creates the hook).
+        const repo = await ctx.kodus.registerRepo(session, {
+            forceRecreate: true,
+        });
         await ctx.kodus.finishOnboarding(session, repo);
 
         const after = await ctx.provider.listWebhooks();


### PR DESCRIPTION
## Problem

The cloud (and self-hosted) e2e matrix flaked intermittently: cells like `code-review-basic` and `command-review` × `paid` went red with "review pipeline never started" / "0 findings" — **without the product being broken**.

## Root cause (traced via QA logs + GitHub webhook delivery)

Every scenario re-onboards its tenant, and `registerRepo` (`POST /code-management/repositories`) makes Kodus **delete+recreate** the repo's GitHub webhook (`github.service.ts` `createPullRequestWebhook`: list → delete → create same-URL hook). The recreate opens a **blind spot**: a PR opened in that window fires its `opened` event at the about-to-be-deleted hook, and GitHub **never redelivers** it to the new one → the review never starts → the test times out waiting for a heartbeat that can no longer come.

Evidence (2026-06-01): the live `tiny-url-cloud` webhook carried the `created_at` of the last cell even though PRs had opened much earlier; and the review only fired on the `closed` event (~10 min later, after the test had already given up and closed the PR).

## Fix (test-side)

Register a repo **once per (apiBaseUrl, provider, org, repo)** within a run. Only the first scenario per tenant pays the webhook churn (and its lone recreate completes before that scenario opens its PR); every later scenario reuses the stable hook. Keyed on `apiBaseUrl` so each hermetic mock server stays isolated.

## Validation

- Manual cloud-matrix run on the branch ref: **26/42 passed, failed=0** (16 skipped = missing tokens). `code-review-basic` and `command-review` × paid passed on github/gitlab/bitbucket/azure.
- Hermetic suite: 55/55.

## Out of scope (follow-up)

The churn is also a minor **product** defect (token refresh / re-auth recreates webhooks and can drop in-flight events). Making `createPullRequestWebhook` idempotent is left as separate hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)