### PR TITLE
fix(e2e): guard heredoc-expanded LLM vars so unset base-url doesn't abort vm.sh

### DIFF
--- a/tests/e2e/provisioning/self-hosted/vm.sh
+++ b/tests/e2e/provisioning/self-hosted/vm.sh
@@ -369,13 +369,13 @@ env_set RESEND_API_KEY "${RESEND_API_KEY:-disabled-for-dev}"
 # LLM provider config — required for Kodus to actually review PRs in the
 # matrix. Caller must provide these via env (no hardcoded fallback).
 if [ -n "${API_OPEN_AI_API_KEY:-}" ]; then
-    env_set API_OPEN_AI_API_KEY "$API_OPEN_AI_API_KEY"
+    env_set API_OPEN_AI_API_KEY "${API_OPEN_AI_API_KEY:-}"
 fi
 if [ -n "${API_OPENAI_FORCE_BASE_URL:-}" ]; then
-    env_set API_OPENAI_FORCE_BASE_URL "$API_OPENAI_FORCE_BASE_URL"
+    env_set API_OPENAI_FORCE_BASE_URL "${API_OPENAI_FORCE_BASE_URL:-}"
 fi
 if [ -n "${API_LLM_PROVIDER_MODEL:-}" ]; then
-    env_set API_LLM_PROVIDER_MODEL "$API_LLM_PROVIDER_MODEL"
+    env_set API_LLM_PROVIDER_MODEL "${API_LLM_PROVIDER_MODEL:-}"
 fi
 REMOTE
 


### PR DESCRIPTION
## Problem

The self-hosted matrix aborted **every** cell at the `Run provisioning + matrix runner` step, ~3min in, with:

```
./tests/e2e/provisioning/self-hosted/vm.sh: line 324: API_OPENAI_FORCE_BASE_URL: unbound variable
```

## Root cause

`vm.sh` runs under `set -euo pipefail`. The heredoc that writes the `.env` on the VM (`ssh_vm bash -s <<REMOTE`) is **unquoted**, so the local shell expands every `$VAR` in the body before sending it. The bare RHS `"$API_OPENAI_FORCE_BASE_URL"` (line 375) tripped `-u` whenever the var was unset — i.e. every cell that isn't a BYOK base-url run. Bash reports the error at the heredoc line (324), which is why the location looked off.

The surrounding `if [ -n "${VAR:-}" ]` guard gives false safety: it is evaluated **remotely**, but the local expansion of the body happens regardless.

`API_OPEN_AI_API_KEY` and `API_LLM_PROVIDER_MODEL` only "worked" because they happen to be set in CI — same latent bomb. `API_OPENAI_FORCE_BASE_URL` was added recently (BYOK base-url work) and is the only one not set, hence the regression.

## Fix

Give all three LLM vars a `:-` default on the RHS, matching the existing `RESEND_API_KEY "${RESEND_API_KEY:-disabled-for-dev}"` pattern. An unset value expands to empty instead of aborting.

## Validation

- Local repro under `set -u` + unquoted heredoc: old pattern aborts with `unbound variable`, `:-` pattern passes.
- Self-hosted matrix re-dispatched on this branch ([run 26788186504](https://github.com/kodustech/kodus-ai/actions/runs/26788186504)): provisioning passes on all cells, 6/7 scenarios green per cell. The only failure (`rbac-authorization` on github-paid) is a **version skew** — the image under test `selfhosted-2.1.15` (cut 2026-05-27) predates the TokenUsage RBAC gate already on main; it clears with the next self-hosted RC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)