### PR TITLE
fix(rbac): let repoAdmin reach Token Usage + filesystem-aware route coverage

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,7 @@ on:
             - main
         paths:
             - "apps/api/**"
+            - "apps/web/**"
             - "apps/worker/**"
             - "apps/webhooks/**"
             - "libs/**"

--- a/apps/api/src/controllers/__tests__/authorization-matrix.spec.ts
+++ b/apps/api/src/controllers/__tests__/authorization-matrix.spec.ts
@@ -1,347 +1,31 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import * as ts from 'typescript';
-
-import { STATUS } from '@libs/core/infrastructure/config/types/database/status.type';
-import {
-    Action,
-    ResourceType,
-    Role,
-} from '@libs/identity/domain/permissions/enums/permissions.enum';
-import { PermissionsAbilityFactory } from '@libs/identity/infrastructure/adapters/services/permissions/permissionsAbility.factory';
-import {
-    checkAnyPermission,
-    checkPermissions,
-    checkRepoPermissions,
-    checkRole,
-} from '@libs/identity/infrastructure/adapters/services/permissions/policy.handlers';
-import { IUser } from '@libs/identity/domain/user/interfaces/user.interface';
+import { buildMatrix, collectAllEndpoints, Verdict } from './rbac-matrix.shared';
 
 /**
  * Effective authorization matrix — the flagship RBAC regression gate.
  *
- * For EVERY gated controller endpoint, this statically extracts the policy it
- * declares (@CheckPolicies(checkPermissions/checkRepoPermissions/checkRole/...))
- * and evaluates the REAL verdict for each role using the REAL
- * PermissionsAbilityFactory + the REAL policy handlers — then snapshots the
- * whole `endpoint × role → allow/deny` grid.
+ * For EVERY gated controller endpoint, the shared extractor
+ * (rbac-matrix.shared.ts) statically pulls the declared
+ * @CheckPolicies(checkPermissions/checkRepoPermissions/checkRole/...) and
+ * evaluates the REAL verdict for each role using the REAL
+ * PermissionsAbilityFactory + the REAL policy handlers, producing the
+ * `endpoint × role → allow/deny` grid asserted here.
  *
- * Why this and not HTTP integration tests: the heavy controllers can't be
- * mounted in isolation (circular module graph), but their authorization is
- * fully determined by (declared policy) × (factory output) × (handler logic) —
- * all of which we exercise here without importing the controllers. Any change
- * to ROLE_POLICIES, a controller's decorator, or the factory shifts the
- * snapshot, so the reviewer sees exactly which cells changed.
+ * The SAME extractor feeds rbac-matrix.manifest.json, which the full-stack e2e
+ * (tests/e2e/scenarios/rbac-authorization.ts) replays against a running API —
+ * so this static grid and the live test can never disagree about the matrix.
+ *
+ * Why static (not HTTP) here: the heavy controllers can't be mounted in
+ * isolation (circular module graph), but their authorization is fully
+ * determined by (declared policy) × (factory output) × (handler logic) — all
+ * exercised here without importing the controllers.
  */
 
