### PR TITLE
ci(release): variables API needs the bot PAT, not GITHUB_TOKEN

### DIFF
--- a/.github/workflows/selfhosted-build-push.yml
+++ b/.github/workflows/selfhosted-build-push.yml
@@ -84,21 +84,18 @@ jobs:
         environment: ci
         permissions:
             contents: read
-            # `gh variable set` below uses GITHUB_TOKEN — variables fall
-            # under the Actions permission scope.
-            actions: write
         steps:
-            # Variable FIRST, ruleset second — and with DIFFERENT tokens.
-            # RELEASE_BOT_TOKEN can PUT rulesets (admin) but has NO Actions
-            # variables access: on the first scheduled run (2026-06-05) the
-            # old single step activated the ruleset and THEN 403'd on
-            # `gh variable set`, killing the whole release at job 1 with the
-            # ruleset left active and unfreeze-main skipped. GITHUB_TOKEN
-            # with `actions: write` handles the variable; the admin token
-            # only touches the ruleset.
+            # Variable FIRST, ruleset second. Both steps use
+            # RELEASE_BOT_TOKEN, which carries BOTH "Administration" (the
+            # ruleset PUT) and "Variables: read/write". Do NOT swap the
+            # variable step to GITHUB_TOKEN: the Actions variables API is
+            # not reachable by the workflow token at all — `actions: write`
+            # still 403s with "Resource not accessible by integration"
+            # (verified live on run 27013019883, 2026-06-05). Only a PAT
+            # (classic `repo` scope or fine-grained with Variables) works.
             - name: Signal freeze to release-freeze-check.yml
               env:
-                  GH_TOKEN: ${{ github.token }}
+                  GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
                   REPO: ${{ github.repository }}
               run: |
                   set -euo pipefail
@@ -658,10 +655,6 @@ jobs:
         environment: ci
         permissions:
             contents: read
-            # `gh variable set` below uses GITHUB_TOKEN — variables fall
-            # under the Actions permission scope (RELEASE_BOT_TOKEN has no
-            # variables access; see freeze-main).
-            actions: write
         steps:
             - name: Deactivate release-freeze ruleset
               env:
@@ -678,7 +671,9 @@ jobs:
 
             - name: Clear freeze signal for release-freeze-check.yml
               env:
-                  GH_TOKEN: ${{ github.token }}
+                  # RELEASE_BOT_TOKEN, NOT github.token — the workflow token
+                  # cannot reach the Actions variables API (see freeze-main).
+                  GH_TOKEN: ${{ secrets.RELEASE_BOT_TOKEN }}
                   REPO: ${{ github.repository }}
               run: |
                   set -euo pipefail


### PR DESCRIPTION
Follow-up to #1270. The `GITHUB_TOKEN` swap for `gh variable set` was wrong: the workflow token cannot reach the Actions variables API at all — `permissions: actions: write` still 403s with `Resource not accessible by integration` (verified live on run [27013019883](https://github.com/kodustech/kodus-ai/actions/runs/27013019883)). Per the REST docs, only OAuth/classic PATs with `repo` scope or fine-grained PATs with the **Variables** permission can write variables.

Both `RELEASE_FREEZE_ACTIVE` writes now use `RELEASE_BOT_TOKEN` again, which is being granted fine-grained **Variables: Read and write** alongside its existing Administration permission. Comments updated so nobody re-attempts the GITHUB_TOKEN route.

What #1270's fixes already proved on that failed run: the failure alert hit Discord immediately (no approval gate) naming the right phase, and unfreeze-main rolled the ruleset back even though freeze failed — main was left unfrozen.

⚠️ Merge only AFTER the RELEASE_BOT_TOKEN PAT gets the Variables permission, then re-dispatch the release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)