### PR TITLE
feat(byok): add anthropic_compatible provider; wire Moonshot Kimi Coding Plan

### DIFF
--- a/apps/web/src/features/ee/byok/_components/catalog/connect-panel.tsx
+++ b/apps/web/src/features/ee/byok/_components/catalog/connect-panel.tsx
@@ -244,7 +244,7 @@ export function CuratedConnectPanel({
                             selectedId={variant?.id}
                             docsUrl={model.docsUrl}
                             onSelect={handleVariantChange}
-                            disabledVariantIds={new Set(["kimi-code"])}
+                            disabledVariantIds={disabledVariants}
                         />
                     )}
 

--- a/apps/web/src/features/ee/byok/_components/catalog/connect-panel.tsx
+++ b/apps/web/src/features/ee/byok/_components/catalog/connect-panel.tsx
@@ -89,7 +89,7 @@ export function CuratedConnectPanel({
         mode: "onChange",
         resolver: zodResolver(connectSchema),
         defaultValues: {
-            provider: model.provider,
+            provider: variant?.provider ?? model.provider,
             model: model.id,
             apiKey: "",
             baseURL: initialBaseURL,
@@ -105,13 +105,17 @@ export function CuratedConnectPanel({
     const activeBaseURL = variant?.baseURL ?? model.defaults.baseURL;
     const activeApiKeyUrl = variant?.apiKeyUrl ?? model.apiKeyUrl;
 
-    const disabledVariants = new Set(["kimi-code"]);
+    const disabledVariants = new Set<string>([]);
 
     const handleVariantChange = (nextId: string) => {
         if (!nextId || !model.variants || disabledVariants.has(nextId)) return;
         const next = model.variants.find((v) => v.id === nextId);
         if (!next || next.id === variant?.id) return;
         setVariant(next);
+        form.setValue("provider", next.provider ?? model.provider, {
+            shouldValidate: true,
+            shouldDirty: true,
+        });
         form.setValue("baseURL", next.baseURL, {
             shouldValidate: true,
             shouldDirty: true,

--- a/apps/web/src/features/ee/byok/_components/page.client.tsx
+++ b/apps/web/src/features/ee/byok/_components/page.client.tsx
@@ -42,6 +42,7 @@ const CURATED_PROVIDERS = new Set([
     "anthropic",
     "openai",
     "openai_compatible",
+    "anthropic_compatible",
     "google_gemini",
     "openrouter",
 ]);
@@ -55,6 +56,8 @@ const providerLabel = (providerId?: string) => {
             return "OpenAI";
         case "openai_compatible":
             return "OpenAI-compatible";
+        case "anthropic_compatible":
+            return "Anthropic-compatible";
         case "anthropic":
             return "Anthropic";
         case "google_gemini":

--- a/apps/web/src/features/ee/byok/_data/curated-models.json
+++ b/apps/web/src/features/ee/byok/_data/curated-models.json
@@ -109,10 +109,11 @@
                 {
                     "id": "kimi-code",
                     "label": "Kimi Code Plan",
-                    "description": "Subscription plan with a dedicated coding endpoint. Capped at 30 concurrent requests.",
-                    "baseURL": "https://api.kimi.com/coding/v1",
+                    "description": "Subscription plan via Moonshot's Anthropic-compatible endpoint. Capped at 30 concurrent requests; subscription usage is governed by Moonshot's community guidelines — for heavy automated usage prefer the Developer API.",
+                    "baseURL": "https://api.kimi.com/coding",
                     "apiKeyUrl": "https://www.kimi.com/code",
-                    "maxConcurrentRequests": 30
+                    "maxConcurrentRequests": 30,
+                    "provider": "anthropic_compatible"
                 }
             ],
             "defaultVariantId": "moonshot",

--- a/apps/web/src/features/ee/byok/_data/curated-models.types.ts
+++ b/apps/web/src/features/ee/byok/_data/curated-models.types.ts
@@ -10,6 +10,10 @@ export type ModelVariant = {
     baseURL: string;
     apiKeyUrl?: string;
     maxConcurrentRequests?: number;
+    /** Overrides the model-level provider for this variant (e.g. the Kimi
+     *  Code Plan speaks the Anthropic protocol while the Developer API is
+     *  OpenAI-compatible). */
+    provider?: string;
 };
 
 export type CuratedModel = {

--- a/apps/web/src/features/ee/byok/manual/page.client.tsx
+++ b/apps/web/src/features/ee/byok/manual/page.client.tsx
@@ -178,7 +178,8 @@ export function ByokManualPageClient({
         // makes the backend reject with "apiKey is required", which nudges
         // the user to paste credentials to authorize the URL change.
         const urlChanged =
-            data.provider === "openai_compatible" &&
+            (data.provider === "openai_compatible" ||
+                data.provider === "anthropic_compatible") &&
             (data.baseURL ?? undefined) !== existingConfig?.baseURL;
 
         if (!hasNewCredentials && !urlChanged) {

--- a/libs/code-review/infrastructure/agents/llm/agent-loop.ts
+++ b/libs/code-review/infrastructure/agents/llm/agent-loop.ts
@@ -230,6 +230,7 @@ function buildOpenRouterRouting(input?: {
  */
 const PROVIDER_OPTIONS_NAMESPACE: Partial<Record<string, string>> = {
     [BYOKProvider.ANTHROPIC]: 'anthropic',
+    [BYOKProvider.ANTHROPIC_COMPATIBLE]: 'anthropic',
     [BYOKProvider.GOOGLE_GEMINI]: 'google',
     [BYOKProvider.GOOGLE_VERTEX]: 'google',
     [BYOKProvider.OPENAI]: 'openai',
@@ -438,6 +439,20 @@ export function buildReasoningProviderOptions(
                 },
             };
         }
+
+        case BYOKProvider.ANTHROPIC_COMPATIBLE:
+            // Anthropic-protocol endpoints from other vendors (Kimi Code,
+            // Z.ai, DeepSeek). They speak the classic thinking shape
+            // (enabled + budget_tokens); none of them implement Anthropic's
+            // newer adaptive thinking, so always use the budget form.
+            return {
+                anthropic: {
+                    thinking: {
+                        type: 'enabled',
+                        budgetTokens: EFFORT_TO_BUDGET[effort],
+                    },
+                },
+            };
 
         default:
             return {};

--- a/libs/code-review/infrastructure/agents/llm/byok-to-vercel.ts
+++ b/libs/code-review/infrastructure/agents/llm/byok-to-vercel.ts
@@ -11,7 +11,11 @@ import { createGoogleGenerativeAI } from '@ai-sdk/google';
 import { createVertex } from '@ai-sdk/google-vertex';
 import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
-import { BYOKConfig, BYOKProvider } from '@kodus/kodus-common/llm';
+import {
+    anthropicCompatibleRootURL,
+    BYOKConfig,
+    BYOKProvider,
+} from '@kodus/kodus-common/llm';
 import { decrypt } from '@libs/common/utils/crypto';
 
 /**
@@ -351,6 +355,15 @@ export function byokToVercelModel(
             return createAnthropic({
                 apiKey,
                 ...(baseURL ? { baseURL } : {}),
+            })(model);
+
+        case BYOKProvider.ANTHROPIC_COMPATIBLE:
+            // Anthropic-compatible endpoints (Kimi Code, Z.ai, DeepSeek):
+            // @ai-sdk/anthropic appends /messages to the base, so the base
+            // must carry the /v1 suffix — normalize whatever the user pasted.
+            return createAnthropic({
+                apiKey,
+                baseURL: `${anthropicCompatibleRootURL(baseURL || '')}/v1`,
             })(model);
 
         case BYOKProvider.GOOGLE_GEMINI:

--- a/libs/core/infrastructure/services/providers/provider.service.ts
+++ b/libs/core/infrastructure/services/providers/provider.service.ts
@@ -79,6 +79,15 @@ export class ProviderService {
             requiresApiKey: true,
             requiresBaseUrl: true,
         },
+        [BYOKProvider.ANTHROPIC_COMPATIBLE]: {
+            id: BYOKProvider.ANTHROPIC_COMPATIBLE,
+            name: 'Anthropic Compatible',
+            description:
+                'Any Anthropic-compatible API endpoint (Kimi Code, Z.ai, DeepSeek, etc.)',
+            supported: true,
+            requiresApiKey: true,
+            requiresBaseUrl: true,
+        },
     };
 
     /**

--- a/libs/organization/application/use-cases/organizationParameters/get-models-by-provider.use-case.ts
+++ b/libs/organization/application/use-cases/organizationParameters/get-models-by-provider.use-case.ts
@@ -102,6 +102,15 @@ export class GetModelsByProviderUseCase {
             case BYOKProvider.AMAZON_BEDROCK:
                 return this.getBedrockModels();
 
+            case BYOKProvider.ANTHROPIC_COMPATIBLE:
+                // Listing needs the user's baseURL + key, which aren't
+                // available here; the frontend forces free-form model input
+                // for baseURL-requiring providers, so this is never called
+                // in the normal flow.
+                throw new BadRequestException(
+                    'Model listing is not available for anthropic_compatible — enter the model ID manually.',
+                );
+
             default:
                 throw new BadRequestException(
                     `Unsupported provider: ${provider}`,

--- a/libs/organization/application/use-cases/organizationParameters/test-byok-connection.use-case.ts
+++ b/libs/organization/application/use-cases/organizationParameters/test-byok-connection.use-case.ts
@@ -1,4 +1,7 @@
-import { BYOKProvider } from '@kodus/kodus-common/llm';
+import {
+    anthropicCompatibleRootURL,
+    BYOKProvider,
+} from '@kodus/kodus-common/llm';
 import { ProviderService } from '@libs/core/infrastructure/services/providers/provider.service';
 import { createLogger } from '@kodus/flow';
 import { BadRequestException, Injectable } from '@nestjs/common';
@@ -189,6 +192,24 @@ export class TestByokConnectionUseCase {
             );
         }
 
+        // Anthropic-compatible: probe the real /v1/messages endpoint with a
+        // 1-token request instead of /v1/models. Some vendors gate the two
+        // differently — Kimi Code's models list is open while chat is
+        // restricted — so a models-list probe can report "connection OK"
+        // for a key whose actual reviews would fail.
+        if (byokProvider === BYOKProvider.ANTHROPIC_COMPATIBLE) {
+            if (!baseURL?.trim()) {
+                throw new BadRequestException(
+                    'baseURL is required for anthropic_compatible',
+                );
+            }
+            return await this.testAnthropicCompatible(
+                apiKey,
+                baseURL,
+                input.model,
+            );
+        }
+
         const { url, headers } = this.buildProbeRequest(byokProvider, apiKey, baseURL);
 
         // SSRF guard: only openai_compatible consumes a user-provided
@@ -213,6 +234,61 @@ export class TestByokConnectionUseCase {
         } catch (err) {
             const latencyMs = Date.now() - start;
             return this.normalizeError(err, latencyMs);
+        }
+    }
+
+    /**
+     * Validate an Anthropic-compatible endpoint (Kimi Code, Z.ai, DeepSeek)
+     * by sending a minimal 1-token /v1/messages request — the same call the
+     * real review path makes. Falls back to GET /v1/models when no model is
+     * provided, accepting the weaker signal.
+     */
+    private async testAnthropicCompatible(
+        apiKey: string,
+        baseURL: string,
+        model?: string,
+    ): Promise<TestByokResult> {
+        const root = anthropicCompatibleRootURL(baseURL);
+
+        // SSRF guard: user-provided base URL, same rules as openai_compatible.
+        await assertSafeOpenAICompatibleUrl(root);
+
+        const headers = {
+            'x-api-key': apiKey,
+            'anthropic-version': '2023-06-01',
+            'Content-Type': 'application/json',
+        };
+
+        const start = Date.now();
+        try {
+            if (model?.trim()) {
+                await axios.post(
+                    `${root}/v1/messages`,
+                    {
+                        model: model.trim(),
+                        max_tokens: 1,
+                        messages: [{ role: 'user', content: 'ping' }],
+                    },
+                    {
+                        headers,
+                        timeout: TEST_TIMEOUT_MS,
+                        maxRedirects: 0,
+                    },
+                );
+            } else {
+                await axios.get(`${root}/v1/models`, {
+                    headers,
+                    timeout: TEST_TIMEOUT_MS,
+                    maxRedirects: 0,
+                });
+            }
+            return {
+                ok: true,
+                code: 'ok',
+                latencyMs: Date.now() - start,
+            };
+        } catch (err) {
+            return this.normalizeError(err, Date.now() - start);
         }
     }
 

--- a/packages/kodus-common/src/llm/byokProvider.service.ts
+++ b/packages/kodus-common/src/llm/byokProvider.service.ts
@@ -10,8 +10,26 @@ export enum BYOKProvider {
     GOOGLE_VERTEX = 'google_vertex',
     AMAZON_BEDROCK = 'amazon_bedrock',
     OPENAI_COMPATIBLE = 'openai_compatible',
+    ANTHROPIC_COMPATIBLE = 'anthropic_compatible',
     OPEN_ROUTER = 'open_router',
     NOVITA = 'novita',
+}
+
+/**
+ * Normalize an Anthropic-compatible base URL to its root form (no trailing
+ * slash, no `/v1` suffix). The two Anthropic SDK paths disagree on shape:
+ * LangChain's ChatAnthropic appends `/v1/messages` to the root, while
+ * `@ai-sdk/anthropic` appends `/messages` to a `/v1`-suffixed base. Users
+ * paste either shape (e.g. `https://api.kimi.com/coding` or
+ * `https://api.kimi.com/coding/v1`), so each call site normalizes from the
+ * root: LangChain uses it as-is, Vercel appends `/v1`.
+ */
+export function anthropicCompatibleRootURL(baseURL: string): string {
+    let trimmed = baseURL.trim();
+    while (trimmed.endsWith('/')) trimmed = trimmed.slice(0, -1);
+    if (/\/v1$/i.test(trimmed)) trimmed = trimmed.slice(0, -3);
+    while (trimmed.endsWith('/')) trimmed = trimmed.slice(0, -1);
+    return trimmed;
 }
 
 export interface BYOKConfig {
@@ -105,11 +123,18 @@ export class BYOKProviderService {
             );
         }
 
+        if (provider === BYOKProvider.ANTHROPIC_COMPATIBLE && !baseURL) {
+            throw new Error(
+                'baseURL is required for Anthropic Compatible provider',
+            );
+        }
+
         const modelInstance = adapter.build({
             model,
             apiKey,
             baseURL:
-                provider === BYOKProvider.OPENAI_COMPATIBLE
+                provider === BYOKProvider.OPENAI_COMPATIBLE ||
+                provider === BYOKProvider.ANTHROPIC_COMPATIBLE
                     ? baseURL
                     : provider === BYOKProvider.OPEN_ROUTER
                       ? 'https://openrouter.ai/api/v1'
@@ -190,6 +215,15 @@ export class BYOKProviderService {
             errors.push('baseURL is required for OpenAI Compatible provider');
         }
 
+        if (
+            providerConfig.provider === BYOKProvider.ANTHROPIC_COMPATIBLE &&
+            !providerConfig.baseURL
+        ) {
+            errors.push(
+                'baseURL is required for Anthropic Compatible provider',
+            );
+        }
+
         if (providerConfig.provider === BYOKProvider.GOOGLE_VERTEX) {
             if (!providerConfig.projectId) {
                 errors.push('projectId is required for Google Vertex AI');
@@ -224,6 +258,7 @@ export class BYOKProviderService {
             [BYOKProvider.GOOGLE_VERTEX]: 'Google Vertex',
             [BYOKProvider.AMAZON_BEDROCK]: 'Amazon Bedrock',
             [BYOKProvider.OPENAI_COMPATIBLE]: 'OpenAI Compatible',
+            [BYOKProvider.ANTHROPIC_COMPATIBLE]: 'Anthropic Compatible',
             [BYOKProvider.OPEN_ROUTER]: 'OpenRouter',
             [BYOKProvider.NOVITA]: 'Novita',
         };

--- a/packages/kodus-common/src/llm/providerAdapters/anthropicAdapter.ts
+++ b/packages/kodus-common/src/llm/providerAdapters/anthropicAdapter.ts
@@ -1,4 +1,5 @@
 import { ChatAnthropic } from '@langchain/anthropic';
+import { anthropicCompatibleRootURL } from '../byokProvider.service';
 import { resolveModelOptions } from './resolver';
 import {
     AdapterBuildParams,
@@ -9,7 +10,7 @@ import {
 
 export class AnthropicAdapter implements ProviderAdapter {
     build(params: AdapterBuildParams): ChatAnthropic {
-        const { model, apiKey, options } = params;
+        const { model, apiKey, baseURL, options } = params;
         const resolved = resolveModelOptions(model, {
             temperature: options?.temperature,
             maxTokens: options?.maxTokens,
@@ -48,6 +49,11 @@ export class AnthropicAdapter implements ProviderAdapter {
         const payload: ConstructorParameters<typeof ChatAnthropic>[0] = {
             model,
             apiKey,
+            // Anthropic-compatible endpoints (Kimi Code, Z.ai, etc.):
+            // ChatAnthropic appends /v1/messages itself, so pass the root.
+            ...(baseURL
+                ? { anthropicApiUrl: anthropicCompatibleRootURL(baseURL) }
+                : {}),
             ...(resolved.temperature !== undefined && !thinkingConfig
                 ? { temperature: resolved.temperature }
                 : {}),

--- a/packages/kodus-common/src/llm/providerAdapters/index.ts
+++ b/packages/kodus-common/src/llm/providerAdapters/index.ts
@@ -22,6 +22,7 @@ export function getAdapter(providerId: string): ProviderAdapter {
         case 'open_router':
             return new OpenAIAdapter();
         case 'anthropic':
+        case 'anthropic_compatible':
             return new AnthropicAdapter();
         case 'google_gemini':
             return new GoogleGeminiAdapter();

--- a/test/integration/byok/kimi-coding-plan.contract.integration.spec.ts
+++ b/test/integration/byok/kimi-coding-plan.contract.integration.spec.ts
@@ -1,0 +1,199 @@
+/**
+ * Live contract test for the `anthropic_compatible` BYOK provider against the
+ * real Moonshot Kimi Code Plan endpoint (`api.kimi.com/coding`).
+ *
+ * Unit tests mock the HTTP layer, so they can't catch a drift in the *external*
+ * contract or in our SDK wiring. Each assertion here maps to a concrete way the
+ * feature breaks in production:
+ *
+ *   1. Adapter routing / baseURL `/v1` shape — a regression that drops
+ *      `anthropic_compatible` to the OpenAI adapter hits Kimi's UA-gated
+ *      `/chat/completions` and 403s; a wrong baseURL shape 404s.
+ *   2. Vercel path with the *root* baseURL shape — the two SDKs require
+ *      opposite shapes, so this guards `anthropicCompatibleRootURL` in the
+ *      other direction.
+ *   3. Tool calling — a protocol-wiring break silently strips tool use from
+ *      reviews.
+ *   4. Prompt-cache token accounting — if SDK normalization or our reading
+ *      regresses, cost tracking silently under/over-counts.
+ *   5. test-byok use-case end-to-end — confirms the real `/v1/messages` probe
+ *      (not the ungated `/v1/models`) actually authenticates.
+ *
+ * Gated on `KIMI_CODING_PLAN_KEY` (a real coding-plan key). Skips — does not
+ * fail — when the key is absent, so CI without the secret stays green. Run
+ * locally with:
+ *   KIMI_CODING_PLAN_KEY=sk-kimi-... yarn test --testPathPatterns=kimi-coding-plan.contract
+ */
+import { getAdapter, BYOKProvider } from '@kodus/kodus-common/llm';
+
+// Identity crypto so byokToVercelModel can "decrypt" a raw key without needing
+// API_CRYPTO_KEY — this test exercises the HTTP contract, not encryption.
+jest.mock('@libs/common/utils/crypto', () => ({
+    encrypt: (v: string) => v,
+    decrypt: (v: string) => v,
+}));
+
+import { byokToVercelModel } from '@libs/code-review/infrastructure/agents/llm/byok-to-vercel';
+import { TestByokConnectionUseCase } from '@libs/organization/application/use-cases/organizationParameters/test-byok-connection.use-case';
+import { generateText, tool } from 'ai';
+import { z } from 'zod';
+
+const KEY = process.env.KIMI_CODING_PLAN_KEY;
+const CODING_BASE = 'https://api.kimi.com/coding';
+const MODEL = 'kimi-for-coding';
+const NET_TIMEOUT = 60_000;
+
+const describeLive = KEY ? describe : describe.skip;
+
+describeLive(
+    'Kimi Code Plan — anthropic_compatible live contract (needs KIMI_CODING_PLAN_KEY)',
+    () => {
+        it(
+            'LangChain adapter reaches the endpoint with a /v1-suffixed baseURL',
+            async () => {
+                // Worst-case input shape (user pastes the /v1 form). A routing
+                // regression to OpenAIAdapter would 403 here; a bad URL 404s.
+                const model = getAdapter(
+                    BYOKProvider.ANTHROPIC_COMPATIBLE,
+                ).build({
+                    model: MODEL,
+                    apiKey: KEY!,
+                    baseURL: `${CODING_BASE}/v1`,
+                    options: { maxTokens: 16, temperature: 1 },
+                });
+                expect(model.constructor.name).toBe('ChatAnthropic');
+
+                const res = await model.invoke('Reply with exactly: ok');
+                const text = Array.isArray(res.content)
+                    ? JSON.stringify(res.content)
+                    : String(res.content);
+                expect(text.toLowerCase()).toContain('ok');
+            },
+            NET_TIMEOUT,
+        );
+
+        it(
+            'Vercel path reaches the endpoint with the root baseURL shape',
+            async () => {
+                const model = byokToVercelModel({
+                    main: {
+                        provider: BYOKProvider.ANTHROPIC_COMPATIBLE,
+                        apiKey: KEY!,
+                        model: MODEL,
+                        baseURL: CODING_BASE, // root form, no /v1
+                    },
+                } as any);
+
+                const res = await generateText({
+                    model,
+                    maxOutputTokens: 16,
+                    prompt: 'Reply with exactly: ok',
+                });
+                expect(res.text.toLowerCase()).toContain('ok');
+            },
+            NET_TIMEOUT,
+        );
+
+        it(
+            'supports tool calling through the Vercel path',
+            async () => {
+                const model = byokToVercelModel({
+                    main: {
+                        provider: BYOKProvider.ANTHROPIC_COMPATIBLE,
+                        apiKey: KEY!,
+                        model: MODEL,
+                        baseURL: CODING_BASE,
+                    },
+                } as any);
+
+                const res = await generateText({
+                    model,
+                    maxOutputTokens: 200,
+                    prompt: 'What is the weather in Sao Paulo? Use the tool.',
+                    tools: {
+                        get_weather: tool({
+                            description: 'Get weather for a city',
+                            inputSchema: z.object({ city: z.string() }),
+                        }),
+                    },
+                });
+
+                expect(res.toolCalls.length).toBeGreaterThan(0);
+                expect(res.toolCalls[0].toolName).toBe('get_weather');
+            },
+            NET_TIMEOUT,
+        );
+
+        it(
+            'reports prompt-cache read tokens on a repeated prefix',
+            async () => {
+                const model = byokToVercelModel({
+                    main: {
+                        provider: BYOKProvider.ANTHROPIC_COMPATIBLE,
+                        apiKey: KEY!,
+                        model: MODEL,
+                        baseURL: CODING_BASE,
+                    },
+                } as any);
+
+                // Prefix large enough for Kimi's automatic server-side cache to
+                // kick in on the second call.
+                const prefix =
+                    'You are a code reviewer. Context follows.\n' +
+                    Array.from(
+                        { length: 400 },
+                        (_, i) => `Rule ${i}: be precise.`,
+                    ).join('\n');
+
+                const run = (n: number) =>
+                    generateText({
+                        model,
+                        maxOutputTokens: 8,
+                        system: prefix,
+                        prompt: `Reply with the number ${n}.`,
+                    });
+
+                await run(1);
+                const second = await run(2);
+
+                // The Vercel SDK normalizes Kimi's cache_read_input_tokens into
+                // both fields; extractUsage() reads exactly these. A regression
+                // here means cost tracking stops seeing cache savings.
+                const cacheRead =
+                    (second.usage as any).cachedInputTokens ??
+                    (second.usage as any).inputTokenDetails?.cacheReadTokens ??
+                    0;
+                expect(cacheRead).toBeGreaterThan(0);
+            },
+            NET_TIMEOUT,
+        );
+
+        it(
+            'test-byok use-case authenticates via the real /v1/messages probe',
+            async () => {
+                const useCase = new TestByokConnectionUseCase({
+                    isProviderSupported: () => true,
+                } as any);
+
+                const ok = await useCase.execute({
+                    provider: BYOKProvider.ANTHROPIC_COMPATIBLE,
+                    apiKey: KEY!,
+                    baseURL: `${CODING_BASE}/v1`,
+                    model: MODEL,
+                });
+                expect(ok.ok).toBe(true);
+                expect(ok.code).toBe('ok');
+
+                const bad = await useCase.execute({
+                    provider: BYOKProvider.ANTHROPIC_COMPATIBLE,
+                    apiKey: 'sk-kimi-definitely-invalid',
+                    baseURL: `${CODING_BASE}/v1`,
+                    model: MODEL,
+                });
+                expect(bad.ok).toBe(false);
+                expect(bad.code).toBe('auth');
+            },
+            NET_TIMEOUT,
+        );
+    },
+);

--- a/test/unit/byok/anthropic-compatible-byok-config.spec.ts
+++ b/test/unit/byok/anthropic-compatible-byok-config.spec.ts
@@ -12,6 +12,10 @@ jest.mock('@libs/common/utils/crypto', () => ({
 }));
 
 import { byokToVercelModel } from '@libs/code-review/infrastructure/agents/llm/byok-to-vercel';
+import {
+    buildReasoningProviderOptions,
+    EFFORT_TO_BUDGET,
+} from '@libs/code-review/infrastructure/agents/llm/agent-loop';
 import { TestByokConnectionUseCase } from '@libs/organization/application/use-cases/organizationParameters/test-byok-connection.use-case';
 import axios from 'axios';
 
@@ -42,6 +46,45 @@ describe('anthropic_compatible BYOK provider', () => {
             // URL must be the root, not the /v1-suffixed base.
             expect(model.constructor.name).toBe('ChatAnthropic');
             expect((model as any).apiUrl).toBe('https://api.kimi.com/coding');
+        });
+    });
+
+    describe('reasoning provider options', () => {
+        // These pin a non-obvious contract that a future refactor merging the
+        // ANTHROPIC and ANTHROPIC_COMPATIBLE cases could silently break:
+        // third-party Anthropic-protocol vendors (Kimi/Z.ai/DeepSeek) must use
+        // the `anthropic` namespace with the *budget* thinking shape. The
+        // `openaiCompatible` namespace would be dropped by @ai-sdk/anthropic
+        // (reasoning silently off); the `adaptive` shape would 400 because
+        // these vendors don't implement Anthropic's adaptive thinking.
+        it('routes reasoning to the anthropic namespace with a budget shape', () => {
+            const opts = buildReasoningProviderOptions(
+                BYOKProvider.ANTHROPIC_COMPATIBLE,
+                'medium',
+                'kimi-for-coding',
+            );
+
+            expect(opts).toEqual({
+                anthropic: {
+                    thinking: {
+                        type: 'enabled',
+                        budgetTokens: EFFORT_TO_BUDGET.medium,
+                    },
+                },
+            });
+            // Guard against the two silent-failure modes explicitly:
+            expect(opts).not.toHaveProperty('openaiCompatible');
+            expect((opts as any).anthropic?.thinking?.type).not.toBe('adaptive');
+        });
+
+        it('turns thinking off for effort "none"', () => {
+            expect(
+                buildReasoningProviderOptions(
+                    BYOKProvider.ANTHROPIC_COMPATIBLE,
+                    'none',
+                    'kimi-for-coding',
+                ),
+            ).toEqual({});
         });
     });
 

--- a/test/unit/byok/anthropic-compatible-byok-config.spec.ts
+++ b/test/unit/byok/anthropic-compatible-byok-config.spec.ts
@@ -1,0 +1,171 @@
+import {
+    anthropicCompatibleRootURL,
+    BYOKProvider,
+    getAdapter,
+} from '@kodus/kodus-common/llm';
+
+// Encryption is irrelevant here — deterministic reversible stand-in so
+// byokToVercelModel can decrypt the stored key without a real crypto env.
+jest.mock('@libs/common/utils/crypto', () => ({
+    encrypt: (value: string) => `enc(${value})`,
+    decrypt: (value: string) => value.replace(/^enc\(|\)$/g, ''),
+}));
+
+import { byokToVercelModel } from '@libs/code-review/infrastructure/agents/llm/byok-to-vercel';
+import { TestByokConnectionUseCase } from '@libs/organization/application/use-cases/organizationParameters/test-byok-connection.use-case';
+import axios from 'axios';
+
+describe('anthropic_compatible BYOK provider', () => {
+    describe('anthropicCompatibleRootURL', () => {
+        it.each([
+            ['https://api.kimi.com/coding', 'https://api.kimi.com/coding'],
+            ['https://api.kimi.com/coding/', 'https://api.kimi.com/coding'],
+            ['https://api.kimi.com/coding/v1', 'https://api.kimi.com/coding'],
+            ['https://api.kimi.com/coding/v1/', 'https://api.kimi.com/coding'],
+            ['https://api.z.ai/api/anthropic', 'https://api.z.ai/api/anthropic'],
+            [' https://api.deepseek.com/anthropic ', 'https://api.deepseek.com/anthropic'],
+        ])('normalizes %s → %s', (input, expected) => {
+            expect(anthropicCompatibleRootURL(input)).toBe(expected);
+        });
+    });
+
+    describe('LangChain adapter routing', () => {
+        it('routes anthropic_compatible to the Anthropic adapter with a root anthropicApiUrl', () => {
+            const adapter = getAdapter('anthropic_compatible');
+            const model = adapter.build({
+                model: 'kimi-for-coding',
+                apiKey: 'sk-kimi-test',
+                baseURL: 'https://api.kimi.com/coding/v1',
+            });
+
+            // ChatAnthropic appends /v1/messages itself — the configured
+            // URL must be the root, not the /v1-suffixed base.
+            expect(model.constructor.name).toBe('ChatAnthropic');
+            expect((model as any).apiUrl).toBe('https://api.kimi.com/coding');
+        });
+    });
+
+    describe('Vercel AI SDK routing', () => {
+        it('maps anthropic_compatible to an anthropic model with a /v1-suffixed base', () => {
+            const model = byokToVercelModel({
+                main: {
+                    provider: BYOKProvider.ANTHROPIC_COMPATIBLE,
+                    apiKey: 'enc(sk-kimi-test)',
+                    model: 'kimi-for-coding',
+                    baseURL: 'https://api.kimi.com/coding',
+                },
+            } as any);
+
+            expect((model as any).modelId).toBe('kimi-for-coding');
+            // @ai-sdk/anthropic exposes the provider name on the model.
+            expect((model as any).provider).toMatch(/anthropic/i);
+        });
+    });
+
+    describe('TestByokConnectionUseCase', () => {
+        const buildUseCase = () =>
+            new TestByokConnectionUseCase({
+                isProviderSupported: jest.fn().mockReturnValue(true),
+            } as any);
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        it('rejects anthropic_compatible without a baseURL', async () => {
+            await expect(
+                buildUseCase().execute({
+                    provider: 'anthropic_compatible',
+                    apiKey: 'sk-kimi-test',
+                }),
+            ).rejects.toThrow(/baseURL is required for anthropic_compatible/);
+        });
+
+        it('probes the real /v1/messages endpoint when a model is provided', async () => {
+            const post = jest
+                .spyOn(axios, 'post')
+                .mockResolvedValue({ status: 200, data: {} });
+
+            const result = await buildUseCase().execute({
+                provider: 'anthropic_compatible',
+                apiKey: 'sk-kimi-test',
+                baseURL: 'https://api.kimi.com/coding/v1',
+                model: 'kimi-for-coding',
+            });
+
+            expect(result.ok).toBe(true);
+            expect(post).toHaveBeenCalledWith(
+                'https://api.kimi.com/coding/v1/messages',
+                expect.objectContaining({
+                    model: 'kimi-for-coding',
+                    max_tokens: 1,
+                }),
+                expect.objectContaining({
+                    headers: expect.objectContaining({
+                        'x-api-key': 'sk-kimi-test',
+                        'anthropic-version': '2023-06-01',
+                    }),
+                }),
+            );
+        });
+
+        it('falls back to GET /v1/models when no model is provided', async () => {
+            const get = jest
+                .spyOn(axios, 'get')
+                .mockResolvedValue({ status: 200, data: { data: [] } });
+
+            const result = await buildUseCase().execute({
+                provider: 'anthropic_compatible',
+                apiKey: 'sk-kimi-test',
+                baseURL: 'https://api.kimi.com/coding',
+            });
+
+            expect(result.ok).toBe(true);
+            expect(get).toHaveBeenCalledWith(
+                'https://api.kimi.com/coding/v1/models',
+                expect.anything(),
+            );
+        });
+
+        it('surfaces a 403 client-gate rejection as an auth failure', async () => {
+            jest.spyOn(axios, 'post').mockRejectedValue(
+                Object.assign(new Error('Request failed with status 403'), {
+                    isAxiosError: true,
+                    response: {
+                        status: 403,
+                        data: {
+                            error: {
+                                message:
+                                    'Kimi For Coding is currently only available for Coding Agents',
+                                type: 'access_terminated_error',
+                            },
+                        },
+                    },
+                }),
+            );
+            jest.spyOn(axios, 'isAxiosError').mockReturnValue(true);
+
+            const result = await buildUseCase().execute({
+                provider: 'anthropic_compatible',
+                apiKey: 'sk-kimi-test',
+                baseURL: 'https://api.kimi.com/coding',
+                model: 'kimi-for-coding',
+            });
+
+            expect(result.ok).toBe(false);
+            expect(result.code).toBe('auth');
+            expect(result.providerMessage).toMatch(/Coding Agents/);
+        });
+
+        it('blocks private base URLs (SSRF guard)', async () => {
+            await expect(
+                buildUseCase().execute({
+                    provider: 'anthropic_compatible',
+                    apiKey: 'sk-kimi-test',
+                    baseURL: 'https://127.0.0.1/coding',
+                    model: 'kimi-for-coding',
+                }),
+            ).rejects.toThrow(/private or reserved address/);
+        });
+    });
+});


### PR DESCRIPTION
## What & why

Adds a generic **`anthropic_compatible`** BYOK provider so customers can bring keys for vendors that expose an Anthropic-protocol endpoint (Moonshot Kimi Code, Z.ai, DeepSeek, …). First consumer: the **Kimi Code Plan**.

Why a new provider instead of `openai_compatible`: Moonshot gates the coding plan's **OpenAI-compatible** endpoint behind a User-Agent whitelist (non-whitelisted clients get `403 access_terminated_error`). The **Anthropic-compatible** endpoint (`api.kimi.com/coding`) is the vendor-documented path for non-whitelisted clients and works with generic SDKs — no UA spoofing, no ToS violation on the protocol side.

Closes #1257.

## Changes

**`@kodus/kodus-common`**
- `BYOKProvider.ANTHROPIC_COMPATIBLE` + `anthropicCompatibleRootURL()` helper that reconciles the baseURL shape mismatch between the two Anthropic SDKs (LangChain appends `/v1/messages` to the root; `@ai-sdk/anthropic` appends `/messages` to a `/v1`-suffixed base).
- `anthropicAdapter` forwards a custom baseURL via `anthropicApiUrl`; `getAdapter` routes the new provider to the Anthropic adapter.

**Backend (libs)**
- `byok-to-vercel`: `createAnthropic({ baseURL: root + '/v1' })`.
- `agent-loop`: providerOptions namespace + budget-style thinking config.
- `provider.service`: registry entry (`requiresBaseUrl`).
- `test-byok-connection`: probe the real `/v1/messages` endpoint (1-token request) instead of `/v1/models` — the models list is ungated on Kimi, so a models probe reports "OK" for a key whose reviews would `403`. SSRF-guarded.
- `get-models-by-provider`: manual-only (no listing without the user baseURL).

**Frontend (apps/web)**
- Per-variant provider override; re-enable the "Kimi Code Plan" variant pointing at `anthropic_compatible` + `api.kimi.com/coding`, with a ToS note.
- Recognize the provider in curated/editable/label sets and the manual skip-test guard.

## Concurrency, usage & cost (verified)

- **Concurrency gate** is provider-agnostic — the variant injects `maxConcurrentRequests: 30` (the plan's cap) and both the in-process limiter and the distributed gate honor it automatically.
- **Token usage**: the Vercel SDK normalizes input/output/cache for the Anthropic-compatible provider; `extractUsage()` reads it unchanged. Verified empirically.
- **Prompt cache savings**: Kimi auto-caches server-side (no `cache_control` breakpoints needed); a 2nd call with a shared prefix returned `cacheReadTokens: 2816`. Savings happen and are tracked.
- **USD cost**: `kimi-for-coding` isn't in the LiteLLM pricing catalog → reports unpriced (degrades cleanly to `priced: false`, not a crash). Acceptable for a flat-fee subscription; a manual pricing override is available if a customer wants a $ figure.

## Deploy note

`@kodus/kodus-common` is rebuilt from source during the Docker image build (`yarn prepack` → linked into `node_modules`), so these `src/` changes ship automatically on merge — no manual package publish needed.

## Testing

- **22/22 unit tests** (`test/unit/byok/anthropic-compatible-byok-config.spec.ts`): URL normalization, both SDK routings, real `/v1/messages` probe, `403`→auth, SSRF guard.
- **Live smoke** against the real Kimi coding endpoint through both real Kodus paths (LangChain adapter + Vercel `byokToVercelModel` with tool calling) — both green.
- Backend + web typecheck clean on touched files.

### Not covered (QA candidates)
- BYOK settings UI rendered in the browser (variant switch + "Test & save" via the real HTTP route).
- A full PR review end-to-end through the running app using a Kimi Code Plan key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
