### PR TITLE
ci(build): authenticate @vscode/ripgrep's postinstall download to stop release-build 403s

### DIFF
--- a/.github/workflows/prod-build-push-and-pr-green.yml
+++ b/.github/workflows/prod-build-push-and-pr-green.yml
@@ -156,6 +156,10 @@ jobs:
 
             - name: Build, tag, and push (api/webhooks/worker)
               env:
+                  # Authenticates @vscode/ripgrep's postinstall download via
+                  # the bake-level `github_token` secret (anonymous GitHub
+                  # API calls from runner IPs are rate-limited → 403).
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
                   API_TAGS: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY_API
                       }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/qa-build-push-and-pr-green.yml
+++ b/.github/workflows/qa-build-push-and-pr-green.yml
@@ -125,6 +125,10 @@ jobs:
 
             - name: Build, tag, and push (api/webhooks/worker)
               env:
+                  # Authenticates @vscode/ripgrep's postinstall download via
+                  # the bake-level `github_token` secret (anonymous GitHub
+                  # API calls from runner IPs are rate-limited → 403).
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
                   API_TAGS: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY_API
                       }}:${{ env.IMAGE_TAG }}

--- a/.github/workflows/selfhosted-build-push.yml
+++ b/.github/workflows/selfhosted-build-push.yml
@@ -311,6 +311,11 @@ jobs:
 
             - name: Build and push RC images
               env:
+                  # Feeds the bake-level `github_token` secret: authenticates
+                  # @vscode/ripgrep's postinstall download (GitHub releases
+                  # API rate-limits anonymous runner IPs — killed the
+                  # 2026-06-05 release build with a 403).
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   # IMPORTANT: only the RC tag is pushed here. The final
                   # X.Y.Z tag and :latest are minted by selfhosted-promote.yml
                   # after the matrix E2E passes — never by this job.

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -45,6 +45,13 @@ target "base" {
     RELEASE_VERSION = "${RELEASE_VERSION}"
     API_CLOUD_MODE = "${API_CLOUD_MODE}"
   }
+  # github_token feeds @vscode/ripgrep's postinstall (via @morphllm/
+  # morphsdk): it downloads a prebuilt binary from the GitHub releases
+  # API, which 403s anonymous calls from shared CI runner IPs (killed
+  # the 2026-06-05 release build). Sourced from the GITHUB_TOKEN env at
+  # bake time; absent env → empty secret → install runs unauthenticated
+  # exactly as before (local builds unaffected).
+  secret = ["id=github_token,env=GITHUB_TOKEN"]
   cache-from = ["type=gha,scope=${CACHE_SCOPE}"]
   cache-to = ["type=gha,scope=${CACHE_SCOPE},mode=max"]
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -66,10 +66,16 @@ RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
   && YARN_CACHE_FOLDER=/yarn-cache yarn install \
   && YARN_CACHE_FOLDER=/yarn-cache yarn build
 
-# Install dependencies and link local packages
+# Install dependencies and link local packages.
+# github_token (optional) authenticates @vscode/ripgrep's postinstall
+# download against the GitHub releases API — anonymous calls from shared
+# CI runner IPs are rate-limited (403) and abort the whole install. Empty
+# or absent secret → unauthenticated, same as a local build.
 RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
+    --mount=type=secret,id=github_token,required=false \
     --mount=type=cache,target=/yarn-cache,sharing=locked \
-    YARN_CACHE_FOLDER=/yarn-cache yarn install --frozen-lockfile
+    if [ -s /run/secrets/github_token ]; then export GITHUB_TOKEN="$(cat /run/secrets/github_token)"; fi \
+ && YARN_CACHE_FOLDER=/yarn-cache yarn install --frozen-lockfile
 RUN rm -rf node_modules/@kodus/kodus-common && cp -r packages/kodus-common node_modules/@kodus/kodus-common
 RUN rm -rf node_modules/@kodus/flow && cp -r packages/kodus-flow node_modules/@kodus/flow
 
@@ -112,9 +118,13 @@ RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
 # ESLint, etc.) since the `build` stage already produced the compiled
 # output in ../build/usr/src/app/dist. --prefer-offline + the shared yarn
 # cache means we reuse the tarballs already downloaded by `deps`.
+# github_token: same ripgrep-postinstall rate-limit story as `deps` —
+# this stage re-runs postinstall scripts on its own node_modules.
 RUN --mount=type=secret,id=npmrc,target=/root/.npmrc,required=false \
+    --mount=type=secret,id=github_token,required=false \
     --mount=type=cache,target=/yarn-cache,sharing=locked \
-    YARN_CACHE_FOLDER=/yarn-cache yarn install --frozen-lockfile --prefer-offline --production=true
+    if [ -s /run/secrets/github_token ]; then export GITHUB_TOKEN="$(cat /run/secrets/github_token)"; fi \
+ && YARN_CACHE_FOLDER=/yarn-cache yarn install --frozen-lockfile --prefer-offline --production=true
 
 # Link local packages. Drop the nested node_modules/src/test that were
 # needed for `yarn prepack` but not at runtime — keeping them would


### PR DESCRIPTION
## Context

The 2026-06-05 release build (run [27013694412](https://github.com/kodustech/kodus-ai/actions/runs/27013694412)) died in `yarn install` on the `webhooks` target:

```
error /usr/src/app/node_modules/@vscode/ripgrep: Command failed.
GET https://api.github.com/repos/microsoft/ripgrep-prebuilt/releases/tags/v15.0.1
Error: Request failed: 403
```

`@vscode/ripgrep` (pulled in via `@morphllm/morphsdk`) downloads a prebuilt binary from the GitHub releases API in its postinstall. Anonymous API calls from shared CI runner IPs are rate-limited → intermittent 403 → the whole image build aborts. This can hit any of the selfhosted / QA / prod image builds.

## Fix

The package officially honors `GITHUB_TOKEN` ([lib/postinstall.js:107](https://github.com/microsoft/vscode-ripgrep/blob/main/lib/postinstall.js)):

- **docker-bake.hcl**: `base` target gains `secret = ["id=github_token,env=GITHUB_TOKEN"]` — sourced from the env at bake time; absent env → empty secret → unauthenticated install exactly as before (local builds unaffected).
- **docker/Dockerfile**: the two app-level `yarn install` RUNs (`deps`, `prod-deps`) mount the secret and `export GITHUB_TOKEN` when non-empty.
- **selfhosted-build-push / qa-build-push / prod-build-push**: pass `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the bake step env.

## Validation

- `docker buildx build --target deps --secret id=github_token,env=GITHUB_TOKEN -f docker/Dockerfile .` — completes locally (exit 0) with the new shell guard.
- `docker buildx bake --print api` — secret wired into the target.
- `actionlint` — clean (pre-existing info-level findings only).

Note: today's release run was retried and may pass on runner-IP luck; this PR removes the luck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)