### PR TITLE
fix(e2e): kill the two cloud-matrix reds — WAF-blocked rbac-frontend-routes, github repo-isolation regression

### DIFF
--- a/.github/workflows/e2e-cloud.yml
+++ b/.github/workflows/e2e-cloud.yml
@@ -64,10 +64,19 @@ jobs:
         name: cloud matrix (${{ inputs.matrix_file || 'matrix/fast.yml' }})
         runs-on: ubuntu-latest
         # QA environment: where the QA-scoped secrets live (GH_REPO_ADMIN_TOKEN
-        # for trial-managed-review's throwaway repos; CLOUD_TENANTS_JSON also
-        # has a copy here). Branch policy allows `main` only — fine, every real
-        # trigger (qa-build workflow_call, nightly schedule, dispatch) runs
-        # from main. Repo-level secrets keep resolving as before.
+        # for trial-managed-review's throwaway repos). Branch policy allows
+        # `main` only — fine, every real trigger (qa-build workflow_call,
+        # nightly schedule, dispatch) runs from main. Repo-level secrets keep
+        # resolving as before.
+        #
+        # CLOUD_TENANTS_JSON must exist ONLY at repo level: environment
+        # secrets SHADOW repo secrets, and a stale environment-scoped copy
+        # (sealed 05-30, pre-#1237, no repoFullName) silently dropped every
+        # GitHub tenant onto one shared repo from 06-03 to 06-05 — webhook
+        # fan-out collisions, "review never started" flakes. The env copy was
+        # deleted on 2026-06-05; don't recreate it. (lib/runner.ts now also
+        # falls back to lib/cloud-tenant-registry.ts for the repo mapping, so
+        # a stale secret can't reintroduce the collision either way.)
         environment: QA
         # fast.yml = ~30-45 min, full.yml = ~75-120 min. Cap with
         # generous headroom; cell-level timeouts inside the runner stop

--- a/tests/e2e/cli/cloud/setup-tenants.ts
+++ b/tests/e2e/cli/cloud/setup-tenants.ts
@@ -35,11 +35,11 @@ import {
 } from "../../lib/onboarding.js";
 import { http } from "../../lib/http.js";
 import { makeProvider } from "../../providers/index.js";
-import type {
-    KodusSession,
-    ProviderName,
-    TargetContext,
-} from "../../lib/types.js";
+import {
+    CLOUD_TENANTS,
+    type TenantSpec,
+} from "../../lib/cloud-tenant-registry.js";
+import type { KodusSession, TargetContext } from "../../lib/types.js";
 
 const QA_WEB_URL =
     process.env.CLOUD_WEB_URL?.replace(/\/$/, "") ?? "https://qa.web.kodus.io";
@@ -58,170 +58,13 @@ const CREDS_FILE = join(homedir(), ".kodus-dev", "cloud-tenants.json");
 const SHARED_PASSWORD =
     process.env.CLOUD_SETUP_PASSWORD ?? "E2eCloud!2026Smoke";
 
-type TenantLicense = "paid" | "trial" | "free" | "community-byok";
+// Tenant registry + the github repo-isolation invariant now live in
+// lib/cloud-tenant-registry.ts so the matrix runner can fall back to the
+// SAME canonical (provider, license) → repoFullName mapping when the
+// CLOUD_TENANTS_JSON secret is stale (see the registry header for the
+// 2026-06-03 environment-secret shadowing incident this guards against).
+const TENANTS: TenantSpec[] = CLOUD_TENANTS;
 
