### PR TITLE
fix(e2e): cloud-matrix readiness gate + benchmark review retry/tolerance

### DIFF
--- a/.github/workflows/e2e-cloud.yml
+++ b/.github/workflows/e2e-cloud.yml
@@ -102,6 +102,39 @@ jobs:
                   COUNT=$(node -e "console.log(JSON.parse(require('fs').readFileSync(process.env.HOME+'/.kodus-dev/cloud-tenants.json','utf8')).length)")
                   echo "Seeded $COUNT cloud tenants"
 
+            - name: Wait for QA backend to be healthy (avoid deploy-race 403s)
+              env:
+                  TARGET_WEB_URL: ${{ vars.CLOUD_QA_WEB_URL || 'https://qa.web.kodus.io' }}
+              run: |
+                  set -uo pipefail
+                  BASE="${TARGET_WEB_URL%/}/api/proxy/api"
+                  # Chained right after the QA GitOps deploy, the backend can still
+                  # be rolling out: the gateway then answers every request with an
+                  # nginx "403 Forbidden" (or 5xx / connection-refused), and the
+                  # matrix reports 40+ confusing `onboarding:login HTTP 403` cell
+                  # failures. Probe the auth layer with a throwaway bad-cred login
+                  # until it responds at the APP level (a real 400/401 for bad
+                  # creds) instead of the gateway, so the run starts against a
+                  # ready backend. A healthy QA passes on the first attempt.
+                  echo "Probing $BASE/auth/login for app-level readiness…"
+                  for i in $(seq 1 60); do
+                      code=$(curl -sS -o /dev/null -w '%{http_code}' \
+                          -X POST "$BASE/auth/login" \
+                          -H 'Content-Type: application/json' \
+                          -d '{"email":"readiness-probe@invalid.kodus","password":"x"}' \
+                          2>/dev/null || echo 000)
+                      case "$code" in
+                          200|201|400|401|404|422)
+                              echo "QA auth healthy (bad-cred login → HTTP $code) after $i attempt(s)."
+                              exit 0 ;;
+                          *)
+                              echo "attempt $i/60: HTTP $code (gateway/rollout) — waiting 10s…"
+                              sleep 10 ;;
+                      esac
+                  done
+                  echo "::error::QA backend never reached app-level readiness in ~10min — aborting before the matrix to avoid deploy-race false failures."
+                  exit 1
+
             - name: Run cloud matrix
               env:
                   # target.sh expects TARGET_BASE_URL + TARGET_WEB_URL.

