### PR TITLE
fix(e2e): one repo per cloud GitHub tenant to kill webhook fan-out collisions

### DIFF
--- a/scripts/e2e/CLOUD_GITHUB_REPO_ISOLATION.md
+++ b/scripts/e2e/CLOUD_GITHUB_REPO_ISOLATION.md
@@ -1,0 +1,75 @@
+# Cloud GitHub repo isolation (1 org : 1 repo)
+
+## Why
+
+On cloud, every license tier (`paid`, `free`, `trial`, `community-byok`,
+the two `stripe-checkout` tenants) is a **separate Kodus organization**.
+They all used to share **one** GitHub fixture repo (`tiny-url-cloud`).
+
+The GitHub PAT webhook is a bare `POST /github/webhook` with no per-org
+discriminator. When a PR opens, the backend resolves repo → org by taking
+the **first** `IntegrationConfig` ordered by `updatedAt DESC`
+(`webhook-context.service.getContext` and `pullRequests/save.use-case`).
+With N orgs on one repo, the review fires for whichever org most recently
+touched its repo config — **not reliably the org under test** — or gets
+silently dropped if none has an active automation at that instant. The
+scenario then times out waiting for a review that landed on a sibling org
+(or nowhere). Non-deterministic ⇒ flaky (`github × paid` failed while
+`github × trial` passed in the same run). GitLab/Bitbucket/Azure never hit
+this because each has only one cloud tenant ⇒ one org per repo.
+
+QA evidence (2026-06-01 run): a single PR #73 webhook created PR docs in
+**4 orgs** at once; **9 orgs** total had been connected to `tiny-url-cloud`
+over time.
+
+## The fix
+
+Give every cloud **GitHub PAT** tenant its **own** repo, restoring the
+1 org : 1 repo invariant the other providers already have. `github-app` is
+already isolated on its App-bound repo; GitLab/Bitbucket/Azure keep their
+env-resolved cloud repos.
+
+Code wiring (already merged with this doc):
+- `tests/e2e/cli/cloud/setup-tenants.ts` — each github tenant has a
+  dedicated `repoFullName`; a load-time `validateGithubRepoIsolation`
+  invariant fails the seed if two github tenants share a repo or one lacks
+  its own. `connectProvider` forwards `repoFullName` to the provider.
+- `tests/e2e/providers/index.ts` — `makeProvider(name, target, repoOverride?)`
+  (GitHub honours it; others ignore it).
+- `tests/e2e/lib/runner.ts` — `CloudTenantEntry.repoFullName` is read and
+  passed to `makeProvider` at run time; the pre-flight stale-PR cleanup
+  now dedupes by `(provider, repo)` so a sibling tenant's repo is cleaned
+  too.
+
+## One-time rollout (live steps — need the QA/GitHub creds)
+
+1. **Provision the repos** (PAT with create rights in `kodus-e2e`):
+   ```
+   GH_TEST_TOKEN=<pat> ./scripts/e2e/provision-cloud-github-repos.sh
+   ```
+   Creates the six `tiny-url-cloud-{paid,free,trial,community,stripe-free,stripe-trial}`
+   repos, mirroring content from `GH_TEST_REPO_CLOUD` (default
+   `kodus-e2e/tiny-url-cloud`).
+
+2. **Re-seed tenants** so each connects its dedicated repo. The
+   `/code-management/repositories` call uses `type:"replace"`, which
+   removes the old shared repo from each tenant's config in the same step:
+   ```
+   yarn cloud:setup-tenants
+   ```
+   This rewrites `~/.kodus-dev/cloud-tenants.json` with `repoFullName` per
+   tenant.
+
+3. **Refresh the CI secret** — the cloud matrix restores
+   `~/.kodus-dev/cloud-tenants.json` from the `CLOUD_TENANTS_JSON` secret
+   (it does NOT re-seed), so push the new file up:
+   ```
+   gh secret set CLOUD_TENANTS_JSON < ~/.kodus-dev/cloud-tenants.json
+   ```
+
+4. **Re-run** the cloud matrix — `github × *` cells are now deterministic.
+
+After step 2, the old `tiny-url-cloud` keeps only the ~3 truly-orphan orgs
+from earlier generations; they never receive PRs again, so no destructive
+DB cleanup is required. (Optional: disconnect them via
+`DELETE /code-management/delete-integration-and-repositories` per org.)

