### PR TITLE
ci(release): only flag freeze-eligibility while the freeze is actually on

### DIFF
--- a/.github/workflows/release-freeze-check.yml
+++ b/.github/workflows/release-freeze-check.yml
@@ -17,8 +17,15 @@ name: Release freeze eligibility
 #         blocked even though it's hidden from changelog, because it can
 #         change behavior in libs/code-review etc.
 #
-# When the freeze ruleset is disabled (most of the time), this status is
-# still posted but is not required for merge — so it's a no-op cost.
+# When the freeze ruleset is disabled (most of the time) this check posts
+# `success` and stays quiet — it does NOT red-flag every feat/fix PR
+# year-round, which was pure noise (a permanent ❌ trains everyone to
+# ignore the check, so the one week it matters nobody looks). The
+# ineligible verdict is only computed while the freeze is actually
+# active. Enforcement stays race-free because the release workflow's
+# freeze-on step re-posts this status on all open PRs the moment it
+# enables the ruleset, so a PR that was quietly `success` off-freeze gets
+# re-evaluated to `failure` when the freeze turns on.
 #
 # Bypass: repo admins can still "Bypass and merge" any PR while the
 # freeze is active; this check only changes the default path.
@@ -41,8 +48,30 @@ jobs:
                   REPO: ${{ github.repository }}
                   SHA: ${{ github.event.pull_request.head.sha }}
                   TITLE: ${{ github.event.pull_request.title }}
+                  # Set to "true" by the release workflow's freeze-on step and
+                  # back to "false"/unset by unfreeze. GITHUB_TOKEN cannot read
+                  # rulesets (no such permission scope), so this repo variable
+                  # is the freeze signal the check can see without a PAT.
+                  FREEZE_ACTIVE: ${{ vars.RELEASE_FREEZE_ACTIVE }}
               run: |
                   set -euo pipefail
+
+                  # Off-freeze (the common case) post success and stay quiet:
+                  # an ineligible verdict only matters while the freeze is on.
+                  # Without this the check red-flagged every feat/fix PR all
+                  # year — noise that trains everyone to ignore it. The freeze
+                  # workflow re-posts the real verdict on open PRs the moment it
+                  # flips the variable on, so enforcement is not weakened.
+                  if [ "${FREEZE_ACTIVE:-false}" != "true" ]; then
+                      gh api -X POST "repos/${REPO}/statuses/${SHA}" \
+                          -f state="success" \
+                          -f context="release-freeze-eligible" \
+                          -f description="release-freeze not active — advisory only" \
+                          -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+                          >/dev/null
+                      echo "::notice::release-freeze not active → posted success (no noise)"
+                      exit 0
+                  fi
 
                   # Match the Conventional Commits prefix at the very start
                   # of the title — same shape pr-title-check.yml enforces.

--- a/.github/workflows/selfhosted-build-push.yml
+++ b/.github/workflows/selfhosted-build-push.yml
@@ -99,7 +99,48 @@ jobs:
                   CURRENT=$(gh api "repos/${REPO}/rulesets/${RULESET_ID}")
                   echo "$CURRENT" | jq '.enforcement="active"' > /tmp/ruleset.json
                   gh api --method PUT "repos/${REPO}/rulesets/${RULESET_ID}" --input /tmp/ruleset.json | jq '{name, enforcement}'
+                  # Signal the freeze to release-freeze-check.yml, which can't
+                  # read rulesets with GITHUB_TOKEN and gates on this variable.
+                  gh variable set RELEASE_FREEZE_ACTIVE --body "true" -R "$REPO"
                   echo "::notice::main is now frozen — no PRs can merge until unfreeze-main runs."