-interface TenantSpec {
-    email: string;
-    name: string;
-    license: TenantLicense;
-    provider: ProviderName;
-    // Dedicated cloud fixture repo for this tenant. REQUIRED for GitHub
-    // PAT tenants and honoured only there (makeProvider forwards it to
-    // the GitHub provider via repoOverride; the other providers resolve
-    // their cloud repo from env). Optional for the rest.
-    repoFullName?: string;
-}
-
-// Tenant registry. Names can only contain letters / spaces / hyphens /
-// apostrophes (Kodus validates `^[A-Za-z\s\-']+$` server-side), so no
-// digits in the visible name.
-//
-// GitHub PAT tenants get ONE REPO EACH (1 org : 1 repo). License tier is
-// per-org on cloud (Stripe-driven), so every tier is a distinct Kodus
-// org. The PAT webhook is a bare `/github/webhook` with no per-org
-// discriminator, and the backend resolves repo→org by picking the first
-// IntegrationConfig ordered by updatedAt DESC (webhook-context.service
-// .getContext / save.use-case). So if several orgs share one repo, a
-// PR's review fires for whichever org most recently touched its repo
-// config — NOT reliably the org under test — and the scenario times out
-// waiting for a review that landed on someone else (or got silently
-// dropped). Giving each tenant its own repo removes the ambiguity
-// entirely, matching what GitLab/Bitbucket/Azure already get for free
-// (one org per repo on cloud). github-app is already isolated on its
-// App-bound repo. Provision the repos with scripts/e2e/provision-cloud-
-// github-repos.sh before the first seed.
-const TENANTS: TenantSpec[] = [
-    {
-        email: "e2e-paid-gh@kodus.io",
-        name: "Smoke Paid GitHub",
-        license: "paid",
-        provider: "github",
-        repoFullName: "kodus-e2e/tiny-url-cloud-paid",
-    },
-    {
-        email: "e2e-free-gh@kodus.io",
-        name: "Smoke Free GitHub",
-        license: "free",
-        provider: "github",
-        repoFullName: "kodus-e2e/tiny-url-cloud-free",
-    },
-    {
-        email: "e2e-trial-gh@kodus.io",
-        name: "Smoke Trial GitHub",
-        license: "trial",
-        provider: "github",
-        repoFullName: "kodus-e2e/tiny-url-cloud-trial",
-    },
-    {
-        email: "e2e-paid-gl@kodus.io",
-        name: "Smoke Paid GitLab",
-        license: "paid",
-        provider: "gitlab",
-        repoFullName: "kodus-e2e/tiny-url",
-    },
-    {
-        email: "e2e-paid-bb@kodus.io",
-        name: "Smoke Paid Bitbucket",
-        license: "paid",
-        provider: "bitbucket",
-        repoFullName: "kodustech/tiny-url",
-    },
-    {
-        email: "e2e-paid-az@kodus.io",
-        name: "Smoke Paid Azure",
-        license: "paid",
-        provider: "azure-devops",
-        repoFullName: "kodustech/kodus-e2e/tiny-url",
-    },
-    {
-        // Community tenant: NO billing subscription, but with BYOK
-        // configured. Reviews work with the 10-rule limit. Distinct
-        // from `free` (trial expired + no BYOK = gate blocks).
-        email: "e2e-community-byok-gh@kodus.io",
-        name: "Smoke Community BYOK GitHub",
-        license: "community-byok",
-        provider: "github",
-        repoFullName: "kodus-e2e/tiny-url-cloud-community",
-    },
-    {
-        // Stripe billing scenario — sub-flow #1 (free → paid via
-        // Checkout) and then sub-flow #3 (cancel via Customer Portal
-        // once paid). Seeded as `free` so the scenario can drive the
-        // first Checkout completion itself; the cancel step runs
-        // inside the same scenario after the upgrade lands. Re-runs
-        // are idempotent: if the tenant ends up cancelled, the next
-        // run starts with the cancel state and exercises the upgrade
-        // path again.
-        email: "e2e-stripe-checkout-free@kodus.io",
-        name: "Stripe Checkout Free GitHub",
-        license: "free",
-        provider: "github",
-        repoFullName: "kodus-e2e/tiny-url-cloud-stripe-free",
-    },
-    {
-        // Stripe billing scenario — sub-flow #2 (trial → paid via
-        // Checkout) and then sub-flow #4 (downgrade paid → free via
-        // /billing/migrate-to-free). Seeded as `trial` so the
-        // /billing/trial call lands a fresh subscription record the
-        // Checkout flow can upgrade.
-        email: "e2e-stripe-checkout-trial@kodus.io",
-        name: "Stripe Checkout Trial GitHub",
-        license: "trial",
-        provider: "github",
-        repoFullName: "kodus-e2e/tiny-url-cloud-stripe-trial",
-    },
-    {
-        // GitHub App (OAuth installation) variant. Needs a DEDICATED
-        // tenant — sharing one with the PAT cells would have the App
-        // and the PAT both registered against the same Kodus
-        // organization, which makes the auth-integration upsert
-        // overwrite one with the other on each run. The repo
-        // (kodus-e2e/tiny-url-app) is the scope-limited install
-        // target of the kodus-ai-qa GitHub App; the App's webhook
-        // delivers to qa.web.kodus.io. Connect step is SKIPPED at
-        // seed time (provider==="github-app") because the scenario
-        // itself calls /code-management/auth-integration with
-        // authMode=oauth + code=installation_id, which has a
-        // different payload than the PAT path used by the seeder.
-        email: "e2e-paid-gh-app@kodus.io",
-        name: "Smoke Paid GitHub App",
-        license: "paid",
-        provider: "github-app",
-        repoFullName: "kodus-e2e/tiny-url-app",
-    },
-];
-
-// Fail-fast invariant: every GitHub PAT tenant MUST have its own repo,
-// and no two may share one. This is the whole point of the 1 org : 1
-// repo fix — a regression here (a new github tenant pointed at a sibling's
-// repo, or left without `repoFullName`) silently reintroduces the
-// webhook fan-out collision. Catch it at load time, loudly, instead of
-// as a flaky "review never started" three matrix runs later.
-function validateGithubRepoIsolation(tenants: TenantSpec[]): void {
-    const seen = new Map<string, string>();
-    const problems: string[] = [];
-    for (const t of tenants) {
-        if (t.provider !== "github") continue; // github-app + others are already isolated
-        if (!t.repoFullName) {
-            problems.push(`${t.email}: github tenant has no dedicated repoFullName`);
-            continue;
-        }
-        const prior = seen.get(t.repoFullName);
-        if (prior) {
-            problems.push(
-                `${t.repoFullName} is shared by ${prior} and ${t.email} — github tenants must not share a repo`,
-            );
-        } else {
-            seen.set(t.repoFullName, t.email);
-        }
-    }
-    if (problems.length) {
-        throw new Error(
-            `[cloud-setup] github repo-isolation invariant violated:\n  - ${problems.join("\n  - ")}`,
-        );
-    }
-}
-validateGithubRepoIsolation(TENANTS);
 
 interface SavedTenant extends TenantSpec {
     password: string;

--- a/tests/e2e/lib/__tests__/cloud-tenant-registry.test.ts
+++ b/tests/e2e/lib/__tests__/cloud-tenant-registry.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+    CLOUD_TENANTS,
+    registryRepoFor,
+    validateGithubRepoIsolation,
+    type TenantSpec,
+} from "../cloud-tenant-registry.js";
+
+// The registry IS the code-level source of truth the runner falls back to
+// when the CLOUD_TENANTS_JSON secret is stale (the 2026-06-03 environment-
+// secret shadowing incident). These tests pin the invariants that fallback
+// relies on.
+
+test("every github PAT tenant has its own dedicated repo (no sharing)", () => {
+    // Throws on violation — the module already runs this at import time,
+    // but assert explicitly so a regression names THIS invariant.
+    assert.doesNotThrow(() => validateGithubRepoIsolation(CLOUD_TENANTS));
+    const githubRepos = CLOUD_TENANTS.filter(
+        (t) => t.provider === "github",
+    ).map((t) => t.repoFullName);
+    assert.ok(githubRepos.length >= 4, "expected the standing github tiers");
+    assert.equal(new Set(githubRepos).size, githubRepos.length);
+});
+
+test("registryRepoFor resolves the per-tier github fixture repos", () => {
+    assert.equal(
+        registryRepoFor("github", "paid"),
+        "kodus-e2e/tiny-url-cloud-paid",
+    );
+    assert.equal(
+        registryRepoFor("github", "trial"),
+        "kodus-e2e/tiny-url-cloud-trial",
+    );
+    assert.equal(
+        registryRepoFor("github", "free"),
+        "kodus-e2e/tiny-url-cloud-free",
+    );
+    assert.equal(
+        registryRepoFor("github", "community-byok"),
+        "kodus-e2e/tiny-url-cloud-community",
+    );
+    // Unknown (provider, license) combos resolve to undefined, never throw —
+    // the runner decides whether that's fatal (github) or fine (others).
+    assert.equal(registryRepoFor("github", "license-paid"), undefined);
+    assert.equal(registryRepoFor("gitlab", "trial"), undefined);
+});
+
+test("validateGithubRepoIsolation rejects shared and missing repos", () => {
+    const shared: TenantSpec[] = [
+        {
+            email: "a@kodus.io",
+            name: "A",
+            license: "paid",
+            provider: "github",
+            repoFullName: "kodus-e2e/dup",
+        },
+        {
+            email: "b@kodus.io",
+            name: "B",
+            license: "trial",
+            provider: "github",
+            repoFullName: "kodus-e2e/dup",
+        },
+    ];
+    assert.throws(
+        () => validateGithubRepoIsolation(shared),
+        /shared by a@kodus\.io and b@kodus\.io/,
+    );
+
+    const missing: TenantSpec[] = [
+        {
+            email: "c@kodus.io",
+            name: "C",
+            license: "paid",
+            provider: "github",
+        },
+    ];
+    assert.throws(
+        () => validateGithubRepoIsolation(missing),
+        /no dedicated repoFullName/,
+    );
+
+    // Non-github providers may share / omit repos freely.
+    const others: TenantSpec[] = [
+        {
+            email: "d@kodus.io",
+            name: "D",
+            license: "paid",
+            provider: "gitlab",
+            repoFullName: "kodus-e2e/shared",
+        },
+        {
+            email: "e@kodus.io",
+            name: "E",
+            license: "trial",
+            provider: "bitbucket",
+            repoFullName: "kodus-e2e/shared",
+        },
+    ];
+    assert.doesNotThrow(() => validateGithubRepoIsolation(others));
+});

