### PR TITLE
fix(benchmark): unbreak the tier-0 model benchmark (creds, repos, parallel) + scorecard to Discord

### DIFF
--- a/.github/workflows/code-review-model-benchmark.yml
+++ b/.github/workflows/code-review-model-benchmark.yml
@@ -132,13 +132,21 @@ jobs:
               run: npm run benchmark:recollect || echo "recollect step failed (non-gating)"
 
             - name: Scorecard (artifact, not a gate)
+              id: scorecard
               if: always()
               working-directory: tests/e2e
               env:
                   ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
               # Never fail the job on the quality scorecard — the gate is the
-              # mechanical "all reviews completed" step above.
-              run: npm run benchmark:scorecard || echo "scorecard step failed (non-gating)"
+              # mechanical "all reviews completed" step above. Capture the printed
+              # table into a step output so the success notification can post it.
+              run: |
+                  npm run benchmark:scorecard 2>&1 | tee /tmp/scorecard.txt || echo "scorecard step failed (non-gating)"
+                  {
+                      echo 'table<<SCORECARD_EOF'
+                      grep -vE '^> |^npm |^$' /tmp/scorecard.txt | tail -n 40 || echo '(scorecard unavailable)'
+                      echo 'SCORECARD_EOF'
+                  } >> "$GITHUB_OUTPUT"
 
             - name: Upload results + scorecard
               if: always()
@@ -166,3 +174,17 @@ jobs:
                       Scope: ${{ steps.scope.outputs.only_model != '' && format('only_model={0}', steps.scope.outputs.only_model) || 'FULL (5 models)' }}
                       Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
                       Trigger: ${{ github.event_name }}
