### PR TITLE
fix(telemetry): run self-hosted heartbeat on code-review worker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -197,8 +197,9 @@ API_RABBITMQ_URI=amqp://dev:devpass@rabbitmq-local:5672/kodus-ai?heartbeat=60
 # Selects which workload this worker container handles. The kodus-worker
 # image refuses to boot without this — and the queues it owns (workflow.jobs.*)
 # are created on its first connection, so if the worker dies on boot the
-# api/webhooks fail with QueueBind 404 on every webhook event. Self-hosted
-# deployments only run the code-review role; analytics is a cloud worker.
+# api/webhooks fail with QueueBind 404 on every webhook event. Every
+# deployment runs code-review; analytics is a separate Cockpit worker when
+# that feature is enabled.
 # (required, type: enum(code-review,analytics))
 WORKER_ROLE=code-review
 
@@ -864,13 +865,21 @@ API_WORKER_DRAIN_TIMEOUT_MS=600000
 
 # Opt out of the daily anonymous heartbeat sent to telemetry.kodus.io.
 # Cloud is unaffected — the cron skips when API_CLOUD_MODE=true regardless.
-# Self-hosted operators flip this to "true" to disable. The payload is
-# aggregated counters (active users, PRs reviewed, repos connected, etc.)
-# plus runtime metadata (Node version, OS, deployment). It never includes
-# emails, repo/branch/PR names, code, or any identifying data. Full schema
-# published at https://github.com/kodustech/kodus-beacon/blob/main/docs/api.md
+# The heartbeat runs from the mandatory code-review worker, so community and
+# enterprise self-hosted installs are covered. Self-hosted operators flip this
+# to "true" to disable. The payload is aggregated counters (active users, PRs
+# reviewed, repos connected, etc.) plus runtime metadata (Node version, OS,
+# deployment). It never includes emails, repo/branch/PR names, code, or any
+# identifying data. Full schema published at
+# https://github.com/kodustech/kodus-beacon/blob/main/docs/api.md
 # (type: boolean)
 KODUS_TELEMETRY_DISABLED=false
+
+# Optional receiver endpoint override for tests or controlled internal
+# deployments. Leave empty in production to use
+# https://telemetry.kodus.io/v1/heartbeat.
+# (type: url)
+KODUS_TELEMETRY_ENDPOINT=
 
 # ============================================================
 # MCP — additional client config

--- a/.env.schema
+++ b/.env.schema
@@ -301,8 +301,9 @@ API_RABBITMQ_URI=amqp://dev:devpass@rabbitmq-local:5672/kodus-ai?heartbeat=60
 # Selects which workload this worker container handles. The kodus-worker
 # image refuses to boot without this — and the queues it owns (workflow.jobs.*)
 # are created on its first connection, so if the worker dies on boot the
-# api/webhooks fail with QueueBind 404 on every webhook event. Self-hosted
-# deployments only run the code-review role; analytics is a cloud worker.
+# api/webhooks fail with QueueBind 404 on every webhook event. Every
+# deployment runs code-review; analytics is a separate Cockpit worker when
+# that feature is enabled.
 # @required @type=enum(code-review,analytics)
 # kodus: audience=both installer-default="code-review"
 WORKER_ROLE=code-review
@@ -1268,14 +1269,23 @@ API_WORKER_DRAIN_TIMEOUT_MS=600000
 
 # Opt out of the daily anonymous heartbeat sent to telemetry.kodus.io.
 # Cloud is unaffected — the cron skips when API_CLOUD_MODE=true regardless.
-# Self-hosted operators flip this to "true" to disable. The payload is
-# aggregated counters (active users, PRs reviewed, repos connected, etc.)
-# plus runtime metadata (Node version, OS, deployment). It never includes
-# emails, repo/branch/PR names, code, or any identifying data. Full schema
-# published at https://github.com/kodustech/kodus-beacon/blob/main/docs/api.md
+# The heartbeat runs from the mandatory code-review worker, so community and
+# enterprise self-hosted installs are covered. Self-hosted operators flip this
+# to "true" to disable. The payload is aggregated counters (active users, PRs
+# reviewed, repos connected, etc.) plus runtime metadata (Node version, OS,
+# deployment). It never includes emails, repo/branch/PR names, code, or any
+# identifying data. Full schema published at
+# https://github.com/kodustech/kodus-beacon/blob/main/docs/api.md
 # @optional @type=boolean
 # kodus: audience=both
 KODUS_TELEMETRY_DISABLED=false
+
+# Optional receiver endpoint override for tests or controlled internal
+# deployments. Leave empty in production to use
+# https://telemetry.kodus.io/v1/heartbeat.
+# @optional @type=url
+# kodus: audience=both
+KODUS_TELEMETRY_ENDPOINT=
 
 # ============================================================
 # MCP — additional client config

--- a/apps/worker/src/cron/self-hosted-beacon.cron.ts
+++ b/apps/worker/src/cron/self-hosted-beacon.cron.ts
@@ -1,8 +1,11 @@
-import { Injectable, Logger, type OnModuleInit } from '@nestjs/common';
+import { Inject, Injectable, Logger, type OnModuleInit } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 
 import { environment } from '@libs/ee/configs/environment';