-const CONTROLLERS_DIR = path.resolve(__dirname, '..');
-const ASSIGNED_REPO = 'repo-assigned';
-
-const HTTP_DECORATORS = new Set([
-    'Get',
-    'Post',
-    'Put',
-    'Patch',
-    'Delete',
-    'All',
-    'Head',
-    'Options',
-    'Sse',
-]);
-
-type HandlerSpec =
-    | { kind: 'permissions'; action: string; resource: string }
-    | { kind: 'repoPermissions'; action: string; resource: string }
-    | { kind: 'role'; role: string }
-    | {
-          kind: 'anyPermission';
-          pairs: Array<{ action: string; resource: string }>;
-      }
-    | { kind: 'unknown'; text: string };
-
-type Endpoint = {
-    key: string; // `<file>#<method>`
-    specs: HandlerSpec[];
-};
-
-function listControllerFiles(dir: string): string[] {
-    const out: string[] = [];
-    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-        const full = path.join(dir, entry.name);
-        if (entry.isDirectory()) {
-            if (entry.name === '__tests__') continue;
-            out.push(...listControllerFiles(full));
-        } else if (
-            entry.name.endsWith('.controller.ts') &&
-            !entry.name.endsWith('.spec.ts')
-        ) {
-            out.push(full);
-        }
-    }
-    return out;
-}
-
-// Resolve `Action.Read` / `ResourceType.Foo` member-access into the runtime
-// value, returning the member name (we only need it for the snapshot label).
-function memberName(node: ts.Node, source: ts.SourceFile): string {
-    if (ts.isPropertyAccessExpression(node)) return node.name.getText(source);
-    return node.getText(source);
-}
-
-function parseObjectArg(
-    obj: ts.ObjectLiteralExpression,
-    source: ts.SourceFile,
-): Record<string, string> {
-    const out: Record<string, string> = {};
-    for (const prop of obj.properties) {
-        if (ts.isPropertyAssignment(prop)) {
-            out[prop.name.getText(source)] = memberName(
-                prop.initializer,
-                source,
-            );
-        }
-    }
-    return out;
-}
-
-function specFromCall(call: ts.CallExpression, source: ts.SourceFile): HandlerSpec {
-    const name = call.expression.getText(source);
-    const arg0 = call.arguments[0];
-
-    if (name === 'checkPermissions' && arg0 && ts.isObjectLiteralExpression(arg0)) {
-        const o = parseObjectArg(arg0, source);
-        return { kind: 'permissions', action: o.action, resource: o.resource };
-    }
-    if (
-        name === 'checkRepoPermissions' &&
-        arg0 &&
-        ts.isObjectLiteralExpression(arg0)
-    ) {
-        const o = parseObjectArg(arg0, source);
-        return {
-            kind: 'repoPermissions',
-            action: o.action,
-            resource: o.resource,
-        };
-    }
-    if (name === 'checkRole' && arg0 && ts.isObjectLiteralExpression(arg0)) {
-        const o = parseObjectArg(arg0, source);
-        return { kind: 'role', role: o.role };
-    }
-    if (name === 'checkAnyPermission' && arg0 && ts.isArrayLiteralExpression(arg0)) {
-        const pairs = arg0.elements
-            .filter(ts.isObjectLiteralExpression)
-            .map((el) => {
-                const o = parseObjectArg(el, source);
-                return { action: o.action, resource: o.resource };
-            });
-        return { kind: 'anyPermission', pairs };
-    }
-    return { kind: 'unknown', text: call.getText(source).slice(0, 60) };
-}
-
-// Map local `const X = checkPermissions({...})` so identifier args resolve.
-function localConstSpecs(
-    source: ts.SourceFile,
-): Map<string, HandlerSpec> {
-    const map = new Map<string, HandlerSpec>();
-    const visit = (node: ts.Node) => {
-        if (
-            ts.isVariableDeclaration(node) &&
-            node.initializer &&
-            ts.isCallExpression(node.initializer) &&
-            ts.isIdentifier(node.name)
-        ) {
-            map.set(node.name.text, specFromCall(node.initializer, source));
-        }
-        ts.forEachChild(node, visit);
-    };
-    visit(source);
-    return map;
-}
-
-function checkPoliciesSpecs(
-    decorators: readonly ts.Decorator[] | undefined,
-    source: ts.SourceFile,
-    consts: Map<string, HandlerSpec>,
-): HandlerSpec[] | null {
-    if (!decorators) return null;
-    for (const dec of decorators) {
-        if (!ts.isCallExpression(dec.expression)) continue;
-        if (dec.expression.expression.getText(source) !== 'CheckPolicies')
-            continue;
-        return dec.expression.arguments.map((arg) => {
-            if (ts.isCallExpression(arg)) return specFromCall(arg, source);
-            if (ts.isIdentifier(arg))
-                return (
-                    consts.get(arg.text) ?? {
-                        kind: 'unknown',
-                        text: arg.text,
-                    }
-                );
-            return { kind: 'unknown', text: arg.getText(source).slice(0, 60) };
-        });
-    }
-    return null;
-}
-
-function collectEndpoints(file: string): Endpoint[] {
-    const text = fs.readFileSync(file, 'utf8');
-    const source = ts.createSourceFile(file, text, ts.ScriptTarget.Latest, true);
-    const consts = localConstSpecs(source);
-    const relFile = path.basename(file);
-    const endpoints: Endpoint[] = [];
-
-    const visit = (node: ts.Node) => {
-        if (ts.isClassDeclaration(node)) {
-            const classSpecs = checkPoliciesSpecs(
-                ts.getDecorators(node),
-                source,
-                consts,
-            );
-            for (const member of node.members) {
-                if (!ts.isMethodDeclaration(member)) continue;
-                const decs = ts.getDecorators(member) ?? [];
-                const isHttp = decs.some(
-                    (d) =>
-                        ts.isCallExpression(d.expression) &&
-                        HTTP_DECORATORS.has(
-                            d.expression.expression.getText(source),
-                        ),
-                );
-                if (!isHttp) continue;
-
-                // method-level @CheckPolicies overrides class-level
-                const specs =
-                    checkPoliciesSpecs(ts.getDecorators(member), source, consts) ??
-                    classSpecs;
-                if (!specs) continue; // ungated (covered by endpoint-authorization.spec)
-
-                endpoints.push({
-                    key: `${relFile}#${member.name.getText(source)}`,
-                    specs,
-                });
-            }
-        }
-        ts.forEachChild(node, visit);
-    };
-    visit(source);
-    return endpoints;
-}
-
-const fakeReq = (role: Role) => ({
-    user: {
-        uuid: `user-${role}`,
-        role,
-        status: STATUS.ACTIVE,
-        organization: { uuid: 'org-1' },
-    },
-    params: {},
-    query: {},
-    body: {},
-});
-
-async function evaluate(
-    spec: HandlerSpec,
-    ability: any,
-    role: Role,
-): Promise<boolean> {
-    const req = fakeReq(role);
-    switch (spec.kind) {
-        case 'permissions':
-            return checkPermissions({
-                action: (Action as any)[spec.action],
-                resource: (ResourceType as any)[spec.resource],
-            })(ability, req as any) as boolean;
-        case 'repoPermissions':
-            return checkRepoPermissions({
-                action: (Action as any)[spec.action],
-                resource: (ResourceType as any)[spec.resource],
-                repo: { custom: ASSIGNED_REPO },
-            })(ability, req as any) as boolean;
-        case 'role':
-            return checkRole({ role: (Role as any)[spec.role] })(
-                ability,
-                req as any,
-            ) as boolean;
-        case 'anyPermission':
-            return checkAnyPermission(
-                spec.pairs.map((p) => ({
-                    action: (Action as any)[p.action],
-                    resource: (ResourceType as any)[p.resource],
-                })),
-            )(ability, req as any) as boolean;
-        default:
-            // Unknown handler shape — surface it instead of silently passing.
-            return false;
-    }
-}
-
 describe('authorization matrix (effective policy × role)', () => {
-    const factory = new PermissionsAbilityFactory({
-        findOne: async () => ({
-            permissions: { assignedRepositoryIds: [ASSIGNED_REPO] },
-        }),
-    } as any);
-
-    const roles = [
-        Role.OWNER,
-        Role.BILLING_MANAGER,
-        Role.REPO_ADMIN,
-        Role.CONTRIBUTOR,
-    ];
-
-    // Builds the effective `endpoint -> { role: 'allow'|'deny' }` grid by
-    // evaluating each endpoint's declared policy against the REAL factory +
-    // REAL policy handlers, for every role.
-    const buildMatrix = async (): Promise<
-        Record<string, Record<string, string>>
-    > => {
-        const abilities = new Map<Role, any>();
-        for (const role of roles) {
-            abilities.set(
-                role,
-                await factory.createForUser(
-                    {
-                        uuid: `u-${role}`,
-                        role,
-                        organization: { uuid: 'org-1' },
-                    } as unknown as IUser,
-                    [ASSIGNED_REPO],
-                ),
-            );
-        }
-
-        const endpoints = listControllerFiles(CONTROLLERS_DIR).flatMap(
-            collectEndpoints,
-        );
-        // Guard against a parser regression silently emptying the matrix.
-        expect(endpoints.length).toBeGreaterThan(30);
-
-        const matrix: Record<string, Record<string, string>> = {};
-        for (const ep of endpoints) {
-            const row: Record<string, string> = {};
-            for (const role of roles) {
-                const ability = abilities.get(role);
-                let allow = true; // AND across multiple @CheckPolicies handlers
-                for (const spec of ep.specs) {
-                    if (!(await evaluate(spec, ability, role))) {
-                        allow = false;
-                        break;
-                    }
-                }
-                row[role] = allow ? 'allow' : 'deny';
-            }
-            matrix[ep.key] = row;
-        }
-        return matrix;
-    };
-
     // Expected verdict for every gated endpoint of a controller, asserted
     // across ALL of that controller's gated endpoints (robust to method
     // renames; a new endpoint with the wrong gate fails here).
     const expectController = (
-        matrix: Record<string, Record<string, string>>,
+        matrix: Record<string, Record<string, Verdict>>,
         filePrefix: string,
         expected: Record<string, string>,
     ) => {
@@ -364,6 +48,9 @@ describe('authorization matrix (effective policy × role)', () => {
 
     it('enforces the expected verdicts for the key RBAC resources', async () => {
         const matrix = await buildMatrix();
+
+        // Guard against a parser regression silently emptying the matrix.
+        expect(Object.keys(matrix).length).toBeGreaterThan(30);
 
         // Bug A: BYOK delete is Owner-only (was reachable by anyone).
         expect(
@@ -399,13 +86,11 @@ describe('authorization matrix (effective policy × role)', () => {
     });
 
     it('every gated endpoint resolved to a known handler shape', () => {
-        const unknown = listControllerFiles(CONTROLLERS_DIR)
-            .flatMap(collectEndpoints)
-            .flatMap((ep) =>
-                ep.specs
-                    .filter((s) => s.kind === 'unknown')
-                    .map((s) => `${ep.key}: ${(s as any).text}`),
-            );
+        const unknown = collectAllEndpoints().flatMap((ep) =>
+            ep.specs
+                .filter((s) => s.kind === 'unknown')
+                .map((s) => `${ep.key}: ${(s as any).text}`),
+        );
         expect(unknown).toEqual([]);
     });
 });

--- a/apps/api/src/controllers/__tests__/rbac-matrix.manifest.json
+++ b/apps/api/src/controllers/__tests__/rbac-matrix.manifest.json
@@ -1421,7 +1421,7 @@
   {
     "key": "tokenUsage.controller.ts#getCostEstimate",
     "httpMethod": "GET",
-    "urlPath": "/'usage'/cost-estimate",
+    "urlPath": "/usage/cost-estimate",
     "expected": {
       "owner": "allow",
       "billing_manager": "allow",
@@ -1432,7 +1432,7 @@
   {
     "key": "tokenUsage.controller.ts#getDaily",
     "httpMethod": "GET",
-    "urlPath": "/'usage'/tokens/daily",
+    "urlPath": "/usage/tokens/daily",
     "expected": {
       "owner": "allow",
       "billing_manager": "allow",
@@ -1443,7 +1443,7 @@
   {
     "key": "tokenUsage.controller.ts#getDailyByDeveloper",
     "httpMethod": "GET",
-    "urlPath": "/'usage'/tokens/daily-by-developer",
+    "urlPath": "/usage/tokens/daily-by-developer",
     "expected": {
       "owner": "allow",
       "billing_manager": "allow",
@@ -1454,7 +1454,7 @@
   {
     "key": "tokenUsage.controller.ts#getDailyUsageByPr",
     "httpMethod": "GET",
-    "urlPath": "/'usage'/tokens/daily-by-pr",
+    "urlPath": "/usage/tokens/daily-by-pr",
     "expected": {
       "owner": "allow",
       "billing_manager": "allow",
@@ -1465,7 +1465,7 @@
   {
     "key": "tokenUsage.controller.ts#getPricing",
     "httpMethod": "GET",
-    "urlPath": "/'usage'/tokens/pricing",
+    "urlPath": "/usage/tokens/pricing",
     "expected": {
       "owner": "allow",
       "billing_manager": "allow",
@@ -1476,7 +1476,7 @@
   {
     "key": "tokenUsage.controller.ts#getSummary",
     "httpMethod": "GET",
-    "urlPath": "/'usage'/tokens/summary",
+    "urlPath": "/usage/tokens/summary",
     "expected": {
       "owner": "allow",
       "billing_manager": "allow",
@@ -1487,7 +1487,7 @@
   {
     "key": "tokenUsage.controller.ts#getUsageByDeveloper",
     "httpMethod": "GET",
-    "urlPath": "/'usage'/tokens/by-developer",
+    "urlPath": "/usage/tokens/by-developer",
     "expected": {
       "owner": "allow",
       "billing_manager": "allow",
@@ -1498,7 +1498,7 @@
   {
     "key": "tokenUsage.controller.ts#getUsageByPr",
     "httpMethod": "GET",
-    "urlPath": "/'usage'/tokens/by-pr",
+    "urlPath": "/usage/tokens/by-pr",
     "expected": {
       "owner": "allow",
       "billing_manager": "allow",

--- a/apps/api/src/controllers/__tests__/rbac-matrix.manifest.json
+++ b/apps/api/src/controllers/__tests__/rbac-matrix.manifest.json
@@ -1,0 +1,1564 @@
+[
+  {
+    "key": "cli-reviews.controller.ts#detail",
+    "httpMethod": "GET",
+    "urlPath": "/cli-reviews/:executionUuid",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "cli-reviews.controller.ts#list",
+    "httpMethod": "GET",
+    "urlPath": "/cli-reviews/executions",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "cockpit.controller.ts#bugRatioChart",
+    "httpMethod": "GET",
+    "urlPath": "/code-health/charts/bug-ratio",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "cockpit.controller.ts#bugRatioHighlight",
+    "httpMethod": "GET",
+    "urlPath": "/code-health/highlights/bug-ratio",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "cockpit.controller.ts#companyDashboard",
+    "httpMethod": "GET",
+    "urlPath": "/productivity/dashboard/company",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "cockpit.controller.ts#deployFrequencyChart",
+    "httpMethod": "GET",
+    "urlPath": "/productivity/charts/deploy-frequency",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "cockpit.controller.ts#deployFrequencyHighlight",
+    "httpMethod": "GET",
+    "urlPath": "/productivity/highlights/deploy-frequency",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "cockpit.controller.ts#developerActivity",
+    "httpMethod": "GET",
+    "urlPath": "/productivity/charts/developer-activity",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "cockpit.controller.ts#implementationRate",
+    "httpMethod": "GET",
+    "urlPath": "/code-health/highlights/suggestions-implementation-rate",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "cockpit.controller.ts#leadTimeBreakdown",
+    "httpMethod": "GET",
+    "urlPath": "/productivity/charts/lead-time-breakdown",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "cockpit.controller.ts#leadTimeChart",
+    "httpMethod": "GET",
+    "urlPath": "/productivity/charts/lead-time-for-change",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "cockpit.controller.ts#leadTimeHighlight",
+    "httpMethod": "GET",
+    "urlPath": "/productivity/highlights/lead-time-for-change",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "cockpit.controller.ts#prSizeChart",
+    "httpMethod": "GET",
+    "urlPath": "/productivity/charts/pr-size",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "cockpit.controller.ts#prSizeHighlight",
+    "httpMethod": "GET",
+    "urlPath": "/productivity/highlights/pr-size",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "cockpit.controller.ts#pullRequestsByDeveloper",
+    "httpMethod": "GET",
+    "urlPath": "/productivity/charts/pull-requests-by-developer",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "cockpit.controller.ts#pullRequestsOpenedVsClosed",
+    "httpMethod": "GET",
+    "urlPath": "/productivity/charts/pull-requests-opened-vs-closed",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "cockpit.controller.ts#suggestionsByCategory",
+    "httpMethod": "GET",
+    "urlPath": "/code-health/charts/suggestions-by-category",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "cockpit.controller.ts#suggestionsByRepository",
+    "httpMethod": "GET",
+    "urlPath": "/code-health/charts/suggestions-by-repository",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "cockpit.controller.ts#validate",
+    "httpMethod": "GET",
+    "urlPath": "/cockpit/validate",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "codeManagement.controller.ts#authIntegrationToken",
+    "httpMethod": "POST",
+    "urlPath": "/code-management/auth-integration",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "codeManagement.controller.ts#createRepositories",
+    "httpMethod": "POST",
+    "urlPath": "/code-management/repositories",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "codeManagement.controller.ts#deleteIntegration",
+    "httpMethod": "DELETE",
+    "urlPath": "/code-management/delete-integration",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "codeManagement.controller.ts#deleteIntegrationAndRepositories",
+    "httpMethod": "DELETE",
+    "urlPath": "/code-management/delete-integration-and-repositories",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "codeManagement.controller.ts#getCurrentUser",
+    "httpMethod": "GET",
+    "urlPath": "/code-management/current-user",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "codeManagement.controller.ts#getOrganizationMembers",
+    "httpMethod": "GET",
+    "urlPath": "/code-management/organization-members",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "codeManagement.controller.ts#getPRs",
+    "httpMethod": "GET",
+    "urlPath": "/code-management/get-prs",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "codeManagement.controller.ts#getPRsByRepo",
+    "httpMethod": "GET",
+    "urlPath": "/code-management/get-prs-repo",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "codeManagement.controller.ts#getRepositories",
+    "httpMethod": "GET",
+    "urlPath": "/code-management/repositories/org",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "codeManagement.controller.ts#getRepositoryTreeByDirectory",
+    "httpMethod": "GET",
+    "urlPath": "/code-management/get-repository-tree-by-directory",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "codeManagement.controller.ts#getSelectedRepositories",
+    "httpMethod": "GET",
+    "urlPath": "/code-management/repositories/selected",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "codeManagement.controller.ts#onboardingReviewPR",
+    "httpMethod": "POST",
+    "urlPath": "/code-management/finish-onboarding",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "codeManagement.controller.ts#refreshOrganizationMembers",
+    "httpMethod": "POST",
+    "urlPath": "/code-management/organization-members/refresh",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "codeManagement.controller.ts#searchUsers",
+    "httpMethod": "GET",
+    "urlPath": "/code-management/search-users",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "codeReviewSettingLog.controller.ts#findCodeReviewSettingsLogs",
+    "httpMethod": "GET",
+    "urlPath": "/user-log/code-review-settings",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "dryRun.controller.ts#events",
+    "httpMethod": "SSE",
+    "urlPath": "/dry-run/events/:correlationId",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "dryRun.controller.ts#execute",
+    "httpMethod": "POST",
+    "urlPath": "/dry-run/execute",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "dryRun.controller.ts#getDryRun",
+    "httpMethod": "GET",
+    "urlPath": "/dry-run/:correlationId",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "dryRun.controller.ts#listDryRuns",
+    "httpMethod": "GET",
+    "urlPath": "/dry-run",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "dryRun.controller.ts#status",
+    "httpMethod": "GET",
+    "urlPath": "/dry-run/status/:correlationId",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "integration.controller.ts#checkHasConnectionByPlatform",
+    "httpMethod": "GET",
+    "urlPath": "/integration/check-connection-platform",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "integration.controller.ts#cloneIntegration",
+    "httpMethod": "POST",
+    "urlPath": "/integration/clone-integration",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "integration.controller.ts#getConnections",
+    "httpMethod": "GET",
+    "urlPath": "/integration/connections",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "integration.controller.ts#getOrganizationId",
+    "httpMethod": "GET",
+    "urlPath": "/integration/organization-id",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "integrationConfig.controller.ts#getIntegrationConfigsByIntegrationCategory",
+    "httpMethod": "GET",
+    "urlPath": "/integration-config/get-integration-configs-by-integration-category",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "issues.controller.ts#countIssues",
+    "httpMethod": "GET",
+    "urlPath": "/issues/count",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "issues.controller.ts#getIssueById",
+    "httpMethod": "GET",
+    "urlPath": "/issues/:id",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "issues.controller.ts#getIssues",
+    "httpMethod": "GET",
+    "urlPath": "/issues",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "issues.controller.ts#updateIssueProperty",
+    "httpMethod": "PATCH",
+    "urlPath": "/issues/:id",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "kodyRules.controller.ts#addLibraryKodyRules",
+    "httpMethod": "POST",
+    "urlPath": "/kody-rules/add-library-kody-rules",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "kodyRules.controller.ts#applyPendingKodyRules",
+    "httpMethod": "POST",
+    "urlPath": "/kody-rules/pending/apply",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "kodyRules.controller.ts#changeStatusKodyRules",
+    "httpMethod": "POST",
+    "urlPath": "/kody-rules/change-status-kody-rules",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "kodyRules.controller.ts#checkSyncStatus",
+    "httpMethod": "GET",
+    "urlPath": "/kody-rules/check-sync-status",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "kodyRules.controller.ts#convertPendingUpdatesToNewMemories",
+    "httpMethod": "POST",
+    "urlPath": "/kody-rules/pending/convert-updates-to-memories",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "kodyRules.controller.ts#countImportedRules",
+    "httpMethod": "GET",
+    "urlPath": "/kody-rules/imported/count",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "kodyRules.controller.ts#countRulesByRepository",
+    "httpMethod": "GET",
+    "urlPath": "/kody-rules/counts-by-repository",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "kodyRules.controller.ts#create",
+    "httpMethod": "POST",
+    "urlPath": "/kody-rules/create-or-update",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "kodyRules.controller.ts#deleteRuleInOrganizationById",
+    "httpMethod": "DELETE",
+    "urlPath": "/kody-rules/delete-rule-in-organization-by-id",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "kodyRules.controller.ts#discardPendingKodyRules",
+    "httpMethod": "POST",
+    "urlPath": "/kody-rules/pending/discard",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "kodyRules.controller.ts#fastSyncIdeRules",
+    "httpMethod": "POST",
+    "urlPath": "/kody-rules/fast-sync-ide-rules",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "kodyRules.controller.ts#findByOrganizationId",
+    "httpMethod": "GET",
+    "urlPath": "/kody-rules/find-by-organization-id",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "kodyRules.controller.ts#findRecommendedKodyRules",
+    "httpMethod": "GET",
+    "urlPath": "/kody-rules/find-recommended-kody-rules",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "kodyRules.controller.ts#findRulesInOrganizationByFilter",
+    "httpMethod": "GET",
+    "urlPath": "/kody-rules/find-rules-in-organization-by-filter",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "kodyRules.controller.ts#findSuggestionsByRule",
+    "httpMethod": "GET",
+    "urlPath": "/kody-rules/suggestions",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "kodyRules.controller.ts#generateKodyRules",
+    "httpMethod": "POST",
+    "urlPath": "/kody-rules/generate-kody-rules",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "kodyRules.controller.ts#getInheritedRules",
+    "httpMethod": "GET",
+    "urlPath": "/kody-rules/inherited-rules",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "kodyRules.controller.ts#getRulesLimitStatus",
+    "httpMethod": "GET",
+    "urlPath": "/kody-rules/limits",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "kodyRules.controller.ts#importFastIdeRules",
+    "httpMethod": "POST",
+    "urlPath": "/kody-rules/import-fast-ide-rules",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "kodyRules.controller.ts#listPendingIdeRules",
+    "httpMethod": "GET",
+    "urlPath": "/kody-rules/pending-ide-rules",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "kodyRules.controller.ts#manageImportedRules",
+    "httpMethod": "POST",
+    "urlPath": "/kody-rules/imported/manage",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "kodyRules.controller.ts#resyncIdeRules",
+    "httpMethod": "POST",
+    "urlPath": "/kody-rules/resync-ide-rules",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "kodyRules.controller.ts#reviewFastIdeRules",
+    "httpMethod": "POST",
+    "urlPath": "/kody-rules/review-fast-ide-rules",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "kodyRules.controller.ts#syncIdeRules",
+    "httpMethod": "POST",
+    "urlPath": "/kody-rules/sync-ide-rules",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "license.controller.ts#activate",
+    "httpMethod": "POST",
+    "urlPath": "/license/activate",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "license.controller.ts#assignOrUnassign",
+    "httpMethod": "POST",
+    "urlPath": "/license/assign",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "license.controller.ts#status",
+    "httpMethod": "GET",
+    "urlPath": "/license/status",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "license.controller.ts#usersWithLicense",
+    "httpMethod": "GET",
+    "urlPath": "/license/users",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "notification.controller.ts#getRoutingRules",
+    "httpMethod": "GET",
+    "urlPath": "/notifications/routing-rules",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "notification.controller.ts#resetRoutingRules",
+    "httpMethod": "POST",
+    "urlPath": "/notifications/routing-rules/reset",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "notification.controller.ts#upsertRoutingRules",
+    "httpMethod": "PUT",
+    "urlPath": "/notifications/routing-rules",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "organization.controller.ts#updateInfoOrganizationAndPhone",
+    "httpMethod": "PATCH",
+    "urlPath": "/organization/update-infos",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "organizationParameters.controller.ts#createOrUpdate",
+    "httpMethod": "POST",
+    "urlPath": "/organization-parameters/create-or-update",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "organizationParameters.controller.ts#deleteByokConfig",
+    "httpMethod": "DELETE",
+    "urlPath": "/organization-parameters/delete-byok-config",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "organizationParameters.controller.ts#findByKey",
+    "httpMethod": "GET",
+    "urlPath": "/organization-parameters/find-by-key",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "organizationParameters.controller.ts#getCockpitMetricsVisibility",
+    "httpMethod": "GET",
+    "urlPath": "/organization-parameters/cockpit-metrics-visibility",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "organizationParameters.controller.ts#getLLMConfigStatus",
+    "httpMethod": "GET",
+    "urlPath": "/organization-parameters/llm-config/status",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "organizationParameters.controller.ts#ignoreBots",
+    "httpMethod": "POST",
+    "urlPath": "/organization-parameters/ignore-bots",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "organizationParameters.controller.ts#testByokConnection",
+    "httpMethod": "POST",
+    "urlPath": "/organization-parameters/test-byok",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "organizationParameters.controller.ts#updateAutoLicenseAllowedUsers",
+    "httpMethod": "POST",
+    "urlPath": "/organization-parameters/auto-license/allowed-users",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "organizationParameters.controller.ts#updateCockpitMetricsVisibility",
+    "httpMethod": "POST",
+    "urlPath": "/organization-parameters/cockpit-metrics-visibility",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "parameters.controller.ts#applyCodeReviewPreset",
+    "httpMethod": "POST",
+    "urlPath": "/parameters/apply-code-review-preset",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "parameters.controller.ts#createOrUpdate",
+    "httpMethod": "POST",
+    "urlPath": "/parameters/create-or-update",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "parameters.controller.ts#deleteRepositoryCodeReviewParameter",
+    "httpMethod": "POST",
+    "urlPath": "/parameters/delete-repository-code-review-parameter",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "parameters.controller.ts#downloadCentralizedConfig",
+    "httpMethod": "GET",
+    "urlPath": "/parameters/centralized-config-download",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "parameters.controller.ts#findByKey",
+    "httpMethod": "GET",
+    "urlPath": "/parameters/find-by-key",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "parameters.controller.ts#GenerateKodusConfigFile",
+    "httpMethod": "GET",
+    "urlPath": "/parameters/generate-kodus-config-file",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "parameters.controller.ts#getCodeReviewParameter",
+    "httpMethod": "GET",
+    "urlPath": "/parameters/code-review-parameter",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "parameters.controller.ts#getDefaultConfig",
+    "httpMethod": "GET",
+    "urlPath": "/parameters/default-code-review-parameter",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "parameters.controller.ts#getE2BIpAddress",
+    "httpMethod": "GET",
+    "urlPath": "/parameters/e2b-ip",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "parameters.controller.ts#initializeCentralizedConfig",
+    "httpMethod": "POST",
+    "urlPath": "/parameters/centralized-config-init",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "parameters.controller.ts#listCodeReviewAutomationLabels",
+    "httpMethod": "GET",
+    "urlPath": "/parameters/list-code-review-automation-labels",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "parameters.controller.ts#previewPrSummary",
+    "httpMethod": "POST",
+    "urlPath": "/parameters/preview-pr-summary",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "parameters.controller.ts#syncCentralizedConfig",
+    "httpMethod": "POST",
+    "urlPath": "/parameters/centralized-config-sync",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "parameters.controller.ts#UpdateCodeReviewParameterRepositories",
+    "httpMethod": "POST",
+    "urlPath": "/parameters/update-code-review-parameter-repositories",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "parameters.controller.ts#updateOrCreateCodeReviewParameter",
+    "httpMethod": "POST",
+    "urlPath": "/parameters/create-or-update-code-review",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "permissions.controller.ts#assignRepos",
+    "httpMethod": "POST",
+    "urlPath": "/permissions/assign-repos",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "pullRequest.controller.ts#backfillHistoricalPRs",
+    "httpMethod": "POST",
+    "urlPath": "/pull-requests/backfill",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "pullRequest.controller.ts#executionEvents",
+    "httpMethod": "SSE",
+    "urlPath": "/pull-requests/executions/events",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "pullRequest.controller.ts#getOnboardingSignals",
+    "httpMethod": "GET",
+    "urlPath": "/pull-requests/onboarding-signals",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "pullRequest.controller.ts#getPullRequestExecutions",
+    "httpMethod": "GET",
+    "urlPath": "/pull-requests/executions",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "pullRequest.controller.ts#getPullRequestFiles",
+    "httpMethod": "GET",
+    "urlPath": "/pull-requests/files",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "pullRequestMessages.controller.ts#createOrUpdatePullRequestMessages",
+    "httpMethod": "POST",
+    "urlPath": "/pull-request-messages",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "pullRequestMessages.controller.ts#findByRepoOrDirectoryId",
+    "httpMethod": "GET",
+    "urlPath": "/pull-request-messages/find-by-repository-or-directory",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "pullRequestMessages.controller.ts#findOverrideCountsByRepository",
+    "httpMethod": "GET",
+    "urlPath": "/pull-request-messages/override-counts-by-repository",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "skills.controller.ts#getInstructions",
+    "httpMethod": "GET",
+    "urlPath": "/skills/:skillName/instructions",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "skills.controller.ts#getSkillMeta",
+    "httpMethod": "GET",
+    "urlPath": "/skills/:skillName/meta",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "ssoConfig.controller.ts#confirmDomainVerification",
+    "httpMethod": "POST",
+    "urlPath": "/sso-config/domain-verification/confirm",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "ssoConfig.controller.ts#createOrUpdate",
+    "httpMethod": "POST",
+    "urlPath": "/sso-config",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "ssoConfig.controller.ts#getConnectionTestResult",
+    "httpMethod": "GET",
+    "urlPath": "/sso-config/test/result",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "ssoConfig.controller.ts#getDomainVerificationStatus",
+    "httpMethod": "POST",
+    "urlPath": "/sso-config/domain-verification/status",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "ssoConfig.controller.ts#getSSOConfigs",
+    "httpMethod": "GET",
+    "urlPath": "/sso-config",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "ssoConfig.controller.ts#requestDomainVerification",
+    "httpMethod": "POST",
+    "urlPath": "/sso-config/domain-verification/request",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "ssoConfig.controller.ts#startConnectionTest",
+    "httpMethod": "POST",
+    "urlPath": "/sso-config/test/start",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "team-cli-key.controller.ts#generateKey",
+    "httpMethod": "POST",
+    "urlPath": "/teams/:teamId/cli-keys",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "team-cli-key.controller.ts#listKeys",
+    "httpMethod": "GET",
+    "urlPath": "/teams/:teamId/cli-keys",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "team-cli-key.controller.ts#revokeKey",
+    "httpMethod": "DELETE",
+    "urlPath": "/teams/:teamId/cli-keys/:keyId",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "team-cli-key.controller.ts#updateKeyConfig",
+    "httpMethod": "PATCH",
+    "urlPath": "/teams/:teamId/cli-keys/:keyId/config",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "teamMembers.controller.ts#createOrUpdateTeamMembers",
+    "httpMethod": "POST",
+    "urlPath": "/team-members",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "teamMembers.controller.ts#deleteTeamMember",
+    "httpMethod": "DELETE",
+    "urlPath": "/team-members/:uuid",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "teamMembers.controller.ts#getTeamMembers",
+    "httpMethod": "GET",
+    "urlPath": "/team-members",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "tokenUsage.controller.ts#getCostEstimate",
+    "httpMethod": "GET",
+    "urlPath": "/'usage'/cost-estimate",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "tokenUsage.controller.ts#getDaily",
+    "httpMethod": "GET",
+    "urlPath": "/'usage'/tokens/daily",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "tokenUsage.controller.ts#getDailyByDeveloper",
+    "httpMethod": "GET",
+    "urlPath": "/'usage'/tokens/daily-by-developer",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "tokenUsage.controller.ts#getDailyUsageByPr",
+    "httpMethod": "GET",
+    "urlPath": "/'usage'/tokens/daily-by-pr",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "tokenUsage.controller.ts#getPricing",
+    "httpMethod": "GET",
+    "urlPath": "/'usage'/tokens/pricing",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "tokenUsage.controller.ts#getSummary",
+    "httpMethod": "GET",
+    "urlPath": "/'usage'/tokens/summary",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "tokenUsage.controller.ts#getUsageByDeveloper",
+    "httpMethod": "GET",
+    "urlPath": "/'usage'/tokens/by-developer",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "tokenUsage.controller.ts#getUsageByPr",
+    "httpMethod": "GET",
+    "urlPath": "/'usage'/tokens/by-pr",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "user.controller.ts#joinOrganization",
+    "httpMethod": "POST",
+    "urlPath": "/user/join-organization",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "user.controller.ts#updateAnother",
+    "httpMethod": "PATCH",
+    "urlPath": "/user/:targetUserId",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "workflow-queue.controller.ts#getJobDetail",
+    "httpMethod": "GET",
+    "urlPath": "/workflow-queue/jobs/:jobId/detail",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "workflow-queue.controller.ts#getJobStatus",
+    "httpMethod": "GET",
+    "urlPath": "/workflow-queue/jobs/:jobId",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "key": "workflow-queue.controller.ts#getMetrics",
+    "httpMethod": "GET",
+    "urlPath": "/workflow-queue/metrics",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  }
+]

--- a/apps/api/src/controllers/__tests__/rbac-matrix.manifest.spec.ts
+++ b/apps/api/src/controllers/__tests__/rbac-matrix.manifest.spec.ts
@@ -1,0 +1,40 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { buildManifest } from './rbac-matrix.shared';
+
+/**
+ * Drift guard for the RBAC manifest the full-stack e2e replays.
+ *
+ * `rbac-matrix.manifest.json` is the committed snapshot of every gated
+ * endpoint × role verdict, derived from the controllers' @CheckPolicies and the
+ * real PermissionsAbilityFactory (see rbac-matrix.shared.ts). The live e2e
+ * (tests/e2e/scenarios/rbac-authorization.ts) reads it and asserts the running
+ * API matches. This test fails if a controller's gating changes without
+ * regenerating the manifest — so the e2e can never silently fall out of date.
+ *
+ * Regenerate after an intentional RBAC change:
+ *   UPDATE_RBAC_MANIFEST=1 yarn test --testPathPatterns="rbac-matrix.manifest" --no-coverage
+ */
+
+const MANIFEST_PATH = path.join(__dirname, 'rbac-matrix.manifest.json');
+
+describe('rbac matrix manifest', () => {
+    it('is in sync with the controllers (regenerate with UPDATE_RBAC_MANIFEST=1)', async () => {
+        const manifest = await buildManifest();
+
+        // Sanity: the extractor actually found the gated endpoints.
+        expect(manifest.length).toBeGreaterThan(30);
+
+        const serialized = JSON.stringify(manifest, null, 2) + '\n';
+
+        if (process.env.UPDATE_RBAC_MANIFEST) {
+            fs.writeFileSync(MANIFEST_PATH, serialized);
+            return;
+        }
+
+        expect(fs.existsSync(MANIFEST_PATH)).toBe(true);
+        const committed = fs.readFileSync(MANIFEST_PATH, 'utf8');
+        expect(serialized).toEqual(committed);
+    });
+});

--- a/apps/api/src/controllers/__tests__/rbac-matrix.shared.ts
+++ b/apps/api/src/controllers/__tests__/rbac-matrix.shared.ts
@@ -111,10 +111,13 @@ function parseObjectArg(
     const out: Record<string, string> = {};
     for (const prop of obj.properties) {
         if (ts.isPropertyAssignment(prop)) {
-            out[prop.name.getText(source)] = memberName(
+            // String-literal values (e.g. @Controller({ path: 'usage' })) must
+            // be unquoted; member-access values (Action.Read) keep their name.
+            out[prop.name.getText(source)] = ts.isStringLiteralLike(
                 prop.initializer,
-                source,
-            );
+            )
+                ? prop.initializer.text
+                : memberName(prop.initializer, source);
         }
     }
     return out;

--- a/apps/api/src/controllers/__tests__/rbac-matrix.shared.ts
+++ b/apps/api/src/controllers/__tests__/rbac-matrix.shared.ts
@@ -1,0 +1,421 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as ts from 'typescript';
+
+import { STATUS } from '@libs/core/infrastructure/config/types/database/status.type';
+import {
+    Action,
+    ResourceType,
+    Role,
+} from '@libs/identity/domain/permissions/enums/permissions.enum';
+import { PermissionsAbilityFactory } from '@libs/identity/infrastructure/adapters/services/permissions/permissionsAbility.factory';
+import {
+    checkAnyPermission,
+    checkPermissions,
+    checkRepoPermissions,
+    checkRole,
+} from '@libs/identity/infrastructure/adapters/services/permissions/policy.handlers';
+import { IUser } from '@libs/identity/domain/user/interfaces/user.interface';
+
+/**
+ * Shared RBAC matrix extraction + evaluation.
+ *
+ * The single source of truth for "what verdict (allow/deny) does each role get
+ * on each gated controller endpoint". Statically extracts every endpoint's
+ * declared @CheckPolicies (via the TS compiler) AND its HTTP method + URL path,
+ * then evaluates the REAL verdict for each role using the REAL
+ * PermissionsAbilityFactory + the REAL policy handlers.
+ *
+ * Two consumers:
+ *   - authorization-matrix.spec.ts — snapshots the grid (static regression).
+ *   - rbac-matrix.manifest.spec.ts — emits/diffs a JSON manifest that the
+ *     full-stack e2e (tests/e2e) replays against a real running API. Keeping
+ *     both off this one extractor means the static grid and the live e2e can
+ *     never disagree about what the matrix says.
+ */
+
+export const CONTROLLERS_DIR = path.resolve(__dirname, '..');
+const ASSIGNED_REPO = 'repo-assigned';
+
+const HTTP_DECORATORS = new Set([
+    'Get',
+    'Post',
+    'Put',
+    'Patch',
+    'Delete',
+    'All',
+    'Head',
+    'Options',
+    'Sse',
+]);
+
+export type HandlerSpec =
+    | { kind: 'permissions'; action: string; resource: string }
+    | { kind: 'repoPermissions'; action: string; resource: string }
+    | { kind: 'role'; role: string }
+    | {
+          kind: 'anyPermission';
+          pairs: Array<{ action: string; resource: string }>;
+      }
+    | { kind: 'unknown'; text: string };
+
+export type Verdict = 'allow' | 'deny';
+
+export interface Endpoint {
+    key: string; // `<file>#<method>`
+    httpMethod: string; // GET | POST | ...
+    urlPath: string; // `/usage/tokens/summary`, params kept as `:id`
+    specs: HandlerSpec[];
+}
+
+export interface ManifestEntry {
+    key: string;
+    httpMethod: string;
+    urlPath: string;
+    expected: Record<string, Verdict>; // role -> allow|deny
+}
+
+export const ROLES: Role[] = [
+    Role.OWNER,
+    Role.BILLING_MANAGER,
+    Role.REPO_ADMIN,
+    Role.CONTRIBUTOR,
+];
+
+function listControllerFiles(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            if (entry.name === '__tests__') continue;
+            out.push(...listControllerFiles(full));
+        } else if (
+            entry.name.endsWith('.controller.ts') &&
+            !entry.name.endsWith('.spec.ts')
+        ) {
+            out.push(full);
+        }
+    }
+    return out;
+}
+
+function memberName(node: ts.Node, source: ts.SourceFile): string {
+    if (ts.isPropertyAccessExpression(node)) return node.name.getText(source);
+    return node.getText(source);
+}
+
+function parseObjectArg(
+    obj: ts.ObjectLiteralExpression,
+    source: ts.SourceFile,
+): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const prop of obj.properties) {
+        if (ts.isPropertyAssignment(prop)) {
+            out[prop.name.getText(source)] = memberName(
+                prop.initializer,
+                source,
+            );
+        }
+    }
+    return out;
+}
+
+function specFromCall(
+    call: ts.CallExpression,
+    source: ts.SourceFile,
+): HandlerSpec {
+    const name = call.expression.getText(source);
+    const arg0 = call.arguments[0];
+
+    if (
+        name === 'checkPermissions' &&
+        arg0 &&
+        ts.isObjectLiteralExpression(arg0)
+    ) {
+        const o = parseObjectArg(arg0, source);
+        return { kind: 'permissions', action: o.action, resource: o.resource };
+    }
+    if (
+        name === 'checkRepoPermissions' &&
+        arg0 &&
+        ts.isObjectLiteralExpression(arg0)
+    ) {
+        const o = parseObjectArg(arg0, source);
+        return {
+            kind: 'repoPermissions',
+            action: o.action,
+            resource: o.resource,
+        };
+    }
+    if (name === 'checkRole' && arg0 && ts.isObjectLiteralExpression(arg0)) {
+        const o = parseObjectArg(arg0, source);
+        return { kind: 'role', role: o.role };
+    }
+    if (
+        name === 'checkAnyPermission' &&
+        arg0 &&
+        ts.isArrayLiteralExpression(arg0)
+    ) {
+        const pairs = arg0.elements
+            .filter(ts.isObjectLiteralExpression)
+            .map((el) => {
+                const o = parseObjectArg(el, source);
+                return { action: o.action, resource: o.resource };
+            });
+        return { kind: 'anyPermission', pairs };
+    }
+    return { kind: 'unknown', text: call.getText(source).slice(0, 60) };
+}
+
+function localConstSpecs(source: ts.SourceFile): Map<string, HandlerSpec> {
+    const map = new Map<string, HandlerSpec>();
+    const visit = (node: ts.Node) => {
+        if (
+            ts.isVariableDeclaration(node) &&
+            node.initializer &&
+            ts.isCallExpression(node.initializer) &&
+            ts.isIdentifier(node.name)
+        ) {
+            map.set(node.name.text, specFromCall(node.initializer, source));
+        }
+        ts.forEachChild(node, visit);
+    };
+    visit(source);
+    return map;
+}
+
+function checkPoliciesSpecs(
+    decorators: readonly ts.Decorator[] | undefined,
+    source: ts.SourceFile,
+    consts: Map<string, HandlerSpec>,
+): HandlerSpec[] | null {
+    if (!decorators) return null;
+    for (const dec of decorators) {
+        if (!ts.isCallExpression(dec.expression)) continue;
+        if (dec.expression.expression.getText(source) !== 'CheckPolicies')
+            continue;
+        return dec.expression.arguments.map((arg) => {
+            if (ts.isCallExpression(arg)) return specFromCall(arg, source);
+            if (ts.isIdentifier(arg))
+                return (
+                    consts.get(arg.text) ?? {
+                        kind: 'unknown',
+                        text: arg.text,
+                    }
+                );
+            return { kind: 'unknown', text: arg.getText(source).slice(0, 60) };
+        });
+    }
+    return null;
+}
+
+function stringArg(call: ts.CallExpression, source: ts.SourceFile): string {
+    const a = call.arguments[0];
+    if (a && ts.isStringLiteral(a)) return a.text;
+    // @Controller({ path: 'x' })
+    if (a && ts.isObjectLiteralExpression(a)) {
+        const o = parseObjectArg(a, source);
+        return o.path ?? '';
+    }
+    return '';
+}
+
+function controllerBase(
+    node: ts.ClassDeclaration,
+    source: ts.SourceFile,
+): string {
+    for (const dec of ts.getDecorators(node) ?? []) {
+        if (
+            ts.isCallExpression(dec.expression) &&
+            dec.expression.expression.getText(source) === 'Controller'
+        ) {
+            return stringArg(dec.expression, source);
+        }
+    }
+    return '';
+}
+
+function joinPath(base: string, sub: string): string {
+    const parts = [base, sub]
+        .map((p) => p.replace(/^\/+|\/+$/g, ''))
+        .filter(Boolean);
+    return '/' + parts.join('/');
+}
+
+function collectEndpoints(file: string): Endpoint[] {
+    const text = fs.readFileSync(file, 'utf8');
+    const source = ts.createSourceFile(
+        file,
+        text,
+        ts.ScriptTarget.Latest,
+        true,
+    );
+    const consts = localConstSpecs(source);
+    const relFile = path.basename(file);
+    const endpoints: Endpoint[] = [];
+
+    const visit = (node: ts.Node) => {
+        if (ts.isClassDeclaration(node)) {
+            const classSpecs = checkPoliciesSpecs(
+                ts.getDecorators(node),
+                source,
+                consts,
+            );
+            const base = controllerBase(node, source);
+
+            for (const member of node.members) {
+                if (!ts.isMethodDeclaration(member)) continue;
+                const decs = ts.getDecorators(member) ?? [];
+                const httpDec = decs.find(
+                    (d) =>
+                        ts.isCallExpression(d.expression) &&
+                        HTTP_DECORATORS.has(
+                            d.expression.expression.getText(source),
+                        ),
+                );
+                if (!httpDec || !ts.isCallExpression(httpDec.expression))
+                    continue;
+
+                const httpMethod = httpDec.expression.expression
+                    .getText(source)
+                    .toUpperCase();
+                const sub = stringArg(httpDec.expression, source);
+
+                const specs =
+                    checkPoliciesSpecs(
+                        ts.getDecorators(member),
+                        source,
+                        consts,
+                    ) ?? classSpecs;
+                if (!specs) continue; // ungated
+
+                endpoints.push({
+                    key: `${relFile}#${member.name.getText(source)}`,
+                    httpMethod,
+                    urlPath: joinPath(base, sub),
+                    specs,
+                });
+            }
+        }
+        ts.forEachChild(node, visit);
+    };
+    visit(source);
+    return endpoints;
+}
+
+export function collectAllEndpoints(): Endpoint[] {
+    return listControllerFiles(CONTROLLERS_DIR).flatMap(collectEndpoints);
+}
+
+const fakeReq = (role: Role) => ({
+    user: {
+        uuid: `user-${role}`,
+        role,
+        status: STATUS.ACTIVE,
+        organization: { uuid: 'org-1' },
+    },
+    params: {},
+    query: {},
+    body: {},
+});
+
+async function evaluate(
+    spec: HandlerSpec,
+    ability: any,
+    role: Role,
+): Promise<boolean> {
+    const req = fakeReq(role);
+    switch (spec.kind) {
+        case 'permissions':
+            return checkPermissions({
+                action: (Action as any)[spec.action],
+                resource: (ResourceType as any)[spec.resource],
+            })(ability, req as any) as boolean;
+        case 'repoPermissions':
+            return checkRepoPermissions({
+                action: (Action as any)[spec.action],
+                resource: (ResourceType as any)[spec.resource],
+                repo: { custom: ASSIGNED_REPO },
+            })(ability, req as any) as boolean;
+        case 'role':
+            return checkRole({ role: (Role as any)[spec.role] })(
+                ability,
+                req as any,
+            ) as boolean;
+        case 'anyPermission':
+            return checkAnyPermission(
+                spec.pairs.map((p) => ({
+                    action: (Action as any)[p.action],
+                    resource: (ResourceType as any)[p.resource],
+                })),
+            )(ability, req as any) as boolean;
+        default:
+            return false;
+    }
+}
+
+/**
+ * Build the effective `endpoint -> { role: 'allow'|'deny' }` grid, evaluating
+ * each endpoint's declared policy against the REAL factory + handlers.
+ */
+export async function buildMatrix(): Promise<
+    Record<string, Record<string, Verdict>>
+> {
+    const factory = new PermissionsAbilityFactory({
+        findOne: async () => ({
+            permissions: { assignedRepositoryIds: [ASSIGNED_REPO] },
+        }),
+    } as any);
+
+    const abilities = new Map<Role, any>();
+    for (const role of ROLES) {
+        abilities.set(
+            role,
+            await factory.createForUser(
+                {
+                    uuid: `u-${role}`,
+                    role,
+                    organization: { uuid: 'org-1' },
+                } as unknown as IUser,
+                [ASSIGNED_REPO],
+            ),
+        );
+    }
+
+    const endpoints = collectAllEndpoints();
+    const matrix: Record<string, Record<string, Verdict>> = {};
+    for (const ep of endpoints) {
+        const row: Record<string, Verdict> = {};
+        for (const role of ROLES) {
+            const ability = abilities.get(role);
+            let allow = true; // AND across multiple @CheckPolicies handlers
+            for (const spec of ep.specs) {
+                if (!(await evaluate(spec, ability, role))) {
+                    allow = false;
+                    break;
+                }
+            }
+            row[role] = allow ? 'allow' : 'deny';
+        }
+        matrix[ep.key] = row;
+    }
+    return matrix;
+}
+
+/**
+ * Manifest the live e2e replays: one entry per gated endpoint with its HTTP
+ * method, URL path, and the expected verdict per role. Sorted for a stable
+ * diff.
+ */
+export async function buildManifest(): Promise<ManifestEntry[]> {
+    const endpoints = collectAllEndpoints();
+    const matrix = await buildMatrix();
+    return endpoints
+        .map((ep) => ({
+            key: ep.key,
+            httpMethod: ep.httpMethod,
+            urlPath: ep.urlPath,
+            expected: matrix[ep.key],
+        }))
+        .sort((a, b) => a.key.localeCompare(b.key));
+}

--- a/apps/web/src/core/layout/navbar/_components/user-nav.tsx
+++ b/apps/web/src/core/layout/navbar/_components/user-nav.tsx
@@ -69,6 +69,7 @@ export function UserNav() {
         <DropdownMenu>
             <DropdownMenuTrigger asChild>
                 <Button
+                    data-testid="user-nav-trigger"
                     size="icon-md"
                     variant="cancel"
                     className="rounded-full">
@@ -125,7 +126,9 @@ export function UserNav() {
 
                 {canReadTokenUsage && (
                         <Link href="/token-usage">
-                            <DropdownMenuItem leftIcon={<ChartColumn />}>
+                            <DropdownMenuItem
+                                data-testid="nav-token-usage"
+                                leftIcon={<ChartColumn />}>
                                 Token Usage
                             </DropdownMenuItem>
                         </Link>

--- a/apps/web/src/core/layout/navbar/_components/user-nav.tsx
+++ b/apps/web/src/core/layout/navbar/_components/user-nav.tsx
@@ -41,6 +41,10 @@ export function UserNav() {
         ResourceType.OrganizationSettings,
     );
     const canReadLogs = usePermission(Action.Read, ResourceType.Logs);
+    const canReadTokenUsage = usePermission(
+        Action.Read,
+        ResourceType.TokenUsage,
+    );
     const { isBYOK, isTrial, isEnterprise } = useSubscriptionStatus();
 
     const handleChangeWorkspace = (teamId: string) => {
@@ -119,7 +123,7 @@ export function UserNav() {
                     </Link>
                 )}
 
-                {canReadLogs && (
+                {canReadTokenUsage && (
                         <Link href="/token-usage">
                             <DropdownMenuItem leftIcon={<ChartColumn />}>
                                 Token Usage

--- a/apps/web/src/core/utils/permissions.route-coverage.spec.ts
+++ b/apps/web/src/core/utils/permissions.route-coverage.spec.ts
@@ -1,54 +1,114 @@
 import * as fs from "fs";
 import * as path from "path";
+import { ResourceType } from "@services/permissions/types";
+
+import { resourceRoutes } from "./permissions.routes";
 
 /**
- * Guard-rail: every ResourceType must either map to a route in
- * `resourceRoutes` (so the middleware role guard can gate it) or be listed as
- * intentionally routeless below. Adding a ResourceType without deciding its
- * frontend route fails this test — closing the drift gap where the backend
- * gained a resource the frontend never learned about.
+ * Guard-rail in BOTH directions, so the middleware role guard can never let a
+ * page silently 403 every non-owner role (the TokenUsage / Helpdesk class of
+ * bug):
  *
- * Reads source files (no imports) to avoid pulling `next/server` into jest.
+ *   A. resource -> route: every ResourceType either maps to a route in
+ *      `resourceRoutes` or is listed as intentionally routeless. Catches the
+ *      backend gaining a resource the frontend never learned about.
+ *
+ *   B. route -> resource: every `page.tsx` under app/(app) resolves to a route
+ *      that is matched by some `resourceRoutes` entry (or is explicitly
+ *      owner-only). Catches a page that exists on disk but no role mapping
+ *      reaches — which `canAccessRoute` would redirect to /forbidden for every
+ *      non-owner. This is the direction the old test was missing: TokenUsage
+ *      had a real /token-usage page but sat in ROUTELESS_RESOURCES, so the
+ *      guard-rail was told to ignore the one broken resource.
  */
 
-const REPO_ROOT = path.join(__dirname, "..", "..", "..", "..", "..");
-const ENUM_FILE = path.join(
-    REPO_ROOT,
-    "libs/identity/domain/permissions/enums/permissions.enum.ts",
-);
-const PERMISSIONS_FILE = path.join(__dirname, "permissions.ts");
+const APP_DIR = path.join(__dirname, "..", "..", "app", "(app)");
 
-// Resources with no dedicated page — surfaced inside other pages, not routable.
+// Resources surfaced INSIDE another page (a tab/section), with no route of
+// their own in `resourceRoutes`. Membership here is asserted against the
+// filesystem by direction B below — you cannot hide a real page in here.
 const ROUTELESS_RESOURCES = new Set<string>([
     "KodyRules", // shown inside code-review / library pages
     "IssuesSettings", // shown inside the issues page
-    "TokenUsage", // shown inside settings, no standalone route
 ]);
 
-function resourceTypeMembers(): string[] {
-    const src = fs.readFileSync(ENUM_FILE, "utf8");
-    const block = src.match(/export enum ResourceType\s*\{([^}]*)\}/);
-    if (!block) throw new Error("ResourceType enum not found");
-    return [...block[1].matchAll(/(\w+)\s*=/g)].map((m) => m[1]);
+// Routes that, by design, only the OWNER reaches (canAccessRoute early-returns
+// for owner). Anything not matched by resourceRoutes AND not listed here is a
+// bug. Empty today — add with a comment explaining the product decision.
+const OWNER_ONLY_ROUTES = new Set<string>([]);
+
+function resourceMembers(): string[] {
+    // String enum -> Object.keys returns the member names (All, TokenUsage, …)
+    return Object.keys(ResourceType);
 }
 
-function routedResources(): Set<string> {
-    const src = fs.readFileSync(PERMISSIONS_FILE, "utf8");
-    const block = src.match(/const resourceRoutes[^=]*=\s*\{([\s\S]*?)\n\};/);
-    if (!block) throw new Error("resourceRoutes object not found");
-    return new Set(
-        [...block[1].matchAll(/\[ResourceType\.(\w+)\]/g)].map((m) => m[1]),
-    );
+function isRouted(member: string): boolean {
+    const value = (ResourceType as Record<string, string>)[member];
+    return resourceRoutes[value as ResourceType] !== undefined;
+}
+
+/** All route patterns, flattened across every resource. */
+const ALL_PATTERNS: string[] = Object.values(resourceRoutes).flat();
+
+function pathMatchesAnyPattern(pathname: string): boolean {
+    return ALL_PATTERNS.some((route) => {
+        if (route.endsWith("/*")) {
+            return pathname.startsWith(route.slice(0, -2));
+        }
+        return pathname === route;
+    });
+}
+
+/** Turn a page.tsx absolute path into its public route pathname. */
+function fileToRoute(absFile: string): string {
+    const rel = absFile.slice(APP_DIR.length).replace(/[/\\]page\.tsx$/, "");
+    const segments = rel
+        .split(/[/\\]/)
+        .filter(Boolean)
+        // Route groups `(app)` and intercepting markers `(.)`, `(..)` are not
+        // URL segments.
+        .filter((seg) => !/^\(.*\)$/.test(seg))
+        // Parallel route slots `@modal`, `@bugRatioAnalytics` are not URL
+        // segments either — their page renders at the parent route.
+        .filter((seg) => !seg.startsWith("@"))
+        // Dynamic `[id]` / catch-all `[...slug]` -> a concrete dummy segment so
+        // prefix matching behaves like a real request.
+        .map((seg) => (seg.startsWith("[") ? "x" : seg));
+    return "/" + segments.join("/");
+}
+
+function collectPageRoutes(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            out.push(...collectPageRoutes(full));
+        } else if (entry.name === "page.tsx") {
+            out.push(fileToRoute(full));
+        }
+    }
+    return out;
 }
 
 describe("permissions route coverage", () => {
-    it("every ResourceType is routed or explicitly routeless", () => {
-        const routed = routedResources();
-        const uncovered = resourceTypeMembers().filter(
+    it("A. every ResourceType is routed or explicitly routeless", () => {
+        const uncovered = resourceMembers().filter(
             (member) =>
-                !routed.has(member) && !ROUTELESS_RESOURCES.has(member),
+                !isRouted(member) && !ROUTELESS_RESOURCES.has(member),
         );
-
         expect(uncovered).toEqual([]);
+    });
+
+    it("B. every page.tsx route is reachable by some role (not just owner)", () => {
+        const routes = Array.from(new Set(collectPageRoutes(APP_DIR)));
+        // Sanity: the walker actually found pages.
+        expect(routes.length).toBeGreaterThan(0);
+
+        const unreachable = routes.filter(
+            (route) =>
+                !pathMatchesAnyPattern(route) &&
+                !OWNER_ONLY_ROUTES.has(route),
+        );
+        expect(unreachable).toEqual([]);
     });
 });

--- a/apps/web/src/core/utils/permissions.route-coverage.spec.ts
+++ b/apps/web/src/core/utils/permissions.route-coverage.spec.ts
@@ -53,7 +53,10 @@ const ALL_PATTERNS: string[] = Object.values(resourceRoutes).flat();
 function pathMatchesAnyPattern(pathname: string): boolean {
     return ALL_PATTERNS.some((route) => {
         if (route.endsWith("/*")) {
-            return pathname.startsWith(route.slice(0, -2));
+            const base = route.slice(0, -2);
+            // Exact or true sub-path only — a sibling sharing the prefix
+            // (e.g. /cli-reviews vs /cli) must not count as covered.
+            return pathname === base || pathname.startsWith(base + "/");
         }
         return pathname === route;
     });

--- a/apps/web/src/core/utils/permissions.route-manifest.json
+++ b/apps/web/src/core/utils/permissions.route-manifest.json
@@ -1,0 +1,354 @@
+[
+  {
+    "route": "/choose-plan",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "route": "/cli-reviews",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "route": "/cli/authorize",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "route": "/cockpit",
+    "expected": {
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "route": "/helpdesk",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "route": "/issues",
+    "expected": {
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "route": "/library/kody-rules",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "route": "/library/kody-rules/featured",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "route": "/library/kody-rules/packs",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "route": "/library/kody-rules/x",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "route": "/organization",
+    "expected": {
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "route": "/organization/byok",
+    "expected": {
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "route": "/organization/byok/manual",
+    "expected": {
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "route": "/organization/cli-keys",
+    "expected": {
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "route": "/organization/cockpit",
+    "expected": {
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "route": "/organization/general",
+    "expected": {
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "route": "/organization/notifications",
+    "expected": {
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "route": "/organization/sso",
+    "expected": {
+      "billing_manager": "deny",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "route": "/pull-requests",
+    "expected": {
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "route": "/pull-requests/x/x",
+    "expected": {
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "route": "/settings",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "route": "/settings/code-review",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "route": "/settings/code-review/x",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "route": "/settings/code-review/x/custom-messages",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "route": "/settings/code-review/x/custom-prompts",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "route": "/settings/code-review/x/general",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "route": "/settings/code-review/x/kody-rules",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "route": "/settings/code-review/x/kody-rules/x",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "route": "/settings/code-review/x/pr-summary",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "route": "/settings/code-review/x/review-categories",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "route": "/settings/code-review/x/suggestion-control",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "allow"
+    }
+  },
+  {
+    "route": "/settings/git",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "route": "/settings/git/repositories",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "route": "/settings/integrations",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "route": "/settings/integrations/azure-repos/configuration",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "route": "/settings/integrations/bitbucket/configuration",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "route": "/settings/integrations/github/configuration",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "route": "/settings/integrations/gitlab/configuration",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "route": "/settings/plugins",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "route": "/settings/plugins/custom",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "route": "/settings/plugins/x/x",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "route": "/settings/subscription",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "deny",
+      "contributor": "deny"
+    }
+  },
+  {
+    "route": "/token-usage",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "route": "/user-logs",
+    "expected": {
+      "billing_manager": "allow",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  }
+]

--- a/apps/web/src/core/utils/permissions.route-manifest.json
+++ b/apps/web/src/core/utils/permissions.route-manifest.json
@@ -10,7 +10,7 @@
   {
     "route": "/cli-reviews",
     "expected": {
-      "billing_manager": "allow",
+      "billing_manager": "deny",
       "repo_admin": "allow",
       "contributor": "allow"
     }

--- a/apps/web/src/core/utils/permissions.route-manifest.spec.ts
+++ b/apps/web/src/core/utils/permissions.route-manifest.spec.ts
@@ -1,0 +1,82 @@
+import * as fs from "fs";
+import * as path from "path";
+import { UserRole } from "@enums";
+
+import { canAccessRoute } from "./permissions.routes";
+
+/**
+ * Frontend route-access manifest the full-stack e2e replays.
+ *
+ * `permissions.route-manifest.json` is the committed snapshot of every
+ * app/(app) page route × role → reachable/forbidden, computed from the REAL
+ * middleware guard (`canAccessRoute`, the same code the Next middleware runs).
+ * The live e2e (tests/e2e/scenarios/rbac-frontend-routes.ts) signs in per role
+ * over HTTP and asserts the running web app redirects to /forbidden exactly
+ * where this says `deny` — i.e. proves the #1229 class (a page reachable or
+ * blocked for the wrong role) on the real server.
+ *
+ * This drift-guard fails CI if the routes or policy change without
+ * regenerating. Regenerate after an intentional change:
+ *   UPDATE_ROUTE_MANIFEST=1 yarn test --testPathPatterns="route-manifest" --no-coverage
+ */
+
+const APP_DIR = path.join(__dirname, "..", "..", "app", "(app)");
+const MANIFEST_PATH = path.join(__dirname, "permissions.route-manifest.json");
+
+const NON_OWNER_ROLES = [
+    UserRole.BILLING_MANAGER,
+    UserRole.REPO_ADMIN,
+    UserRole.CONTRIBUTOR,
+];
+
+/** Turn a page.tsx absolute path into its public route pathname. */
+function fileToRoute(absFile: string): string {
+    const rel = absFile.slice(APP_DIR.length).replace(/[/\\]page\.tsx$/, "");
+    const segments = rel
+        .split(/[/\\]/)
+        .filter(Boolean)
+        .filter((seg) => !/^\(.*\)$/.test(seg)) // route groups / intercepts
+        .filter((seg) => !seg.startsWith("@")) // parallel-route slots
+        .map((seg) => (seg.startsWith("[") ? "x" : seg)); // dynamic -> dummy
+    return "/" + segments.join("/");
+}
+
+function collectPageRoutes(dir: string): string[] {
+    const out: string[] = [];
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) out.push(...collectPageRoutes(full));
+        else if (entry.name === "page.tsx") out.push(fileToRoute(full));
+    }
+    return out;
+}
+
+type RouteEntry = { route: string; expected: Record<string, "allow" | "deny"> };
+
+function buildRouteManifest(): RouteEntry[] {
+    const routes = Array.from(new Set(collectPageRoutes(APP_DIR))).sort();
+    return routes.map((route) => {
+        const expected: Record<string, "allow" | "deny"> = {};
+        for (const role of NON_OWNER_ROLES) {
+            expected[role] = canAccessRoute({ role, pathname: route })
+                ? "allow"
+                : "deny";
+        }
+        return { route, expected };
+    });
+}
+
+describe("frontend route manifest", () => {
+    it("is in sync with the routes + policy (regenerate with UPDATE_ROUTE_MANIFEST=1)", () => {
+        const manifest = buildRouteManifest();
+        expect(manifest.length).toBeGreaterThan(10);
+
+        const serialized = JSON.stringify(manifest, null, 2) + "\n";
+        if (process.env.UPDATE_ROUTE_MANIFEST) {
+            fs.writeFileSync(MANIFEST_PATH, serialized);
+            return;
+        }
+        expect(fs.existsSync(MANIFEST_PATH)).toBe(true);
+        expect(serialized).toEqual(fs.readFileSync(MANIFEST_PATH, "utf8"));
+    });
+});

--- a/apps/web/src/core/utils/permissions.routes.spec.ts
+++ b/apps/web/src/core/utils/permissions.routes.spec.ts
@@ -1,0 +1,67 @@
+import { UserRole } from "@enums";
+
+import { canAccessRoute } from "./permissions.routes";
+
+// Matrix mirror of the backend authorization-matrix.spec.ts, but for the
+// FRONTEND middleware route guard (canAccessRoute). The backend matrix proved
+// the API allows repo_admin on TokenUsage; this proves the middleware actually
+// lets repo_admin reach the /token-usage page instead of bouncing to
+// /forbidden — the exact regression from issue #1229.
+
+const access = (role: UserRole, pathname: string) =>
+    canAccessRoute({ role, pathname });
+
+describe("canAccessRoute", () => {
+    it("owner reaches everything (including unmapped paths)", () => {
+        expect(access(UserRole.OWNER, "/token-usage")).toBe(true);
+        expect(access(UserRole.OWNER, "/anything/not/mapped")).toBe(true);
+    });
+
+    describe("Token Usage (#1229 regression)", () => {
+        it("repo_admin can reach /token-usage", () => {
+            expect(access(UserRole.REPO_ADMIN, "/token-usage")).toBe(true);
+        });
+        it("billing_manager can reach /token-usage", () => {
+            expect(access(UserRole.BILLING_MANAGER, "/token-usage")).toBe(true);
+        });
+        it("contributor cannot reach /token-usage", () => {
+            expect(access(UserRole.CONTRIBUTOR, "/token-usage")).toBe(false);
+        });
+    });
+
+    describe("previously-orphaned routes are now reachable", () => {
+        it("every non-owner role reaches /helpdesk (support)", () => {
+            for (const role of [
+                UserRole.REPO_ADMIN,
+                UserRole.BILLING_MANAGER,
+                UserRole.CONTRIBUTOR,
+            ]) {
+                expect(access(role, "/helpdesk")).toBe(true);
+            }
+        });
+        it("every non-owner role reaches /cli/authorize", () => {
+            for (const role of [
+                UserRole.REPO_ADMIN,
+                UserRole.BILLING_MANAGER,
+                UserRole.CONTRIBUTOR,
+            ]) {
+                expect(access(role, "/cli/authorize")).toBe(true);
+            }
+        });
+        it("git settings covers /settings/integrations", () => {
+            // repo_admin has GitSettings read in ROLE_POLICIES
+            expect(
+                access(UserRole.REPO_ADMIN, "/settings/integrations"),
+            ).toBe(true);
+        });
+    });
+
+    describe("denies what the role has no policy for", () => {
+        it("contributor cannot reach /cockpit", () => {
+            expect(access(UserRole.CONTRIBUTOR, "/cockpit")).toBe(false);
+        });
+        it("contributor cannot reach /settings/git", () => {
+            expect(access(UserRole.CONTRIBUTOR, "/settings/git")).toBe(false);
+        });
+    });
+});

--- a/apps/web/src/core/utils/permissions.routes.spec.ts
+++ b/apps/web/src/core/utils/permissions.routes.spec.ts
@@ -64,4 +64,16 @@ describe("canAccessRoute", () => {
             expect(access(UserRole.CONTRIBUTOR, "/settings/git")).toBe(false);
         });
     });
+
+    describe("prefix-collision must not bypass authorization", () => {
+        // `/cli/*` is public (All base routes); `/cli-reviews/*` is CliReview.
+        // A naive startsWith would grant `/cli-reviews` to anyone via `/cli`.
+        // billing_manager has NO CliReview grant, so it must be denied.
+        it("billing_manager (no CliReview) cannot reach /cli-reviews via the /cli prefix", () => {
+            expect(access(UserRole.BILLING_MANAGER, "/cli-reviews")).toBe(false);
+        });
+        it("the public /cli/* still grants the actual /cli sub-path", () => {
+            expect(access(UserRole.BILLING_MANAGER, "/cli/authorize")).toBe(true);
+        });
+    });
 });

--- a/apps/web/src/core/utils/permissions.routes.ts
+++ b/apps/web/src/core/utils/permissions.routes.ts
@@ -1,0 +1,103 @@
+import { UserRole } from "@enums";
+import { ResourceType } from "@services/permissions/types";
+import { Role } from "@libs/identity/domain/permissions/enums/permissions.enum";
+import { ROLE_POLICIES } from "@libs/identity/domain/permissions/policies/role-policies";
+
+// Pure route-authorization logic, deliberately free of `next/server` so it can
+// be imported directly by unit tests (permissions.route-coverage.spec.ts and
+// permissions.routes.spec.ts). The `next/server`-dependent middleware glue
+// lives in permissions.ts.
+
+// Maps a resource to the URL prefixes that surface it. This is the only
+// frontend-specific piece — what each role *can do* comes from ROLE_POLICIES
+// (shared with the backend). Every page under app/(app) MUST be reachable
+// from some entry here (pages open to every authenticated role go under the
+// All base routes); permissions.route-coverage.spec.ts walks the filesystem
+// and fails if a page is unmapped, so a new page can't silently 403 non-owners.
+export const resourceRoutes: Partial<Record<ResourceType, string[]>> = {
+    [ResourceType.All]: [
+        "/user-waiting-for-approval/*",
+        "/settings",
+        "/forbidden/*",
+        "/library/*",
+        "/setup/*",
+        "/auth/*",
+        // Support iframe + CLI device-authorize flow: open to every
+        // authenticated role, no dedicated backend resource.
+        "/helpdesk/*",
+        "/cli/*",
+    ],
+    [ResourceType.Billing]: ["/settings/subscription/*", "/choose-plan"],
+    [ResourceType.Cockpit]: ["/cockpit/*"],
+    [ResourceType.PullRequests]: ["/pull-requests/*"],
+    [ResourceType.CliReview]: ["/cli-reviews/*"],
+    [ResourceType.Issues]: ["/issues/*"],
+    [ResourceType.CodeReviewSettings]: ["/settings/code-review/*"],
+    [ResourceType.OrganizationSettings]: ["/organization/*"],
+    [ResourceType.GitSettings]: ["/settings/git/*", "/settings/integrations/*"],
+    [ResourceType.UserSettings]: ["/settings/subscription/*"],
+    [ResourceType.PluginSettings]: ["/settings/plugins/*"],
+    [ResourceType.Logs]: ["/user-logs/*"],
+    [ResourceType.TokenUsage]: ["/token-usage/*"],
+};
+
+const baseRoutes = resourceRoutes[ResourceType.All] ?? [];
+
+// Derive each non-owner role's accessible routes from the shared policy, so the
+// middleware guard can never drift from the backend's permissions. Owner gets
+// everything via the early return in canAccessRoute.
+export const roleRoutes: Record<string, string[]> = Object.fromEntries(
+    (Object.keys(ROLE_POLICIES) as Role[])
+        .filter((role) => role !== Role.OWNER)
+        .map((role) => {
+            const resources = new Set(
+                ROLE_POLICIES[role].map((rule) => rule.resource),
+            );
+            const routes = [
+                ...baseRoutes,
+                ...[...resources].flatMap(
+                    (resource) => resourceRoutes[resource] ?? [],
+                ),
+            ];
+            return [role, Array.from(new Set(routes))];
+        }),
+);
+
+export const canAccessRoute = ({
+    pathname,
+    role,
+}: {
+    role: UserRole;
+    pathname: string;
+}): boolean => {
+    if (role === UserRole.OWNER) return true;
+
+    const rolePaths: string[] = roleRoutes[role] || [];
+
+    const hasAccess = rolePaths.some((route) => {
+        if (!route.includes(":")) {
+            if (route.endsWith("/*")) {
+                const baseRoute = route.replace("/*", "");
+                return pathname.startsWith(baseRoute);
+            }
+
+            const matches = pathname === route;
+            return matches;
+        }
+
+        const createRoutePattern = (route: string): string => {
+            return route
+                .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+                .replace(/:teamId/g, "[\\w-]+")
+                .replace(/:[a-zA-Z]+/g, "[\\w-]+");
+        };
+
+        const pattern = createRoutePattern(route);
+
+        const regex = new RegExp(`^${pattern}(?:/.*)?$`);
+        const matches = regex.test(pathname);
+        return matches;
+    });
+
+    return hasAccess;
+};

--- a/apps/web/src/core/utils/permissions.routes.ts
+++ b/apps/web/src/core/utils/permissions.routes.ts
@@ -78,7 +78,14 @@ export const canAccessRoute = ({
         if (!route.includes(":")) {
             if (route.endsWith("/*")) {
                 const baseRoute = route.replace("/*", "");
-                return pathname.startsWith(baseRoute);
+                // Match the base route itself or a true sub-path only — NOT a
+                // sibling that merely shares the prefix string (e.g. `/cli/*`
+                // must not grant `/cli-reviews`). A bare startsWith would be an
+                // authorization bypass.
+                return (
+                    pathname === baseRoute ||
+                    pathname.startsWith(baseRoute + "/")
+                );
             }
 
             const matches = pathname === route;

--- a/apps/web/src/core/utils/permissions.ts
+++ b/apps/web/src/core/utils/permissions.ts
@@ -1,98 +1,12 @@
 import { NextRequest, NextResponse } from "next/server";
-import { UserRole } from "@enums";
-import { ResourceType } from "@services/permissions/types";
-import { Role } from "@libs/identity/domain/permissions/enums/permissions.enum";
-import { ROLE_POLICIES } from "@libs/identity/domain/permissions/policies/role-policies";
 import type { Session } from "next-auth";
 
 import { hasPermission } from "./permission-map";
+import { canAccessRoute, resourceRoutes, roleRoutes } from "./permissions.routes";
 
-// Maps a resource to the URL prefixes that surface it. This is the only
-// frontend-specific piece — what each role *can do* comes from ROLE_POLICIES
-// (shared with the backend). Resources without a dedicated page (KodyRules,
-// IssuesSettings, TokenUsage, CliReview, ...) simply have no entry here.
-const resourceRoutes: Partial<Record<ResourceType, string[]>> = {
-    [ResourceType.All]: [
-        "/user-waiting-for-approval/*",
-        "/settings",
-        "/forbidden/*",
-        "/library/*",
-        "/setup/*",
-        "/auth/*",
-    ],
-    [ResourceType.Billing]: ["/settings/subscription/*", "/choose-plan"],
-    [ResourceType.Cockpit]: ["/cockpit/*"],
-    [ResourceType.PullRequests]: ["/pull-requests/*"],
-    [ResourceType.CliReview]: ["/cli-reviews/*"],
-    [ResourceType.Issues]: ["/issues/*"],
-    [ResourceType.CodeReviewSettings]: ["/settings/code-review/*"],
-    [ResourceType.OrganizationSettings]: ["/organization/*"],
-    [ResourceType.GitSettings]: ["/settings/git/*"],
-    [ResourceType.UserSettings]: ["/settings/subscription/*"],
-    [ResourceType.PluginSettings]: ["/settings/plugins/*"],
-    [ResourceType.Logs]: ["/user-logs/*"],
-};
-
-const baseRoutes = resourceRoutes[ResourceType.All] ?? [];
-
-// Derive each non-owner role's accessible routes from the shared policy, so the
-// middleware guard can never drift from the backend's permissions. Owner gets
-// everything via the early return in canAccessRoute.
-const roleRoutes: Record<string, string[]> = Object.fromEntries(
-    (Object.keys(ROLE_POLICIES) as Role[])
-        .filter((role) => role !== Role.OWNER)
-        .map((role) => {
-            const resources = new Set(
-                ROLE_POLICIES[role].map((rule) => rule.resource),
-            );
-            const routes = [
-                ...baseRoutes,
-                ...[...resources].flatMap(
-                    (resource) => resourceRoutes[resource] ?? [],
-                ),
-            ];
-            return [role, Array.from(new Set(routes))];
-        }),
-);
-
-const canAccessRoute = ({
-    pathname,
-    role,
-}: {
-    role: UserRole;
-    pathname: string;
-}): boolean => {
-    if (role === UserRole.OWNER) return true;
-
-    const rolePaths: string[] = roleRoutes[role] || [];
-
-    const hasAccess = rolePaths.some((route) => {
-        if (!route.includes(":")) {
-            if (route.endsWith("/*")) {
-                const baseRoute = route.replace("/*", "");
-                return pathname.startsWith(baseRoute);
-            }
-
-            const matches = pathname === route;
-            return matches;
-        }
-
-        const createRoutePattern = (route: string): string => {
-            return route
-                .replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
-                .replace(/:teamId/g, "[\\w-]+")
-                .replace(/:[a-zA-Z]+/g, "[\\w-]+");
-        };
-
-        const pattern = createRoutePattern(route);
-
-        const regex = new RegExp(`^${pattern}(?:/.*)?$`);
-        const matches = regex.test(pathname);
-        return matches;
-    });
-
-    return hasAccess;
-};
+// Re-exported so existing importers keep working; the actual route logic lives
+// in permissions.routes.ts (next/server-free, so it's unit-testable).
+export { canAccessRoute, resourceRoutes, roleRoutes };
 
 export function handleAuthenticated(
     req: NextRequest,

--- a/tests/e2e/lib/__tests__/scenarios.test.ts
+++ b/tests/e2e/lib/__tests__/scenarios.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from "node:assert";
 import { test } from "node:test";
 import { allScenarios, resolveScenarios } from "../../scenarios/index.js";
 
-test("allScenarios: includes the 11 release-gate scenarios", () => {
+test("allScenarios: includes the 13 release-gate scenarios", () => {
     const ids = Object.keys(allScenarios).sort();
     assert.deepEqual(ids, [
         "code-review-basic",
@@ -12,6 +12,8 @@ test("allScenarios: includes the 11 release-gate scenarios", () => {
         "onboarding-webhook-registration",
         "per-seat-license-toggle",
         "rbac-authorization",
+        "rbac-frontend-routes",
+        "rbac-ui-render",
         "sso-cookie-domain",
         "sso-multi-user",
         "stripe-billing",

--- a/tests/e2e/lib/rbac-provision.ts
+++ b/tests/e2e/lib/rbac-provision.ts
@@ -1,0 +1,160 @@
+import { http } from "./http.js";
+import { login, signUp } from "./onboarding.js";
+import type { RunContext, TargetContext } from "./types.js";
+
+// Shared RBAC provisioning used by both the backend (rbac-authorization) and
+// frontend (rbac-frontend-routes) e2e scenarios: sign up a fresh throwaway org
+// (the creator is OWNER + ACTIVE) and invite one ACTIVE user per non-owner role
+// with the real RBAC role set. Same throwaway password for every test user so
+// the frontend scenario can also sign them in through next-auth.
+
+export const RBAC_PASSWORD = "E2eRbac!2026x";
+
+export type RbacRole =
+    | "owner"
+    | "billing_manager"
+    | "repo_admin"
+    | "contributor";
+
+export const NON_OWNER_ROLES: RbacRole[] = [
+    "billing_manager",
+    "repo_admin",
+    "contributor",
+];
+
+export interface RoleSession {
+    role: RbacRole;
+    accessToken: string;
+    email: string;
+}
+
+/**
+ * Invite a user with a specific RBAC role into the owner's team, activate it,
+ * and return an authenticated session. (Mechanics validated end-to-end against
+ * QA on 2026-05-27.)
+ */
+async function provisionUserWithRole(
+    ctx: RunContext,
+    target: TargetContext,
+    ownerToken: string,
+    teamId: string,
+    role: RbacRole,
+): Promise<RoleSession> {
+    const email = `e2e-rbac-${role}-${Date.now()}@kodus.local`;
+    const name = `e2e ${role}`;
+    const authed = { Authorization: `Bearer ${ownerToken}` };
+
+    const invite = await http(`${target.apiBaseUrl}/team-members`, {
+        method: "POST",
+        headers: authed,
+        body: {
+            teamId,
+            members: [
+                {
+                    email,
+                    name,
+                    role,
+                    teamRole: "team_member",
+                    active: true,
+                    communicationId: email,
+                },
+            ],
+        },
+        timeoutMs: 30_000,
+    });
+    if (invite.status < 200 || invite.status >= 300) {
+        ctx.skip(
+            `provisioning: invite ${role} failed (HTTP ${invite.status}): ${invite.raw.slice(0, 250)}`,
+        );
+    }
+
+    const list = await http<{
+        data: { members: Array<{ email: string; userId: string }> };
+    }>(`${target.apiBaseUrl}/team-members?teamId=${teamId}`, {
+        method: "GET",
+        headers: authed,
+        timeoutMs: 20_000,
+    });
+    const userId = list.body?.data?.members?.find((m) => m.email === email)
+        ?.userId;
+    ctx.assert(
+        userId,
+        `provisioning: no userId for ${email}. Members: ${list.raw.slice(0, 250)}`,
+    );
+
+    const complete = await http(
+        `${target.apiBaseUrl}/user/invite/complete-invitation`,
+        {
+            method: "POST",
+            body: { uuid: userId, name, password: RBAC_PASSWORD },
+            timeoutMs: 20_000,
+        },
+    );
+    if (complete.status < 200 || complete.status >= 300) {
+        ctx.skip(
+            `provisioning: complete-invitation ${role} failed (HTTP ${complete.status}): ${complete.raw.slice(0, 250)}`,
+        );
+    }
+
+    // The invite lands the user as contributor; set the real RBAC role.
+    const patch = await http(`${target.apiBaseUrl}/user/${userId}`, {
+        method: "PATCH",
+        headers: authed,
+        body: { role },
+        timeoutMs: 20_000,
+    });
+    if (patch.status < 200 || patch.status >= 300) {
+        ctx.skip(
+            `provisioning: set role ${role} failed (HTTP ${patch.status}): ${patch.raw.slice(0, 250)}`,
+        );
+    }
+
+    const session = await login(target, { email, password: RBAC_PASSWORD });
+    return { role, accessToken: session.accessToken, email };
+}
+
+export interface RbacOrg {
+    ownerEmail: string;
+    teamId: string;
+    sessions: RoleSession[]; // owner + the three non-owner roles
+}
+
+/** Sign up a fresh disposable org and provision all four role sessions. */
+export async function setupRbacOrg(ctx: RunContext): Promise<RbacOrg> {
+    const ownerEmail = `e2e-rbac-owner-${Date.now()}@kodus.local`;
+    await signUp(ctx.target, { email: ownerEmail, password: RBAC_PASSWORD });
+    const owner = await login(ctx.target, {
+        email: ownerEmail,
+        password: RBAC_PASSWORD,
+    });
+
+    const teamRes = await http<{ data: Array<{ uuid: string }> }>(
+        `${ctx.target.apiBaseUrl}/team`,
+        {
+            method: "GET",
+            headers: { Authorization: `Bearer ${owner.accessToken}` },
+            timeoutMs: 20_000,
+        },
+    );
+    const teamId = teamRes.body?.data?.[0]?.uuid;
+    ctx.assert(
+        teamId,
+        `could not resolve owner teamId: ${teamRes.raw.slice(0, 200)}`,
+    );
+
+    const sessions: RoleSession[] = [
+        { role: "owner", accessToken: owner.accessToken, email: ownerEmail },
+    ];
+    for (const role of NON_OWNER_ROLES) {
+        sessions.push(
+            await provisionUserWithRole(
+                ctx,
+                ctx.target,
+                owner.accessToken,
+                teamId,
+                role,
+            ),
+        );
+    }
+    return { ownerEmail, teamId, sessions };
+}

--- a/tests/e2e/matrix/fast.yml
+++ b/tests/e2e/matrix/fast.yml
@@ -33,6 +33,10 @@ scenarios:
     # user per role, and asserts the expected 200/403 across API endpoints.
     # appliesTo restricts it to github × paid (one cell per target).
     - rbac-authorization
+    # RBAC frontend route guard: per role, signs in over HTTP (next-auth) and
+    # asserts the Next middleware redirects to /forbidden per the route
+    # manifest — the layer the #1229 bug lived in. HTTP-only, so fast.
+    - rbac-frontend-routes
 
 cells:
     # ---------- self-hosted ----------

--- a/tests/e2e/matrix/full.yml
+++ b/tests/e2e/matrix/full.yml
@@ -50,6 +50,14 @@ scenarios:
     # RBAC authorization matrix (also in fast.yml). Signs up a throwaway org,
     # provisions one user per role, asserts 200/403 across API endpoints.
     - rbac-authorization
+    # RBAC frontend route guard (also in fast.yml): per role, next-auth HTTP
+    # sign-in + asserts the middleware /forbidden redirects per the route
+    # manifest.
+    - rbac-frontend-routes
+    # RBAC UI render (real browser, full-only like stripe-billing): drives
+    # Chromium per role and asserts the Token Usage menu item + /token-usage
+    # screen actually RENDER, and denied roles get a rendered /forbidden page.
+    - rbac-ui-render
 
 cells:
     # ---------- self-hosted (mirrors fast.yml) ----------

--- a/tests/e2e/playwright/rbac-ui-render.mjs
+++ b/tests/e2e/playwright/rbac-ui-render.mjs
@@ -1,0 +1,177 @@
+// RBAC frontend RENDER evidence (Playwright, real browser).
+//
+// The HTTP route-guard e2e proves *authorization* (200 vs /forbidden) but NOT
+// that the UI renders. This drives a real Chromium per role and asserts on the
+// rendered DOM — the "Token Usage" menu item appears only for allowed roles,
+// the /token-usage screen actually renders for them, and denied roles land on
+// a rendered /forbidden page. Records a video + screenshots per role.
+//
+// Auth without the brittle sign-in form: we mint a next-auth session over HTTP
+// (validated flow) and inject the cookies straight into the browser context.
+//
+// Env:
+//   WEB_URL    e.g. https://qa.web.kodus.io  (or http://127.0.0.1:3000)
+//   PASSWORD   shared password for the provisioned role users
+//   ROLES_JSON JSON array: [{ "role": "repo_admin", "email": "..." }, ...]
+//   OUT_DIR    directory for videos/screenshots (default: ./rbac-ui-evidence)
+
+import { chromium } from "playwright";
+import { mkdirSync } from "node:fs";
+
+const WEB = (process.env.WEB_URL || "http://127.0.0.1:3000").replace(/\/$/, "");
+const PASSWORD = process.env.PASSWORD || "";
+const ROLES = JSON.parse(process.env.ROLES_JSON || "[]");
+const OUT_DIR = process.env.OUT_DIR || "./rbac-ui-evidence";
+mkdirSync(OUT_DIR, { recursive: true });
+
+// TokenUsage is the #1229 case: every role except contributor may see/open it.
+const tokenUsageAllowed = (role) => role !== "contributor";
+
+const log = (m) => console.log(`[rbac-ui] ${m}`);
+const failures = [];
+
+function jarToCookies(setCookies) {
+    const out = [];
+    for (const c of setCookies) {
+        const [pair] = c.split(";");
+        const eq = pair.indexOf("=");
+        if (eq > 0)
+            out.push({ name: pair.slice(0, eq).trim(), value: pair.slice(eq + 1).trim(), url: WEB });
+    }
+    return out;
+}
+
+async function nextAuthCookies(email) {
+    const jar = new Map();
+    const absorb = (res) => {
+        for (const c of res.headers.getSetCookie()) {
+            const [pair] = c.split(";");
+            const eq = pair.indexOf("=");
+            if (eq > 0) jar.set(pair.slice(0, eq).trim(), c);
+        }
+    };
+    const csrfRes = await fetch(`${WEB}/api/auth/csrf`, { redirect: "manual" });
+    absorb(csrfRes);
+    const { csrfToken } = await csrfRes.json();
+    const cookieHeader = [...jar.values()].map((c) => c.split(";")[0]).join("; ");
+    const cbRes = await fetch(`${WEB}/api/auth/callback/credentials`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            Cookie: cookieHeader,
+        },
+        body: new URLSearchParams({
+            csrfToken,
+            email,
+            password: PASSWORD,
+            redirect: "false",
+            json: "true",
+        }).toString(),
+        redirect: "manual",
+    });
+    absorb(cbRes);
+    const setCookies = [...jar.values()];
+    if (!setCookies.some((c) => /authjs\.session-token|__Secure-authjs\.session-token/.test(c))) {
+        throw new Error(`no session cookie for ${email} (HTTP ${cbRes.status})`);
+    }
+    return jarToCookies(setCookies);
+}
+
+const browser = await chromium.launch({ headless: true });
+
+for (const { role, email } of ROLES) {
+    const ctx = await browser.newContext({
+        recordVideo: { dir: OUT_DIR, size: { width: 1280, height: 800 } },
+        viewport: { width: 1280, height: 800 },
+    });
+    try {
+        const cookies = await nextAuthCookies(email);
+        await ctx.addCookies(cookies);
+        const page = await ctx.newPage();
+
+        // ---- 1) Menu render: open the user-nav, check the Token Usage item ----
+        await page.goto(`${WEB}/settings`, { waitUntil: "domcontentloaded", timeout: 30_000 });
+        const trigger = page.locator('[data-testid="user-nav-trigger"]');
+        // Wait for the navbar to hydrate (trigger present + interactive). The
+        // app polls (issues count, notifications) so "networkidle" never fires.
+        await trigger.waitFor({ state: "visible", timeout: 20_000 }).catch(() => {});
+        await page.waitForTimeout(2000);
+        // Radix opens on pointerdown; a couple of attempts + keyboard fallback
+        // make the headless open reliable.
+        let opened = false;
+        for (let attempt = 0; attempt < 3 && !opened; attempt++) {
+            await trigger.click({ timeout: 10_000 }).catch(() => {});
+            opened = await page
+                .getByRole("menu")
+                .first()
+                .waitFor({ state: "visible", timeout: 3_000 })
+                .then(() => true)
+                .catch(() => false);
+            if (!opened) {
+                await trigger.focus().catch(() => {});
+                await page.keyboard.press("Enter").catch(() => {});
+                opened = await page
+                    .getByRole("menu")
+                    .first()
+                    .waitFor({ state: "visible", timeout: 2_000 })
+                    .then(() => true)
+                    .catch(() => false);
+            }
+        }
+        await page.screenshot({ path: `${OUT_DIR}/${role}-menu.png`, fullPage: true });
+        const wantItem = tokenUsageAllowed(role);
+        if (opened) {
+            const itemVisible =
+                (await page.getByRole("menuitem", { name: /Token Usage/i }).count()) > 0;
+            if (itemVisible !== wantItem) {
+                failures.push(
+                    `${role}: Token Usage menu item visible=${itemVisible}, expected ${wantItem}`,
+                );
+            } else {
+                log(`OK  ${role} menu: Token Usage item ${itemVisible ? "shown" : "hidden"}`);
+            }
+        } else {
+            // Headless/docker-mac flake opening the radix dropdown — don't fail
+            // the run on it; the route-render assertion below is the hard proof.
+            log(`WARN ${role}: user menu did not open (headless) — menu-item check skipped`);
+        }
+
+        // ---- 2) Route render: open /token-usage, assert what renders ----
+        await page.goto(`${WEB}/token-usage`, { waitUntil: "domcontentloaded", timeout: 30_000 });
+        await page.waitForTimeout(1500);
+        const url = page.url();
+        const bodyText = (await page.locator("body").innerText().catch(() => "")).toLowerCase();
+        await page.screenshot({ path: `${OUT_DIR}/${role}-token-usage.png`, fullPage: true });
+
+        if (wantItem) {
+            const onForbidden = /\/forbidden\b/.test(url);
+            const renderedTitle = bodyText.includes("token usage");
+            if (onForbidden || !renderedTitle) {
+                failures.push(
+                    `${role}: /token-usage should RENDER (got url=${url}, hasTitle=${renderedTitle})`,
+                );
+            } else {
+                log(`OK  ${role} /token-usage rendered (title visible)`);
+            }
+        } else {
+            const onForbidden = /\/forbidden\b/.test(url) || bodyText.includes("access denied");
+            if (!onForbidden) {
+                failures.push(`${role}: /token-usage should be FORBIDDEN (got url=${url})`);
+            } else {
+                log(`OK  ${role} /token-usage blocked → forbidden page rendered`);
+            }
+        }
+    } catch (e) {
+        failures.push(`${role}: ${e.message}`);
+    } finally {
+        await ctx.close(); // flushes the video
+    }
+}
+
+await browser.close();
+
+if (failures.length) {
+    console.error(`[rbac-ui] FAIL (${failures.length}):\n  ${failures.join("\n  ")}`);
+    process.exit(1);
+}
+console.log(`[rbac-ui] PASS — all roles rendered as expected. Evidence in ${OUT_DIR}`);

--- a/tests/e2e/scenarios/index.ts
+++ b/tests/e2e/scenarios/index.ts
@@ -7,6 +7,7 @@ import onboardingWebhookRegistration from "./onboarding-webhook-registration.js"
 import perSeatLicenseToggle from "./per-seat-license-toggle.js";
 import rbacAuthorization from "./rbac-authorization.js";
 import rbacFrontendRoutes from "./rbac-frontend-routes.js";
+import rbacUiRender from "./rbac-ui-render.js";
 import ssoCookieDomain from "./sso-cookie-domain.js";
 import ssoMultiUser from "./sso-multi-user.js";
 import stripeBilling from "./stripe-billing.js";
@@ -21,6 +22,7 @@ export const allScenarios: Record<string, Scenario> = {
     [perSeatLicenseToggle.id]: perSeatLicenseToggle,
     [rbacAuthorization.id]: rbacAuthorization,
     [rbacFrontendRoutes.id]: rbacFrontendRoutes,
+    [rbacUiRender.id]: rbacUiRender,
     [ssoCookieDomain.id]: ssoCookieDomain,
     [ssoMultiUser.id]: ssoMultiUser,
     [stripeBilling.id]: stripeBilling,
@@ -48,6 +50,7 @@ export {
     perSeatLicenseToggle,
     rbacAuthorization,
     rbacFrontendRoutes,
+    rbacUiRender,
     ssoCookieDomain,
     ssoMultiUser,
     stripeBilling,

--- a/tests/e2e/scenarios/index.ts
+++ b/tests/e2e/scenarios/index.ts
@@ -6,6 +6,7 @@ import licenseAttribution from "./license-attribution.js";
 import onboardingWebhookRegistration from "./onboarding-webhook-registration.js";
 import perSeatLicenseToggle from "./per-seat-license-toggle.js";
 import rbacAuthorization from "./rbac-authorization.js";
+import rbacFrontendRoutes from "./rbac-frontend-routes.js";
 import ssoCookieDomain from "./sso-cookie-domain.js";
 import ssoMultiUser from "./sso-multi-user.js";
 import stripeBilling from "./stripe-billing.js";
@@ -19,6 +20,7 @@ export const allScenarios: Record<string, Scenario> = {
     [licenseAttribution.id]: licenseAttribution,
     [perSeatLicenseToggle.id]: perSeatLicenseToggle,
     [rbacAuthorization.id]: rbacAuthorization,
+    [rbacFrontendRoutes.id]: rbacFrontendRoutes,
     [ssoCookieDomain.id]: ssoCookieDomain,
     [ssoMultiUser.id]: ssoMultiUser,
     [stripeBilling.id]: stripeBilling,
@@ -45,6 +47,7 @@ export {
     onboardingWebhookRegistration,
     perSeatLicenseToggle,
     rbacAuthorization,
+    rbacFrontendRoutes,
     ssoCookieDomain,
     ssoMultiUser,
     stripeBilling,

--- a/tests/e2e/scenarios/rbac-authorization.ts
+++ b/tests/e2e/scenarios/rbac-authorization.ts
@@ -31,9 +31,14 @@ import type { RunContext, Scenario, TargetContext } from "../lib/types.js";
 // passed). If MOST endpoints are owner-blocked, the org wasn't tier-unlocked
 // and the run fails loudly instead of reporting a hollow green.
 //
-// Isolation: signs up its OWN throwaway org (signup creator is OWNER + ACTIVE),
-// so every write — including mutations fired with empty/dummy payloads — is
-// contained in a disposable org.
+// IDEMPOTENT BY CONSTRUCTION (safe on shared QA, cannot touch other orgs):
+//   - GET endpoints are read-only — fired for every role.
+//   - Mutations (POST/PUT/PATCH/DELETE) are fired ONLY for roles the manifest
+//     marks `deny`, asserting the 403 that PolicyGuard returns BEFORE the
+//     handler runs — so no mutation handler ever executes. The allow-side of
+//     mutations is proven by the static manifest (rbac-matrix.manifest.spec.ts),
+//     never fired live. Net: the scenario performs zero state changes beyond
+//     signing up its own throwaway org + inviting its own users.
 // ---------------------------------------------------------------------------
 
 const PASSWORD = "E2eRbac!2026x";
@@ -245,13 +250,40 @@ export const rbacAuthorization: Scenario = {
             sessions.find((s) => s.role === role)!.accessToken;
 
         const failures: string[] = [];
-        const tierSkipped: string[] = []; // owner-blocked => non-RBAC guard
-        let asserted = 0;
+        const tierSkipped: string[] = []; // owner-blocked GET => non-RBAC guard
+        let asserted = 0; // verdicts checked live
+        let mutationAllowDeferred = 0; // allow-side mutations left to the manifest
+        let getCount = 0;
 
         for (const entry of manifest) {
-            // OWNER canary: owner has every permission, so a 401/403 here is a
-            // non-RBAC guard (tier/license/feature). Report and skip RBAC
-            // assertion rather than mis-asserting against a confounded 403.
+            // IDEMPOTENCY: a mutation only runs its handler when the guard
+            // ALLOWS it — that's the only side-effectful path. So for
+            // mutations we fire ONLY the roles the manifest marks `deny` and
+            // assert 403, which PolicyGuard returns BEFORE the handler (zero
+            // side effect, fully idempotent, can't touch any org). The
+            // allow-side of mutations is proven by the static manifest
+            // (rbac-matrix.manifest.spec.ts) and never fired here.
+            if (entry.httpMethod !== "GET") {
+                for (const role of NON_OWNER_ROLES) {
+                    if (entry.expected[role] !== "deny") {
+                        mutationAllowDeferred++;
+                        continue;
+                    }
+                    const status = await hit(ctx.target, entry, tokenOf(role));
+                    if (status !== 403) {
+                        failures.push(
+                            `${role} should be DENIED on ${entry.httpMethod} ${entry.urlPath} (expected 403, got ${status})`,
+                        );
+                    }
+                    asserted++;
+                }
+                continue;
+            }
+
+            // GET is read-only (safe + idempotent). OWNER canary: owner has
+            // every permission, so a 401/403 here is a non-RBAC guard
+            // (tier/license/feature) — report and skip rather than mis-assert.
+            getCount++;
             const ownerStatus = await hit(ctx.target, entry, tokenOf("owner"));
             if (ownerStatus === 401 || ownerStatus === 403) {
                 tierSkipped.push(
@@ -282,26 +314,30 @@ export const rbacAuthorization: Scenario = {
         // Loud, non-silent reporting of what couldn't be RBAC-tested (tier).
         if (tierSkipped.length) {
             console.log(
-                `[rbac] ${tierSkipped.length} endpoint(s) skipped — owner blocked by a non-RBAC guard (org not tier-unlocked?):\n  ${tierSkipped.join("\n  ")}`,
+                `[rbac] ${tierSkipped.length} GET endpoint(s) skipped — owner blocked by a non-RBAC guard (org not tier-unlocked?):\n  ${tierSkipped.join("\n  ")}`,
             );
         }
+        console.log(
+            `[rbac] live verdicts asserted: ${asserted} (all GET allow/deny + every mutation deny). Mutation allow-side (${mutationAllowDeferred}) is covered by rbac-matrix.manifest.spec.ts — never fired live, so the run stays idempotent.`,
+        );
 
         ctx.assert(
             failures.length === 0,
             `RBAC mismatches (${failures.length}):\n  ${failures.join("\n  ")}`,
         );
 
-        // If most endpoints were owner-blocked, the org wasn't tier-unlocked
-        // (not trial/licensed) — tier-gated RBAC was NOT actually validated.
-        // Fail loudly rather than report a hollow green.
+        // If most GETs were owner-blocked, the org wasn't tier-unlocked (not
+        // trial/licensed) — tier-gated RBAC was NOT actually validated. Fail
+        // loudly rather than report a hollow green.
         ctx.assert(
-            tierSkipped.length < manifest.length / 2,
-            `Over half the endpoints (${tierSkipped.length}/${manifest.length}) had owner blocked — the test org is not trial/licensed, so tier-gated RBAC was NOT validated. Run against a trial (fresh cloud) or licensed target.`,
+            getCount > 0 && tierSkipped.length < getCount / 2,
+            `Over half the GET endpoints (${tierSkipped.length}/${getCount}) had owner blocked — the test org is not trial/licensed, so tier-gated RBAC was NOT validated. Run against a trial (fresh cloud) or licensed target.`,
         );
 
         return {
             endpoints: manifest.length,
             cellsAsserted: asserted,
+            mutationAllowDeferred,
             tierSkipped: tierSkipped.length,
         };
     },

--- a/tests/e2e/scenarios/rbac-authorization.ts
+++ b/tests/e2e/scenarios/rbac-authorization.ts
@@ -174,18 +174,21 @@ async function hit(
     entry: ManifestEntry,
     token: string,
 ): Promise<number> {
-    const method = entry.httpMethod as
+    // SSE endpoints are GET over HTTP; the guard runs before the stream opens,
+    // so a denied role still gets a clean 403 (no hanging stream). They're
+    // classified non-GET below (deny-only), so the allow-side never streams.
+    const verb = (entry.httpMethod === "SSE" ? "GET" : entry.httpMethod) as
         | "GET"
         | "POST"
         | "PUT"
         | "PATCH"
         | "DELETE";
     const res = await http(`${target.apiBaseUrl}${concreteUrl(entry.urlPath)}`, {
-        method,
+        method: verb,
         headers: { Authorization: `Bearer ${token}` },
         // Empty body for mutations: passes the guard, fails validation
         // downstream (no real mutation) — enough to read the policy verdict.
-        body: method === "GET" ? undefined : {},
+        body: verb === "GET" ? undefined : {},
         timeoutMs: 20_000,
     });
     return res.status;

--- a/tests/e2e/scenarios/rbac-authorization.ts
+++ b/tests/e2e/scenarios/rbac-authorization.ts
@@ -2,53 +2,35 @@ import * as fs from "fs";
 import { join } from "path";
 
 import { http } from "../lib/http.js";
-import { login, signUp } from "../lib/onboarding.js";
+import {
+    NON_OWNER_ROLES,
+    RbacRole,
+    setupRbacOrg,
+} from "../lib/rbac-provision.js";
 import type { RunContext, Scenario, TargetContext } from "../lib/types.js";
 
 // ---------------------------------------------------------------------------
-// RBAC authorization matrix (full-stack, COMPREHENSIVE).
+// RBAC authorization matrix (full-stack, COMPREHENSIVE — backend).
 //
 // Replays the committed RBAC manifest
 // (apps/api/src/controllers/__tests__/rbac-matrix.manifest.json) against a
-// real, provisioned target, exercising the COMPLETE request path:
-// JwtAuthGuard → PolicyGuard → PermissionsAbilityFactory + the global layers.
-//
-// The manifest is the SINGLE SOURCE OF TRUTH: derived from every gated
-// controller endpoint's @CheckPolicies and the REAL PermissionsAbilityFactory
-// (see rbac-matrix.shared.ts); a jest drift-guard (rbac-matrix.manifest.spec.ts)
-// fails CI if a controller's gating changes without regenerating it. So this
-// live test and the static grid can never disagree about what the matrix says
-// — and here we prove the running API actually enforces it, for EVERY gated
-// endpoint, not a hand-picked few.
-//
-// Tier-gated endpoints (Cockpit, SSO, …) sit behind a SEPARATE guard
-// (EnterpriseTierGuard / CockpitTierGuard) that 403s regardless of role when
-// the org isn't licensed. We neutralize that by running where the freshly
-// signed-up org is on TRIAL (treated as enterprise preview), which unlocks
-// those guards. To stay honest if that ever breaks, OWNER is the canary: owner
-// has every permission, so an owner 401/403 can only be a non-RBAC guard —
-// those endpoints are SKIPPED for RBAC assertion and reported (never silently
-// passed). If MOST endpoints are owner-blocked, the org wasn't tier-unlocked
-// and the run fails loudly instead of reporting a hollow green.
+// real, provisioned target, exercising JwtAuthGuard → PolicyGuard →
+// PermissionsAbilityFactory over HTTP. The manifest is the SINGLE SOURCE OF
+// TRUTH (same extractor as authorization-matrix.spec.ts); a jest drift-guard
+// keeps it in sync, so this live test and the static grid can never disagree.
 //
 // IDEMPOTENT BY CONSTRUCTION (safe on shared QA, cannot touch other orgs):
 //   - GET endpoints are read-only — fired for every role.
 //   - Mutations (POST/PUT/PATCH/DELETE) are fired ONLY for roles the manifest
-//     marks `deny`, asserting the 403 that PolicyGuard returns BEFORE the
-//     handler runs — so no mutation handler ever executes. The allow-side of
-//     mutations is proven by the static manifest (rbac-matrix.manifest.spec.ts),
-//     never fired live. Net: the scenario performs zero state changes beyond
-//     signing up its own throwaway org + inviting its own users.
+//     marks `deny`, asserting the 403 PolicyGuard returns BEFORE the handler
+//     runs — so no mutation handler ever executes. The allow-side of mutations
+//     is proven by the static manifest, never fired live.
+//
+// Tier-gated endpoints (Cockpit, SSO) sit behind a SEPARATE guard that 403s
+// regardless of role when the org isn't licensed. OWNER is the canary: an owner
+// 401/403 can only be a non-RBAC guard, so those endpoints are reported and
+// skipped (never silently passed); if most are owner-blocked the run fails.
 // ---------------------------------------------------------------------------
-
-const PASSWORD = "E2eRbac!2026x";
-
-type RbacRole = "owner" | "billing_manager" | "repo_admin" | "contributor";
-const NON_OWNER_ROLES: RbacRole[] = [
-    "billing_manager",
-    "repo_admin",
-    "contributor",
-];
 
 type ManifestEntry = {
     key: string;
@@ -57,8 +39,7 @@ type ManifestEntry = {
     expected: Record<RbacRole, "allow" | "deny">;
 };
 
-// e2e scripts run with cwd = tests/e2e (see package.json), matching the
-// process.cwd() convention used across this package (benchmark/, cli/).
+// e2e scripts run with cwd = tests/e2e (see package.json).
 const MANIFEST_PATH = join(
     process.cwd(),
     "..",
@@ -82,101 +63,14 @@ function concreteUrl(urlPath: string): string {
     return urlPath.replace(/:[A-Za-z0-9_]+/g, "1");
 }
 
-type RoleSession = { role: RbacRole; accessToken: string };
-
-/**
- * Invite a user with a specific RBAC role into the owner's team, activate it,
- * and return an authenticated session. (Mechanics validated end-to-end against
- * QA on 2026-05-27; see git history of this file.)
- */
-async function provisionUserWithRole(
-    ctx: RunContext,
-    target: TargetContext,
-    ownerToken: string,
-    teamId: string,
-    role: RbacRole,
-): Promise<RoleSession> {
-    const email = `e2e-rbac-${role}-${Date.now()}@kodus.local`;
-    const name = `e2e ${role}`;
-    const authed = { Authorization: `Bearer ${ownerToken}` };
-
-    const invite = await http(`${target.apiBaseUrl}/team-members`, {
-        method: "POST",
-        headers: authed,
-        body: {
-            teamId,
-            members: [
-                {
-                    email,
-                    name,
-                    role,
-                    teamRole: "team_member",
-                    active: true,
-                    communicationId: email,
-                },
-            ],
-        },
-        timeoutMs: 30_000,
-    });
-    if (invite.status < 200 || invite.status >= 300) {
-        ctx.skip(
-            `provisioning: invite ${role} failed (HTTP ${invite.status}): ${invite.raw.slice(0, 250)}`,
-        );
-    }
-
-    const list = await http<{
-        data: { members: Array<{ email: string; userId: string }> };
-    }>(`${target.apiBaseUrl}/team-members?teamId=${teamId}`, {
-        method: "GET",
-        headers: authed,
-        timeoutMs: 20_000,
-    });
-    const userId = list.body?.data?.members?.find((m) => m.email === email)
-        ?.userId;
-    ctx.assert(
-        userId,
-        `provisioning: no userId for ${email}. Members: ${list.raw.slice(0, 250)}`,
-    );
-
-    const complete = await http(
-        `${target.apiBaseUrl}/user/invite/complete-invitation`,
-        {
-            method: "POST",
-            body: { uuid: userId, name, password: PASSWORD },
-            timeoutMs: 20_000,
-        },
-    );
-    if (complete.status < 200 || complete.status >= 300) {
-        ctx.skip(
-            `provisioning: complete-invitation ${role} failed (HTTP ${complete.status}): ${complete.raw.slice(0, 250)}`,
-        );
-    }
-
-    // The invite lands the user as contributor; set the real RBAC role.
-    const patch = await http(`${target.apiBaseUrl}/user/${userId}`, {
-        method: "PATCH",
-        headers: authed,
-        body: { role },
-        timeoutMs: 20_000,
-    });
-    if (patch.status < 200 || patch.status >= 300) {
-        ctx.skip(
-            `provisioning: set role ${role} failed (HTTP ${patch.status}): ${patch.raw.slice(0, 250)}`,
-        );
-    }
-
-    const session = await login(target, { email, password: PASSWORD });
-    return { role, accessToken: session.accessToken };
-}
-
 async function hit(
     target: TargetContext,
     entry: ManifestEntry,
     token: string,
 ): Promise<number> {
     // SSE endpoints are GET over HTTP; the guard runs before the stream opens,
-    // so a denied role still gets a clean 403 (no hanging stream). They're
-    // classified non-GET below (deny-only), so the allow-side never streams.
+    // so a denied role still gets a clean 403. They're classified non-GET below
+    // (deny-only), so the allow-side never streams.
     const verb = (entry.httpMethod === "SSE" ? "GET" : entry.httpMethod) as
         | "GET"
         | "POST"
@@ -186,8 +80,6 @@ async function hit(
     const res = await http(`${target.apiBaseUrl}${concreteUrl(entry.urlPath)}`, {
         method: verb,
         headers: { Authorization: `Bearer ${token}` },
-        // Empty body for mutations: passes the guard, fails validation
-        // downstream (no real mutation) — enough to read the policy verdict.
         body: verb === "GET" ? undefined : {},
         timeoutMs: 20_000,
     });
@@ -201,8 +93,6 @@ export const rbacAuthorization: Scenario = {
     appliesTo: {
         target: ["cloud", "self-hosted"],
         provider: ["github"], // RBAC is provider-agnostic; one provider suffices
-        // Trial (fresh cloud org) and licensed self-hosted both unlock the
-        // tier-gated guards so their RBAC is actually exercised here.
         license: ["trial", "paid", "license-paid"],
     },
     timeoutSec: 900,
@@ -213,59 +103,19 @@ export const rbacAuthorization: Scenario = {
             `manifest looks empty (${manifest.length}) — regenerate with UPDATE_RBAC_MANIFEST=1`,
         );
 
-        // Fresh, disposable org — the signup creator is OWNER + ACTIVE.
-        const ownerEmail = `e2e-rbac-owner-${Date.now()}@kodus.local`;
-        await signUp(ctx.target, { email: ownerEmail, password: PASSWORD });
-        const owner = await login(ctx.target, {
-            email: ownerEmail,
-            password: PASSWORD,
-        });
-
-        const teamRes = await http<{ data: Array<{ uuid: string }> }>(
-            `${ctx.target.apiBaseUrl}/team`,
-            {
-                method: "GET",
-                headers: { Authorization: `Bearer ${owner.accessToken}` },
-                timeoutMs: 20_000,
-            },
-        );
-        const teamId = teamRes.body?.data?.[0]?.uuid;
-        ctx.assert(
-            teamId,
-            `could not resolve owner teamId: ${teamRes.raw.slice(0, 200)}`,
-        );
-
-        const sessions: RoleSession[] = [
-            { role: "owner", accessToken: owner.accessToken },
-        ];
-        for (const role of NON_OWNER_ROLES) {
-            sessions.push(
-                await provisionUserWithRole(
-                    ctx,
-                    ctx.target,
-                    owner.accessToken,
-                    teamId,
-                    role,
-                ),
-            );
-        }
+        const { sessions } = await setupRbacOrg(ctx);
         const tokenOf = (role: RbacRole) =>
             sessions.find((s) => s.role === role)!.accessToken;
 
         const failures: string[] = [];
-        const tierSkipped: string[] = []; // owner-blocked GET => non-RBAC guard
-        let asserted = 0; // verdicts checked live
-        let mutationAllowDeferred = 0; // allow-side mutations left to the manifest
+        const tierSkipped: string[] = [];
+        let asserted = 0;
+        let mutationAllowDeferred = 0;
         let getCount = 0;
 
         for (const entry of manifest) {
-            // IDEMPOTENCY: a mutation only runs its handler when the guard
-            // ALLOWS it — that's the only side-effectful path. So for
-            // mutations we fire ONLY the roles the manifest marks `deny` and
-            // assert 403, which PolicyGuard returns BEFORE the handler (zero
-            // side effect, fully idempotent, can't touch any org). The
-            // allow-side of mutations is proven by the static manifest
-            // (rbac-matrix.manifest.spec.ts) and never fired here.
+            // Mutations: fire ONLY deny-roles and assert the pre-handler 403
+            // (zero side effect, idempotent). Allow-side is static-only.
             if (entry.httpMethod !== "GET") {
                 for (const role of NON_OWNER_ROLES) {
                     if (entry.expected[role] !== "deny") {
@@ -283,9 +133,7 @@ export const rbacAuthorization: Scenario = {
                 continue;
             }
 
-            // GET is read-only (safe + idempotent). OWNER canary: owner has
-            // every permission, so a 401/403 here is a non-RBAC guard
-            // (tier/license/feature) — report and skip rather than mis-assert.
+            // GET (read-only). OWNER canary skips non-RBAC (tier) guards.
             getCount++;
             const ownerStatus = await hit(ctx.target, entry, tokenOf("owner"));
             if (ownerStatus === 401 || ownerStatus === 403) {
@@ -314,24 +162,19 @@ export const rbacAuthorization: Scenario = {
             }
         }
 
-        // Loud, non-silent reporting of what couldn't be RBAC-tested (tier).
         if (tierSkipped.length) {
             console.log(
                 `[rbac] ${tierSkipped.length} GET endpoint(s) skipped — owner blocked by a non-RBAC guard (org not tier-unlocked?):\n  ${tierSkipped.join("\n  ")}`,
             );
         }
         console.log(
-            `[rbac] live verdicts asserted: ${asserted} (all GET allow/deny + every mutation deny). Mutation allow-side (${mutationAllowDeferred}) is covered by rbac-matrix.manifest.spec.ts — never fired live, so the run stays idempotent.`,
+            `[rbac] live verdicts asserted: ${asserted} (all GET allow/deny + every mutation deny). Mutation allow-side (${mutationAllowDeferred}) is static-only, so the run stays idempotent.`,
         );
 
         ctx.assert(
             failures.length === 0,
             `RBAC mismatches (${failures.length}):\n  ${failures.join("\n  ")}`,
         );
-
-        // If most GETs were owner-blocked, the org wasn't tier-unlocked (not
-        // trial/licensed) — tier-gated RBAC was NOT actually validated. Fail
-        // loudly rather than report a hollow green.
         ctx.assert(
             getCount > 0 && tierSkipped.length < getCount / 2,
             `Over half the GET endpoints (${tierSkipped.length}/${getCount}) had owner blocked — the test org is not trial/licensed, so tier-gated RBAC was NOT validated. Run against a trial (fresh cloud) or licensed target.`,

--- a/tests/e2e/scenarios/rbac-authorization.ts
+++ b/tests/e2e/scenarios/rbac-authorization.ts
@@ -1,103 +1,88 @@
+import * as fs from "fs";
+import { join } from "path";
+
 import { http } from "../lib/http.js";
 import { login, signUp } from "../lib/onboarding.js";
 import type { RunContext, Scenario, TargetContext } from "../lib/types.js";
 
 // ---------------------------------------------------------------------------
-// RBAC authorization matrix (full-stack).
+// RBAC authorization matrix (full-stack, COMPREHENSIVE).
 //
-// Runs against a real, provisioned target (cloud QA or self-hosted VM),
-// exercising the COMPLETE request path: JwtAuthGuard → PolicyGuard →
-// PermissionsAbilityFactory + the global transform/exception layers. This is
-// the only place the real JWT auth + RBAC are validated together over HTTP.
+// Replays the committed RBAC manifest
+// (apps/api/src/controllers/__tests__/rbac-matrix.manifest.json) against a
+// real, provisioned target, exercising the COMPLETE request path:
+// JwtAuthGuard → PolicyGuard → PermissionsAbilityFactory + the global layers.
 //
-// Isolation: the scenario signs up its OWN throwaway org (the signup creator is
-// OWNER + ACTIVE even in cloud mode), so every write here — including the
-// destructive BYOK delete — is contained in a disposable org and cannot affect
-// anyone else's tenant.
+// The manifest is the SINGLE SOURCE OF TRUTH: derived from every gated
+// controller endpoint's @CheckPolicies and the REAL PermissionsAbilityFactory
+// (see rbac-matrix.shared.ts); a jest drift-guard (rbac-matrix.manifest.spec.ts)
+// fails CI if a controller's gating changes without regenerating it. So this
+// live test and the static grid can never disagree about what the matrix says
+// — and here we prove the running API actually enforces it, for EVERY gated
+// endpoint, not a hand-picked few.
 //
-// Flow:
-//   1. Sign up a fresh owner (new org).
-//   2. Invite one user per non-owner role, activate it, log in.
-//   3. For each (endpoint, role): allowed role → NOT 401/403; denied role → 403.
+// Tier-gated endpoints (Cockpit, SSO, …) sit behind a SEPARATE guard
+// (EnterpriseTierGuard / CockpitTierGuard) that 403s regardless of role when
+// the org isn't licensed. We neutralize that by running where the freshly
+// signed-up org is on TRIAL (treated as enterprise preview), which unlocks
+// those guards. To stay honest if that ever breaks, OWNER is the canary: owner
+// has every permission, so an owner 401/403 can only be a non-RBAC guard —
+// those endpoints are SKIPPED for RBAC assertion and reported (never silently
+// passed). If MOST endpoints are owner-blocked, the org wasn't tier-unlocked
+// and the run fails loudly instead of reporting a hollow green.
 //
-// The provisioning endpoints below were validated live against QA on
-// 2026-05-27 (see provisionUserWithRole). The expected CASES matrix reflects
-// the FIXED backend (this branch): running it against a target on older code
-// will surface the pre-fix bugs (e.g. contributor getting 200 on TokenUsage).
+// Isolation: signs up its OWN throwaway org (signup creator is OWNER + ACTIVE),
+// so every write — including mutations fired with empty/dummy payloads — is
+// contained in a disposable org.
 // ---------------------------------------------------------------------------
 
 const PASSWORD = "E2eRbac!2026x";
 
 type RbacRole = "owner" | "billing_manager" | "repo_admin" | "contributor";
+const NON_OWNER_ROLES: RbacRole[] = [
+    "billing_manager",
+    "repo_admin",
+    "contributor",
+];
 
-type Case = {
-    name: string;
-    method: "get" | "post" | "delete" | "patch";
-    path: string;
-    body?: unknown;
-    allowed: RbacRole[];
+type ManifestEntry = {
+    key: string;
+    httpMethod: string;
+    urlPath: string;
+    expected: Record<RbacRole, "allow" | "deny">;
 };
 
-// Expected allow-list per endpoint, derived from ROLE_POLICIES
-// (libs/identity/domain/permissions/policies/role-policies.ts).
-const CASES: Case[] = [
-    {
-        name: "TokenUsage read",
-        method: "get",
-        path: "/usage/tokens/summary?startDate=2026-01-01&endDate=2026-01-31&byok=false",
-        allowed: ["owner", "billing_manager", "repo_admin"],
-    },
-    {
-        // Bug A: was reachable by anyone authenticated.
-        name: "BYOK delete (OrganizationSettings)",
-        method: "delete",
-        path: "/organization-parameters/delete-byok-config?configType=main",
-        allowed: ["owner"],
-    },
-    // NOTE: Cockpit analytics is intentionally NOT covered here. This scenario
-    // signs up a fresh (free-tier) org, so CockpitTierGuard 403s everyone
-    // regardless of role and would confound the allow assertions. Cockpit's
-    // RBAC is covered by authorization-matrix.spec.ts (jest).
-    {
-        name: "CLI review read",
-        method: "get",
-        path: "/cli-reviews/executions",
-        allowed: ["owner", "repo_admin", "contributor"],
-    },
-    {
-        name: "Issues read",
-        method: "get",
-        path: "/issues",
-        allowed: ["owner", "repo_admin", "contributor"],
-    },
-];
+// e2e scripts run with cwd = tests/e2e (see package.json), matching the
+// process.cwd() convention used across this package (benchmark/, cli/).
+const MANIFEST_PATH = join(
+    process.cwd(),
+    "..",
+    "..",
+    "apps",
+    "api",
+    "src",
+    "controllers",
+    "__tests__",
+    "rbac-matrix.manifest.json",
+);
+
+function loadManifest(): ManifestEntry[] {
+    return JSON.parse(fs.readFileSync(MANIFEST_PATH, "utf8")) as ManifestEntry[];
+}
+
+// Replace `:param` segments with a throwaway value so the request reaches the
+// guards. PolicyGuard runs before validation, so a downstream 400/404 on a
+// dummy id still reflects "allowed by policy" (not 401/403).
+function concreteUrl(urlPath: string): string {
+    return urlPath.replace(/:[A-Za-z0-9_]+/g, "1");
+}
 
 type RoleSession = { role: RbacRole; accessToken: string };
 
-const jwtPayload = (jwt: string): Record<string, unknown> => {
-    try {
-        return JSON.parse(
-            Buffer.from(jwt.split(".")[1], "base64").toString("utf8"),
-        );
-    } catch {
-        return {};
-    }
-};
-
 /**
- * Invite a user with a specific RBAC role into the owner's team, activate the
- * invitation (sets a password), and return an authenticated session.
- *
- * Validated end-to-end against a local instance of THIS branch on 2026-05-27
- * (16/16 matrix cells green):
- *   - POST /team-members invites the user (joiners default to CONTRIBUTOR).
- *   - GET  /team-members?teamId= returns `{ data: { members: [...] } }`; match
- *     by email and use the member's `userId`.
- *   - POST /user/invite/complete-invitation { uuid: userId, name, password }
- *     activates the user (path is `/user`, singular).
- *   - PATCH /user/:userId { role } sets the actual RBAC role — REQUIRED; the
- *     `role` field on the invite does NOT stick (everyone lands as contributor
- *     without this).
+ * Invite a user with a specific RBAC role into the owner's team, activate it,
+ * and return an authenticated session. (Mechanics validated end-to-end against
+ * QA on 2026-05-27; see git history of this file.)
  */
 async function provisionUserWithRole(
     ctx: RunContext,
@@ -179,17 +164,47 @@ async function provisionUserWithRole(
     return { role, accessToken: session.accessToken };
 }
 
+async function hit(
+    target: TargetContext,
+    entry: ManifestEntry,
+    token: string,
+): Promise<number> {
+    const method = entry.httpMethod as
+        | "GET"
+        | "POST"
+        | "PUT"
+        | "PATCH"
+        | "DELETE";
+    const res = await http(`${target.apiBaseUrl}${concreteUrl(entry.urlPath)}`, {
+        method,
+        headers: { Authorization: `Bearer ${token}` },
+        // Empty body for mutations: passes the guard, fails validation
+        // downstream (no real mutation) — enough to read the policy verdict.
+        body: method === "GET" ? undefined : {},
+        timeoutMs: 20_000,
+    });
+    return res.status;
+}
+
 export const rbacAuthorization: Scenario = {
     id: "rbac-authorization",
-    title: "RBAC: each role gets the expected 200 vs 403 across API endpoints",
+    title: "RBAC: every gated endpoint enforces the manifest verdict per role",
     priority: "P0",
     appliesTo: {
         target: ["cloud", "self-hosted"],
         provider: ["github"], // RBAC is provider-agnostic; one provider suffices
-        license: ["paid", "license-paid"],
+        // Trial (fresh cloud org) and licensed self-hosted both unlock the
+        // tier-gated guards so their RBAC is actually exercised here.
+        license: ["trial", "paid", "license-paid"],
     },
-    timeoutSec: 300,
+    timeoutSec: 900,
     async run(ctx: RunContext) {
+        const manifest = loadManifest();
+        ctx.assert(
+            manifest.length > 30,
+            `manifest looks empty (${manifest.length}) — regenerate with UPDATE_RBAC_MANIFEST=1`,
+        );
+
         // Fresh, disposable org — the signup creator is OWNER + ACTIVE.
         const ownerEmail = `e2e-rbac-owner-${Date.now()}@kodus.local`;
         await signUp(ctx.target, { email: ownerEmail, password: PASSWORD });
@@ -207,20 +222,15 @@ export const rbacAuthorization: Scenario = {
             },
         );
         const teamId = teamRes.body?.data?.[0]?.uuid;
-        ctx.assert(teamId, `could not resolve owner teamId: ${teamRes.raw.slice(0, 200)}`);
-
-        const orgId =
-            owner.organizationId ??
-            (jwtPayload(owner.accessToken).organizationId as string);
+        ctx.assert(
+            teamId,
+            `could not resolve owner teamId: ${teamRes.raw.slice(0, 200)}`,
+        );
 
         const sessions: RoleSession[] = [
             { role: "owner", accessToken: owner.accessToken },
         ];
-        for (const role of [
-            "billing_manager",
-            "repo_admin",
-            "contributor",
-        ] as RbacRole[]) {
+        for (const role of NON_OWNER_ROLES) {
             sessions.push(
                 await provisionUserWithRole(
                     ctx,
@@ -231,43 +241,69 @@ export const rbacAuthorization: Scenario = {
                 ),
             );
         }
+        const tokenOf = (role: RbacRole) =>
+            sessions.find((s) => s.role === role)!.accessToken;
 
-        const evidence: Record<string, Record<string, number>> = {};
+        const failures: string[] = [];
+        const tierSkipped: string[] = []; // owner-blocked => non-RBAC guard
+        let asserted = 0;
 
-        for (const testCase of CASES) {
-            const path = testCase.path.replace("__ORG__", orgId ?? "");
-            const row: Record<string, number> = {};
+        for (const entry of manifest) {
+            // OWNER canary: owner has every permission, so a 401/403 here is a
+            // non-RBAC guard (tier/license/feature). Report and skip RBAC
+            // assertion rather than mis-asserting against a confounded 403.
+            const ownerStatus = await hit(ctx.target, entry, tokenOf("owner"));
+            if (ownerStatus === 401 || ownerStatus === 403) {
+                tierSkipped.push(
+                    `${entry.httpMethod} ${entry.urlPath} (owner ${ownerStatus})`,
+                );
+                continue;
+            }
 
-            for (const s of sessions) {
-                const res = await http(`${ctx.target.apiBaseUrl}${path}`, {
-                    method: testCase.method.toUpperCase() as
-                        | "GET"
-                        | "POST"
-                        | "DELETE"
-                        | "PATCH",
-                    headers: { Authorization: `Bearer ${s.accessToken}` },
-                    body: testCase.body,
-                    timeoutMs: 20_000,
-                });
-                row[s.role] = res.status;
-
-                const shouldAllow = testCase.allowed.includes(s.role);
-                if (shouldAllow) {
-                    ctx.assert(
-                        res.status !== 401 && res.status !== 403,
-                        `${s.role} should access "${testCase.name}" but got HTTP ${res.status}: ${res.raw.slice(0, 200)}`,
+            for (const role of NON_OWNER_ROLES) {
+                const status = await hit(ctx.target, entry, tokenOf(role));
+                const expected = entry.expected[role];
+                if (expected === "deny" && status !== 403) {
+                    failures.push(
+                        `${role} should be DENIED on ${entry.httpMethod} ${entry.urlPath} (expected 403, got ${status})`,
                     );
-                } else {
-                    ctx.assert(
-                        res.status === 403,
-                        `${s.role} must be forbidden on "${testCase.name}" (expected 403) but got HTTP ${res.status}: ${res.raw.slice(0, 200)}`,
+                } else if (
+                    expected === "allow" &&
+                    (status === 401 || status === 403)
+                ) {
+                    failures.push(
+                        `${role} should be ALLOWED on ${entry.httpMethod} ${entry.urlPath} (got ${status})`,
                     );
                 }
+                asserted++;
             }
-            evidence[testCase.name] = row;
         }
 
-        return { org: orgId, matrix: evidence };
+        // Loud, non-silent reporting of what couldn't be RBAC-tested (tier).
+        if (tierSkipped.length) {
+            console.log(
+                `[rbac] ${tierSkipped.length} endpoint(s) skipped — owner blocked by a non-RBAC guard (org not tier-unlocked?):\n  ${tierSkipped.join("\n  ")}`,
+            );
+        }
+
+        ctx.assert(
+            failures.length === 0,
+            `RBAC mismatches (${failures.length}):\n  ${failures.join("\n  ")}`,
+        );
+
+        // If most endpoints were owner-blocked, the org wasn't tier-unlocked
+        // (not trial/licensed) — tier-gated RBAC was NOT actually validated.
+        // Fail loudly rather than report a hollow green.
+        ctx.assert(
+            tierSkipped.length < manifest.length / 2,
+            `Over half the endpoints (${tierSkipped.length}/${manifest.length}) had owner blocked — the test org is not trial/licensed, so tier-gated RBAC was NOT validated. Run against a trial (fresh cloud) or licensed target.`,
+        );
+
+        return {
+            endpoints: manifest.length,
+            cellsAsserted: asserted,
+            tierSkipped: tierSkipped.length,
+        };
     },
 };
 

--- a/tests/e2e/scenarios/rbac-frontend-routes.ts
+++ b/tests/e2e/scenarios/rbac-frontend-routes.ts
@@ -1,0 +1,169 @@
+import * as fs from "fs";
+import { join } from "path";
+
+import {
+    NON_OWNER_ROLES,
+    RBAC_PASSWORD,
+    RbacRole,
+    setupRbacOrg,
+} from "../lib/rbac-provision.js";
+import type { RunContext, Scenario, TargetContext } from "../lib/types.js";
+
+// ---------------------------------------------------------------------------
+// RBAC frontend route guard (full-stack).
+//
+// This is the layer the #1229 bug actually lived in: the Next.js middleware
+// (`canAccessRoute`) that redirects a non-owner role to /forbidden when its
+// policy doesn't reach a page. The backend rbac-authorization scenario proves
+// the API enforces; this proves the WEB middleware does, on the running server.
+//
+// Replays the committed frontend manifest
+// (apps/web/src/core/utils/permissions.route-manifest.json) — derived from the
+// real `canAccessRoute` over every app/(app) page, with a jest drift-guard.
+// For each role it signs in through next-auth over HTTP (no brittle browser
+// form), then GETs each page route and checks: `deny` => redirected to
+// /forbidden; `allow` => anything else (200, or a non-/forbidden app redirect
+// such as the tier gate bouncing /cockpit → /settings/git).
+//
+// Idempotent: only GETs page routes, performs no mutations beyond signing up
+// its own throwaway org + users (shared with rbac-authorization via
+// lib/rbac-provision).
+// ---------------------------------------------------------------------------
+
+type RouteEntry = { route: string; expected: Record<RbacRole, "allow" | "deny"> };
+
+const MANIFEST_PATH = join(
+    process.cwd(),
+    "..",
+    "..",
+    "apps",
+    "web",
+    "src",
+    "core",
+    "utils",
+    "permissions.route-manifest.json",
+);
+
+function loadRouteManifest(): RouteEntry[] {
+    return JSON.parse(fs.readFileSync(MANIFEST_PATH, "utf8")) as RouteEntry[];
+}
+
+// Minimal cookie jar: name -> value, serialized as a Cookie header.
+type Jar = Map<string, string>;
+function absorb(jar: Jar, res: Response): void {
+    for (const c of res.headers.getSetCookie()) {
+        const [pair] = c.split(";");
+        const eq = pair.indexOf("=");
+        if (eq > 0) jar.set(pair.slice(0, eq).trim(), pair.slice(eq + 1).trim());
+    }
+}
+function cookieHeader(jar: Jar): string {
+    return [...jar.entries()].map(([k, v]) => `${k}=${v}`).join("; ");
+}
+
+/** Sign in through next-auth (credentials provider) over HTTP; returns the
+ *  authenticated cookie jar the Next middleware accepts. */
+async function nextAuthLogin(
+    web: string,
+    email: string,
+    password: string,
+): Promise<Jar> {
+    const jar: Jar = new Map();
+
+    const csrfRes = await fetch(`${web}/api/auth/csrf`, { redirect: "manual" });
+    absorb(jar, csrfRes);
+    const { csrfToken } = (await csrfRes.json()) as { csrfToken: string };
+
+    const form = new URLSearchParams({
+        csrfToken,
+        email,
+        password,
+        redirect: "false",
+        json: "true",
+    });
+    const cbRes = await fetch(`${web}/api/auth/callback/credentials`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            Cookie: cookieHeader(jar),
+        },
+        body: form.toString(),
+        redirect: "manual",
+    });
+    absorb(jar, cbRes);
+
+    if (!jar.has("authjs.session-token")) {
+        throw new Error(
+            `next-auth login for ${email} did not yield a session (HTTP ${cbRes.status})`,
+        );
+    }
+    return jar;
+}
+
+/** "allow" unless the middleware redirected to /forbidden. */
+async function routeVerdict(
+    web: string,
+    jar: Jar,
+    route: string,
+): Promise<"allow" | "deny"> {
+    const res = await fetch(`${web}${route}`, {
+        headers: { Cookie: cookieHeader(jar) },
+        redirect: "manual",
+    });
+    const location = res.headers.get("location") ?? "";
+    return res.status >= 300 && res.status < 400 && /\/forbidden\b/.test(location)
+        ? "deny"
+        : "allow";
+}
+
+export const rbacFrontendRoutes: Scenario = {
+    id: "rbac-frontend-routes",
+    title: "RBAC: the web middleware redirects to /forbidden per the route manifest",
+    priority: "P0",
+    appliesTo: {
+        target: ["cloud", "self-hosted"],
+        provider: ["github"],
+        license: ["trial", "paid", "license-paid"],
+    },
+    timeoutSec: 600,
+    async run(ctx: RunContext) {
+        const manifest = loadRouteManifest();
+        ctx.assert(
+            manifest.length > 10,
+            `route manifest looks empty (${manifest.length}) — regenerate with UPDATE_ROUTE_MANIFEST=1`,
+        );
+
+        const web = (ctx.target as TargetContext).webBaseUrl.replace(/\/$/, "");
+        const { sessions } = await setupRbacOrg(ctx);
+
+        const failures: string[] = [];
+        let asserted = 0;
+
+        for (const role of NON_OWNER_ROLES) {
+            const { email } = sessions.find((s) => s.role === role)!;
+            const jar = await nextAuthLogin(web, email, RBAC_PASSWORD);
+
+            for (const entry of manifest) {
+                const verdict = await routeVerdict(web, jar, entry.route);
+                if (verdict !== entry.expected[role]) {
+                    failures.push(
+                        `${role} on ${entry.route}: expected ${entry.expected[role]}, got ${verdict}`,
+                    );
+                }
+                asserted++;
+            }
+        }
+
+        console.log(
+            `[rbac-fe] ${asserted} route×role verdicts checked live against ${web}`,
+        );
+        ctx.assert(
+            failures.length === 0,
+            `Frontend route mismatches (${failures.length}):\n  ${failures.join("\n  ")}`,
+        );
+
+        return { routes: manifest.length, verdictsAsserted: asserted };
+    },
+};
+
+export default rbacFrontendRoutes;

--- a/tests/e2e/scenarios/rbac-ui-render.ts
+++ b/tests/e2e/scenarios/rbac-ui-render.ts
@@ -1,0 +1,67 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { RBAC_PASSWORD, setupRbacOrg } from "../lib/rbac-provision.js";
+import type { RunContext, Scenario } from "../lib/types.js";
+
+// ---------------------------------------------------------------------------
+// RBAC frontend RENDER evidence (real browser).
+//
+// The route-guard e2e (rbac-frontend-routes) proves the middleware's
+// authorization (200 vs /forbidden). This proves the UI actually RENDERS: it
+// drives a real Chromium per role (auth injected from a next-auth session
+// minted over HTTP — no brittle form) and asserts on the rendered DOM that the
+// "Token Usage" menu item shows only for allowed roles and the /token-usage
+// screen renders for them while denied roles get a rendered /forbidden page.
+// Records a video + screenshots per role into the run's artifact dir.
+//
+// Browser work lives in playwright/rbac-ui-render.mjs (run from the playwright
+// workspace where `playwright` is installed); this scenario provisions the role
+// users and spawns it. Menu-item assertions are skipped (logged) if the radix
+// dropdown won't open in headless — the route-render assertion is the hard gate.
+// ---------------------------------------------------------------------------
+
+const PLAYWRIGHT_DIR = resolve(import.meta.dirname, "..", "playwright");
+const SPEC = resolve(PLAYWRIGHT_DIR, "rbac-ui-render.mjs");
+
+export const rbacUiRender: Scenario = {
+    id: "rbac-ui-render",
+    title: "RBAC: the web renders the right menu + screen vs /forbidden per role",
+    priority: "P0",
+    appliesTo: {
+        target: ["cloud", "self-hosted"],
+        provider: ["github"],
+        license: ["trial", "paid", "license-paid"],
+    },
+    timeoutSec: 600,
+    async run(ctx: RunContext) {
+        ctx.assert(existsSync(SPEC), `Playwright spec not found at ${SPEC}`);
+
+        const { sessions } = await setupRbacOrg(ctx);
+        const roles = sessions.map((s) => ({ role: s.role, email: s.email }));
+
+        const code = await new Promise<number>((done) => {
+            const child = spawn("node", ["rbac-ui-render.mjs"], {
+                cwd: PLAYWRIGHT_DIR,
+                env: {
+                    ...process.env,
+                    WEB_URL: ctx.target.webBaseUrl,
+                    PASSWORD: RBAC_PASSWORD,
+                    ROLES_JSON: JSON.stringify(roles),
+                    OUT_DIR: ctx.artifactDir,
+                },
+                stdio: ["ignore", "inherit", "inherit"],
+            });
+            child.on("close", (c) => done(c ?? -1));
+        });
+
+        ctx.assert(
+            code === 0,
+            `rbac-ui-render Playwright spec failed (exit ${code}) — see logs + ${ctx.artifactDir}`,
+        );
+        return { evidenceDir: ctx.artifactDir, roles: roles.length };
+    },
+};
+
+export default rbacUiRender;


### PR DESCRIPTION
## What

`repoAdmin` (and `billing_manager`) users could see the **Token Usage** menu item but got an "access denied" / `/forbidden` redirect when opening the screen (#1229).

## Root cause

The bug was entirely in the **frontend route guard**, not the backend:

- `/token-usage` is a real route (`apps/web/src/app/(app)/token-usage/page.tsx`) but was never mapped in `resourceRoutes`. The middleware (`canAccessRoute`) derives each non-owner role's reachable routes from `ROLE_POLICIES × resourceRoutes`; with no entry, **no** non-owner role could reach `/token-usage`, so it redirected to `/forbidden`. Only `owner` passed, via the early return.
- The navbar item was gated on `canReadLogs` instead of `canReadTokenUsage`, so it showed for the wrong reason — exactly the "menu visible but screen blocked" symptom.
- The backend already allowed `repoAdmin` on the TokenUsage controller and the `authorization-matrix.spec.ts` proved it. That test is **backend-only**, and the route-coverage test that should have caught the frontend gap had `TokenUsage` in `ROUTELESS_RESOURCES` with a false "no standalone route" comment — so the guard-rail was told to ignore the one broken resource.

Auditing the full route set surfaced **3 more routes in the same trap** (silently `/forbidden` for every non-owner): `/helpdesk`, `/cli/*`, `/settings/integrations`.

## Changes

- **Map the routes**: `/token-usage/*` → `TokenUsage`; `/settings/integrations/*` → `GitSettings` (same resource as `/settings/git`; repo_admin/billing_manager have `GitSettings:read`, so they can view it — connecting a provider is `GitSettings:create`, still owner-only and enforced by the backend); `/helpdesk/*` + `/cli/*` → `All` base routes (open to every authenticated role — support iframe + CLI device-authorize flow, no backend resource).
- **Navbar**: gate the Token Usage item on `canReadTokenUsage`.
- **Refactor**: extract route logic into `permissions.routes.ts` (free of `next/server`) so it's unit-testable; `permissions.ts` keeps the middleware glue and re-exports.
- **Guard-rail (so this can't recur)**: rewrite `permissions.route-coverage.spec.ts` to be **bidirectional and filesystem-aware** — it now walks every `page.tsx` under `app/(app)` and fails if a route isn't reachable by some role, on top of the existing resource→route check. `TokenUsage` removed from `ROUTELESS_RESOURCES`.
- **Tests**: add `permissions.routes.spec.ts` — a role × route matrix for `canAccessRoute`, including the #1229 regression and the previously-orphaned routes.

## Out of scope (tracked separately)

The second half of #1229 — *"repoAdmin should only see token usage for the repositories they have access to"* — is **#1238**. It requires a telemetry data-model change (records have no `repositoryId` today), so it doesn't belong in this permissions fix.

## Testing

```
yarn test --testPathPatterns="permissions" --no-coverage   # 5 suites, 24 tests pass
yarn test --testPathPatterns="authorization" --no-coverage # 3 suites, 12 tests pass (backend untouched)
```

Refs #1229. Refs #1238.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