--- a/tests/e2e/lib/cloud-tenant-registry.ts
+++ b/tests/e2e/lib/cloud-tenant-registry.ts
@@ -1,0 +1,195 @@
+import type { ProviderName } from "./types.js";
+
+// Canonical registry of the persistent QA-cloud E2E tenants. Lives in lib/
+// (not cli/cloud/setup-tenants.ts) because TWO consumers must agree on it:
+//
+//   1. cli/cloud/setup-tenants.ts seeds the tenants and persists creds to
+//      ~/.kodus-dev/cloud-tenants.json (mirrored into the CLOUD_TENANTS_JSON
+//      secret for CI).
+//   2. lib/runner.ts resolves the per-cell tenant from that file — and falls
+//      back to THIS registry for `repoFullName` when the file entry lacks it.
+//
+// Consumer 2 is the hard-won lesson: on 2026-06-03 the cloud-matrix job
+// gained `environment: QA`, whose stale environment-scoped copy of
+// CLOUD_TENANTS_JSON (sealed 05-30, before the 1-repo-per-tenant fix in
+// #1237) silently shadowed the fresh repo-level secret. Every GitHub tenant
+// fell back to the shared kodus-e2e/tiny-url-cloud repo and the webhook
+// fan-out collision came right back ("review never started" flakes). With
+// the repo mapping ALSO in code, a stale secret can no longer reintroduce
+// the collision — the secret only carries credentials/org ids.
+
+export type TenantLicense = "paid" | "trial" | "free" | "community-byok";
+
+export interface TenantSpec {
+    email: string;
+    name: string;
+    license: TenantLicense;
+    provider: ProviderName;
+    // Dedicated cloud fixture repo for this tenant. REQUIRED for GitHub
+    // PAT tenants and honoured only there (makeProvider forwards it to
+    // the GitHub provider via repoOverride; the other providers resolve
+    // their cloud repo from env). Optional for the rest.
+    repoFullName?: string;
+}
+
+// Tenant registry. Names can only contain letters / spaces / hyphens /
+// apostrophes (Kodus validates `^[A-Za-z\s\-']+$` server-side), so no
+// digits in the visible name.
+//
+// GitHub PAT tenants get ONE REPO EACH (1 org : 1 repo). License tier is
+// per-org on cloud (Stripe-driven), so every tier is a distinct Kodus
+// org. The PAT webhook is a bare `/github/webhook` with no per-org
+// discriminator, and the backend resolves repo→org by picking the first
+// IntegrationConfig ordered by updatedAt DESC (webhook-context.service
+// .getContext / save.use-case). So if several orgs share one repo, a
+// PR's review fires for whichever org most recently touched its repo
+// config — NOT reliably the org under test — and the scenario times out
+// waiting for a review that landed on someone else (or got silently
+// dropped). Giving each tenant its own repo removes the ambiguity
+// entirely, matching what GitLab/Bitbucket/Azure already get for free
+// (one org per repo on cloud). github-app is already isolated on its
+// App-bound repo. Provision the repos with scripts/e2e/provision-cloud-
+// github-repos.sh before the first seed.
+export const CLOUD_TENANTS: TenantSpec[] = [
+    {
+        email: "e2e-paid-gh@kodus.io",
+        name: "Smoke Paid GitHub",
+        license: "paid",
+        provider: "github",
+        repoFullName: "kodus-e2e/tiny-url-cloud-paid",
+    },
+    {
+        email: "e2e-free-gh@kodus.io",
+        name: "Smoke Free GitHub",
+        license: "free",
+        provider: "github",
+        repoFullName: "kodus-e2e/tiny-url-cloud-free",
+    },
+    {
+        email: "e2e-trial-gh@kodus.io",
+        name: "Smoke Trial GitHub",
+        license: "trial",
+        provider: "github",
+        repoFullName: "kodus-e2e/tiny-url-cloud-trial",
+    },
+    {
+        email: "e2e-paid-gl@kodus.io",
+        name: "Smoke Paid GitLab",
+        license: "paid",
+        provider: "gitlab",
+        repoFullName: "kodus-e2e/tiny-url",
+    },
+    {
+        email: "e2e-paid-bb@kodus.io",
+        name: "Smoke Paid Bitbucket",
+        license: "paid",
+        provider: "bitbucket",
+        repoFullName: "kodustech/tiny-url",
+    },
+    {
+        email: "e2e-paid-az@kodus.io",
+        name: "Smoke Paid Azure",
+        license: "paid",
+        provider: "azure-devops",
+        repoFullName: "kodustech/kodus-e2e/tiny-url",
+    },
+    {
+        // Community tenant: NO billing subscription, but with BYOK
+        // configured. Reviews work with the 10-rule limit. Distinct
+        // from `free` (trial expired + no BYOK = gate blocks).
+        email: "e2e-community-byok-gh@kodus.io",
+        name: "Smoke Community BYOK GitHub",
+        license: "community-byok",
+        provider: "github",
+        repoFullName: "kodus-e2e/tiny-url-cloud-community",
+    },
+    {
+        // Stripe billing scenario — sub-flow #1 (free → paid via
+        // Checkout) and then sub-flow #3 (cancel via Customer Portal
+        // once paid). Seeded as `free` so the scenario can drive the
+        // first Checkout completion itself; the cancel step runs
+        // inside the same scenario after the upgrade lands. Re-runs
+        // are idempotent: if the tenant ends up cancelled, the next
+        // run starts with the cancel state and exercises the upgrade
+        // path again.
+        email: "e2e-stripe-checkout-free@kodus.io",
+        name: "Stripe Checkout Free GitHub",
+        license: "free",
+        provider: "github",
+        repoFullName: "kodus-e2e/tiny-url-cloud-stripe-free",
+    },
+    {
+        // Stripe billing scenario — sub-flow #2 (trial → paid via
+        // Checkout) and then sub-flow #4 (downgrade paid → free via
+        // /billing/migrate-to-free). Seeded as `trial` so the
+        // /billing/trial call lands a fresh subscription record the
+        // Checkout flow can upgrade.
+        email: "e2e-stripe-checkout-trial@kodus.io",
+        name: "Stripe Checkout Trial GitHub",
+        license: "trial",
+        provider: "github",
+        repoFullName: "kodus-e2e/tiny-url-cloud-stripe-trial",
+    },
+    {
+        // GitHub App (OAuth installation) variant. Needs a DEDICATED
+        // tenant — sharing one with the PAT cells would have the App
+        // and the PAT both registered against the same Kodus
+        // organization, which makes the auth-integration upsert
+        // overwrite one with the other on each run. The repo
+        // (kodus-e2e/tiny-url-app) is the scope-limited install
+        // target of the kodus-ai-qa GitHub App; the App's webhook
+        // delivers to qa.web.kodus.io. Connect step is SKIPPED at
+        // seed time (provider==="github-app") because the scenario
+        // itself calls /code-management/auth-integration with
+        // authMode=oauth + code=installation_id, which has a
+        // different payload than the PAT path used by the seeder.
+        email: "e2e-paid-gh-app@kodus.io",
+        name: "Smoke Paid GitHub App",
+        license: "paid",
+        provider: "github-app",
+        repoFullName: "kodus-e2e/tiny-url-app",
+    },
+];
+
+// Fail-fast invariant: every GitHub PAT tenant MUST have its own repo,
+// and no two may share one. This is the whole point of the 1 org : 1
+// repo fix — a regression here (a new github tenant pointed at a sibling's
+// repo, or left without `repoFullName`) silently reintroduces the
+// webhook fan-out collision. Catch it at load time, loudly, instead of
+// as a flaky "review never started" three matrix runs later.
+export function validateGithubRepoIsolation(tenants: TenantSpec[]): void {
+    const seen = new Map<string, string>();
+    const problems: string[] = [];
+    for (const t of tenants) {
+        if (t.provider !== "github") continue; // github-app + others are already isolated
+        if (!t.repoFullName) {
+            problems.push(`${t.email}: github tenant has no dedicated repoFullName`);
+            continue;
+        }
+        const prior = seen.get(t.repoFullName);
+        if (prior) {
+            problems.push(
+                `${t.repoFullName} is shared by ${prior} and ${t.email} — github tenants must not share a repo`,
+            );
+        } else {
+            seen.set(t.repoFullName, t.email);
+        }
+    }
+    if (problems.length) {
+        throw new Error(
+            `[cloud-tenants] github repo-isolation invariant violated:\n  - ${problems.join("\n  - ")}`,
+        );
+    }
+}
+validateGithubRepoIsolation(CLOUD_TENANTS);
+
+/** Canonical fixture repo for a (provider, license) cloud tenant, or
+ *  undefined when the registry has no such tenant / no pinned repo. */
+export function registryRepoFor(
+    provider: ProviderName,
+    license: string,
+): string | undefined {
+    return CLOUD_TENANTS.find(
+        (t) => t.provider === provider && t.license === license,
+    )?.repoFullName;
+}