-import { SelfHostedBeaconService } from '@libs/telemetry/application/services/self-hosted-beacon.service';
+import {
+    ISelfHostedBeaconService,
+    SELF_HOSTED_BEACON_SERVICE_TOKEN,
+} from '@libs/telemetry/application/services/self-hosted-beacon.service';
 
 /**
  * Daily anonymous heartbeat for self-hosted instances. Sends one POST per
@@ -25,7 +28,10 @@ import { SelfHostedBeaconService } from '@libs/telemetry/application/services/se
 export class SelfHostedBeaconCron implements OnModuleInit {
     private readonly logger = new Logger(SelfHostedBeaconCron.name);
 
-    constructor(private readonly beacon: SelfHostedBeaconService) {}
+    constructor(
+        @Inject(SELF_HOSTED_BEACON_SERVICE_TOKEN)
+        private readonly beacon: ISelfHostedBeaconService,
+    ) {}
 
     onModuleInit(): void {
         // Defensive: this is a transparency log, never a critical path.

--- a/apps/worker/src/worker-role.ts
+++ b/apps/worker/src/worker-role.ts
@@ -3,8 +3,8 @@
  * `WORKER_ROLE`:
  *
  *   code-review  → RabbitMQ consumers, code review pipeline, outbox
- *                  relay, monitors. Does not touch the analytics
- *                  warehouse.
+ *                  relay, monitors, and the self-hosted telemetry
+ *                  heartbeat. Does not touch the analytics warehouse.
  *   analytics    → Analytics ingestion cron + warehouse connection.
  *                  No queue consumers (`enableConsumers: false`), but
  *                  RabbitMQWrapperModule is still imported because
@@ -15,9 +15,10 @@
  *                  alternative is a refactor of the
  *                  OrganizationParametersModule → PlatformModule edge.
  *
- * Both cloud and self-hosted deploy both replicas. Keeping the topology
- * identical across environments is a non-negotiable property of this
- * migration (see issue #951): one pipeline, same bugs, same fixes.
+ * Every deployment needs the code-review role. The analytics role is a
+ * separate Cockpit/warehouse worker and may be absent in community
+ * self-hosted installs, so any fleet-wide self-hosted responsibility must
+ * live on the code-review role.
  */
 export type WorkerRole = 'code-review' | 'analytics';
 

--- a/apps/worker/src/worker.module.ts
+++ b/apps/worker/src/worker.module.ts
@@ -41,8 +41,9 @@ import { WorkerHealthGuardService } from './worker-health-guard.service';
 
 /**
  * Worker boots code-review OR analytics — never both. See
- * `./worker-role.ts` for the contract. Cloud and self-hosted run both
- * replicas so the topology is identical across environments.
+ * `./worker-role.ts` for the contract. Self-hosted telemetry is wired to the
+ * code-review role because that is the mandatory worker in every deployment;
+ * analytics is optional for community installs.
  */
 @Module({})
 export class WorkerModule {
@@ -78,6 +79,7 @@ export class WorkerModule {
                     PlatformModule,
                     SandboxModule, // provides SANDBOX_LEASE_MANAGER_TOKEN for OutboxRelayService
                     NotificationModule,
+                    SelfHostedBeaconModule,
                 ],
                 providers: [
                     WorkerDrainService,
@@ -86,6 +88,7 @@ export class WorkerModule {
                     ErrorRateMonitorService,
                     ReviewResponseMonitorService,
                     WebhookFailureMonitorService,
+                    SelfHostedBeaconCron,
                     LangfuseShutdownProvider,
                 ] satisfies Provider[],
             };
@@ -122,7 +125,6 @@ export class WorkerModule {
                 // and CockpitModule doesn't re-export that token.
                 CockpitModule,
                 OrganizationModule,
-                SelfHostedBeaconModule,
             ],
             providers: [
                 WorkerDrainService,
@@ -130,7 +132,6 @@ export class WorkerModule {
                 AnalyticsIngestionCron,
                 AnalyticsClassifierCron,
                 WeeklyRecapCron,
-                SelfHostedBeaconCron,
                 LangfuseShutdownProvider,
             ] satisfies Provider[],
         };

--- a/docs/_snippets/env-vars-generated.mdx
+++ b/docs/_snippets/env-vars-generated.mdx
@@ -82,7 +82,7 @@
 
 | Variable | Required | Type | Scope | Description |
 | --- | --- | --- | --- | --- |
-| `WORKER_ROLE` | ✅ | enum(code-review,analytics) | ⚙️ Both | Selects which workload this worker container handles. The kodus-worker image refuses to boot without this — and the queues it owns (workflow.jobs.*) are created on its first connection, so if the worker dies on boot the api/webhooks fail with QueueBind 404 on every webhook event. Self-hosted deployments only run the code-review role; analytics is a cloud worker. |
+| `WORKER_ROLE` | ✅ | enum(code-review,analytics) | ⚙️ Both | Selects which workload this worker container handles. The kodus-worker image refuses to boot without this — and the queues it owns (workflow.jobs.*) are created on its first connection, so if the worker dies on boot the api/webhooks fail with QueueBind 404 on every webhook event. Every deployment runs code-review; analytics is a separate Cockpit worker when that feature is enabled. |
 | `WORKFLOW_QUEUE_WORKER_PREFETCH` | – | number | ⚙️ Both |  |
 | `WORKFLOW_QUEUE_PUBLISHER_PREFETCH` | – | number | ⚙️ Both |  |
 | `WORKFLOW_QUEUE_WEBHOOK_PREFETCH` | – | number | ⚙️ Both |  |
@@ -364,7 +364,8 @@
 
 | Variable | Required | Type | Scope | Description |
 | --- | --- | --- | --- | --- |
-| `KODUS_TELEMETRY_DISABLED` | – | boolean | ⚙️ Both | Opt out of the daily anonymous heartbeat sent to telemetry.kodus.io. Cloud is unaffected — the cron skips when API_CLOUD_MODE=true regardless. Self-hosted operators flip this to "true" to disable. The payload is aggregated counters (active users, PRs reviewed, repos connected, etc.) plus runtime metadata (Node version, OS, deployment). It never includes emails, repo/branch/PR names, code, or any identifying data. Full schema published at https://github.com/kodustech/kodus-beacon/blob/main/docs/api.md |
+| `KODUS_TELEMETRY_DISABLED` | – | boolean | ⚙️ Both | Opt out of the daily anonymous heartbeat sent to telemetry.kodus.io. Cloud is unaffected — the cron skips when API_CLOUD_MODE=true regardless. The heartbeat runs from the mandatory code-review worker, so community and enterprise self-hosted installs are covered. Self-hosted operators flip this to "true" to disable. The payload is aggregated counters (active users, PRs reviewed, repos connected, etc.) plus runtime metadata (Node version, OS, deployment). It never includes emails, repo/branch/PR names, code, or any identifying data. Full schema published at https://github.com/kodustech/kodus-beacon/blob/main/docs/api.md |
+| `KODUS_TELEMETRY_ENDPOINT` | – | url | ⚙️ Both | Optional receiver endpoint override for tests or controlled internal deployments. Leave empty in production to use https://telemetry.kodus.io/v1/heartbeat. |
 
 ## MCP — additional client config
 

--- a/libs/telemetry/application/services/heartbeat-collector.service.ts
+++ b/libs/telemetry/application/services/heartbeat-collector.service.ts
@@ -66,8 +66,16 @@ export interface HeartbeatMetrics {
     };
 }
 
