### PR TITLE
fix(e2e): kill the three recurring matrix reds — trial expiry, deploy-lag 404s, HTTPS session cookie

### DIFF
--- a/.github/workflows/e2e-cloud.yml
+++ b/.github/workflows/e2e-cloud.yml
@@ -63,6 +63,12 @@ jobs:
     cloud-matrix:
         name: cloud matrix (${{ inputs.matrix_file || 'matrix/fast.yml' }})
         runs-on: ubuntu-latest
+        # QA environment: where the QA-scoped secrets live (GH_REPO_ADMIN_TOKEN
+        # for trial-managed-review's throwaway repos; CLOUD_TENANTS_JSON also
+        # has a copy here). Branch policy allows `main` only — fine, every real
+        # trigger (qa-build workflow_call, nightly schedule, dispatch) runs
+        # from main. Repo-level secrets keep resolving as before.
+        environment: QA
         # fast.yml = ~30-45 min, full.yml = ~75-120 min. Cap with
         # generous headroom; cell-level timeouts inside the runner stop
         # individual flakes from eating the whole budget.
@@ -105,9 +111,49 @@ jobs:
             - name: Wait for QA backend to be healthy (avoid deploy-race 403s)
               env:
                   TARGET_WEB_URL: ${{ vars.CLOUD_QA_WEB_URL || 'https://qa.web.kodus.io' }}
+                  # The image tag GitOps is deploying for THIS run. When set we
+                  # poll the backend's /health `version` until it reports this
+                  # tag — otherwise the matrix races the rollout and tests the
+                  # PREVIOUS build (e.g. a brand-new endpoint 404s even though
+                  # the code is on main). See the deploy-lag class of failures.
+                  EXPECTED_VERSION: ${{ inputs.image_tag }}
               run: |
                   set -uo pipefail
                   BASE="${TARGET_WEB_URL%/}/api/proxy/api"
+
+                  # --- Phase 0: version gate (best-effort) ----------------------
+                  # Health (@Public, @Controller('health')) returns the running
+                  # build's RELEASE_VERSION. If we know the tag we just deployed,
+                  # wait until the live version matches it so the matrix runs the
+                  # build under test, not the one it replaced. This is BEST-EFFORT:
+                  # if the version is 'unknown' (RELEASE_VERSION unset) or never
+                  # converges, we WARN and fall through to the app-readiness probe
+                  # rather than fail — never trade deploy-lag for a new false-fail.
+                  if [ -n "${EXPECTED_VERSION:-}" ]; then
+                      SHORT="${EXPECTED_VERSION:0:7}"
+                      echo "Waiting for QA /health version to report '$EXPECTED_VERSION' (short '$SHORT')…"
+                      matched=""
+                      for i in $(seq 1 60); do
+                          ver=$(curl -sS "$BASE/health" 2>/dev/null \
+                              | node -e "let s='';process.stdin.on('data',d=>s+=d).on('end',()=>{try{console.log(JSON.parse(s).version||'')}catch{console.log('')}})" \
+                              2>/dev/null || echo "")
+                          case "$ver" in
+                              "" |unknown)
+                                  echo "attempt $i/60: version='${ver:-<none>}' (health not reporting a build yet) — waiting 10s…" ; sleep 10 ;;
+                              *"$EXPECTED_VERSION"*|*"$SHORT"*)
+                                  echo "QA is running the expected build (version=$ver) after $i attempt(s)." ; matched=1 ; break ;;
+                              *)
+                                  echo "attempt $i/60: version=$ver (still the prior build) — waiting 10s…" ; sleep 10 ;;
+                          esac
+                      done
+                      if [ -z "$matched" ]; then
+                          echo "::warning::QA /health never reported expected version '$EXPECTED_VERSION' within ~10min — proceeding on app-readiness only (deploy-lag false failures possible)."
+                      fi
+                  else
+                      echo "No image_tag input — skipping version gate, app-readiness probe only."
+                  fi
+
+                  # --- Phase 1: app-level readiness (hard gate) ----------------
                   # Chained right after the QA GitOps deploy, the backend can still
                   # be rolling out: the gateway then answers every request with an
                   # nginx "403 Forbidden" (or 5xx / connection-refused), and the
@@ -152,6 +198,11 @@ jobs:
                   GH_TEST_REPO: ${{ secrets.GH_TEST_REPO }}
                   GH_TEST_REPO_CLOUD: ${{ secrets.GH_TEST_REPO_CLOUD }}
                   GH_TEST_PR_NUMBER: ${{ secrets.GH_TEST_PR_NUMBER }}
+                  # Org-Administration token (QA environment secret) used ONLY
+                  # by trial-managed-review to create/delete its throwaway repo
+                  # per run. Absent → that scenario is SKIPPED, not failed
+                  # (SCENARIO_REQUIRED in run-matrix.ts).
+                  GH_REPO_ADMIN_TOKEN: ${{ secrets.GH_REPO_ADMIN_TOKEN }}
 
                   GL_TEST_TOKEN: ${{ secrets.GL_TEST_TOKEN }}
                   GL_TEST_REPO: ${{ secrets.GL_TEST_REPO }}

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -119,7 +119,8 @@ yarn e2e:matrix matrix/full.yml
 | `TARGET_BASE_URL` | URL of the API to test against | Always |
 | `TARGET_WEB_URL` | URL of the dashboard | Always |
 | `TARGET_TUNNEL_URL` | Public tunnel URL for webhooks (self-hosted only) | `target=self-hosted` |
-| `GH_TEST_TOKEN` | GitHub PAT, `repo` + `admin:repo_hook` | `provider=github` |
+| `GH_TEST_TOKEN` | GitHub PAT, `repo` + `admin:repo_hook`. Must be a token whose FIRST org is `kodus-e2e` (a fine-grained PAT with resource owner `kodus-e2e`, Repository access = All repositories) — the Kodus integration binds to `orgs[0]` (github.service.ts), so a personal token whose first org is `kodustech` binds the wrong org. | `provider=github` |
+| `GH_REPO_ADMIN_TOKEN` | Token with org Administration on `kodus-e2e` (create + delete repos). Used ONLY by `trial-managed-review` to mint/delete its throwaway repo per run; everything else stays on `GH_TEST_TOKEN`. Falls back to `GH_TEST_TOKEN` if unset (a single fully-privileged token also works). | `scenario=trial-managed-review` |
 | `GH_TEST_REPO` | GitHub test repo `owner/repo` | `provider=github` |
 | `GL_TEST_TOKEN` | GitLab PAT, `api` + `write_repository` | `provider=gitlab` |
 | `GL_TEST_REPO` | GitLab project path | `provider=gitlab` |

