### PR TITLE
fix(env): declare API_MOONSHOT_API_KEY in .env.schema

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -314,6 +314,11 @@ API_GOOGLE_AI_PROVIDER=gemini
 # (secret)
 API_NOVITA_AI_API_KEY=
 
+# Moonshot AI key for Kimi BYOK presets (OpenAI-compatible adapter in
+# byok-to-vercel.ts).
+# (secret)
+API_MOONSHOT_API_KEY=
+
 # (type: url)
 API_GROQ_BASE_URL=https://api.groq.com/openai/v1
 

--- a/.env.schema
+++ b/.env.schema
@@ -447,6 +447,12 @@ API_GOOGLE_AI_PROVIDER=gemini
 # kodus: audience=cloud
 API_NOVITA_AI_API_KEY=
 
+# Moonshot AI key for Kimi BYOK presets (OpenAI-compatible adapter in
+# byok-to-vercel.ts).
+# @optional @sensitive
+# kodus: audience=cloud
+API_MOONSHOT_API_KEY=
+
 # @type=url
 # kodus: audience=cloud
 API_GROQ_BASE_URL=https://api.groq.com/openai/v1

--- a/docs/_snippets/env-vars-generated.mdx
+++ b/docs/_snippets/env-vars-generated.mdx
@@ -118,6 +118,7 @@
 | `API_VERTEX_AI_LOCATION` | – | string | ☁️ Cloud |  |
 | `API_GOOGLE_AI_PROVIDER` | – | enum(gemini,vertex) | ☁️ Cloud | Google AI provider: gemini (AI Studio) or vertex (Vertex AI). |
 | `API_NOVITA_AI_API_KEY` | – | secret | ☁️ Cloud |  |
+| `API_MOONSHOT_API_KEY` | – | secret | ☁️ Cloud | Moonshot AI key for Kimi BYOK presets (OpenAI-compatible adapter in byok-to-vercel.ts). |
 | `API_GROQ_BASE_URL` | – | url | ☁️ Cloud |  |
 | `API_GROQ_API_KEY` | – | secret | ☁️ Cloud |  |
 | `API_CEREBRAS_BASE_URL` | – | url | ☁️ Cloud |  |


### PR DESCRIPTION
## What

`byok-to-vercel.ts` reads `API_MOONSHOT_API_KEY` (fallback key for Kimi BYOK presets via the OpenAI-compatible Moonshot adapter, added in #1247), but the var was never declared in `.env.schema` — so `env-drift-check` has been failing on **every PR** since that merge.

## Fix

- Declare `API_MOONSHOT_API_KEY` in `.env.schema` as `@optional @sensitive`, `audience=cloud` (not needed for self-hosted)
- Regenerated `.env.example` + `docs/_snippets/env-vars-generated.mdx` via `yarn env:apply`

`yarn env:check` ✓ locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)