--- a/tests/e2e/lib/http.ts
+++ b/tests/e2e/lib/http.ts
@@ -28,6 +28,10 @@ export interface HttpOptions {
     headers?: Record<string, string>;
     body?: unknown;
     timeoutMs?: number;
+    // "manual" surfaces 3xx responses instead of following them — needed
+    // by callers that assert ON the redirect itself (e.g. the RBAC route
+    // guard checking for a /forbidden Location). Default: fetch's "follow".
+    redirect?: "follow" | "manual";
 }
 
 export interface HttpResponse<T = unknown> {
@@ -72,6 +76,7 @@ async function attempt<T>(
         method: opts.method ?? "GET",
         headers: { ...(opts.headers ?? {}), ...wafBypassHeader(url) },
         signal: controller.signal,
+        ...(opts.redirect ? { redirect: opts.redirect } : {}),
     };
     if (opts.body !== undefined && opts.body !== null) {
         init.body =

--- a/tests/e2e/lib/runner.ts
+++ b/tests/e2e/lib/runner.ts
@@ -22,6 +22,7 @@ import {
     signUp,
 } from "./onboarding.js";
 import { randomBytes } from "node:crypto";
+import { registryRepoFor } from "./cloud-tenant-registry.js";
 import { logger } from "./log.js";
 
 const log = logger("runner");
@@ -173,6 +174,42 @@ function readCloudTenantsFile(): CloudTenantEntry[] {
     }
 }
 
+// Per-tenant fixture repo for a cloud cell. Prefers what the tenants file
+// (CLOUD_TENANTS_JSON in CI) says, but falls back to the canonical
+// lib/cloud-tenant-registry.ts mapping when the entry predates the
+// 1-repo-per-tenant fix (#1237) and lacks `repoFullName`. Without the
+// fallback, a stale secret silently drops every GitHub tenant onto the
+// shared env-resolved repo (GH_TEST_REPO_CLOUD) and the webhook fan-out
+// collision returns as "review never started" flakes — exactly what
+// happened 2026-06-03 when `environment: QA` started shadowing the fresh
+// repo-level secret with a 05-30 environment-scoped copy. For GitHub the
+// repo is load-bearing (1 org : 1 repo), so having NEITHER source is a
+// hard config error, not a quiet fallback.
+function resolveCloudRepo(
+    fromTenantsFile: string | undefined,
+    provider: ProviderName,
+    license: LicenseMode,
+): string | undefined {
+    if (fromTenantsFile) return fromTenantsFile;
+    const fromRegistry = registryRepoFor(provider, license);
+    if (provider !== "github") return fromRegistry;
+    if (!fromRegistry) {
+        throw new Error(
+            `cloud github tenant (license=${license}) has no dedicated fixture repo: ` +
+                `the tenants file entry lacks repoFullName AND lib/cloud-tenant-registry.ts ` +
+                `has no (github, ${license}) tenant. Re-seed with \`yarn cloud:setup-tenants\` ` +
+                `or add the tenant to the registry — falling back to a shared repo would ` +
+                `reintroduce the webhook fan-out collision (#1237).`,
+        );
+    }
+    log.info(
+        `[tenant] cloud-tenants entry for (github, ${license}) lacks repoFullName ` +
+            `(stale CLOUD_TENANTS_JSON / cloud-tenants.json) — using registry default ${fromRegistry}. ` +
+            `Re-seed with \`yarn cloud:setup-tenants\` and refresh the secret.`,
+    );
+    return fromRegistry;
+}
+
 async function resolveTenantForCell(
     target: TargetContext,
     license: LicenseMode,
@@ -192,7 +229,11 @@ async function resolveTenantForCell(
             return {
                 email: match.email,
                 password: match.password,
-                repoFullName: match.repoFullName,
+                repoFullName: resolveCloudRepo(
+                    match.repoFullName,
+                    provider,
+                    license,
+                ),
             };
 
         // Legacy fallback: per-license env vars (CLOUD_TENANT_PAID_EMAIL
@@ -208,7 +249,11 @@ async function resolveTenantForCell(
         const email = process.env[key[0]];
         const password = process.env[key[1]];
         if (!email || !password) return undefined;
-        return { email, password };
+        return {
+            email,
+            password,
+            repoFullName: resolveCloudRepo(undefined, provider, license),
+        };
     }
     // self-hosted: fresh tenant per matrix run. Deterministic per
     // (runId, provider) so all cells/scenarios within ONE matrix run
@@ -311,9 +356,15 @@ export async function runMatrix(opts: RunOptions): Promise<RunOutcome> {
         >();
         for (const c of opts.cells) {
             if (c.target !== opts.target) continue;
+            // Same stale-tenants-file fallback as resolveCloudRepo (non-
+            // throwing here: a cleanup miss is survivable, a dead run is
+            // not) — otherwise the sweep visits the shared default repo
+            // while the actual per-tenant repos keep their orphaned PRs.
             const repo =
                 opts.target === "cloud"
-                    ? repoByProviderLicense.get(`${c.provider}::${c.license}`)
+                    ? (repoByProviderLicense.get(
+                          `${c.provider}::${c.license}`,
+                      ) ?? registryRepoFor(c.provider, c.license))
                     : undefined;
             fixtures.set(`${c.provider}::${repo ?? "default"}`, {
                 provider: c.provider,

--- a/tests/e2e/scenarios/rbac-frontend-routes.ts
+++ b/tests/e2e/scenarios/rbac-frontend-routes.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs";
 import { join } from "path";
 
+import { http } from "../lib/http.js";
 import {
     NON_OWNER_ROLES,
     RBAC_PASSWORD,
@@ -50,8 +51,8 @@ function loadRouteManifest(): RouteEntry[] {
 
 // Minimal cookie jar: name -> value, serialized as a Cookie header.
 type Jar = Map<string, string>;
-function absorb(jar: Jar, res: Response): void {
-    for (const c of res.headers.getSetCookie()) {
+function absorb(jar: Jar, headers: Headers): void {
+    for (const c of headers.getSetCookie()) {
         const [pair] = c.split(";");
         const eq = pair.indexOf("=");
         if (eq > 0) jar.set(pair.slice(0, eq).trim(), pair.slice(eq + 1).trim());
@@ -60,6 +61,14 @@ function absorb(jar: Jar, res: Response): void {
 function cookieHeader(jar: Jar): string {
     return [...jar.entries()].map(([k, v]) => `${k}=${v}`).join("; ");
 }
+
+// All requests go through lib/http.ts — NOT bare fetch — for two
+// load-bearing reasons: (1) http() injects the AWS WAF bypass header on
+// qa.*.kodus.io hosts; without it the WAF intermittently 403s
+// GitHub-hosted runner IPs with an nginx HTML page, which a bare
+// `res.json()` surfaces as the useless "Unexpected token '<'" (the exact
+// 2026-06-05 nightly failure). (2) http() retries transport errors and
+// 429s, so a single connection reset doesn't fail 130+ route verdicts.
 
 /** Sign in through next-auth (credentials provider) over HTTP; returns the
  *  authenticated cookie jar the Next middleware accepts. */
@@ -70,9 +79,19 @@ async function nextAuthLogin(
 ): Promise<Jar> {
     const jar: Jar = new Map();
 
-    const csrfRes = await fetch(`${web}/api/auth/csrf`, { redirect: "manual" });
-    absorb(jar, csrfRes);
-    const { csrfToken } = (await csrfRes.json()) as { csrfToken: string };
+    const csrfRes = await http<{ csrfToken?: string }>(
+        `${web}/api/auth/csrf`,
+        { redirect: "manual" },
+    );
+    absorb(jar, csrfRes.headers);
+    const csrfToken = csrfRes.body?.csrfToken;
+    if (csrfRes.status !== 200 || typeof csrfToken !== "string") {
+        throw new Error(
+            `GET /api/auth/csrf returned HTTP ${csrfRes.status} ` +
+                `(${csrfRes.headers.get("content-type") ?? "no content-type"}) ` +
+                `instead of a JSON csrfToken: ${csrfRes.raw.slice(0, 200)}`,
+        );
+    }
 
     const form = new URLSearchParams({
         csrfToken,
@@ -81,7 +100,7 @@ async function nextAuthLogin(
         redirect: "false",
         json: "true",
     });
-    const cbRes = await fetch(`${web}/api/auth/callback/credentials`, {
+    const cbRes = await http(`${web}/api/auth/callback/credentials`, {
         method: "POST",
         headers: {
             "Content-Type": "application/x-www-form-urlencoded",
@@ -90,7 +109,7 @@ async function nextAuthLogin(
         body: form.toString(),
         redirect: "manual",
     });
-    absorb(jar, cbRes);
+    absorb(jar, cbRes.headers);
 
     // Auth.js v5 names the session cookie `authjs.session-token` over HTTP but
     // prefixes it `__Secure-authjs.session-token` over HTTPS (QA cloud), and
@@ -103,7 +122,8 @@ async function nextAuthLogin(
     );
     if (!hasSession) {
         throw new Error(
-            `next-auth login for ${email} did not yield a session (HTTP ${cbRes.status})`,
+            `next-auth login for ${email} did not yield a session ` +
+                `(HTTP ${cbRes.status}): ${cbRes.raw.slice(0, 200)}`,
         );
     }
     return jar;
@@ -115,7 +135,7 @@ async function routeVerdict(
     jar: Jar,
     route: string,
 ): Promise<"allow" | "deny"> {
-    const res = await fetch(`${web}${route}`, {
+    const res = await http(`${web}${route}`, {
         headers: { Cookie: cookieHeader(jar) },
         redirect: "manual",
     });


### PR DESCRIPTION
## Context

Two gating P0 failures across runs [26982837088](https://github.com/kodustech/kodus-ai/actions/runs/26982837088) and [27000013256](https://github.com/kodustech/kodus-ai/actions/runs/27000013256):

- `code-review-basic × cloud × github × paid` — "No kody-codereview status comment on PR #131 within 60s"
- `rbac-frontend-routes × cloud × github × paid/trial` — `Unexpected token '<', "<html>"`

Both are test/infra-side; neither is a product bug.

## Root cause 1 — rbac-frontend-routes: bare fetch misses the WAF bypass header

The scenario used bare `fetch()` for the next-auth csrf/callback calls and the per-route GETs — so it never sent the AWS WAF bypass header (`QA_WAF_BYPASS_HEADER`, enforced on the QA ALB since 06-04) and had no transport retries. When a GitHub-hosted runner landed on a WAF-flagged IP, the first `fetch('/api/auth/csrf')` got the nginx 403 HTML page and `csrfRes.json()` died with the useless `Unexpected token '<'`. Everything that already went through `lib/http.ts` (e.g. `rbac-authorization`, 333 asserts, seconds earlier in the same run) passed.

**Fix:** all three call sites now go through `http()` (WAF header + transport retries + 429 handling). `http()` gains a `redirect: "manual"` option since the route guard asserts ON the redirect itself. A non-JSON csrf response now fails with status + content-type + body snippet instead of a JSON parse error.

## Root cause 2 — github repo isolation regressed via environment-secret shadowing

The 1-repo-per-tenant fix (#1237) worked from 06-02 to 06-03 (PRs landing on `tiny-url-cloud-{paid,free,trial,community}`). Then #1254 added `environment: QA` to the cloud-matrix job — and the QA environment's **stale copy** of `CLOUD_TENANTS_JSON` (sealed 05-30, pre-#1237, no `repoFullName`) silently **shadowed** the fresh repo-level secret. Every GitHub tenant fell back to the shared `kodus-e2e/tiny-url-cloud` repo (PRs #102–#142 all landed there), reviving the webhook fan-out collision: the PAT webhook has no per-org discriminator, the backend picks the first org by `updatedAt DESC`, and the review fires for whichever org most recently touched the shared repo — hence "review never started".

**Fixes, in layers:**
- **Infra:** deleted the stale environment-scoped `CLOUD_TENANTS_JSON` (the fresh repo-level secret resolves again). The workflow comment now documents why the env copy must never be recreated.
- **Code:** the tenant registry moved from `cli/cloud/setup-tenants.ts` to `lib/cloud-tenant-registry.ts`, shared by the seeder AND the runner. `resolveTenantForCell` now falls back to the canonical `(provider, license) → repoFullName` mapping when a tenants-file entry lacks it — and **hard-fails** a cloud github cell that would otherwise land on a shared repo. The stale-PR cleanup sweep gets the same (non-throwing) fallback so per-tenant repos keep getting swept. A stale secret can no longer reintroduce the collision.

## Validation

- Live against QA cloud: `rbac-frontend-routes × cloud × github × paid` **PASS 54.6s** (132 route×role verdicts); `code-review-basic × cloud × github × paid` **PASS 97.6s** — PR opened on `kodus-e2e/tiny-url-cloud-paid`, review started and completed.
- Hermetic: typecheck, 65/65 unit tests (3 new registry tests), `fast.yml` dry-run 0 failed, actionlint.
- Fixture repos verified: 0 orphaned open `[e2e]` PRs across all 8 cloud fixture repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)