### PR TITLE
fix(env): declare API_MOONSHOT_API_KEY in .env.schema (unblocks env coverage gate)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -314,6 +314,15 @@ API_GOOGLE_AI_PROVIDER=gemini
 # (secret)
 API_NOVITA_AI_API_KEY=
 
+# Moonshot AI (Kimi) — used by the public-demo trial flow in
+# libs/code-review/infrastructure/agents/llm/byok-to-vercel.ts when the
+# default model name matches /^kimi[-_.]/. Wires through the OpenAI-
+# compatible adapter pointed at https://api.moonshot.ai/v1. The eval
+# scripts (evals/{investigation,promotion}/run-eval.js) also reference
+# this key by name. Cloud-only — self-hosted has no Moonshot demo path.
+# (secret)
+API_MOONSHOT_API_KEY=
+
 # (type: url)
 API_GROQ_BASE_URL=https://api.groq.com/openai/v1
 

--- a/.env.schema
+++ b/.env.schema
@@ -447,6 +447,16 @@ API_GOOGLE_AI_PROVIDER=gemini
 # kodus: audience=cloud
 API_NOVITA_AI_API_KEY=
 
+# Moonshot AI (Kimi) — used by the public-demo trial flow in
+# libs/code-review/infrastructure/agents/llm/byok-to-vercel.ts when the
+# default model name matches /^kimi[-_.]/. Wires through the OpenAI-
+# compatible adapter pointed at https://api.moonshot.ai/v1. The eval
+# scripts (evals/{investigation,promotion}/run-eval.js) also reference
+# this key by name. Cloud-only — self-hosted has no Moonshot demo path.
+# @optional @sensitive
+# kodus: audience=cloud
+API_MOONSHOT_API_KEY=
+
 # @type=url
 # kodus: audience=cloud
 API_GROQ_BASE_URL=https://api.groq.com/openai/v1

--- a/docs/_snippets/env-vars-generated.mdx
+++ b/docs/_snippets/env-vars-generated.mdx
@@ -118,6 +118,7 @@
 | `API_VERTEX_AI_LOCATION` | – | string | ☁️ Cloud |  |
 | `API_GOOGLE_AI_PROVIDER` | – | enum(gemini,vertex) | ☁️ Cloud | Google AI provider: gemini (AI Studio) or vertex (Vertex AI). |
 | `API_NOVITA_AI_API_KEY` | – | secret | ☁️ Cloud |  |
+| `API_MOONSHOT_API_KEY` | – | secret | ☁️ Cloud | Moonshot AI (Kimi) — used by the public-demo trial flow in libs/code-review/infrastructure/agents/llm/byok-to-vercel.ts when the default model name matches /^kimi[-_.]/. Wires through the OpenAI- compatible adapter pointed at https://api.moonshot.ai/v1. The eval scripts (evals/{investigation,promotion}/run-eval.js) also reference this key by name. Cloud-only — self-hosted has no Moonshot demo path. |
 | `API_GROQ_BASE_URL` | – | url | ☁️ Cloud |  |
 | `API_GROQ_API_KEY` | – | secret | ☁️ Cloud |  |
 | `API_CEREBRAS_BASE_URL` | – | url | ☁️ Cloud |  |


### PR DESCRIPTION
## Problem

`API_MOONSHOT_API_KEY` is read by the public-demo trial flow (`libs/code-review/infrastructure/agents/llm/byok-to-vercel.ts`, landed via #1247) but was never declared in `.env.schema`. The `env-drift-check` coverage gate now fails on **every PR** that triggers it — #1251 is the first innocent victim ([failing run](https://github.com/kodustech/kodus-ai/actions/runs/26905601612)).

The PR that introduced the code reference didn't touch the workflow's path filter, so the gate never ran there and the gap landed on main silently.

## Fix

- Declare `API_MOONSHOT_API_KEY` in `.env.schema` (`@optional @sensitive`, `audience=cloud`) next to the other LLM provider keys
- Regenerate derived artifacts via `yarn env:apply` (`.env.example`, docs snippet)

## Validation

`yarn env:check` (drift + coverage) green locally:

```
OK:    kodus-ai/.env.example
OK:    docs/_snippets/env-vars-generated.mdx
✓ All code-referenced env vars are declared in .env.schema.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)