--- a/scripts/e2e/provision-cloud-github-repos.sh
+++ b/scripts/e2e/provision-cloud-github-repos.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Provision the per-tenant cloud GitHub fixture repos used by the E2E
+# matrix. Each cloud GitHub PAT tenant runs on its OWN repo (1 org : 1
+# repo) so a single PR webhook never fans out across multiple Kodus orgs
+# — the root cause of the flaky "review pipeline never started" failures
+# on cloud × github cells. See tests/e2e/cli/cloud/setup-tenants.ts.
+#
+# Idempotent: a repo that already exists is left as-is unless
+# --force-content is passed, in which case its default branch is
+# re-mirrored from the base repo.
+#
+# Required env:
+#   GH_TEST_TOKEN        PAT with `repo` + repo-creation rights in the
+#                        target org (kodus-e2e). Same token the matrix uses.
+# Optional env:
+#   BASE_REPO            owner/name to mirror content from
+#                        (default: ${GH_TEST_REPO_CLOUD:-kodus-e2e/tiny-url-cloud})
+#   REPO_OWNER           org/user to create repos under (default: kodus-e2e)
+#   REPO_VISIBILITY      private | public (default: private)
+#
+# Usage:
+#   GH_TEST_TOKEN=... ./scripts/e2e/provision-cloud-github-repos.sh
+#   GH_TEST_TOKEN=... ./scripts/e2e/provision-cloud-github-repos.sh --force-content
+set -euo pipefail
+
+FORCE_CONTENT=0
+[ "${1:-}" = "--force-content" ] && FORCE_CONTENT=1
+
+: "${GH_TEST_TOKEN:?set GH_TEST_TOKEN (PAT with repo + create rights in the target org)}"
+BASE_REPO="${BASE_REPO:-${GH_TEST_REPO_CLOUD:-kodus-e2e/tiny-url-cloud}}"
+REPO_OWNER="${REPO_OWNER:-kodus-e2e}"
+REPO_VISIBILITY="${REPO_VISIBILITY:-private}"
+API="https://api.github.com"
+AUTH=(-H "Authorization: Bearer ${GH_TEST_TOKEN}" -H "Accept: application/vnd.github+json")
+
+# MUST mirror the repoFullName values in tests/e2e/cli/cloud/setup-tenants.ts
+TARGET_REPOS=(
+    "${REPO_OWNER}/tiny-url-cloud-paid"
+    "${REPO_OWNER}/tiny-url-cloud-free"
+    "${REPO_OWNER}/tiny-url-cloud-trial"
+    "${REPO_OWNER}/tiny-url-cloud-community"
+    "${REPO_OWNER}/tiny-url-cloud-stripe-free"
+    "${REPO_OWNER}/tiny-url-cloud-stripe-trial"
+)
+
+say() { printf '\033[0;34m[provision]\033[0m %s\n' "$*"; }
+ok()  { printf '\033[0;32m[ok]\033[0m        %s\n' "$*"; }
+err() { printf '\033[0;31m[err]\033[0m       %s\n' "$*" >&2; }
+
+repo_exists() {
+    local full="$1"
+    local code
+    code=$(curl -sS -o /dev/null -w '%{http_code}' "${AUTH[@]}" "${API}/repos/${full}")
+    [ "$code" = "200" ]
+}
+
+create_repo() {
+    local full="$1" owner="${1%%/*}" name="${1##*/}"
+    local priv="true"; [ "$REPO_VISIBILITY" = "public" ] && priv="false"
+    # Try org endpoint first; fall back to user endpoint if owner is the token's user.
+    local code
+    code=$(curl -sS -o /tmp/.gh_create.json -w '%{http_code}' "${AUTH[@]}" \
+        -X POST "${API}/orgs/${owner}/repos" \
+        -d "{\"name\":\"${name}\",\"private\":${priv},\"auto_init\":false,\"has_issues\":false,\"has_projects\":false,\"has_wiki\":false}")
+    if [ "$code" = "201" ]; then return 0; fi
+    code=$(curl -sS -o /tmp/.gh_create.json -w '%{http_code}' "${AUTH[@]}" \
+        -X POST "${API}/user/repos" \
+        -d "{\"name\":\"${name}\",\"private\":${priv},\"auto_init\":false}")
+    if [ "$code" = "201" ]; then return 0; fi
+    err "create ${full} failed (HTTP ${code}): $(head -c 300 /tmp/.gh_create.json)"
+    return 1
+}
+
+mirror_default_branch() {
+    # Push the BASE_REPO default branch into the target so the fixture
+    # content (the tiny-url app the scenarios diff against) is identical.
+    local target="$1"
+    local tmp
+    tmp="$(mktemp -d)"
+    git clone --quiet --bare "https://x-access-token:${GH_TEST_TOKEN}@github.com/${BASE_REPO}.git" "${tmp}/base.git"
+    git -C "${tmp}/base.git" push --quiet --mirror "https://x-access-token:${GH_TEST_TOKEN}@github.com/${target}.git" \
+        2>/dev/null || git -C "${tmp}/base.git" push --quiet \
+        "https://x-access-token:${GH_TEST_TOKEN}@github.com/${target}.git" 'HEAD'
+    rm -rf "${tmp}"
+}
+
+say "base repo (content source): ${BASE_REPO}"
+say "owner: ${REPO_OWNER} | visibility: ${REPO_VISIBILITY} | force-content: ${FORCE_CONTENT}"
+repo_exists "$BASE_REPO" || { err "base repo ${BASE_REPO} not reachable with this token"; exit 1; }
+
+created=0; mirrored=0; skipped=0
+for full in "${TARGET_REPOS[@]}"; do
+    if repo_exists "$full"; then
+        if [ "$FORCE_CONTENT" = "1" ]; then
+            say "${full} exists — re-mirroring content (--force-content)"
+            mirror_default_branch "$full"; mirrored=$((mirrored+1))
+        else
+            ok "${full} already exists — skipping"; skipped=$((skipped+1))
+        fi
+        continue
+    fi
+    say "creating ${full}"
+    create_repo "$full"
+    say "mirroring content into ${full}"
+    mirror_default_branch "$full"
+    ok "${full} ready"
+    created=$((created+1))
+done
+
+echo
+ok "done — created=${created} mirrored=${mirrored} skipped=${skipped}"
+echo "Next: re-seed tenants so each connects its dedicated repo (type:replace"
+echo "moves it off the shared repo):  yarn cloud:setup-tenants"