+export const HEARTBEAT_COLLECTOR_SERVICE_TOKEN = Symbol.for(
+    'HeartbeatCollectorService',
+);
+
+export interface IHeartbeatCollectorService {
+    collect(input: { firstSeenAt: Date }): Promise<HeartbeatMetrics>;
+}
+
 @Injectable()
-export class HeartbeatCollectorService {
+export class HeartbeatCollectorService implements IHeartbeatCollectorService {
     private readonly logger = createLogger(HeartbeatCollectorService.name);
 
     constructor(

--- a/libs/telemetry/application/services/self-hosted-beacon.service.ts
+++ b/libs/telemetry/application/services/self-hosted-beacon.service.ts
@@ -24,6 +24,16 @@ interface TelemetryStateValue {
     in_flight_started_at: string | null; // ISO-8601 UTC
 }
 
+export const SELF_HOSTED_BEACON_SERVICE_TOKEN = Symbol.for(
+    'SelfHostedBeaconService',
+);
+
+export interface ISelfHostedBeaconService {
+    isDisabled(): boolean;
+    run(): Promise<void>;
+    preview(): Promise<Record<string, unknown>>;
+}
+
 /**
  * Orchestrator for the self-hosted heartbeat. Handles:
  *
@@ -38,7 +48,7 @@ interface TelemetryStateValue {
  * never break a host flow.
  */
 @Injectable()
-export class SelfHostedBeaconService {
+export class SelfHostedBeaconService implements ISelfHostedBeaconService {
     private readonly logger = createLogger(SelfHostedBeaconService.name);
 
     constructor(

--- a/libs/telemetry/application/services/self-hosted-beacon.service.ts
+++ b/libs/telemetry/application/services/self-hosted-beacon.service.ts
@@ -7,8 +7,14 @@ import { GlobalParametersKey } from '@libs/core/domain/enums/global-parameters-k
 import { GLOBAL_PARAMETERS_SERVICE_TOKEN } from '@libs/organization/domain/global-parameters/contracts/global-parameters.service.contract';
 import { IGlobalParametersService } from '@libs/organization/domain/global-parameters/contracts/global-parameters.service.contract';
 
-import { BeaconHttpProvider } from '../../infrastructure/providers/beacon-http.provider';
-import { HeartbeatCollectorService } from './heartbeat-collector.service';
+import {
+    BEACON_HTTP_PROVIDER_TOKEN,
+    IBeaconHttpProvider,
+} from '../../infrastructure/providers/beacon-http.provider';
+import {
+    HEARTBEAT_COLLECTOR_SERVICE_TOKEN,
+    IHeartbeatCollectorService,
+} from './heartbeat-collector.service';
 
 interface TelemetryStateValue {
     instance_id: string;
@@ -38,8 +44,10 @@ export class SelfHostedBeaconService {
     constructor(
         @Inject(GLOBAL_PARAMETERS_SERVICE_TOKEN)
         private readonly globalParameters: IGlobalParametersService,
-        private readonly collector: HeartbeatCollectorService,
-        private readonly transport: BeaconHttpProvider,
+        @Inject(HEARTBEAT_COLLECTOR_SERVICE_TOKEN)
+        private readonly collector: IHeartbeatCollectorService,
+        @Inject(BEACON_HTTP_PROVIDER_TOKEN)
+        private readonly transport: IBeaconHttpProvider,
     ) {}
 
     /**

--- a/libs/telemetry/application/services/self-hosted-beacon.service.ts
+++ b/libs/telemetry/application/services/self-hosted-beacon.service.ts
@@ -14,6 +14,8 @@ interface TelemetryStateValue {
     instance_id: string;
     first_seen_at: string; // ISO-8601 UTC
     last_sent_day: string | null; // YYYY-MM-DD UTC
+    in_flight_day: string | null; // YYYY-MM-DD UTC
+    in_flight_started_at: string | null; // ISO-8601 UTC
 }
 
 /**
@@ -21,6 +23,7 @@ interface TelemetryStateValue {
  *
  *   - opt-out resolution (`KODUS_TELEMETRY_DISABLED`, `DO_NOT_TRACK`)
  *   - daily dedupe via `last_sent_day` in `global_parameters[telemetry_state]`
+ *   - best-effort multi-worker dedupe via `in_flight_day`
  *   - lazy creation + persistence of `instance_id`
  *   - assembling the wire payload from `HeartbeatCollectorService`
  *   - delegating transport to `BeaconHttpProvider`
@@ -50,6 +53,8 @@ export class SelfHostedBeaconService {
 
     /** Daily entrypoint. Idempotent within the same UTC day. */
     async run(): Promise<void> {
+        let claimedState: TelemetryStateValue | null = null;
+
         try {
             if (this.transport.isDisabled()) {
                 return;
@@ -61,6 +66,19 @@ export class SelfHostedBeaconService {
             if (state.last_sent_day === today) {
                 return;
             }
+
+            if (hasFreshInFlightClaim(state, today, new Date())) {
+                return;
+            }
+
+            const nextClaimedState: TelemetryStateValue = {
+                ...state,
+                in_flight_day: today,
+                in_flight_started_at: new Date().toISOString(),
+            };
+
+            await this.persistState(nextClaimedState);
+            claimedState = nextClaimedState;
 
             const metrics = await this.collector.collect({
                 firstSeenAt: new Date(state.first_seen_at),
@@ -80,14 +98,27 @@ export class SelfHostedBeaconService {
 
             if (ok) {
                 await this.persistState({
-                    ...state,
+                    ...claimedState,
                     last_sent_day: today,
+                    in_flight_day: null,
+                    in_flight_started_at: null,
                 });
+            } else {
+                await this.persistState(clearInFlightClaim(claimedState));
             }
         } catch (error) {
             // Defense in depth: any unexpected throw is swallowed so the cron
             // never fails the worker. The transport already swallows network
             // errors; this catches storage / collector bugs.
+            if (claimedState) {
+                try {
+                    await this.persistState(clearInFlightClaim(claimedState));
+                } catch {
+                    // If cleanup also fails, keep the original error as the
+                    // useful signal. A stale in-flight claim expires.
+                }
+            }
+
             this.logger.warn({
                 message: 'self-hosted beacon run failed (swallowed)',
                 context: SelfHostedBeaconService.name,
@@ -133,6 +164,8 @@ export class SelfHostedBeaconService {
                 instance_id: value.instance_id,
                 first_seen_at: value.first_seen_at,
                 last_sent_day: value.last_sent_day ?? null,
+                in_flight_day: value.in_flight_day ?? null,
+                in_flight_started_at: value.in_flight_started_at ?? null,
             };
         }
 
@@ -140,6 +173,8 @@ export class SelfHostedBeaconService {
             instance_id: randomUUID(),
             first_seen_at: new Date().toISOString(),
             last_sent_day: null,
+            in_flight_day: null,
+            in_flight_started_at: null,
         };
 
         await this.persistState(fresh);
@@ -156,4 +191,31 @@ export class SelfHostedBeaconService {
 
 function utcDayString(date: Date): string {
     return date.toISOString().slice(0, 10);
+}
+
+function hasFreshInFlightClaim(
+    state: TelemetryStateValue,
+    today: string,
+    now: Date,
+): boolean {
+    if (
+        state.in_flight_day !== today ||
+        !state.in_flight_started_at ||
+        Number.isNaN(Date.parse(state.in_flight_started_at))
+    ) {
+        return false;
+    }
+
+    const startedAt = new Date(state.in_flight_started_at).getTime();
+    return now.getTime() - startedAt < 30 * 60 * 1000;
+}
+
+function clearInFlightClaim(
+    state: TelemetryStateValue,
+): TelemetryStateValue {
+    return {
+        ...state,
+        in_flight_day: null,
+        in_flight_started_at: null,
+    };
 }

--- a/libs/telemetry/infrastructure/providers/beacon-http.provider.ts
+++ b/libs/telemetry/infrastructure/providers/beacon-http.provider.ts
@@ -4,6 +4,16 @@ import { Injectable } from '@nestjs/common';
 const DEFAULT_ENDPOINT = 'https://telemetry.kodus.io/v1/heartbeat';
 const TIMEOUT_MS = 5_000;
 
+export const BEACON_HTTP_PROVIDER_TOKEN = Symbol.for('BeaconHttpProvider');
+
+export interface IBeaconHttpProvider {
+    isDisabled(): boolean;
+    send(
+        payload: Record<string, unknown>,
+        kodusVersion: string,
+    ): Promise<boolean>;
+}
+
 /**
  * Pure HTTP transport for the self-hosted beacon. One responsibility: POST a
  * pre-built payload to the receiver and surface only "did it land" — the
@@ -14,7 +24,7 @@ const TIMEOUT_MS = 5_000;
  * flip it at runtime without restarting the worker.
  */
 @Injectable()
-export class BeaconHttpProvider {
+export class BeaconHttpProvider implements IBeaconHttpProvider {
     private readonly logger = createLogger(BeaconHttpProvider.name);
 
     isDisabled(): boolean {

--- a/libs/telemetry/infrastructure/providers/beacon-http.provider.ts
+++ b/libs/telemetry/infrastructure/providers/beacon-http.provider.ts
@@ -1,7 +1,7 @@
 import { createLogger } from '@kodus/flow';
 import { Injectable } from '@nestjs/common';
 
-const ENDPOINT = 'https://telemetry.kodus.io/v1/heartbeat';
+const DEFAULT_ENDPOINT = 'https://telemetry.kodus.io/v1/heartbeat';
 const TIMEOUT_MS = 5_000;
 
 /**
@@ -33,7 +33,7 @@ export class BeaconHttpProvider {
         const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
 
         try {
-            const response = await fetch(ENDPOINT, {
+            const response = await fetch(this.endpoint(), {
                 body: JSON.stringify(payload),
                 headers: {
                     'Content-Type': 'application/json',
@@ -66,5 +66,9 @@ export class BeaconHttpProvider {
         } finally {
             clearTimeout(timer);
         }
+    }
+
+    private endpoint(): string {
+        return process.env.KODUS_TELEMETRY_ENDPOINT?.trim() || DEFAULT_ENDPOINT;
     }
 }

--- a/libs/telemetry/modules/self-hosted-beacon.module.ts
+++ b/libs/telemetry/modules/self-hosted-beacon.module.ts
@@ -12,9 +12,15 @@ import {
     PullRequestsSchema,
 } from '@libs/platformData/infrastructure/adapters/repositories/schemas/pullRequests.model';
 
-import { HeartbeatCollectorService } from '../application/services/heartbeat-collector.service';
+import {
+    HEARTBEAT_COLLECTOR_SERVICE_TOKEN,
+    HeartbeatCollectorService,
+} from '../application/services/heartbeat-collector.service';
 import { SelfHostedBeaconService } from '../application/services/self-hosted-beacon.service';
-import { BeaconHttpProvider } from '../infrastructure/providers/beacon-http.provider';
+import {
+    BEACON_HTTP_PROVIDER_TOKEN,
+    BeaconHttpProvider,
+} from '../infrastructure/providers/beacon-http.provider';
 
 @Module({
     imports: [
@@ -27,7 +33,15 @@ import { BeaconHttpProvider } from '../infrastructure/providers/beacon-http.prov
     ],
     providers: [
         BeaconHttpProvider,
+        {
+            provide: BEACON_HTTP_PROVIDER_TOKEN,
+            useExisting: BeaconHttpProvider,
+        },
         HeartbeatCollectorService,
+        {
+            provide: HEARTBEAT_COLLECTOR_SERVICE_TOKEN,
+            useExisting: HeartbeatCollectorService,
+        },
         SelfHostedBeaconService,
     ],
     exports: [SelfHostedBeaconService],

--- a/libs/telemetry/modules/self-hosted-beacon.module.ts
+++ b/libs/telemetry/modules/self-hosted-beacon.module.ts
@@ -16,7 +16,10 @@ import {
     HEARTBEAT_COLLECTOR_SERVICE_TOKEN,
     HeartbeatCollectorService,
 } from '../application/services/heartbeat-collector.service';
-import { SelfHostedBeaconService } from '../application/services/self-hosted-beacon.service';
+import {
+    SELF_HOSTED_BEACON_SERVICE_TOKEN,
+    SelfHostedBeaconService,
+} from '../application/services/self-hosted-beacon.service';
 import {
     BEACON_HTTP_PROVIDER_TOKEN,
     BeaconHttpProvider,
@@ -42,8 +45,11 @@ import {
             provide: HEARTBEAT_COLLECTOR_SERVICE_TOKEN,
             useExisting: HeartbeatCollectorService,
         },
-        SelfHostedBeaconService,
+        {
+            provide: SELF_HOSTED_BEACON_SERVICE_TOKEN,
+            useClass: SelfHostedBeaconService,
+        },
     ],
-    exports: [SelfHostedBeaconService],
+    exports: [SELF_HOSTED_BEACON_SERVICE_TOKEN],
 })
 export class SelfHostedBeaconModule {}

--- a/test/integration/telemetry/self-hosted-beacon-http.integration.spec.ts
+++ b/test/integration/telemetry/self-hosted-beacon-http.integration.spec.ts
@@ -1,0 +1,217 @@
+import { createServer, type IncomingMessage, type Server } from 'node:http';
+
+import { GlobalParametersKey } from '@libs/core/domain/enums/global-parameters-key.enum';
+import { HeartbeatCollectorService } from '@libs/telemetry/application/services/heartbeat-collector.service';
+import { SelfHostedBeaconService } from '@libs/telemetry/application/services/self-hosted-beacon.service';
+import { BeaconHttpProvider } from '@libs/telemetry/infrastructure/providers/beacon-http.provider';
+
+type CapturedRequest = {
+    body: Record<string, unknown>;
+    headers: IncomingMessage['headers'];
+    method: string | undefined;
+    url: string | undefined;
+};
+
+type TelemetryState = {
+    instance_id: string;
+    first_seen_at: string;
+    last_sent_day: string | null;
+    in_flight_day?: string | null;
+    in_flight_started_at?: string | null;
+};
+
+async function startReceiver(): Promise<{
+    close: () => Promise<void>;
+    requests: CapturedRequest[];
+    url: string;
+}> {
+    const requests: CapturedRequest[] = [];
+
+    const server = createServer((req, res) => {
+        let rawBody = '';
+
+        req.setEncoding('utf8');
+        req.on('data', (chunk) => {
+            rawBody += chunk;
+        });
+        req.on('end', () => {
+            requests.push({
+                body: rawBody ? JSON.parse(rawBody) : {},
+                headers: req.headers,
+                method: req.method,
+                url: req.url,
+            });
+
+            res.writeHead(204);
+            res.end();
+        });
+    });
+
+    await new Promise<void>((resolve, reject) => {
+        server.once('error', reject);
+        server.listen(0, '127.0.0.1', () => {
+            server.off('error', reject);
+            resolve();
+        });
+    });
+
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+        throw new Error('receiver did not bind to a TCP port');
+    }
+
+    return {
+        close: () => closeServer(server),
+        requests,
+        url: `http://127.0.0.1:${address.port}/v1/heartbeat`,
+    };
+}
+
+function makeMongoModel(count: number) {
+    return {
+        countDocuments: jest.fn().mockReturnValue({
+            exec: jest.fn().mockResolvedValue(count),
+        }),
+    };
+}
+
+function makeCollector(): HeartbeatCollectorService {
+    const dataSource = {
+        query: jest.fn(async (sql: string) => {
+            if (sql.includes('SELECT version()')) {
+                return [{ version: 'PostgreSQL 16.0 (Debian)' }];
+            }
+            if (sql.includes('FROM "organizations"')) {
+                return [{ count: 1 }];
+            }
+            if (sql.includes('FROM "teams"')) {
+                return [{ count: 2 }];
+            }
+            if (sql.includes('FROM "repositories"')) {
+                return [{ count: 4 }];
+            }
+            if (sql.includes('FROM auth')) {
+                return [{ count: 3 }];
+            }
+            if (sql.includes('FROM integrations')) {
+                return [{ platform: 'github' }];
+            }
+            return [];
+        }),
+    };
+
+    return new HeartbeatCollectorService(
+        dataSource as never,
+        makeMongoModel(9) as never,
+        makeMongoModel(1) as never,
+    );
+}
+
+async function closeServer(server: Server): Promise<void> {
+    await new Promise<void>((resolve, reject) => {
+        server.close((error) => {
+            if (error) {
+                reject(error);
+                return;
+            }
+            resolve();
+        });
+    });
+}
+
+describe('self-hosted telemetry HTTP flow', () => {
+    const originalEnv = { ...process.env };
+
+    afterEach(() => {
+        process.env = { ...originalEnv };
+        jest.useRealTimers();
+    });
+
+    it('sends one real heartbeat POST to the configured receiver and marks the day as sent', async () => {
+        const receiver = await startReceiver();
+        process.env.KODUS_TELEMETRY_ENDPOINT = receiver.url;
+        delete process.env.KODUS_TELEMETRY_DISABLED;
+
+        let state: TelemetryState | null = {
+            instance_id: '55555555-5555-4555-8555-555555555555',
+            first_seen_at: '2026-01-01T00:00:00.000Z',
+            last_sent_day: null,
+        };
+
+        const globalParameters = {
+            findByKey: jest.fn(async (key: GlobalParametersKey) => {
+                expect(key).toBe(GlobalParametersKey.TELEMETRY_STATE);
+                return state ? { configValue: state } : null;
+            }),
+            createOrUpdateConfig: jest.fn(
+                async (key: GlobalParametersKey, value: TelemetryState) => {
+                    expect(key).toBe(GlobalParametersKey.TELEMETRY_STATE);
+                    state = value;
+                    return true;
+                },
+            ),
+        };
+        const collector = makeCollector();
+        const collectSpy = jest.spyOn(collector, 'collect');
+
+        try {
+            const service = new SelfHostedBeaconService(
+                globalParameters as never,
+                collector as never,
+                new BeaconHttpProvider(),
+            );
+
+            await service.run();
+            await service.run();
+
+            expect(receiver.requests).toHaveLength(1);
+            expect(receiver.requests[0]).toEqual(
+                expect.objectContaining({
+                    method: 'POST',
+                    url: '/v1/heartbeat',
+                }),
+            );
+            expect(receiver.requests[0].headers['content-type']).toContain(
+                'application/json',
+            );
+            const body = receiver.requests[0].body;
+            expect(receiver.requests[0].headers['user-agent']).toBe(
+                `kodus-self-hosted/${(body.kodus as { version: string }).version}`,
+            );
+            expect(body).toEqual(
+                expect.objectContaining({
+                    schema_version: 1,
+                    instance_id: '55555555-5555-4555-8555-555555555555',
+                    kodus: expect.objectContaining({
+                        version: expect.stringMatching(/^\d+\.\d+\.\d+/),
+                    }),
+                    runtime: expect.objectContaining({
+                        db_version: 'PostgreSQL 16.0',
+                    }),
+                    usage_7d: expect.objectContaining({
+                        active_users: 3,
+                        organizations: 1,
+                        repos_connected: 4,
+                        prs_reviewed: 9,
+                    }),
+                    config: expect.objectContaining({
+                        kody_rules_enabled: true,
+                        integrations: ['github'],
+                    }),
+                }),
+            );
+
+            expect(state).toEqual(
+                expect.objectContaining({
+                    instance_id: '55555555-5555-4555-8555-555555555555',
+                    last_sent_day: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+                    in_flight_day: null,
+                    in_flight_started_at: null,
+                }),
+            );
+            expect(collectSpy).toHaveBeenCalledTimes(1);
+        } finally {
+            await receiver.close();
+        }
+    });
+});

--- a/test/unit/telemetry/beacon-http.provider.spec.ts
+++ b/test/unit/telemetry/beacon-http.provider.spec.ts
@@ -57,6 +57,24 @@ describe('BeaconHttpProvider', () => {
             );
         });
 
+        it('uses KODUS_TELEMETRY_ENDPOINT when set', async () => {
+            process.env.KODUS_TELEMETRY_ENDPOINT =
+                'http://127.0.0.1:43111/test-heartbeat';
+            global.fetch = jest
+                .fn()
+                .mockResolvedValue({ status: 204 }) as unknown as typeof fetch;
+
+            const ok = await new BeaconHttpProvider().send({ a: 1 }, '1.0.0');
+
+            expect(ok).toBe(true);
+            expect(global.fetch).toHaveBeenCalledWith(
+                'http://127.0.0.1:43111/test-heartbeat',
+                expect.objectContaining({
+                    method: 'POST',
+                }),
+            );
+        });
+
         it('returns false on non-204 (e.g. 400)', async () => {
             global.fetch = jest
                 .fn()

--- a/test/unit/telemetry/self-hosted-beacon.service.spec.ts
+++ b/test/unit/telemetry/self-hosted-beacon.service.spec.ts
@@ -112,19 +112,35 @@ describe('SelfHostedBeaconService', () => {
                 ),
                 first_seen_at: expect.any(String),
                 last_sent_day: null,
+                in_flight_day: null,
+                in_flight_started_at: null,
             }),
         );
 
         expect(collector.collect).toHaveBeenCalledTimes(1);
         expect(transport.send).toHaveBeenCalledTimes(1);
 
-        // Second persist: marks today as sent.
+        // Second persist: claims today before sending so another worker skips.
         const secondPersist =
             globalParameters.createOrUpdateConfig.mock.calls[1]?.[1];
         expect(secondPersist).toEqual(
             expect.objectContaining({
                 instance_id: firstPersist.instance_id,
+                last_sent_day: null,
+                in_flight_day: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+                in_flight_started_at: expect.any(String),
+            }),
+        );
+
+        // Third persist: marks today as sent and clears the in-flight claim.
+        const thirdPersist =
+            globalParameters.createOrUpdateConfig.mock.calls[2]?.[1];
+        expect(thirdPersist).toEqual(
+            expect.objectContaining({
+                instance_id: firstPersist.instance_id,
                 last_sent_day: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+                in_flight_day: null,
+                in_flight_started_at: null,
             }),
         );
     });
@@ -163,8 +179,48 @@ describe('SelfHostedBeaconService', () => {
 
         expect(collector.collect).toHaveBeenCalledTimes(1);
         expect(transport.send).toHaveBeenCalledTimes(1);
-        // No persist call at all — state was already initialised, and we
-        // only persist the day marker on success.
+        expect(globalParameters.createOrUpdateConfig).toHaveBeenCalledTimes(2);
+
+        const claimPersist =
+            globalParameters.createOrUpdateConfig.mock.calls[0]?.[1];
+        expect(claimPersist).toEqual(
+            expect.objectContaining({
+                last_sent_day: '2026-01-01',
+                in_flight_day: expect.stringMatching(/^\d{4}-\d{2}-\d{2}$/),
+                in_flight_started_at: expect.any(String),
+            }),
+        );
+
+        const clearPersist =
+            globalParameters.createOrUpdateConfig.mock.calls[1]?.[1];
+        expect(clearPersist).toEqual(
+            expect.objectContaining({
+                last_sent_day: '2026-01-01',
+                in_flight_day: null,
+                in_flight_started_at: null,
+            }),
+        );
+    });
+
+    it('skips send when another worker already claimed today', async () => {
+        const { service, globalParameters, collector, transport } = build();
+        const now = new Date('2026-06-01T03:17:30.000Z');
+        jest.useFakeTimers().setSystemTime(now);
+
+        globalParameters.findByKey.mockResolvedValue({
+            configValue: {
+                instance_id: '22222222-2222-4222-8222-222222222222',
+                first_seen_at: '2026-01-01T00:00:00.000Z',
+                last_sent_day: '2026-01-01',
+                in_flight_day: '2026-06-01',
+                in_flight_started_at: '2026-06-01T03:17:00.000Z',
+            },
+        });
+
+        await service.run();
+
+        expect(collector.collect).not.toHaveBeenCalled();
+        expect(transport.send).not.toHaveBeenCalled();
         expect(globalParameters.createOrUpdateConfig).not.toHaveBeenCalled();
     });
 
@@ -181,6 +237,15 @@ describe('SelfHostedBeaconService', () => {
 
         await expect(service.run()).resolves.toBeUndefined();
         expect(transport.send).not.toHaveBeenCalled();
+        expect(globalParameters.createOrUpdateConfig).toHaveBeenCalledTimes(2);
+        expect(
+            globalParameters.createOrUpdateConfig.mock.calls[1]?.[1],
+        ).toEqual(
+            expect.objectContaining({
+                in_flight_day: null,
+                in_flight_started_at: null,
+            }),
+        );
     });
 
     it('preview returns the payload that would be sent without calling transport', async () => {

--- a/test/unit/worker/worker-module.spec.ts
+++ b/test/unit/worker/worker-module.spec.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('WorkerModule telemetry wiring', () => {
+    const source = readFileSync(
+        join(process.cwd(), 'apps/worker/src/worker.module.ts'),
+        'utf8',
+    );
+
+    function roleBranch(role: 'code-review' | 'analytics'): string {
+        if (role === 'code-review') {
+            const start = source.indexOf("if (role === 'code-review')");
+            const end = source.indexOf('// analytics');
+            return source.slice(start, end);
+        }
+
+        return source.slice(source.indexOf('// analytics'));
+    }
+
+    it('runs the self-hosted beacon on the mandatory code-review worker', () => {
+        const branch = roleBranch('code-review');
+
+        expect(source).toContain(
+            "import { SelfHostedBeaconModule } from '@libs/telemetry/modules/self-hosted-beacon.module';",
+        );
+        expect(source).toContain(
+            "import { SelfHostedBeaconCron } from './cron/self-hosted-beacon.cron';",
+        );
+        expect(branch).toContain('SelfHostedBeaconModule');
+        expect(branch).toContain('SelfHostedBeaconCron');
+    });
+
+    it('does not run the self-hosted beacon on the optional analytics worker', () => {
+        const branch = roleBranch('analytics');
+
+        expect(branch).not.toContain('SelfHostedBeaconModule');
+        expect(branch).not.toContain('SelfHostedBeaconCron');
+    });
+});


### PR DESCRIPTION
## Summary

Moves the self-hosted telemetry heartbeat from the optional analytics worker to the mandatory code-review worker so Community and Enterprise self-hosted installs are covered. Adds best-effort in-flight dedupe for scaled code-review workers and a configurable telemetry endpoint for hermetic tests.

Closes #1234

## Changelog routing (driven by the PR title prefix)

The prefix in your PR title decides where this change appears in the public changelog. No labels needed — the title is the source of truth.

| Prefix     | Public changelog                              |
| ---------- | --------------------------------------------- |
| `feat:`    | **Improvements** section (or tied to a tracked feature, see below) |
| `fix:`     | **Bug fixes** section                         |
| `perf:`    | **Performance** section                       |
| `docs:`, `style:`, `refactor:`, `test:`, `chore:`, `ci:`, `build:` | Hidden from public changelog |

## Test plan

- [x] `API_NODE_ENV=test NODE_PATH=/Users/gabrielmalinosqui/dev/kodus/kodus-ai/node_modules /Users/gabrielmalinosqui/dev/kodus/kodus-ai/node_modules/.bin/jest --forceExit --runInBand --detectOpenHandles --config jest.config.ts test/unit/worker/worker-module.spec.ts test/unit/worker/worker-role.spec.ts test/unit/telemetry/beacon-http.provider.spec.ts test/unit/telemetry/self-hosted-beacon.service.spec.ts test/integration/telemetry/self-hosted-beacon-http.integration.spec.ts`
- [x] `git diff --check`

## Notes for the reviewer

The integration test uses `KODUS_TELEMETRY_ENDPOINT` to point the real BeaconHttpProvider at a local HTTP receiver, so it validates the POST flow without touching `telemetry.kodus.io`. The code-review worker owns the cron now; analytics intentionally does not register it to avoid duplicate heartbeats in Enterprise deployments.