+
+            - name: Re-evaluate freeze eligibility on open PRs
+              env:
+                  GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+                  REPO: ${{ github.repository }}
+              run: |
+                  set -euo pipefail
+                  # release-freeze-check.yml posts `success` while the freeze is
+                  # OFF (to stay quiet). Now that we just turned it ON, re-post
+                  # the real verdict on every open PR so ineligible ones
+                  # (feat/fix/perf/refactor) flip to `failure` immediately —
+                  # the check itself only re-runs on PR events, and flipping a
+                  # ruleset is not one, so without this an already-open
+                  # ineligible PR would keep its stale `success` and slip
+                  # through the freeze.
+                  gh pr list -R "$REPO" --state open --limit 200 \
+                      --json title,headRefOid \
+                      --jq '.[] | "\(.headRefOid)\t\(.title)"' > /tmp/open-prs.tsv || true
+                  while IFS=$'\t' read -r SHA TITLE; do
+                      [ -z "$SHA" ] && continue
+                      TYPE=$(printf '%s' "$TITLE" | grep -oE '^(feat|fix|perf|refactor|docs|style|test|chore|ci|build)' || true)
+                      case "$TYPE" in
+                          chore|ci|docs|build|test|style)
+                              STATE=success
+                              DESC="$TYPE: PR exempt from release-freeze (not user-facing, no runtime impact)"
+                              ;;
+                          *)
+                              STATE=failure
+                              DESC="${TYPE:-unknown}: PR blocked while release-freeze is active (touches runtime). Admins can Bypass and merge."
+                              ;;
+                      esac
+                      gh api -X POST "repos/${REPO}/statuses/${SHA}" \
+                          -f state="$STATE" \
+                          -f context="release-freeze-eligible" \
+                          -f description="$DESC" >/dev/null || true
+                      echo "  PR sha=${SHA:0:7} type=${TYPE:-?} -> $STATE"
+                  done < /tmp/open-prs.tsv
+                  echo "::notice::Re-posted release-freeze-eligible on all open PRs (freeze ON)"
 
     plan-release:
         name: Plan release (compute version and RC version)
@@ -606,7 +647,32 @@ jobs:
                   CURRENT=$(gh api "repos/${REPO}/rulesets/${RULESET_ID}")
                   echo "$CURRENT" | jq '.enforcement="disabled"' > /tmp/ruleset.json
                   gh api --method PUT "repos/${REPO}/rulesets/${RULESET_ID}" --input /tmp/ruleset.json | jq '{name, enforcement}'
+                  # Clear the freeze signal read by release-freeze-check.yml.
+                  gh variable set RELEASE_FREEZE_ACTIVE --body "false" -R "$REPO"
                   echo "::notice::main is unfrozen — PRs can merge again."
+
+            - name: Clear freeze-eligibility red on open PRs
+              env:
+                  GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
+                  REPO: ${{ github.repository }}
+              run: |
+                  set -euo pipefail
+                  # Symmetric to the freeze-on re-post: now that the freeze is
+                  # OFF, flip every open PR's release-freeze-eligible back to
+                  # `success` so no stale ❌ lingers (it's already advisory once
+                  # the ruleset is disabled, but a leftover red is exactly the
+                  # noise this whole change removes). New events would clear it
+                  # anyway; this just does it immediately.
+                  gh pr list -R "$REPO" --state open --limit 200 \
+                      --json headRefOid --jq '.[].headRefOid' > /tmp/open-shas.txt || true
+                  while read -r SHA; do
+                      [ -z "$SHA" ] && continue
+                      gh api -X POST "repos/${REPO}/statuses/${SHA}" \
+                          -f state="success" \
+                          -f context="release-freeze-eligible" \
+                          -f description="release-freeze not active — advisory only" >/dev/null || true
+                  done < /tmp/open-shas.txt
+                  echo "::notice::Cleared release-freeze-eligible to success on all open PRs (freeze OFF)"
 
     notify-discord-failure:
         name: Notify Discord (failure only)


### PR DESCRIPTION
## Problem

`release-freeze-eligible` posts a **`failure` ❌ status on every feat/fix/perf/refactor PR year-round** — but the `release-freeze` ruleset is `disabled` except during the Friday release window. So 51 weeks a year that red is **pure noise**: it doesn't block anything (the ruleset isn't enforcing), and a permanent ❌ just trains everyone to ignore the check — so the one week it actually gates merges, nobody looks.

(Confirmed: the active main ruleset requires no status checks; `release-freeze-eligible` is required only by the `release-freeze` ruleset, which sits `enforcement=disabled`.)

## Fix

- **`release-freeze-check.yml`** stays quiet off-freeze: posts `success` ("advisory only") and only computes the ineligible verdict while the freeze is on. GITHUB_TOKEN can't read rulesets (no such permission scope), so the freeze signal is a repo variable `RELEASE_FREEZE_ACTIVE`.
- **`selfhosted-build-push.yml`** freeze-on step sets `RELEASE_FREEZE_ACTIVE=true`; unfreeze sets it `false`.

## Race-free enforcement

Flipping a ruleset/variable does **not** fire a `pull_request` event, so an already-open ineligible PR would keep its quiet `success`. To close that gap:

- the **freeze-on** step re-posts the real verdict on every open PR (ineligible → `failure`) right after it freezes;
- **unfreeze** clears them back to `success`;
- PRs opened *during* the freeze hit the check normally and get the verdict.

Net: red appears **only during an actual freeze**, and the freeze still blocks ineligible merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)