--- a/tests/e2e/benchmark/run.ts
+++ b/tests/e2e/benchmark/run.ts
@@ -332,7 +332,14 @@ async function reviewOnePR(model: BenchModel, pr: BenchPR): Promise<{ ok: boolea
         if (outcome !== "completed") {
             retried = true;
             log.info(`${model.slug} ${repoShort}: review ${outcome} — retrying once via @kody review (PR #${opened.number})`);
-            const retryAt = Date.now();
+            // GitHub comment `created_at` is second-precision, so `sinceMs` needs
+            // the same -5s padding `openedAt` uses or a banner posted in the same
+            // second would be filtered out (its timestamp truncates to .000 <
+            // sinceMs) and the poll would hang the full cap. But padding back 5s
+            // would also re-match the FIRST attempt's failure banner — so first
+            // sleep 5s to push it outside the window, then pad.
+            await sleep(5_000);
+            const retryAt = Date.now() - 5_000;
             await provider.postComment(opened.number, "@kody review").catch(() => {});
             outcome = await waitForReviewOutcome(pr.repo, opened.number, retryAt);
         }

--- a/tests/e2e/benchmark/run.ts
+++ b/tests/e2e/benchmark/run.ts
@@ -258,23 +258,43 @@ async function collectFindings(repo: string, prNumber: number): Promise<string[]
 // waits longer; we never falsely declare "no review" on a blind timer (the old
 // pollForReview gave up at 25min and mislabeled a review that landed at min 42).
 // Returns true once the marker appears, false only after a generous cap.
-async function waitForReviewComplete(repo: string, prNumber: number, capSec = 3000): Promise<boolean> {
+type ReviewOutcome = "completed" | "failed" | "timeout";
+
+async function waitForReviewOutcome(
+    repo: string,
+    prNumber: number,
+    sinceMs: number,
+    capSec = 3000,
+): Promise<ReviewOutcome> {
     const deadline = Date.now() + capSec * 1000;
     while (Date.now() < deadline) {
         try {
-            const comments = await ghGetJson<{ body?: string }[]>(
+            const comments = await ghGetJson<
+                { body?: string; created_at?: string }[]
+            >(
                 `https://api.github.com/repos/${repo}/issues/${prNumber}/comments?per_page=100`,
             );
+            // Only consider comments at/after `sinceMs` so a retry isn't fooled
+            // by the previous attempt's banner still on the PR.
+            const fresh = comments.filter(
+                (c) => !c.created_at || new Date(c.created_at).getTime() >= sinceMs,
+            );
+            // Failure first: a "Could Not Complete ⚠️" banner (usually a transient
+            // model/provider error, e.g. an openai_compatible 5xx) is terminal for
+            // this attempt — return immediately instead of burning the ~50min cap.
+            if (fresh.some((c) => /could not complete|review failed before/i.test(c.body ?? ""))) {
+                return "failed";
+            }
             // Kody posts ONE of two completion banners depending on findings:
             //   "## Code Review Completed! 🔥"   (issues found / standard)
             //   "# Kody Review Complete … No issues were found"  (zero findings)
-            // Match BOTH — the earlier regex only caught the first, so every
-            // 0-finding review was falsely declared "NO review" after the cap.
-            if (comments.some((c) => /review complet(ed|e)\b/i.test(c.body ?? ""))) return true;
+            if (fresh.some((c) => /review complet(ed|e)\b/i.test(c.body ?? ""))) {
+                return "completed";
+            }
         } catch { /* transient — keep polling */ }
         await sleep(15_000);
     }
-    return false;
+    return "timeout";
 }
 
 // After "Completed" the inline findings can still trickle in for a few seconds;
@@ -297,15 +317,30 @@ type ModelOutcome = { ok: number; fail: number; results: unknown[] };
 // parallel mode), so this is topology-agnostic.
 async function reviewOnePR(model: BenchModel, pr: BenchPR): Promise<{ ok: boolean; result: unknown }> {
     const provider = new GitHubProvider({ repoOverride: pr.repo, target: "cloud" });
+    const repoShort = pr.repo.split("/")[1];
     let opened;
     try {
-        opened = await provider.openPRFromBranches!({ head: pr.head, base: pr.base, title: `[bench] ${model.slug} ${pr.repo.split("/")[1]}`, body: `Model benchmark: ${model.id}` });
-        // Wait for Kody's explicit "Completed" marker (deterministic, slow-model-safe), then settle findings.
-        const reviewed = await waitForReviewComplete(pr.repo, opened.number);
+        const openedAt = Date.now();
+        opened = await provider.openPRFromBranches!({ head: pr.head, base: pr.base, title: `[bench] ${model.slug} ${repoShort}`, body: `Model benchmark: ${model.id}` });
+        // Wait for Kody's terminal marker (Completed / Could-Not-Complete /
+        // timeout). A non-completed first attempt is retried ONCE via
+        // `@kody review`: a "Could Not Complete" is usually a transient model/
+        // provider error (Kody itself tells you to re-run), and a single flake
+        // would otherwise red the whole 25-review gate.
+        let outcome = await waitForReviewOutcome(pr.repo, opened.number, openedAt - 5_000);
+        let retried = false;
+        if (outcome !== "completed") {
+            retried = true;
+            log.info(`${model.slug} ${repoShort}: review ${outcome} — retrying once via @kody review (PR #${opened.number})`);
+            const retryAt = Date.now();
+            await provider.postComment(opened.number, "@kody review").catch(() => {});
+            outcome = await waitForReviewOutcome(pr.repo, opened.number, retryAt);
+        }
+        const reviewed = outcome === "completed";
         const findings = reviewed ? await collectFindingsStable(pr.repo, opened.number) : [];
-        if (reviewed) log.ok(`${model.slug} ${pr.repo.split("/")[1]}: reviewed (${findings.length} findings)`);
-        else log.err(`${model.slug} ${pr.repo.split("/")[1]}: NO review after cap (PR #${opened.number})`);
-        return { ok: reviewed, result: { model: model.slug, modelId: model.id, repo: pr.repo, prNumber: opened.number, head: pr.head, golden_comments: pr.golden_comments, findings } };
+        if (reviewed) log.ok(`${model.slug} ${repoShort}: reviewed (${findings.length} findings)${retried ? " [after retry]" : ""}`);
+        else log.err(`${model.slug} ${repoShort}: ${outcome} after retry (PR #${opened.number})`);
+        return { ok: reviewed, result: { model: model.slug, modelId: model.id, repo: pr.repo, prNumber: opened.number, head: pr.head, golden_comments: pr.golden_comments, findings, retried } };
     } catch (err) {
         log.err(`${model.slug} ${pr.repo}: ${(err as Error).message}`);
         return { ok: false, result: { model: model.slug, repo: pr.repo, head: pr.head, error: (err as Error).message } };
@@ -434,7 +469,20 @@ async function main() {
     const outPath = join(process.cwd(), "benchmark", "results.json");
     writeFileSync(outPath, JSON.stringify({ ranAt: new Date().toISOString(), models: selected.map((m) => m.slug), results: allResults }, null, 2));
     log.info(`RESULT: ${totalOk} reviewed, ${totalFail} failed (of ${selected.length * prs.length}). → ${outPath}`);
-    if (totalFail > 0) process.exit(1);
+    // Tolerate a small number of residual failures (i.e. that survived the
+    // per-PR retry) so a single transient model/provider error doesn't red the
+    // whole 25-review run. A genuine model regression fails many PRs and still
+    // trips the gate. Tolerated failures are logged loudly per-PR above (and
+    // listed in results.json) — never silently swallowed. Tune via
+    // BENCH_MAX_FAILURES (default 1; set 0 for strict).
+    const maxFail = Math.max(0, Number(process.env.BENCH_MAX_FAILURES ?? 1));
+    if (totalFail > maxFail) {
+        log.err(`gate FAILED: ${totalFail} review failure(s) exceed BENCH_MAX_FAILURES=${maxFail}`);
+        process.exit(1);
+    }
+    if (totalFail > 0) {
+        log.info(`gate PASSED with ${totalFail} tolerated failure(s) (<= BENCH_MAX_FAILURES=${maxFail}) — investigate if recurring`);
+    }
 }
 
 main().catch((e) => { log.err(String(e?.stack ?? e)); process.exit(1); });


### PR DESCRIPTION
Two QA-resilience fixes on one branch off main.

## 1. Cloud-matrix readiness gate (`e2e-cloud.yml`)
The cloud matrix is chained right after the QA GitOps deploy, but the ECS rollout is asynchronous — so it routinely starts mid-rollout and the gateway answers every request with an nginx **403** (or 5xx), producing 40+ misleading `onboarding:login: HTTP 403` cell failures on essentially every merge. Adds a readiness probe before `Run cloud matrix`: poll `/auth/login` with a bad credential until the auth layer answers at the **app level** (400/401/404) rather than the gateway (403/5xx/000).

## 2. Benchmark review retry + tolerance (`benchmark/run.ts`)
A single transient model/provider error (e.g. an `openai_compatible` 5xx that posts "Code Review Could Not Complete") failed the whole 25-review mechanical gate. Now:
- `waitForReviewOutcome` distinguishes `completed`/`failed`/`timeout` (and exits a failed attempt fast instead of burning the 50-min cap),
- `reviewOnePR` retries once via `@kody review`,
- the gate tolerates up to `BENCH_MAX_FAILURES` (default 1) residual failures, logged loudly per-PR — a real model regression fails many PRs and still trips the gate.

Validated live (full 5-model local run): the retry recovered 4 kimi timeouts; the tolerance correctly **failed** the gate when glm-5.1 errored on all 5 of its PRs (a real model/provider issue, not the test).

> Note: the QA deploy health-verify false-failure is a **separate repo** (kodus-infra #435) — can't share this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)