--- a/tests/e2e/cli/run-matrix.ts
+++ b/tests/e2e/cli/run-matrix.ts
@@ -99,6 +99,7 @@ function missingEnvFor(provider: string): string[] {
 interface ScenarioRequirement {
     files?: string[]; // absolute paths; presence required
     envOrFiles?: Array<{ env: string; defaultFile: string }>; // satisfied if either present
+    env?: string[]; // env vars whose non-empty presence is required
 }
 
 function resolveHome(p: string): string {
@@ -116,6 +117,14 @@ const SCENARIO_REQUIRED: Record<string, ScenarioRequirement> = {
             },
         ],
     },
+    // Mints a throwaway repo per run, which needs org Administration on
+    // kodus-e2e (create + delete). The regular fine-grained GH_TEST_TOKEN
+    // lacks that by design, so without the admin token the scenario would
+    // 403 at repo creation — skip it instead. In CI the token is the QA
+    // environment secret GH_REPO_ADMIN_TOKEN; set it locally to opt in.
+    "trial-managed-review": {
+        env: ["GH_REPO_ADMIN_TOKEN"],
+    },
 };
 
 function missingScenarioRequirements(scenarioId: string): string[] {
@@ -131,6 +140,9 @@ function missingScenarioRequirements(scenarioId: string): string[] {
         if (!existsSync(path)) {
             missing.push(`${env} (or file ${defaultFile})`);
         }
+    }
+    for (const env of req.env ?? []) {
+        if (!process.env[env]) missing.push(`env:${env}`);
     }
     return missing;
 }

--- a/tests/e2e/lib/__tests__/scenarios.test.ts
+++ b/tests/e2e/lib/__tests__/scenarios.test.ts
@@ -2,7 +2,7 @@ import { strict as assert } from "node:assert";
 import { test } from "node:test";
 import { allScenarios, resolveScenarios } from "../../scenarios/index.js";
 
