### PR TITLE
fix(forgejo): formatPromptForLLM reads non-existent field, prompt section always empty

### DIFF
--- a/libs/platform/infrastructure/adapters/services/forgejo.service.ts
+++ b/libs/platform/infrastructure/adapters/services/forgejo.service.ts
@@ -2843,9 +2843,29 @@ export class ForgejoService implements Omit<
     }
 
     private formatPromptForLLM(lineComment: any): string {
-        const prompt = lineComment?.body?.oneLineSummary;
-        if (!prompt) return '';
-        return `\n<details>\n<summary>Prompt for AI</summary>\n\n\`${prompt}\`\n</details>\n`;
+        let copyPrompt = '';
+        if (lineComment?.suggestion?.llmPrompt) {
+            if (lineComment.path) {
+                copyPrompt += `File ${lineComment.path}:\n\n`;
+            }
+
+            if (lineComment.start_line && lineComment.line) {
+                copyPrompt += `Line ${lineComment.start_line} to ${lineComment.line}:\n\n`;
+            } else if (lineComment.line) {
+                copyPrompt += `Line ${lineComment.line}:\n\n`;
+            }
+
+            copyPrompt += lineComment?.suggestion?.llmPrompt;
+
+            if (lineComment?.body?.improvedCode) {
+                copyPrompt +=
+                    '\n\nSuggested Code:\n\n' + lineComment?.body?.improvedCode;
+            }
+
+            copyPrompt = `\n<details>\n<summary>Prompt for LLM</summary>\n\n\`\`\`\n${copyPrompt}\n\`\`\`\n</details>\n`;
+        }
+
+        return copyPrompt;
     }
 
     async formatReviewCommentBody(params: {


### PR DESCRIPTION
## Summary

The Forgejo `formatPromptForLLM` reads `lineComment?.body?.oneLineSummary`, which is never populated anywhere in the codebase. This means the "Prompt for LLM" `<details>` section is always silently omitted from Forgejo review comments, while it works correctly on GitHub, GitLab, and Azure Repos.

## Root Cause

The field `oneLineSummary` appears exactly once in the entire codebase — in the Forgejo stub itself. It is never set. `llmPrompt` is the standard field, populated in `base-code-review-agent.provider.ts`.

## Fix

Aligned Forgejo's `formatPromptForLLM` with the GitHub/GitLab/Azure implementations:

- Read `lineComment?.suggestion?.llmPrompt` instead of `lineComment?.body?.oneLineSummary`
- Include file path context
- Include line number range
- Include suggested code when available
- Use code fences (triple backtick) instead of inline backtick
- Summary text: "Prompt for LLM" (consistent with other platforms)

Fixes #1178
