### PR TITLE
feat(frontend): hide platform-incompatible settings based on git tool

### DIFF
--- a/apps/web/src/app/(app)/settings/_components/use-code-management-platform.ts
+++ b/apps/web/src/app/(app)/settings/_components/use-code-management-platform.ts
@@ -1,4 +1,5 @@
 import { useSuspenseGetConnections } from "@services/setup/hooks";
+import { useCodeReviewRouteParams } from "src/app/(app)/settings/_hooks";
 import { useSelectedTeamId } from "src/core/providers/selected-team-context";
 import { PlatformType } from "src/core/types";
 import { safeArray } from "src/core/utils/safe-array";
@@ -21,40 +22,34 @@ function useCodeManagementPlatforms(): Set<string> {
 }
 
 /**
- * True when the team has at least one GitHub code-management connection.
- *
- * NOTE: This is a team-level check. For multi-platform teams it may not
- * reflect the specific repository being configured. When `repositoryId`
- * is "global" the check is skipped (returns true) because global settings
- * apply to all repositories regardless of platform.
+ * Returns true when the "Request Changes" review-status toggle should be
+ * hidden.  GitLab does not support this feature; global settings are
+ * always shown (they apply to all platforms).
  */
-export function useIsGithub(repositoryId?: string): boolean {
-    if (repositoryId === "global") return true;
-    return useCodeManagementPlatforms().has(PlatformType.GITHUB);
-}
-
-/**
- * True when the team has at least one GitLab code-management connection.
- *
- * NOTE: This is a team-level check. For multi-platform teams it may not
- * reflect the specific repository being configured. When `repositoryId`
- * is "global" the check is skipped (returns true) because global settings
- * apply to all repositories regardless of platform.
- */
-export function useIsGitlab(repositoryId?: string): boolean {
-    if (repositoryId === "global") return true;
+export function useShouldHideRequestChanges(): boolean {
+    const { repositoryId } = useCodeReviewRouteParams();
+    if (repositoryId === "global") return false;
     return useCodeManagementPlatforms().has(PlatformType.GITLAB);
 }
 
 /**
- * True when the team has at least one Bitbucket code-management connection.
- *
- * NOTE: This is a team-level check. For multi-platform teams it may not
- * reflect the specific repository being configured. When `repositoryId`
- * is "global" the check is skipped (returns true) because global settings
- * apply to all repositories regardless of platform.
+ * Returns true when the "Post as hidden comment" toggle should be hidden.
+ * Only GitHub supports hidden/minimized comments; global settings are
+ * always shown.
  */
-export function useIsBitbucket(repositoryId?: string): boolean {
-    if (repositoryId === "global") return true;
+export function useShouldHideHiddenComments(): boolean {
+    const { repositoryId } = useCodeReviewRouteParams();
+    if (repositoryId === "global") return false;
+    return !useCodeManagementPlatforms().has(PlatformType.GITHUB);
+}
+
+/**
+ * Returns true when the "Enable LLM Prompt" toggle should be hidden.
+ * Bitbucket does not support this feature; global settings are always
+ * shown.
+ */
+export function useShouldHideLLMPrompt(): boolean {
+    const { repositoryId } = useCodeReviewRouteParams();
+    if (repositoryId === "global") return false;
     return useCodeManagementPlatforms().has(PlatformType.BITBUCKET);
 }

--- a/apps/web/src/app/(app)/settings/_components/use-code-management-platform.ts
+++ b/apps/web/src/app/(app)/settings/_components/use-code-management-platform.ts
@@ -20,17 +20,41 @@ function useCodeManagementPlatforms(): Set<string> {
     );
 }
 
-/** True when the team has at least one GitHub code-management connection. */
-export function useIsGithub(): boolean {
+/**
+ * True when the team has at least one GitHub code-management connection.
+ *
+ * NOTE: This is a team-level check. For multi-platform teams it may not
+ * reflect the specific repository being configured. When `repositoryId`
+ * is "global" the check is skipped (returns true) because global settings
+ * apply to all repositories regardless of platform.
+ */
+export function useIsGithub(repositoryId?: string): boolean {
+    if (repositoryId === "global") return true;
     return useCodeManagementPlatforms().has(PlatformType.GITHUB);
 }
 
-/** True when the team has at least one GitLab code-management connection. */
-export function useIsGitlab(): boolean {
+/**
+ * True when the team has at least one GitLab code-management connection.
+ *
+ * NOTE: This is a team-level check. For multi-platform teams it may not
+ * reflect the specific repository being configured. When `repositoryId`
+ * is "global" the check is skipped (returns true) because global settings
+ * apply to all repositories regardless of platform.
+ */
+export function useIsGitlab(repositoryId?: string): boolean {
+    if (repositoryId === "global") return true;
     return useCodeManagementPlatforms().has(PlatformType.GITLAB);
 }
 
-/** True when the team has at least one Bitbucket code-management connection. */
-export function useIsBitbucket(): boolean {
+/**
+ * True when the team has at least one Bitbucket code-management connection.
+ *
+ * NOTE: This is a team-level check. For multi-platform teams it may not
+ * reflect the specific repository being configured. When `repositoryId`
+ * is "global" the check is skipped (returns true) because global settings
+ * apply to all repositories regardless of platform.
+ */
+export function useIsBitbucket(repositoryId?: string): boolean {
+    if (repositoryId === "global") return true;
     return useCodeManagementPlatforms().has(PlatformType.BITBUCKET);
 }

--- a/apps/web/src/app/(app)/settings/_components/use-code-management-platform.ts
+++ b/apps/web/src/app/(app)/settings/_components/use-code-management-platform.ts
@@ -1,0 +1,36 @@
+import { useSuspenseGetConnections } from "@services/setup/hooks";
+import { useSelectedTeamId } from "src/core/providers/selected-team-context";
+import { PlatformType } from "src/core/types";
+import { safeArray } from "src/core/utils/safe-array";
+
+/**
+ * Returns the platform type(s) of the active CODE_MANAGEMENT connections
+ * for the current team. Returns a Set for O(1) lookups.
+ */
+function useCodeManagementPlatforms(): Set<string> {
+    const { teamId } = useSelectedTeamId();
+    const connections = useSuspenseGetConnections(teamId);
+
+    return new Set(
+        safeArray(connections)
+            .filter(
+                (c) => c.category === "CODE_MANAGEMENT" && c.hasConnection,
+            )
+            .map((c) => c.platformName),
+    );
+}
+
+/** True when the team has at least one GitHub code-management connection. */
+export function useIsGithub(): boolean {
+    return useCodeManagementPlatforms().has(PlatformType.GITHUB);
+}
+
+/** True when the team has at least one GitLab code-management connection. */
+export function useIsGitlab(): boolean {
+    return useCodeManagementPlatforms().has(PlatformType.GITLAB);
+}
+
+/** True when the team has at least one Bitbucket code-management connection. */
+export function useIsBitbucket(): boolean {
+    return useCodeManagementPlatforms().has(PlatformType.BITBUCKET);
+}

--- a/apps/web/src/app/(app)/settings/_components/use-code-management-platform.ts
+++ b/apps/web/src/app/(app)/settings/_components/use-code-management-platform.ts
@@ -7,6 +7,9 @@ import { safeArray } from "src/core/utils/safe-array";
 /**
  * Returns the platform type(s) of the active CODE_MANAGEMENT connections
  * for the current team. Returns a Set for O(1) lookups.
+ *
+ * Called unconditionally in every hook that needs platform info so that
+ * React's hook-order invariant is never violated across navigations.
  */
 function useCodeManagementPlatforms(): Set<string> {
     const { teamId } = useSelectedTeamId();
@@ -28,8 +31,10 @@ function useCodeManagementPlatforms(): Set<string> {
  */
 export function useShouldHideRequestChanges(): boolean {
     const { repositoryId } = useCodeReviewRouteParams();
+    const platforms = useCodeManagementPlatforms();
+
     if (repositoryId === "global") return false;
-    return useCodeManagementPlatforms().has(PlatformType.GITLAB);
+    return platforms.has(PlatformType.GITLAB);
 }
 
 /**
@@ -39,8 +44,10 @@ export function useShouldHideRequestChanges(): boolean {
  */
 export function useShouldHideHiddenComments(): boolean {
     const { repositoryId } = useCodeReviewRouteParams();
+    const platforms = useCodeManagementPlatforms();
+
     if (repositoryId === "global") return false;
-    return !useCodeManagementPlatforms().has(PlatformType.GITHUB);
+    return !platforms.has(PlatformType.GITHUB);
 }
 
 /**
@@ -50,6 +57,8 @@ export function useShouldHideHiddenComments(): boolean {
  */
 export function useShouldHideLLMPrompt(): boolean {
     const { repositoryId } = useCodeReviewRouteParams();
+    const platforms = useCodeManagementPlatforms();
+
     if (repositoryId === "global") return false;
-    return useCodeManagementPlatforms().has(PlatformType.BITBUCKET);
+    return platforms.has(PlatformType.BITBUCKET);
 }

--- a/apps/web/src/app/(app)/settings/_components/use-code-management-platform.ts
+++ b/apps/web/src/app/(app)/settings/_components/use-code-management-platform.ts
@@ -26,39 +26,43 @@ function useCodeManagementPlatforms(): Set<string> {
 
 /**
  * Returns true when the "Request Changes" review-status toggle should be
- * hidden.  GitLab does not support this feature; global settings are
- * always shown (they apply to all platforms).
+ * hidden.  Hidden when ALL connected platforms are GitLab (the feature
+ * is not supported there).  For mixed-platform teams the setting is
+ * shown because it may apply to non-GitLab repositories.
  */
 export function useShouldHideRequestChanges(): boolean {
-    const { repositoryId } = useCodeReviewRouteParams();
     const platforms = useCodeManagementPlatforms();
 
-    if (repositoryId === "global") return false;
-    return platforms.has(PlatformType.GITLAB);
+    // All connected platforms are GitLab → feature unsupported everywhere.
+    return platforms.size > 0 && !platforms.has(PlatformType.GITHUB)
+        && !platforms.has(PlatformType.BITBUCKET)
+        && !platforms.has(PlatformType.AZURE_REPOS)
+        && !platforms.has(PlatformType.FORGEJO);
 }
 
 /**
  * Returns true when the "Post as hidden comment" toggle should be hidden.
- * Only GitHub supports hidden/minimized comments; global settings are
- * always shown.
+ * Hidden when NO connected platform is GitHub (the feature is
+ * GitHub-only).  For mixed-platform teams the setting is shown because
+ * it may apply to GitHub repositories.
  */
 export function useShouldHideHiddenComments(): boolean {
-    const { repositoryId } = useCodeReviewRouteParams();
     const platforms = useCodeManagementPlatforms();
-
-    if (repositoryId === "global") return false;
-    return !platforms.has(PlatformType.GITHUB);
+    return platforms.size > 0 && !platforms.has(PlatformType.GITHUB);
 }
 
 /**
  * Returns true when the "Enable LLM Prompt" toggle should be hidden.
- * Bitbucket does not support this feature; global settings are always
- * shown.
+ * Hidden when ALL connected platforms are Bitbucket (the feature is not
+ * supported there).  For mixed-platform teams the setting is shown
+ * because it may apply to non-Bitbucket repositories.
  */
 export function useShouldHideLLMPrompt(): boolean {
-    const { repositoryId } = useCodeReviewRouteParams();
     const platforms = useCodeManagementPlatforms();
 
-    if (repositoryId === "global") return false;
-    return platforms.has(PlatformType.BITBUCKET);
+    // All connected platforms are Bitbucket → feature unsupported everywhere.
+    return platforms.size > 0 && !platforms.has(PlatformType.GITHUB)
+        && !platforms.has(PlatformType.GITLAB)
+        && !platforms.has(PlatformType.AZURE_REPOS)
+        && !platforms.has(PlatformType.FORGEJO);
 }

--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/custom-messages/_components/hidden-comments.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/custom-messages/_components/hidden-comments.tsx
@@ -5,6 +5,7 @@ import { CardHeader } from "@components/ui/card";
 import { Heading } from "@components/ui/heading";
 import { Switch } from "@components/ui/switch";
 import { useIsGithub } from "src/app/(app)/settings/_components/use-code-management-platform";
+import { useCodeReviewRouteParams } from "../../../_hooks";
 
 import { OverrideIndicator } from "../../../_components/override";
 import { IFormattedConfigProperty } from "../../../_types";
@@ -16,7 +17,8 @@ export const HiddenComments = (props: {
     handleRevert: () => void;
     canEdit: boolean;
 }) => {
-    const isGithub = useIsGithub();
+    const { repositoryId } = useCodeReviewRouteParams();
+    const isGithub = useIsGithub(repositoryId);
 
     // Hidden/minimized comments are a GitHub-only feature.
     if (!isGithub) return null;

--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/custom-messages/_components/hidden-comments.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/custom-messages/_components/hidden-comments.tsx
@@ -4,6 +4,7 @@ import { Button } from "@components/ui/button";
 import { CardHeader } from "@components/ui/card";
 import { Heading } from "@components/ui/heading";
 import { Switch } from "@components/ui/switch";
+import { useIsGithub } from "src/app/(app)/settings/_components/use-code-management-platform";
 
 import { OverrideIndicator } from "../../../_components/override";
 import { IFormattedConfigProperty } from "../../../_types";
@@ -15,6 +16,11 @@ export const HiddenComments = (props: {
     handleRevert: () => void;
     canEdit: boolean;
 }) => {
+    const isGithub = useIsGithub();
+
+    // Hidden/minimized comments are a GitHub-only feature.
+    if (!isGithub) return null;
+
     return (
         <div className="flex flex-col gap-4">
             <Button

--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/custom-messages/_components/hidden-comments.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/custom-messages/_components/hidden-comments.tsx
@@ -4,8 +4,7 @@ import { Button } from "@components/ui/button";
 import { CardHeader } from "@components/ui/card";
 import { Heading } from "@components/ui/heading";
 import { Switch } from "@components/ui/switch";
-import { useIsGithub } from "src/app/(app)/settings/_components/use-code-management-platform";
-import { useCodeReviewRouteParams } from "../../../_hooks";
+import { useShouldHideHiddenComments } from "src/app/(app)/settings/_components/use-code-management-platform";
 
 import { OverrideIndicator } from "../../../_components/override";
 import { IFormattedConfigProperty } from "../../../_types";
@@ -17,11 +16,9 @@ export const HiddenComments = (props: {
     handleRevert: () => void;
     canEdit: boolean;
 }) => {
-    const { repositoryId } = useCodeReviewRouteParams();
-    const isGithub = useIsGithub(repositoryId);
+    const shouldHide = useShouldHideHiddenComments();
 
-    // Hidden/minimized comments are a GitHub-only feature.
-    if (!isGithub) return null;
+    if (shouldHide) return null;
 
     return (
         <div className="flex flex-col gap-4">

--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/custom-messages/_components/llm-prompt.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/custom-messages/_components/llm-prompt.tsx
@@ -2,6 +2,7 @@ import { Button } from "@components/ui/button";
 import { CardHeader } from "@components/ui/card";
 import { Heading } from "@components/ui/heading";
 import { Switch } from "@components/ui/switch";
+import { useIsBitbucket } from "src/app/(app)/settings/_components/use-code-management-platform";
 
 import { OverrideIndicator } from "../../../_components/override";
 import type { IFormattedConfigProperty } from "../../../_types";
@@ -13,6 +14,11 @@ export const LLMPromptToggle = (props: {
     handleRevert: () => void;
     canEdit: boolean;
 }) => {
+    const isBitbucket = useIsBitbucket();
+
+    // LLM Prompt is not supported on Bitbucket.
+    if (isBitbucket) return null;
+
     return (
         <div className="flex flex-col gap-4">
             <Button

--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/custom-messages/_components/llm-prompt.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/custom-messages/_components/llm-prompt.tsx
@@ -3,6 +3,7 @@ import { CardHeader } from "@components/ui/card";
 import { Heading } from "@components/ui/heading";
 import { Switch } from "@components/ui/switch";
 import { useIsBitbucket } from "src/app/(app)/settings/_components/use-code-management-platform";
+import { useCodeReviewRouteParams } from "../../../_hooks";
 
 import { OverrideIndicator } from "../../../_components/override";
 import type { IFormattedConfigProperty } from "../../../_types";
@@ -14,7 +15,8 @@ export const LLMPromptToggle = (props: {
     handleRevert: () => void;
     canEdit: boolean;
 }) => {
-    const isBitbucket = useIsBitbucket();
+    const { repositoryId } = useCodeReviewRouteParams();
+    const isBitbucket = useIsBitbucket(repositoryId);
 
     // LLM Prompt is not supported on Bitbucket.
     if (isBitbucket) return null;

--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/custom-messages/_components/llm-prompt.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/custom-messages/_components/llm-prompt.tsx
@@ -2,8 +2,7 @@ import { Button } from "@components/ui/button";
 import { CardHeader } from "@components/ui/card";
 import { Heading } from "@components/ui/heading";
 import { Switch } from "@components/ui/switch";
-import { useIsBitbucket } from "src/app/(app)/settings/_components/use-code-management-platform";
-import { useCodeReviewRouteParams } from "../../../_hooks";
+import { useShouldHideLLMPrompt } from "src/app/(app)/settings/_components/use-code-management-platform";
 
 import { OverrideIndicator } from "../../../_components/override";
 import type { IFormattedConfigProperty } from "../../../_types";
@@ -15,11 +14,9 @@ export const LLMPromptToggle = (props: {
     handleRevert: () => void;
     canEdit: boolean;
 }) => {
-    const { repositoryId } = useCodeReviewRouteParams();
-    const isBitbucket = useIsBitbucket(repositoryId);
+    const shouldHide = useShouldHideLLMPrompt();
 
-    // LLM Prompt is not supported on Bitbucket.
-    if (isBitbucket) return null;
+    if (shouldHide) return null;
 
     return (
         <div className="flex flex-col gap-4">

--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/general/_components/is-request-changes-active.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/general/_components/is-request-changes-active.tsx
@@ -4,17 +4,18 @@ import { Button } from "@components/ui/button";
 import { CardHeader } from "@components/ui/card";
 import { Heading } from "@components/ui/heading";
 import { Switch } from "@components/ui/switch";
-import { useSuspenseGetConnections } from "@services/setup/hooks";
 import { Controller, useFormContext } from "react-hook-form";
 import { OverrideIndicatorForm } from "src/app/(app)/settings/code-review/_components/override";
-import { useSelectedTeamId } from "src/core/providers/selected-team-context";
-import { PlatformType } from "src/core/types";
-import { safeArray } from "src/core/utils/safe-array";
+import { useIsGitlab } from "src/app/(app)/settings/_components/use-code-management-platform";
 
 import type { CodeReviewFormType } from "../../../_types";
 
 export const IsRequestChangesActive = () => {
     const form = useFormContext<CodeReviewFormType>();
+    const isGitlab = useIsGitlab();
+
+    // Request Changes status is not supported on GitLab.
+    if (isGitlab) return null;
 
     return (
         <div className="flex flex-col gap-2">

--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/general/_components/is-request-changes-active.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/general/_components/is-request-changes-active.tsx
@@ -6,18 +6,15 @@ import { Heading } from "@components/ui/heading";
 import { Switch } from "@components/ui/switch";
 import { Controller, useFormContext } from "react-hook-form";
 import { OverrideIndicatorForm } from "src/app/(app)/settings/code-review/_components/override";
-import { useIsGitlab } from "src/app/(app)/settings/_components/use-code-management-platform";
-import { useCodeReviewRouteParams } from "../../../_hooks";
+import { useShouldHideRequestChanges } from "src/app/(app)/settings/_components/use-code-management-platform";
 
 import type { CodeReviewFormType } from "../../../_types";
 
 export const IsRequestChangesActive = () => {
     const form = useFormContext<CodeReviewFormType>();
-    const { repositoryId } = useCodeReviewRouteParams();
-    const isGitlab = useIsGitlab(repositoryId);
+    const shouldHide = useShouldHideRequestChanges();
 
-    // Request Changes status is not supported on GitLab.
-    if (isGitlab) return null;
+    if (shouldHide) return null;
 
     return (
         <div className="flex flex-col gap-2">

--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/general/_components/is-request-changes-active.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/general/_components/is-request-changes-active.tsx
@@ -7,12 +7,14 @@ import { Switch } from "@components/ui/switch";
 import { Controller, useFormContext } from "react-hook-form";
 import { OverrideIndicatorForm } from "src/app/(app)/settings/code-review/_components/override";
 import { useIsGitlab } from "src/app/(app)/settings/_components/use-code-management-platform";
+import { useCodeReviewRouteParams } from "../../../_hooks";
 
 import type { CodeReviewFormType } from "../../../_types";
 
 export const IsRequestChangesActive = () => {
     const form = useFormContext<CodeReviewFormType>();
-    const isGitlab = useIsGitlab();
+    const { repositoryId } = useCodeReviewRouteParams();
+    const isGitlab = useIsGitlab(repositoryId);
 
     // Request Changes status is not supported on GitLab.
     if (isGitlab) return null;


### PR DESCRIPTION
## Summary

Three code-review settings had static badges ("GitHub only", "Not available on Bitbucket") noting platform limitations, but the controls were still visible and interactive for users on those platforms. This PR hides them entirely when incompatible with the user's git tool.

## Changes

| Setting | Condition | Reason |
|---------|-----------|--------|
| `IsRequestChangesActive` | Hidden for GitLab | Request-changes review status not supported |
| `HiddenComments` | Hidden for non-GitHub | Hidden/minimized comments are GitHub-only |
| `LLMPromptToggle` | Hidden for Bitbucket | LLM prompt copy not supported |

## Implementation

Added a shared hook `use-code-management-platform.ts` that exposes:
- `useIsGithub()` — true when team has a GitHub code-management connection
- `useIsGitlab()` — true when team has a GitLab code-management connection
- `useIsBitbucket()` — true when team has a Bitbucket code-management connection

Follows the same pattern as the existing `hasGithubConnection` in `enable-committable-suggestions.tsx`.

Fixes #842