+
+            - name: Notify Discord on success (scorecard)
+              if: success()
+              uses: ./.github/actions/discord-notify
+              with:
+                  webhook: ${{ secrets.DISCORD_WEBHOOK_INTERNAL || secrets.DISCORD_WEBHOOK }}
+                  status: success
+                  title: "✅ Model code-review benchmark — scorecard"
+                  description: |
+                      Scope: ${{ steps.scope.outputs.only_model != '' && format('only_model={0}', steps.scope.outputs.only_model) || 'FULL (5 models)' }}
+                      ```
+                      ${{ steps.scorecard.outputs.table }}
+                      ```
+                      Run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/scripts/benchmark/tier0-bench-prs.json
+++ b/scripts/benchmark/tier0-bench-prs.json
@@ -2,7 +2,7 @@
   "description": "Tier-0 model benchmark subset: 1 PR per repo (5), diverse size/complexity. Fixed set \u2014 must stay identical across runs.",
   "prs": [
     {
-      "repo": "ai-code-review-benchmark/grafana-codex",
+      "repo": "kodus-e2e/grafana-codex",
       "head": "asset-loading-optimized",
       "base": "asset-loading-baseline",
       "title": "Frontend Asset Optimization",
@@ -19,7 +19,7 @@
       ]
     },
     {
-      "repo": "ai-code-review-benchmark/sentry",
+      "repo": "kodus-e2e/sentry",
       "head": "span-flusher-multiprocess",
       "base": "span-flusher-stable",
       "title": "Span Buffer Multiprocess Enhancement with Health Monitoring",
@@ -48,7 +48,7 @@
       ]
     },
     {
-      "repo": "ai-code-review-benchmark/cal.com",
+      "repo": "kodus-e2e/cal.com",
       "head": "oauth-security-enhanced",
       "base": "oauth-security-base",
       "title": "OAuth credential sync and app integration enhancements",
@@ -77,7 +77,7 @@
       ]
     },
     {
-      "repo": "ai-code-review-benchmark/discourse-cursor",
+      "repo": "kodus-e2e/discourse-cursor",
       "head": "embed-url-handling-post",
       "base": "embed-url-handling-pre",
       "title": "Enhance embed URL handling and validation system",
@@ -110,7 +110,7 @@
       ]
     },
     {
-      "repo": "ai-code-review-benchmark/keycloak",
+      "repo": "kodus-e2e/keycloak",
       "head": "feature-html-sanitizer-implementation",
       "base": "feature-html-sanitizer-baseline",
       "title": "Add HTML sanitizer for translated message resources",

--- a/tests/e2e/benchmark/run.ts
+++ b/tests/e2e/benchmark/run.ts
@@ -72,10 +72,14 @@ function loadPRs(): BenchPR[] {
 // QA tenants; override via env for a one-off. signUp is idempotent (409-OK),
 // so first run creates it and later runs reuse it.
 async function getSession(): Promise<KodusSession> {
-    const email = process.env.BENCH_TENANT_EMAIL ?? "e2e-bench-tier0@kodus.io";
+    // `||` (not `??`) so an EMPTY string falls through to the default too.
+    // CI passes `${{ secrets.X }}` which is "" when the secret is unset, and
+    // "" is not null/undefined → `??` would keep it → empty creds → 401. An
+    // empty email/password is never valid here, so `||` is strictly safer.
+    const email = process.env.BENCH_TENANT_EMAIL || "e2e-bench-tier0@kodus.io";
     const password =
-        process.env.BENCH_TENANT_PASSWORD ??
-        process.env.TEST_USER_PASSWORD ??
+        process.env.BENCH_TENANT_PASSWORD ||
+        process.env.TEST_USER_PASSWORD ||
         "E2eBench!a1b2c3d4";
     await signUp(QA, { email, password }).catch(() => {});
     return login(QA, { email, password });
@@ -344,7 +348,7 @@ async function runModelShared(
 }
 
 const benchPassword = () =>
-    process.env.BENCH_TENANT_PASSWORD ?? process.env.TEST_USER_PASSWORD ?? "E2eBench!a1b2c3d4";
+    process.env.BENCH_TENANT_PASSWORD || process.env.TEST_USER_PASSWORD || "E2eBench!a1b2c3d4";
 
 // PARALLEL mode: each model gets its OWN tenant + its OWN copy of the fixture
 // repos (kodus-e2e/<base>-<slug>), so no BYOK clobber and no shared-repo webhook


### PR DESCRIPTION
The tier-0 model benchmark never completed in CI. Three layered issues, all fixed here; validated end-to-end (local 5/5, CI single-model 5/5, **CI full 5-model 5/5**, scorecard posted to Discord).

## 1. Empty-secret defeats `??` → login 401
`getSession()`/`benchPassword()` used `??`, which only falls through on null/undefined. CI passes `${{ secrets.BENCH_TENANT_PASSWORD }}` as `""` when unset, and `""` is not null/undefined → empty creds → 401 (locally the var is truly unset → default → worked). Switched to `||` so an empty string also falls through. The `BENCH_TENANT_EMAIL`/`BENCH_TENANT_PASSWORD` secrets are now also set explicitly.

## 2. Fixture pointed at the source org, not the test org
`tier0-bench-prs.json` referenced `ai-code-review-benchmark/<repo>` (where the fixtures were curated FROM), but the GH_TEST_TOKEN integration only surfaces `kodus-e2e/*`, `provision-repos.ts` uses `ORG="kodus-e2e"`, and run.ts documents "the shared kodus-e2e benchmark repos". Repointed to `kodus-e2e`. This also un-breaks **parallel mode**: `isolatedReposReady` builds the isolated repo name from the fixture org, so with `ai-crb` it probed nonexistent repos → fell back to the shared sequential tenant → connected repos the CI token can't see → failed. The kodus-e2e copies are mirrors with the exact head+base branches, so golden_comments are unchanged.

## 3. Scorecard now posts to Discord on success
Previously the only Discord notify was `if: failure()`; a green run sent nothing and the prec/recall/f1 table never reached the model-quality channel. Capture the scorecard table into a step output and add an `if: success()` notification that posts it.

## Validation
- Full 5-model CI run: all models 5/5 reviewed, gate green, scorecard delivered to Discord.

🤖 Generated with [Claude Code](https://claude.com/claude-code)