--- a/tests/e2e/cli/cloud/setup-tenants.ts
+++ b/tests/e2e/cli/cloud/setup-tenants.ts
@@ -65,45 +65,52 @@ interface TenantSpec {
     name: string;
     license: TenantLicense;
     provider: ProviderName;
-    repoFullName: string;
+    // Dedicated cloud fixture repo for this tenant. REQUIRED for GitHub
+    // PAT tenants and honoured only there (makeProvider forwards it to
+    // the GitHub provider via repoOverride; the other providers resolve
+    // their cloud repo from env). Optional for the rest.
+    repoFullName?: string;
 }
 
 // Tenant registry. Names can only contain letters / spaces / hyphens /
 // apostrophes (Kodus validates `^[A-Za-z\s\-']+$` server-side), so no
 // digits in the visible name.
 //
-// Repos are shared across tiers of the same provider — license tier is
-// per-org on cloud (Stripe-driven), so each tier needs its own
-// organization, but webhooks from a single repo can be disambiguated
-// by Kodus per integration (App installation id for GitHub, OAuth/PAT
-// integration uuid for GitLab/Bitbucket/Azure). One downside: the
-// `generateKodyRulesUseCase` step at finish-onboarding reads the
-// repo's PR history regardless of which org is onboarding, so the
-// rules generated for tier B can be shaped by traffic from tier A —
-// acceptable for the QA matrix where the license-attribution and
-// per-seat gates are the real signal; revisit if a scenario needs
-// strictly isolated rule histories.
+// GitHub PAT tenants get ONE REPO EACH (1 org : 1 repo). License tier is
+// per-org on cloud (Stripe-driven), so every tier is a distinct Kodus
+// org. The PAT webhook is a bare `/github/webhook` with no per-org
+// discriminator, and the backend resolves repo→org by picking the first
+// IntegrationConfig ordered by updatedAt DESC (webhook-context.service
+// .getContext / save.use-case). So if several orgs share one repo, a
+// PR's review fires for whichever org most recently touched its repo
+// config — NOT reliably the org under test — and the scenario times out
+// waiting for a review that landed on someone else (or got silently
+// dropped). Giving each tenant its own repo removes the ambiguity
+// entirely, matching what GitLab/Bitbucket/Azure already get for free
+// (one org per repo on cloud). github-app is already isolated on its
+// App-bound repo. Provision the repos with scripts/e2e/provision-cloud-
+// github-repos.sh before the first seed.
 const TENANTS: TenantSpec[] = [
     {
         email: "e2e-paid-gh@kodus.io",
         name: "Smoke Paid GitHub",
         license: "paid",
         provider: "github",
-        repoFullName: "kodus-e2e/tiny-url",
+        repoFullName: "kodus-e2e/tiny-url-cloud-paid",
     },
     {
         email: "e2e-free-gh@kodus.io",
         name: "Smoke Free GitHub",
         license: "free",
         provider: "github",
-        repoFullName: "kodus-e2e/tiny-url",
+        repoFullName: "kodus-e2e/tiny-url-cloud-free",
     },
     {
         email: "e2e-trial-gh@kodus.io",
         name: "Smoke Trial GitHub",
         license: "trial",
         provider: "github",
-        repoFullName: "kodus-e2e/tiny-url",
+        repoFullName: "kodus-e2e/tiny-url-cloud-trial",
     },
     {
         email: "e2e-paid-gl@kodus.io",
@@ -134,7 +141,7 @@ const TENANTS: TenantSpec[] = [
         name: "Smoke Community BYOK GitHub",
         license: "community-byok",
         provider: "github",
-        repoFullName: "kodus-e2e/tiny-url",
+        repoFullName: "kodus-e2e/tiny-url-cloud-community",
     },
     {
         // Stripe billing scenario — sub-flow #1 (free → paid via
@@ -149,7 +156,7 @@ const TENANTS: TenantSpec[] = [
         name: "Stripe Checkout Free GitHub",
         license: "free",
         provider: "github",
-        repoFullName: "kodus-e2e/tiny-url",
+        repoFullName: "kodus-e2e/tiny-url-cloud-stripe-free",
     },
     {
         // Stripe billing scenario — sub-flow #2 (trial → paid via
@@ -161,7 +168,7 @@ const TENANTS: TenantSpec[] = [
         name: "Stripe Checkout Trial GitHub",
         license: "trial",
         provider: "github",
-        repoFullName: "kodus-e2e/tiny-url",
+        repoFullName: "kodus-e2e/tiny-url-cloud-stripe-trial",
     },
     {
         // GitHub App (OAuth installation) variant. Needs a DEDICATED
@@ -183,6 +190,38 @@ const TENANTS: TenantSpec[] = [
         repoFullName: "kodus-e2e/tiny-url-app",
     },
 ];
+
+// Fail-fast invariant: every GitHub PAT tenant MUST have its own repo,
+// and no two may share one. This is the whole point of the 1 org : 1
+// repo fix — a regression here (a new github tenant pointed at a sibling's
+// repo, or left without `repoFullName`) silently reintroduces the
+// webhook fan-out collision. Catch it at load time, loudly, instead of
+// as a flaky "review never started" three matrix runs later.
+function validateGithubRepoIsolation(tenants: TenantSpec[]): void {
+    const seen = new Map<string, string>();
+    const problems: string[] = [];
+    for (const t of tenants) {
+        if (t.provider !== "github") continue; // github-app + others are already isolated
+        if (!t.repoFullName) {
+            problems.push(`${t.email}: github tenant has no dedicated repoFullName`);
+            continue;
+        }
+        const prior = seen.get(t.repoFullName);
+        if (prior) {
+            problems.push(
+                `${t.repoFullName} is shared by ${prior} and ${t.email} — github tenants must not share a repo`,
+            );
+        } else {
+            seen.set(t.repoFullName, t.email);
+        }
+    }
+    if (problems.length) {
+        throw new Error(
+            `[cloud-setup] github repo-isolation invariant violated:\n  - ${problems.join("\n  - ")}`,
+        );
+    }
+}
+validateGithubRepoIsolation(TENANTS);
 
 interface SavedTenant extends TenantSpec {
     password: string;
@@ -435,18 +474,23 @@ async function connectProvider(
     repoRegistered: boolean;
     onboardingFinished: boolean;
 }> {
-    // Provider PATs + repo addressing come from the same env vars the
-    // self-hosted matrix uses (GH_TEST_TOKEN / GH_TEST_REPO / GL_*,
-    // BB_*, AZ_TEST_ORG/PROJECT/REPO). All cloud tenants point at the
-    // same fixture repos as self-hosted — there's nothing per-tenant
-    // to override here. The earlier attempt to overwrite e.g.
-    // `AZ_TEST_REPO` with the full `<org>/<project>/<repo>` path broke
-    // the Azure provider because it composes the URL from the three
-    // separate env pieces and the merged string isn't a valid repo
-    // name. Leave env alone.
-    // Cloud tenant seeding uses the cloud-target repo so onboarding registers
-    // the same `*-cloud` fixture repo the cloud cells open PRs against.
-    const provider = makeProvider(tenant.provider, "cloud");
+    // Provider PATs come from the same env vars the self-hosted matrix
+    // uses (GH_TEST_TOKEN / GL_*, BB_*, AZ_TEST_ORG/PROJECT/REPO).
+    //
+    // Repo addressing: GitHub PAT tenants pin their OWN repo via
+    // `tenant.repoFullName` (1 org : 1 repo — see the registry comment),
+    // forwarded as makeProvider's repoOverride. The other providers
+    // ignore the override and resolve their cloud repo from env
+    // (GL_TEST_REPO_CLOUD etc.) — they're already 1 org : 1 repo on
+    // cloud. NB: an earlier attempt to overwrite `AZ_TEST_REPO` with the
+    // full `<org>/<project>/<repo>` path broke Azure (it composes the URL
+    // from three separate env pieces), which is exactly why the override
+    // is scoped to GitHub only and the others keep reading env.
+    const provider = makeProvider(
+        tenant.provider,
+        "cloud",
+        tenant.repoFullName,
+    );
     await registerIntegration(target, provider, session);
     // Wait for /code-management/auth-integration's async post-processing
     // to land before /repositories queries depend on it. The UI flow

--- a/tests/e2e/lib/runner.ts
+++ b/tests/e2e/lib/runner.ts
@@ -272,8 +272,18 @@ export async function runMatrix(opts: RunOptions): Promise<RunOutcome> {
     // tenant's repo and 409 its next run — visit every distinct repo,
     // not just every provider. `opts.dryRun` short-circuits.
     if (!opts.dryRun) {
-        const cloudEntries =
-            opts.target === "cloud" ? readCloudTenantsFile() : [];
+        // Index the cloud tenants by (provider, license) once so the
+        // per-cell repo lookup below is an O(1) Map.get instead of a
+        // .find() scan inside the loop.
+        const repoByProviderLicense = new Map<string, string | undefined>();
+        if (opts.target === "cloud") {
+            for (const e of readCloudTenantsFile()) {
+                repoByProviderLicense.set(
+                    `${e.provider}::${e.license}`,
+                    e.repoFullName,
+                );
+            }
+        }
         const fixtures = new Map<
             string,
             { provider: ProviderName; repo?: string }
@@ -282,11 +292,7 @@ export async function runMatrix(opts: RunOptions): Promise<RunOutcome> {
             if (c.target !== opts.target) continue;
             const repo =
                 opts.target === "cloud"
-                    ? cloudEntries.find(
-                          (e) =>
-                              e.provider === c.provider &&
-                              e.license === c.license,
-                      )?.repoFullName
+                    ? repoByProviderLicense.get(`${c.provider}::${c.license}`)
                     : undefined;
             fixtures.set(`${c.provider}::${repo ?? "default"}`, {
                 provider: c.provider,

--- a/tests/e2e/lib/runner.ts
+++ b/tests/e2e/lib/runner.ts
@@ -154,6 +154,11 @@ interface CloudTenantEntry {
     provider: ProviderName;
     organizationId?: string;
     teamId?: string;
+    // Per-tenant fixture repo persisted by setup-tenants. Drives the
+    // provider's repo for this cell so each cloud GitHub tenant runs on
+    // its own repo (1 org : 1 repo). Absent for providers that don't
+    // need isolation → falls back to the env-resolved per-target repo.
+    repoFullName?: string;
 }
 
 function readCloudTenantsFile(): CloudTenantEntry[] {
@@ -183,7 +188,12 @@ async function resolveTenantForCell(
         const match = entries.find(
             (e) => e.provider === provider && e.license === license,
         );
-        if (match) return { email: match.email, password: match.password };
+        if (match)
+            return {
+                email: match.email,
+                password: match.password,
+                repoFullName: match.repoFullName,
+            };
 
         // Legacy fallback: per-license env vars (CLOUD_TENANT_PAID_EMAIL
         // etc.). Kept so a one-off run can drive a hand-seeded tenant
@@ -257,33 +267,54 @@ export async function runMatrix(opts: RunOptions): Promise<RunOutcome> {
     // or webhook bursts on auto-closed orphans across all providers.
     // Cleaning up here makes every run start from a known-clean
     // state regardless of how the previous one ended. Deduped on
-    // provider so 4 cells × 1 provider only hit the upstream API
-    // once. `opts.dryRun` short-circuits (no upstream calls).
+    // (provider, repo): cloud GitHub tenants each own a SEPARATE repo
+    // (1 org : 1 repo), so a stale [e2e] PR can hide on a sibling
+    // tenant's repo and 409 its next run — visit every distinct repo,
+    // not just every provider. `opts.dryRun` short-circuits.
     if (!opts.dryRun) {
-        const uniqueProviders = Array.from(
-            new Set(
-                opts.cells
-                    .filter((c) => c.target === opts.target)
-                    .map((c) => c.provider),
-            ),
-        );
-        for (const providerName of uniqueProviders) {
+        const cloudEntries =
+            opts.target === "cloud" ? readCloudTenantsFile() : [];
+        const fixtures = new Map<
+            string,
+            { provider: ProviderName; repo?: string }
+        >();
+        for (const c of opts.cells) {
+            if (c.target !== opts.target) continue;
+            const repo =
+                opts.target === "cloud"
+                    ? cloudEntries.find(
+                          (e) =>
+                              e.provider === c.provider &&
+                              e.license === c.license,
+                      )?.repoFullName
+                    : undefined;
+            fixtures.set(`${c.provider}::${repo ?? "default"}`, {
+                provider: c.provider,
+                repo,
+            });
+        }
+        for (const { provider: providerName, repo } of fixtures.values()) {
+            const label = `${providerName}${repo ? ` (${repo})` : ""}`;
             try {
-                const provider = makeProvider(providerName, opts.target);
+                const provider = makeProvider(
+                    providerName,
+                    opts.target,
+                    repo,
+                );
                 const { closed } = await provider.cleanupStaleE2EArtifacts();
                 if (closed > 0) {
                     log.info(
-                        `[cleanup] ${providerName}: abandoned ${closed} stale [e2e]-prefixed PR(s) from prior runs`,
+                        `[cleanup] ${label}: abandoned ${closed} stale [e2e]-prefixed PR(s) from prior runs`,
                     );
                 }
             } catch (err) {
                 // Best-effort. Don't poison the entire matrix run just
-                // because cleanup couldn't list PRs on one provider —
+                // because cleanup couldn't list PRs on one fixture —
                 // the per-scenario open path still throws its own
                 // specific error if a stale PR ends up blocking it,
                 // and that error is what the operator sees.
                 log.info(
-                    `[cleanup] ${providerName}: skipped (${err instanceof Error ? err.message : String(err)})`,
+                    `[cleanup] ${label}: skipped (${err instanceof Error ? err.message : String(err)})`,
                 );
             }
         }
@@ -333,7 +364,11 @@ export async function runMatrix(opts: RunOptions): Promise<RunOutcome> {
             log.info(`RUN   ${cellLabel}`);
             const t0 = Date.now();
             try {
-                const provider = makeProvider(cell.provider, cell.target);
+                const provider = makeProvider(
+                    cell.provider,
+                    cell.target,
+                    tenant?.repoFullName,
+                );
                 const scenarioArtifactDir = join(
                     artifactDir,
                     `${scenario.id}-${cell.target}-${cell.provider}-${cell.license}`,

--- a/tests/e2e/lib/types.ts
+++ b/tests/e2e/lib/types.ts
@@ -178,6 +178,16 @@ export interface Provider {
 export interface TenantCredentials {
     email: string;
     password: string;
+    // Optional per-tenant fixture repo (cloud only). When set, the
+    // provider for this cell targets THIS repo instead of the
+    // env-resolved per-target default. Required for cloud GitHub PAT
+    // tenants, where each license tier is a separate Kodus org: sharing
+    // one repo across orgs makes the webhook→org resolution ambiguous
+    // (it picks the first org by updatedAt DESC), so the test's own org
+    // isn't reliably the one that reviews its PR. One repo per tenant
+    // restores the 1 org : 1 repo invariant the other providers already
+    // have. `owner/name` form, e.g. `kodus-e2e/tiny-url-cloud-paid`.
+    repoFullName?: string;
 }
 
 export interface KodusSession {

--- a/tests/e2e/providers/index.ts
+++ b/tests/e2e/providers/index.ts
@@ -8,13 +8,21 @@ import { GitLabProvider } from "./gitlab.js";
 // `target` selects the per-target fixture repo (cloud vs self-hosted) so the
 // two targets hit independent repos and can run concurrently without colliding.
 // Defaults to self-hosted, which falls back to the original `*_TEST_REPO`.
+//
+// `repoOverride` pins THIS provider to a specific `owner/name` repo,
+// taking precedence over the env-resolved per-target default. Used to
+// give each cloud GitHub PAT tenant its own repo (1 org : 1 repo), so a
+// shared repo never fans a webhook out across multiple orgs. Only the
+// GitHub PAT provider honours it; the others are already 1 org : 1 repo
+// on cloud and ignore it, and github-app is pinned to its App-bound repo.
 export function makeProvider(
     name: ProviderName,
     target: Target = "self-hosted",
+    repoOverride?: string,
 ): Provider {
     switch (name) {
         case "github":
-            return new GitHubProvider({ target });
+            return new GitHubProvider({ target, repoOverride });
         case "github-app":
             // App variant is cloud-only and pinned to its own App-bound repo
             // (GH_APP_TEST_REPO), so it's already repo-independent.

--- a/tests/e2e/provisioning/self-hosted/vm.sh
+++ b/tests/e2e/provisioning/self-hosted/vm.sh
@@ -369,13 +369,13 @@ env_set RESEND_API_KEY "${RESEND_API_KEY:-disabled-for-dev}"
 # LLM provider config — required for Kodus to actually review PRs in the
 # matrix. Caller must provide these via env (no hardcoded fallback).
 if [ -n "${API_OPEN_AI_API_KEY:-}" ]; then
-    env_set API_OPEN_AI_API_KEY "$API_OPEN_AI_API_KEY"
+    env_set API_OPEN_AI_API_KEY "${API_OPEN_AI_API_KEY:-}"
 fi
 if [ -n "${API_OPENAI_FORCE_BASE_URL:-}" ]; then
-    env_set API_OPENAI_FORCE_BASE_URL "$API_OPENAI_FORCE_BASE_URL"
+    env_set API_OPENAI_FORCE_BASE_URL "${API_OPENAI_FORCE_BASE_URL:-}"
 fi
 if [ -n "${API_LLM_PROVIDER_MODEL:-}" ]; then
-    env_set API_LLM_PROVIDER_MODEL "$API_LLM_PROVIDER_MODEL"
+    env_set API_LLM_PROVIDER_MODEL "${API_LLM_PROVIDER_MODEL:-}"
 fi
 REMOTE
 


### PR DESCRIPTION
## Problem

Cloud `github × paid` cells (`code-review-basic`, `command-review`) flake with **"review pipeline never started"** / **"0 findings"**, while the same scenarios pass on every other provider and on `github × trial` in the same run. Non-deterministic → flaky.

## Root cause (evidence-backed)

On cloud, each license tier is a **separate Kodus org**, but all GitHub **PAT** tenants shared **one** fixture repo (`tiny-url-cloud`). The PAT webhook is a bare `POST /github/webhook` with no per-org discriminator, and the backend resolves repo→org by taking the **first** `IntegrationConfig` ordered by `updatedAt DESC` (`webhook-context.service.getContext` + `pullRequests/save.use-case`). With N orgs on one repo, a PR's review fires for whichever org most recently touched its repo config — **not reliably the org under test** — or is silently dropped if none has an active automation at that instant. The scenario times out waiting for a review that landed elsewhere.

GitLab/Bitbucket/Azure never hit this: one cloud tenant each ⇒ one org per repo.

**QA evidence (2026-06-01):** a single PR #73 webhook created PR docs in **4 orgs** at once; **9 orgs** total had accumulated on `tiny-url-cloud`.

## Fix

Give every cloud GitHub PAT tenant its **own** repo (1 org : 1 repo), matching the other providers. `github-app` is already isolated on its App-bound repo.

- `providers/index.ts` — `makeProvider(name, target, repoOverride?)`; GitHub honours it, others ignore it.
- `cli/cloud/setup-tenants.ts` — dedicated `repoFullName` per github tenant; `connectProvider` forwards it; load-time `validateGithubRepoIsolation()` fails the seed if two github tenants share a repo or one lacks its own (**no silent collision**).
- `lib/runner.ts` — `CloudTenantEntry.repoFullName` read + passed to `makeProvider` at run time; pre-flight stale-PR cleanup now dedupes by `(provider, repo)`.
- `lib/types.ts` — `TenantCredentials.repoFullName`.
- `scripts/e2e/provision-cloud-github-repos.sh` + `CLOUD_GITHUB_REPO_ISOLATION.md` — one-time provisioning + rollout runbook.

## Rollout (live steps, in the runbook)

1. `GH_TEST_TOKEN=… ./scripts/e2e/provision-cloud-github-repos.sh` — create the 6 dedicated repos.
2. `yarn cloud:setup-tenants` — re-seed; `type:"replace"` moves each tenant off the shared repo onto its own.
3. `gh secret set CLOUD_TENANTS_JSON < ~/.kodus-dev/cloud-tenants.json` — CI restores tenants from this secret (it does not re-seed).
4. Re-run the cloud matrix.

## Validation

- `tests/e2e` `tsc --noEmit` clean.
- Repo-isolation invariant verified (6 unique github repos).
- Code-only PR; the repos + re-seed + secret refresh are the rollout steps above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)