-test("allScenarios: includes the 13 release-gate scenarios", () => {
+test("allScenarios: includes the 16 release-gate scenarios", () => {
     const ids = Object.keys(allScenarios).sort();
     assert.deepEqual(ids, [
         "code-review-basic",
@@ -11,17 +11,20 @@ test("allScenarios: includes the 13 release-gate scenarios", () => {
         "license-attribution",
         "onboarding-webhook-registration",
         "per-seat-license-toggle",
+        "public-pr-demo",
         "rbac-authorization",
         "rbac-frontend-routes",
         "rbac-ui-render",
         "sso-cookie-domain",
         "sso-multi-user",
         "stripe-billing",
+        "trial-entitlement-gate",
+        "trial-managed-review",
         "upgrade-n-1-to-n",
     ]);
 });
 
-test("command-review: cloud + self-hosted × github + github-app + 3 others × paid/trial/license-paid", () => {
+test("command-review: cloud + self-hosted × github + github-app + 3 others × paid/license-paid", () => {
     const s = allScenarios["command-review"];
     assert.deepEqual(s.appliesTo.target, ["cloud", "self-hosted"]);
     assert.deepEqual(s.appliesTo.provider, [
@@ -31,7 +34,9 @@ test("command-review: cloud + self-hosted × github + github-app + 3 others × p
         "bitbucket",
         "azure-devops",
     ]);
-    assert.deepEqual(s.appliesTo.license, ["paid", "trial", "license-paid"]);
+    // `trial` moved to the dedicated trial-entitlement-gate scenario (a
+    // standing trial expires after 14 days and broke this every release).
+    assert.deepEqual(s.appliesTo.license, ["paid", "license-paid"]);
 });
 
 test("sso-multi-user: single-cell self-hosted × github × license-paid", () => {
@@ -94,28 +99,36 @@ test("each scenario has required fields", () => {
     }
 });
 
-test("code-review-basic applies to paid/trial/license-paid but not free/license-free", () => {
+test("code-review-basic applies to paid/license-paid but not trial/free/license-free", () => {
     const s = allScenarios["code-review-basic"];
     assert.ok(s.appliesTo.license);
     assert.ok(s.appliesTo.license.includes("paid"));
-    assert.ok(s.appliesTo.license.includes("trial"));
     assert.ok(s.appliesTo.license.includes("license-paid"));
+    // `trial` moved to trial-entitlement-gate (standing trial expires).
+    assert.ok(!s.appliesTo.license.includes("trial"));
     assert.ok(!s.appliesTo.license.includes("free"));
     assert.ok(!s.appliesTo.license.includes("license-free"));
 });
 
-test("license-attribution applies to every reviewable license mode except self-hosted license-free", () => {
+test("license-attribution applies to every reviewable license mode except trial and self-hosted license-free", () => {
     const s = allScenarios["license-attribution"];
     assert.ok(s.appliesTo.license);
     for (const m of [
         "free",
-        "trial",
         "paid",
         "community-byok",
         "license-paid",
     ] as const) {
         assert.ok(s.appliesTo.license.includes(m), `missing license: ${m}`);
     }
+    // `trial` is intentionally excluded: a standing trial expires after 14
+    // days (no reset endpoint) and broke this scenario every release. The
+    // trial entitlement is proved webhook-free against a fresh org by
+    // trial-entitlement-gate instead.
+    assert.ok(
+        !s.appliesTo.license.includes("trial"),
+        "trial must NOT be in scope (covered by trial-entitlement-gate)",
+    );
     // self-hosted `license-free` is intentionally excluded: an absent or
     // invalid self-hosted license drops to Community Edition (reviews fire,
     // no notice), so the scenario's "no review + trial/BYOK notice"
@@ -125,6 +138,20 @@ test("license-attribution applies to every reviewable license mode except self-h
         !s.appliesTo.license.includes("license-free"),
         "license-free must NOT be in scope (notice unreachable on self-hosted)",
     );
+});
+
+test("trial-entitlement-gate: single-cell cloud × github × trial", () => {
+    const s = allScenarios["trial-entitlement-gate"];
+    assert.deepEqual(s.appliesTo.target, ["cloud"]);
+    assert.deepEqual(s.appliesTo.provider, ["github"]);
+    assert.deepEqual(s.appliesTo.license, ["trial"]);
+});
+
+test("trial-managed-review: single-cell cloud × github × trial (the only managed-LLM review cell)", () => {
+    const s = allScenarios["trial-managed-review"];
+    assert.deepEqual(s.appliesTo.target, ["cloud"]);
+    assert.deepEqual(s.appliesTo.provider, ["github"]);
+    assert.deepEqual(s.appliesTo.license, ["trial"]);
 });
 
 test("upgrade-n-1-to-n only applies to self-hosted", () => {

--- a/tests/e2e/lib/github-repos.ts
+++ b/tests/e2e/lib/github-repos.ts
@@ -1,0 +1,195 @@
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { run } from "./git.js";
+import { http } from "./http.js";
+import { logger } from "./log.js";
+
+const log = logger("gh-repos");
+const API = "https://api.github.com";
+
+// Throwaway GitHub repos for scenarios that need an EXCLUSIVE repo per run
+// (cloud webhook→org resolution returns the first IntegrationConfig with an
+// active code-review automation — webhook-context.service.ts — so a repo
+// shared across throwaway orgs lets a stale org intercept the review).
+//
+// Mechanics mirror scripts/e2e/provision-cloud-github-repos.sh: create via
+// the org endpoint (user fallback), then `git clone --bare` + `push --mirror`
+// from the base fixture repo so ALL branch pairs (feature/add-stats,
+// bug/missing-null-check, …) come along for openPRFromBranches.
+
+// Repo CREATE/DELETE needs org Administration rights, which the regular
+// fine-grained GH_TEST_TOKEN (scoped to kodus-e2e, All-repositories but no
+// admin) typically lacks. GH_REPO_ADMIN_TOKEN, when set, is used ONLY here —
+// for minting/mirroring/deleting the throwaway repo. Everything else
+// (integration binding, listing, PRs, polling) keeps using GH_TEST_TOKEN,
+// whose first org is kodus-e2e (that's what the Kodus integration binds to —
+// github.service.ts picks orgs[0]). Falls back to GH_TEST_TOKEN when the
+// admin var is absent (a single fully-privileged token also works).
+function token(): string {
+    const t = process.env.GH_REPO_ADMIN_TOKEN || process.env.GH_TEST_TOKEN;
+    if (!t)
+        throw new Error(
+            "GH_REPO_ADMIN_TOKEN or GH_TEST_TOKEN is required for throwaway repos",
+        );
+    return t;
+}
+
+function headers(): Record<string, string> {
+    return {
+        Authorization: `Bearer ${token()}`,
+        Accept: "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    };
+}
+
+/** Create `owner/name` (private) and mirror every ref from `baseRepo` into
+ *  it. Returns the new full_name. */
+export async function createThrowawayRepo(
+    baseRepo: string,
+    name: string,
+): Promise<string> {
+    const owner = baseRepo.split("/")[0];
+    const full = `${owner}/${name}`;
+
+    log.info(`Creating throwaway repo ${full} (mirror of ${baseRepo})`);
+    let resp = await http(`${API}/orgs/${owner}/repos`, {
+        method: "POST",
+        headers: headers(),
+        body: {
+            name,
+            private: true,
+            auto_init: false,
+            has_issues: false,
+            has_projects: false,
+            has_wiki: false,
+        },
+        timeoutMs: 30_000,
+    });
+    if (resp.status === 404) {
+        // Owner is the token's user, not an org.
+        resp = await http(`${API}/user/repos`, {
+            method: "POST",
+            headers: headers(),
+            body: { name, private: true, auto_init: false },
+            timeoutMs: 30_000,
+        });
+    }
+    if (resp.status !== 201) {
+        const hint =
+            resp.status === 403
+                ? " — GH_TEST_TOKEN cannot create repos in the org. It needs repo-creation rights on kodus-e2e (classic PAT: `repo` scope + org membership allowing repo creation; fine-grained: org Administration/repo-create). Same requirement as scripts/e2e/provision-cloud-github-repos.sh."
+                : "";
+        throw new Error(
+            `create repo ${full} failed (HTTP ${resp.status}): ${resp.raw.slice(0, 300)}${hint}`,
+        );
+    }
+
+    const tmp = mkdtempSync(join(tmpdir(), "e2e-mirror-"));
+    try {
+        const src = `https://x-access-token:${token()}@github.com/${baseRepo}.git`;
+        const dst = `https://x-access-token:${token()}@github.com/${full}.git`;
+        // Transient local socket errors ("Recv failure: Can't assign
+        // requested address") have been observed on the very first push to a
+        // just-created repo — retry the network steps instead of leaking a
+        // half-set-up repo.
+        await withRetry("clone base", () =>
+            run("git", ["clone", "--quiet", "--bare", src, "base.git"], {
+                cwd: tmp,
+                capture: true,
+            }),
+        );
+        // --mirror also pushes hidden refs (refs/pull/*) which GitHub
+        // rejects; push branches + tags explicitly instead.
+        await withRetry("push branches", () =>
+            run("git", ["push", "--quiet", dst, "refs/heads/*:refs/heads/*"], {
+                cwd: join(tmp, "base.git"),
+                capture: true,
+            }),
+        );
+        await run(
+            "git",
+            ["push", "--quiet", dst, "refs/tags/*:refs/tags/*"],
+            { cwd: join(tmp, "base.git"), capture: true },
+        ).catch(() => undefined); // tags are optional fixture content
+    } catch (err) {
+        // Mirror failed after the repo was created — delete it (best-effort)
+        // so a transient git failure doesn't leak an empty repo the next
+        // run's name can't reuse anyway.
+        await deleteRepo(full).catch(() => false);
+        throw err;
+    } finally {
+        rmSync(tmp, { recursive: true, force: true });
+    }
+    log.ok(`${full} ready (branches mirrored from ${baseRepo})`);
+    return full;
+}
+
+async function withRetry<T>(
+    label: string,
+    fn: () => Promise<T>,
+    attempts = 3,
+): Promise<T> {
+    let lastErr: unknown;
+    for (let i = 1; i <= attempts; i++) {
+        try {
+            return await fn();
+        } catch (err) {
+            lastErr = err;
+            if (i < attempts) {
+                log.info(
+                    `${label} failed (attempt ${i}/${attempts}) — retrying in 5s: ${(err as Error).message.split("\n")[0]}`,
+                );
+                await new Promise((r) => setTimeout(r, 5_000));
+            }
+        }
+    }
+    throw lastErr;
+}
+
+/** Best-effort delete. Requires the PAT to carry `delete_repo`; a 403 is
+ *  logged (repos accumulate until swept by hand) instead of failing the
+ *  scenario — the assertion already passed by the time cleanup runs. */
+export async function deleteRepo(full: string): Promise<boolean> {
+    const resp = await http(`${API}/repos/${full}`, {
+        method: "DELETE",
+        headers: headers(),
+        timeoutMs: 30_000,
+    });
+    if (resp.status === 204) {
+        log.ok(`Deleted throwaway repo ${full}`);
+        return true;
+    }
+    log.info(
+        `Could not delete ${full} (HTTP ${resp.status}) — likely the PAT lacks delete_repo; leaving it for the stale sweep`,
+    );
+    return false;
+}
+
+/** Sweep throwaway repos a crashed prior run leaked: every repo under
+ *  `owner` whose name starts with `prefix` and was created more than
+ *  `maxAgeHours` ago. Best-effort — failures only log. */
+export async function sweepStaleThrowawayRepos(
+    owner: string,
+    prefix: string,
+    maxAgeHours = 24,
+): Promise<number> {
+    const resp = await http<
+        Array<{ full_name: string; name: string; created_at: string }>
+    >(`${API}/orgs/${owner}/repos?per_page=100&sort=created&direction=asc`, {
+        headers: headers(),
+        timeoutMs: 30_000,
+    });
+    if (resp.status !== 200 || !Array.isArray(resp.body)) return 0;
+
+    const cutoff = Date.now() - maxAgeHours * 3_600_000;
+    let swept = 0;
+    for (const repo of resp.body) {
+        if (!repo.name.startsWith(prefix)) continue;
+        if (new Date(repo.created_at).getTime() > cutoff) continue;
+        if (await deleteRepo(repo.full_name)) swept++;
+    }
+    if (swept) log.ok(`Swept ${swept} stale ${prefix}* repo(s)`);
+    return swept;
+}

--- a/tests/e2e/lib/github-repos.ts
+++ b/tests/e2e/lib/github-repos.ts
@@ -88,8 +88,23 @@ export async function createThrowawayRepo(
 
     const tmp = mkdtempSync(join(tmpdir(), "e2e-mirror-"));
     try {
-        const src = `https://x-access-token:${token()}@github.com/${baseRepo}.git`;
-        const dst = `https://x-access-token:${token()}@github.com/${full}.git`;
+        // Token deliberately NOT in the URL (and not in argv at all): run()
+        // builds its error message from cmd+args, so an embedded credential
+        // would land in plaintext in the test runner's logs on any git
+        // failure (withRetry then prints it again). Inject the auth header
+        // through git's env-based config instead — same mechanism
+        // actions/checkout uses — which keeps both argv and error messages
+        // secret-free. (A `-c http.extraHeader=Basic <base64>` arg would
+        // only obfuscate: base64 decodes straight back to the token.)
+        const src = `https://github.com/${baseRepo}.git`;
+        const dst = `https://github.com/${full}.git`;
+        const gitEnv = {
+            GIT_CONFIG_COUNT: "1",
+            GIT_CONFIG_KEY_0: "http.https://github.com/.extraheader",
+            GIT_CONFIG_VALUE_0: `Authorization: Basic ${Buffer.from(
+                `x-access-token:${token()}`,
+            ).toString("base64")}`,
+        };
         // Transient local socket errors ("Recv failure: Can't assign
         // requested address") have been observed on the very first push to a
         // just-created repo — retry the network steps instead of leaking a
@@ -97,6 +112,7 @@ export async function createThrowawayRepo(
         await withRetry("clone base", () =>
             run("git", ["clone", "--quiet", "--bare", src, "base.git"], {
                 cwd: tmp,
+                env: gitEnv,
                 capture: true,
             }),
         );
@@ -105,13 +121,14 @@ export async function createThrowawayRepo(
         await withRetry("push branches", () =>
             run("git", ["push", "--quiet", dst, "refs/heads/*:refs/heads/*"], {
                 cwd: join(tmp, "base.git"),
+                env: gitEnv,
                 capture: true,
             }),
         );
         await run(
             "git",
             ["push", "--quiet", dst, "refs/tags/*:refs/tags/*"],
-            { cwd: join(tmp, "base.git"), capture: true },
+            { cwd: join(tmp, "base.git"), env: gitEnv, capture: true },
         ).catch(() => undefined); // tags are optional fixture content
     } catch (err) {
         // Mirror failed after the repo was created — delete it (best-effort)

--- a/tests/e2e/lib/trial-provision.ts
+++ b/tests/e2e/lib/trial-provision.ts
@@ -1,0 +1,108 @@
+import { http } from "./http.js";
+import { login, signUp } from "./onboarding.js";
+import type { KodusSession, RunContext, TargetContext } from "./types.js";
+
+// Shared trial-org provisioning used by `trial-entitlement-gate` (API-level
+// gate check) and `trial-managed-review` (real managed review on a throwaway
+// repo): sign up a brand-new org and start its 14-day managed trial.
+//
+// Why fresh-org-per-run instead of a standing trial tenant: a cloud
+// `/billing/trial` row expires 14 days after creation and there is NO
+// trial-reset endpoint (billing exposes only `trial`, `migrate-to-free`,
+// `validate-org-license`; re-POSTing `trial` 409s). A long-lived trial tenant
+// therefore silently lapses ~2 weeks after seeding — the recurring matrix red.
+// A brand-new org is always inside a fresh window.
+
+export const TRIAL_ORG_PASSWORD = "E2eTrial!2026x";
+
+/** Unique, [a-z0-9]-safe slug for throwaway org emails / repo names. Uses
+ *  the END of the runId — the head is `YYYY-MM-DDT…` (identical across
+ *  same-day runs), the tail is `…<ms>Z-<randomhex>`. */
+export function runSlug(runId: string): string {
+    return runId.replace(/[^a-z0-9]/gi, "").toLowerCase().slice(-12);
+}
+
+export interface FreshTrialOrg {
+    email: string;
+    session: KodusSession;
+}
+
+/** Sign up a fresh throwaway org and activate its managed (byok:false)
+ *  trial. Asserts the billing service actually landed a `trial` row. */
+export async function provisionFreshTrialOrg(
+    ctx: RunContext,
+    emailPrefix: string,
+): Promise<FreshTrialOrg> {
+    const target = ctx.target as TargetContext;
+    // `@kodus.local` matches the throwaway domain the RBAC scenarios
+    // already use on cloud QA. Slug from the runId TAIL — the head is the
+    // date (collides across same-day runs); the tail carries ms + the
+    // random hex suffix.
+    const email = `${emailPrefix}-${runSlug(ctx.runId)}@kodus.local`;
+    await signUp(target, { email, password: TRIAL_ORG_PASSWORD });
+    const session = await login(target, {
+        email,
+        password: TRIAL_ORG_PASSWORD,
+    });
+
+    // Mirrors setup-tenants.ts: byok:false → a managed (Kodus-keys) trial.
+    // 409 / "already exists" is idempotent OK — the desired end-state (a
+    // valid trial subscription record) is satisfied either way.
+    const resp = await http(`${target.webBaseUrl}/api/proxy/billing/trial`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${session.accessToken}` },
+        body: {
+            organizationId: session.organizationId,
+            teamId: session.teamId,
+            byok: false,
+        },
+        timeoutMs: 30_000,
+    });
+    const trialStarted =
+        (resp.status >= 200 &&
+            resp.status < 300 &&
+            (resp.body as { subscriptionStatus?: string })
+                ?.subscriptionStatus === "trial") ||
+        resp.status === 409 ||
+        (resp.status === 400 &&
+            /already|trial|existe/i.test(
+                (resp.body as any)?.error ??
+                    (resp.body as any)?.message ??
+                    "",
+            ));
+    ctx.assert(
+        trialStarted,
+        `POST /billing/trial did not yield a trial subscription (HTTP ${resp.status}): ${resp.raw.slice(0, 250)}`,
+    );
+
+    return { email, session };
+}
+
+export interface OrgLicense {
+    valid?: boolean;
+    subscriptionStatus?: string;
+    planType?: string;
+}
+
+/** GET the org license exactly the way the backend's entitlement gate does
+ *  (PermissionValidationService → validateOrganizationLicense). */
+export async function fetchOrgLicense(
+    ctx: RunContext,
+    session: KodusSession,
+): Promise<OrgLicense> {
+    const target = ctx.target as TargetContext;
+    const url =
+        `${target.webBaseUrl}/api/proxy/billing/validate-org-license` +
+        `?organizationId=${encodeURIComponent(session.organizationId)}` +
+        `&teamId=${encodeURIComponent(session.teamId)}`;
+    const resp = await http<OrgLicense>(url, {
+        method: "GET",
+        headers: { Authorization: `Bearer ${session.accessToken}` },
+        timeoutMs: 30_000,
+    });
+    ctx.assert(
+        resp.status >= 200 && resp.status < 300,
+        `GET validate-org-license failed (HTTP ${resp.status}): ${resp.raw.slice(0, 250)}`,
+    );
+    return resp.body ?? {};
+}

--- a/tests/e2e/matrix/fast.yml
+++ b/tests/e2e/matrix/fast.yml
@@ -25,6 +25,17 @@ scenarios:
     - command-review
     - kody-rules-create-and-apply
     - license-attribution
+    # Trial coverage (cloud × github × trial, one cell each). Both sign up a
+    # FRESH org per run so the 14-day trial window never lapses — the standing
+    # trial tenant expired every ~2 weeks and broke the old `trial` cells on
+    # the review scenarios.
+    #   * trial-entitlement-gate: API-level, fails in seconds with a precise
+    #     billing-level message (validate-org-license = valid + 'trial').
+    #   * trial-managed-review: the REAL thing — throwaway repo (exclusive
+    #     webhook route) + PR + managed-LLM review. The only cell exercising
+    #     Kodus-managed keys; every other review cell is BYOK.
+    - trial-entitlement-gate
+    - trial-managed-review
     # Per-seat gate: appliesTo restricts to self-hosted × github × license-paid
     # (one cell). Skipped automatically when SH_LICENSE_KEY_PATH (default
     # ~/.kodus-dev/license-seats1.jwt) isn't available — see run-matrix.ts.

--- a/tests/e2e/matrix/full.yml
+++ b/tests/e2e/matrix/full.yml
@@ -24,6 +24,12 @@ scenarios:
     - command-review
     - kody-rules-create-and-apply
     - license-attribution
+    # Trial coverage (cloud × github × trial): fresh org per run (14-day
+    # window never lapses). entitlement-gate = fast API check;
+    # managed-review = throwaway repo + real managed-LLM review (the only
+    # cell on Kodus-managed keys). See fast.yml for the full rationale.
+    - trial-entitlement-gate
+    - trial-managed-review
     # Per-seat gate: appliesTo restricts to self-hosted × github × license-paid
     # (one cell). Skipped automatically when SH_LICENSE_KEY_PATH (default
     # ~/.kodus-dev/license-seats1.jwt) isn't available — see run-matrix.ts.

--- a/tests/e2e/scenarios/code-review-basic.ts
+++ b/tests/e2e/scenarios/code-review-basic.ts
@@ -68,7 +68,12 @@ export const codeReviewBasic: Scenario = {
     appliesTo: {
         target: ["cloud", "self-hosted"],
         provider: ["github", "github-app", "gitlab", "bitbucket", "azure-devops"],
-        license: ["paid", "trial", "license-paid"],
+        // `trial` is intentionally NOT here: a standing trial subscription
+        // expires after 14 days (no reset endpoint) and broke this scenario
+        // every release. Trial coverage moved to fresh-org-per-run scenarios:
+        // `trial-entitlement-gate` (fast API gate check) and
+        // `trial-managed-review` (real managed-LLM review on a throwaway repo).
+        license: ["paid", "license-paid"],
     },
     // Scenario budget must comfortably exceed the inner pollForReview
     // budget (1500s) + onboarding + open-PR overhead. 1800s gives a

--- a/tests/e2e/scenarios/command-review.ts
+++ b/tests/e2e/scenarios/command-review.ts
@@ -27,7 +27,11 @@ export const commandReview: Scenario = {
     appliesTo: {
         target: ["cloud", "self-hosted"],
         provider: ["github", "github-app", "gitlab", "bitbucket", "azure-devops"],
-        license: ["paid", "trial", "license-paid"],
+        // `trial` dropped here for the same reason as code-review-basic: a
+        // standing trial expires after 14 days. Trial is covered by the
+        // fresh-org scenarios `trial-entitlement-gate` + `trial-managed-review`;
+        // `paid` covers the command review path.
+        license: ["paid", "license-paid"],
     },
     // Same envelope as code-review-basic: needs room for onboarding +
     // disable-auto-review setup + open PR + post-comment +

--- a/tests/e2e/scenarios/index.ts
+++ b/tests/e2e/scenarios/index.ts
@@ -12,6 +12,8 @@ import rbacUiRender from "./rbac-ui-render.js";
 import ssoCookieDomain from "./sso-cookie-domain.js";
 import ssoMultiUser from "./sso-multi-user.js";
 import stripeBilling from "./stripe-billing.js";
+import trialEntitlementGate from "./trial-entitlement-gate.js";
+import trialManagedReview from "./trial-managed-review.js";
 import upgradeNMinusOneToN from "./upgrade.js";
 
 export const allScenarios: Record<string, Scenario> = {
@@ -28,6 +30,8 @@ export const allScenarios: Record<string, Scenario> = {
     [ssoCookieDomain.id]: ssoCookieDomain,
     [ssoMultiUser.id]: ssoMultiUser,
     [stripeBilling.id]: stripeBilling,
+    [trialEntitlementGate.id]: trialEntitlementGate,
+    [trialManagedReview.id]: trialManagedReview,
     [upgradeNMinusOneToN.id]: upgradeNMinusOneToN,
 };
 
@@ -57,5 +61,7 @@ export {
     ssoCookieDomain,
     ssoMultiUser,
     stripeBilling,
+    trialEntitlementGate,
+    trialManagedReview,
     upgradeNMinusOneToN,
 };

--- a/tests/e2e/scenarios/license-attribution.ts
+++ b/tests/e2e/scenarios/license-attribution.ts
@@ -68,11 +68,16 @@ export const licenseAttribution: Scenario = {
         // "trial ended" comment in validate-prerequisites.stage:681 is only
         // reachable from the cloud path (BYOK_REQUIRED, INVALID_LICENSE,
         // PLAN_LIMIT_EXCEEDED errorTypes), so license-free × self-hosted is
-        // structurally unprovable. Keep `free` (cloud post-trial no-BYOK) and
-        // `trial` (cloud) here — those DO trigger the notice path.
+        // structurally unprovable. `free` (cloud post-trial no-BYOK) stays —
+        // it triggers the notice path. `trial` is intentionally absent: a
+        // standing trial expires after 14 days and there is no reset endpoint,
+        // so it broke this scenario every release; trial moved to the
+        // fresh-org-per-run scenarios `trial-entitlement-gate` (API gate) and
+        // `trial-managed-review` (real managed review on a throwaway repo).
+        // The remaining tiers here cover review-positive (paid /
+        // community-byok / license-paid) and the blocked path (free).
         license: [
             "free",
-            "trial",
             "paid",
             "community-byok",
             "license-paid",

--- a/tests/e2e/scenarios/rbac-frontend-routes.ts
+++ b/tests/e2e/scenarios/rbac-frontend-routes.ts
@@ -92,7 +92,16 @@ async function nextAuthLogin(
     });
     absorb(jar, cbRes);
 
-    if (!jar.has("authjs.session-token")) {
+    // Auth.js v5 names the session cookie `authjs.session-token` over HTTP but
+    // prefixes it `__Secure-authjs.session-token` over HTTPS (QA cloud), and
+    // chunks it (`…-token.0`, `.1`) once the JWT grows past the 4KB cookie
+    // limit. Match by substring — the same shape the proxy uses
+    // (create-proxy-handler.ts) — so the check survives all three variants
+    // instead of only the bare HTTP name.
+    const hasSession = [...jar.keys()].some((k) =>
+        k.includes("authjs.session-token"),
+    );
+    if (!hasSession) {
         throw new Error(
             `next-auth login for ${email} did not yield a session (HTTP ${cbRes.status})`,
         );

--- a/tests/e2e/scenarios/trial-entitlement-gate.ts
+++ b/tests/e2e/scenarios/trial-entitlement-gate.ts
@@ -1,0 +1,67 @@
+import {
+    fetchOrgLicense,
+    provisionFreshTrialOrg,
+} from "../lib/trial-provision.js";
+import type { RunContext, Scenario } from "../lib/types.js";
+
+// ---------------------------------------------------------------------------
+// Trial entitlement gate (cloud-only, API-level, NO webhook).
+//
+// Fast, precise check that a fresh trial org is entitled to managed reviews:
+// sign up a brand-new org (always inside its fresh 14-day window — see
+// lib/trial-provision.ts for why a standing trial tenant can't work), start
+// its trial, and assert the organization license the gate keys off is exactly
+// `valid + subscriptionStatus === 'trial'`. That is the precise input that
+// makes permissionValidation.service.ts:168 return `{ allowed: true }` with no
+// BYOK required.
+//
+// This scenario fails in seconds with a billing-level message when the trial
+// plumbing breaks; its sibling `trial-managed-review` proves the same
+// entitlement end-to-end (real PR → webhook → managed-LLM review) on a
+// throwaway repo and takes ~15 min. Keep both: this one localizes failures,
+// that one proves the full path.
+// ---------------------------------------------------------------------------
+
+export const trialEntitlementGate: Scenario = {
+    id: "trial-entitlement-gate",
+    title:
+        "A fresh trial org is entitled to managed reviews (valid + subscriptionStatus=trial), no BYOK",
+    priority: "P0",
+    appliesTo: {
+        // Cloud-only: the trial subscription model is a Stripe/billing concept
+        // that does not exist self-hosted (SelfHostedLicenseService has no
+        // trial state — see license-attribution.ts). github is enough; the
+        // gate is provider-agnostic (no integration/repo is touched here).
+        target: ["cloud"],
+        provider: ["github"],
+        license: ["trial"],
+    },
+    timeoutSec: 120,
+    async run(ctx: RunContext) {
+        const { email, session } = await provisionFreshTrialOrg(
+            ctx,
+            "e2e-trial-gate",
+        );
+
+        const license = await fetchOrgLicense(ctx, session);
+        ctx.assert(
+            license.valid === true,
+            `Expected a fresh trial org to be valid:true, got ${JSON.stringify(license)}`,
+        );
+        ctx.assert(
+            license.subscriptionStatus === "trial",
+            `Expected subscriptionStatus='trial' (the state that makes the entitlement gate allow managed reviews with no BYOK), got '${license.subscriptionStatus}'. Full license=${JSON.stringify(license)}`,
+        );
+
+        return {
+            email,
+            organizationId: session.organizationId,
+            teamId: session.teamId,
+            subscriptionStatus: license.subscriptionStatus,
+            valid: license.valid,
+            planType: license.planType,
+        };
+    },
+};
+
+export default trialEntitlementGate;

--- a/tests/e2e/scenarios/trial-managed-review.ts
+++ b/tests/e2e/scenarios/trial-managed-review.ts
@@ -1,0 +1,196 @@
+import {
+    createThrowawayRepo,
+    deleteRepo,
+    sweepStaleThrowawayRepos,
+} from "../lib/github-repos.js";
+import {
+    finishOnboarding,
+    registerIntegration,
+    registerRepo,
+} from "../lib/onboarding.js";
+import {
+    fetchOrgLicense,
+    provisionFreshTrialOrg,
+    runSlug,
+} from "../lib/trial-provision.js";
+import type { RunContext, Scenario, TargetContext } from "../lib/types.js";
+import { makeProvider } from "../providers/index.js";
+
+// ---------------------------------------------------------------------------
+// Trial managed review (cloud × github × trial, one cell).
+//
+// The ONLY matrix cell that runs a review on Kodus-MANAGED LLM keys — what a
+// real trial (and paid) customer gets in prod. Every other review-running
+// cell is BYOK (`paid` is seeded as free_byok by decision — see
+// setup-tenants.ts:304 — and `community-byok` is BYOK by definition), so
+// without this scenario the managed path has zero E2E coverage.
+//
+// Why throwaway org AND throwaway repo per run:
+//   * org: a `/billing/trial` row expires in 14 days with no reset endpoint,
+//     so a standing trial tenant rots ~2 weeks after seeding (the recurring
+//     matrix red). A fresh org is always inside a fresh window.
+//   * repo: cloud resolves a PR webhook to the FIRST IntegrationConfig with
+//     an active code-review automation on that repo
+//     (webhook-context.service.ts), so a fresh org sharing the standing
+//     trial repo gets its review intercepted by a stale org. The fresh org
+//     must exclusively own its repo — mirrored from the base fixture so the
+//     committed branch pairs come along.
+//
+// Cost note: each run burns one managed-LLM review on Kodus's own keys.
+// That's the point — it's the path under test — but it's why this exists as
+// ONE scenario instead of re-adding `trial` to all three review scenarios.
+//
+// Cleanup: closes the PR and deletes the repo (needs `delete_repo` on
+// GH_TEST_TOKEN; tolerated if absent). A start-of-run sweep removes >24h-old
+// leftovers from crashed runs.
+// ---------------------------------------------------------------------------
+
+const REPO_PREFIX = "tiny-url-trial-e2e-";
+
+// Same head/base pair license-attribution uses: a persistent committed diff
+// (/stats endpoint, ~30 lines) meaty enough that Kody reliably surfaces
+// SOMETHING. The mirror copies all branches, and the repo is exclusive to
+// this run, so there is no open-PR collision with other scenarios.
+const FIXTURE = { head: "feature/add-stats", base: "main" };
+
+export const trialManagedReview: Scenario = {
+    id: "trial-managed-review",
+    title:
+        "A fresh trial org gets a REAL managed-LLM review (no BYOK) on its own throwaway repo",
+    priority: "P0",
+    appliesTo: {
+        target: ["cloud"],
+        provider: ["github"],
+        license: ["trial"],
+    },
+    // Onboarding (~3-5 min incl. kody-rules generation) + 900s review poll.
+    timeoutSec: 1800,
+    async run(ctx: RunContext) {
+        const target = ctx.target as TargetContext;
+        const baseRepo =
+            process.env.GH_TEST_REPO_CLOUD ?? "kodus-e2e/tiny-url-cloud";
+        const owner = baseRepo.split("/")[0];
+
+        // Best-effort: clear >24h-old leftovers from crashed prior runs so
+        // throwaway repos don't accumulate when the PAT can delete them.
+        await sweepStaleThrowawayRepos(owner, REPO_PREFIX).catch(() => 0);
+
+        const repoFullName = await createThrowawayRepo(
+            baseRepo,
+            `${REPO_PREFIX}${runSlug(ctx.runId)}`,
+        );
+
+        try {
+            const { email, session } = await provisionFreshTrialOrg(
+                ctx,
+                "e2e-trial-rev",
+            );
+
+            // Sanity gate before spending 15 min on the review poll: the org
+            // must actually be in the state the entitlement gate allows.
+            const license = await fetchOrgLicense(ctx, session);
+            ctx.assert(
+                license.valid === true &&
+                    license.subscriptionStatus === "trial",
+                `Fresh org is not in trial state (valid=${license.valid}, subscriptionStatus='${license.subscriptionStatus}') — review would be blocked for the wrong reason. license=${JSON.stringify(license)}`,
+            );
+
+            // Provider bound to the throwaway repo: clone URL, /repos/*,
+            // webhook listing and PR surface all point at it.
+            const provider = makeProvider("github", "cloud", repoFullName);
+
+            await registerIntegration(target, provider, session);
+
+            // The freshly-minted repo can take a little while to appear in
+            // the integration's available-repos listing (GitHub propagation
+            // after create + Kodus-side listing). Observed live: 19s after
+            // creation the repo was still absent. Retry the lookup for up to
+            // ~2 min before declaring failure; any OTHER registerRepo error
+            // rethrows immediately.
+            let repo: Awaited<ReturnType<typeof registerRepo>> | undefined;
+            for (let attempt = 1; ; attempt++) {
+                try {
+                    repo = await registerRepo(target, provider, session);
+                    break;
+                } catch (err) {
+                    const msg = (err as Error).message;
+                    if (
+                        attempt >= 8 ||
+                        !/not in integration's available list/.test(msg)
+                    ) {
+                        throw err;
+                    }
+                    await new Promise((r) => setTimeout(r, 15_000));
+                }
+            }
+            await finishOnboarding(target, session, repo!);
+
+            const sinceIso = new Date().toISOString();
+            ctx.assert(
+                provider.openPRFromBranches,
+                "github provider must implement openPRFromBranches",
+            );
+            const pr = await provider.openPRFromBranches!({
+                head: FIXTURE.head,
+                base: FIXTURE.base,
+                title: `[e2e] trial-managed-review ${ctx.runId.slice(0, 8)}`,
+                body: `Automated PR opened by Kodus E2E run ${ctx.runId} to validate that a fresh trial org receives a managed-LLM review. Repo is throwaway and deleted by the scenario.`,
+            });
+
+            try {
+                // Phase A — fail fast (~2 min) if the webhook never reached
+                // the fresh org, instead of burning the whole 900s budget.
+                // Distinguishes "webhook/org-routing broke" from "pipeline
+                // ran but produced nothing".
+                if (provider.waitForPipelineStart) {
+                    await provider.waitForPipelineStart(
+                        { number: pr.number },
+                        { sinceIso, timeoutSec: 120 },
+                    );
+                }
+
+                // Phase B — same 900s budget license-attribution gave the
+                // trial path (slowest legitimate managed review observed
+                // ~10-11 min end-to-end).
+                const review = await provider.pollForReview(
+                    { number: pr.number },
+                    { sinceIso, timeoutSec: 900 },
+                );
+
+                const sawRealReview =
+                    review.reviewComments +
+                        review.issueComments +
+                        review.reviews >
+                    0;
+                ctx.assert(
+                    sawRealReview,
+                    `Expected a real managed-LLM review on the fresh trial org but none arrived within 900s. licenseBlockedNotice=${JSON.stringify(review.licenseBlockedNotice)}`,
+                );
+                ctx.assert(
+                    !review.licenseBlockedNotice,
+                    `Trial must NOT trigger a BYOK/trial-ended notice, but Kody posted one: ${JSON.stringify(review.licenseBlockedNotice)}`,
+                );
+
+                return {
+                    email,
+                    organizationId: session.organizationId,
+                    repoFullName,
+                    prNumber: pr.number,
+                    prUrl: pr.url,
+                    review,
+                    subscriptionStatus: license.subscriptionStatus,
+                };
+            } finally {
+                try {
+                    await provider.closePR(pr);
+                } catch {
+                    // best-effort — the repo is deleted right after anyway
+                }
+            }
+        } finally {
+            await deleteRepo(repoFullName).catch(() => false);
+        }
+    },
+};
+
+export default trialManagedReview;


### PR DESCRIPTION
## Why

Run [26891414288](https://github.com/kodustech/kodus-ai/actions/runs/26891414288) failed 6 cells of `matrix/fast.yml` against QA cloud. Root-caused to **three independent causes — none a product regression** — and all three are of the kind that re-breaks the matrix every release:

| Failing cells | Root cause |
|---|---|
| `code-review-basic` / `command-review` / `license-attribution` × trial | Standing trial tenant's `/billing/trial` row **expires after 14 days** (no reset endpoint) → backend correctly answers `BYOK_REQUIRED` ~2 weeks after every seed. A literal time bomb. |
| `public-pr-demo` × paid (404) | **Deploy lag**: the matrix raced the GitOps rollout and tested the previous build (the `featured-reviews` endpoint from #1247 wasn't deployed yet). The readiness gate only probed health, not version. |
| `rbac-frontend-routes` × paid + trial (302) | **Test bug**: the login helper required the exact cookie key `authjs.session-token`, but Auth.js v5 over HTTPS prefixes it `__Secure-` (and chunks it). The proxy already matches by substring; the test didn't. |

## What

**Trial → fresh-org-per-run (never expires):**
- `trial-entitlement-gate` (new): signs up a fresh org + starts its trial, asserts `validate-org-license` = `valid + subscriptionStatus='trial'` — the exact input the entitlement gate allows on (`permissionValidation.service.ts:168`). API-level, fails in seconds with a precise billing-level message.
- `trial-managed-review` (new): the **only cell exercising Kodus-managed LLM keys** end-to-end (e2e `paid` is seeded as `free_byok` by decision; every other review cell is BYOK). Throwaway org **and** throwaway repo per run — cloud resolves a PR webhook to the first org with an active automation on the repo (`webhook-context.service.ts`), so the fresh org must own its repo exclusively. Mints a mirror of `tiny-url-cloud`, onboards, opens a real PR, requires a real managed review with no BYOK notice, then deletes the repo (+ sweeps >24h leftovers).
- Repo create/delete needs org Administration → new **QA environment secret `GH_REPO_ADMIN_TOKEN`** (already provisioned). Absent → the scenario **skips** via `SCENARIO_REQUIRED`, so forks/local runs stay green.
- `trial` removed from the three review scenarios' `appliesTo` (covered above; `paid`/`community-byok`/`free` keep the BYOK + blocked paths).

**Deploy-lag:** the e2e-cloud readiness step now first polls `/health` `version` (QA stamps it with the deployed commit SHA — verified live) until it matches the `image_tag` input. Best-effort: warns and falls through rather than introducing a new hard-fail. The job now binds to the `QA` environment.

**Cookie fix:** `nextAuthLogin` matches the session cookie by substring (covers `__Secure-` prefix + chunking).

**Bonus:** the scenario-registry assertion was already red on main — `public-pr-demo` (#1247) was never added to it. Fixed (now 16 scenarios).

## Validation

Live against QA cloud:
- `trial-entitlement-gate` — **PASS 9s**
- `trial-managed-review` — **PASS 239s** (real managed review posted, no BYOK notice, repo cleaned up)
- `rbac-frontend-routes` — **PASS 31.5s** (132 route×role verdicts; previously died at login on this exact cell)
- `/health` on QA confirmed returning the deployed commit SHA (version gate assumption)

Hermetic: `tsc --noEmit` ✓ · 57/57 unit tests ✓ · `fast.yml`/`full.yml` dry-runs 0 failed (fast ⊆ full invariant holds) ✓ · actionlint ✓ · skip-gating verified both ways (with token → runs in the trial cell only; without → clean skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)