### PR TITLE
ci(release): pass the docker tag (rc_version), not the git tag, to the e2e matrix

### DIFF
--- a/.github/workflows/e2e-self-hosted-matrix.yml
+++ b/.github/workflows/e2e-self-hosted-matrix.yml
@@ -14,7 +14,8 @@ permissions:
 # an RC build, before any promotion is allowed.
 #
 # Inputs:
-#   image_tag    Image tag to test against (REQUIRED, e.g. selfhosted-1.42.0-rc.1)
+#   image_tag    DOCKER image tag to test against (REQUIRED, e.g. 1.42.0-rc.1 —
+#                the ghcr tag, NOT the selfhosted-* git tag)
 #   matrix_file  Path to a matrix YAML file in tests/e2e/matrix/ (default fast.yml)
 #   keep_running Optional — leave droplets alive after each cell for debug
 #

--- a/.github/workflows/selfhosted-build-push.yml
+++ b/.github/workflows/selfhosted-build-push.yml
@@ -413,7 +413,12 @@ jobs:
             packages: read
         uses: ./.github/workflows/e2e-self-hosted-matrix.yml
         with:
-            image_tag: ${{ needs.plan-release.outputs.rc_tag }}
+            # rc_version (the DOCKER tag, e.g. 2.1.16-rc.68) — NOT rc_tag
+            # (the GIT tag, selfhosted-2.1.16-rc.68). The images are pushed
+            # as :<rc_version>; since kodus-installer#21 the droplet compose
+            # actually pins IMAGE_TAG, so passing the git tag makes every
+            # pull 404 ("manifest not found", all 5 cells, run 27021899293).
+            image_tag: ${{ needs.plan-release.outputs.rc_version }}
             # FULL coverage on release: adds upgrade-N-1→N, SSO,
             # Stripe billing — the lifecycle scenarios that only matter
             # when cutting a customer-visible release. e2e-cloud


### PR DESCRIPTION
## Context

Run [27021899293](https://github.com/kodustech/kodus-ai/actions/runs/27021899293) (first release attempt with kodus-installer#21 in effect): all 5 matrix cells failed at health check because every image pull 404'd:

```
Error: ghcr.io/.../kodus-ai-web:selfhosted-2.1.16-rc.68: not found
```

The build job pushes images tagged `:<rc_version>` (`2.1.16-rc.68`), but the matrix call passed `rc_tag` (the **git** tag, `selfhosted-2.1.16-rc.68`) as `image_tag`. Before installer#21 this mismatch was invisible — the droplet compose ignored `IMAGE_TAG` entirely and always pulled `:latest` (the actual bug #21 fixed). Now that the pin is real, the wrong string 404s.

## Fix

- `selfhosted-build-push.yml`: matrix `image_tag` ← `rc_version` (the docker tag).
- `e2e-self-hosted-matrix.yml`: doc comment now states `image_tag` is the ghcr tag, not the `selfhosted-*` git tag.

actionlint clean.

With this, the chain for today's release is: freeze ✅ (#1270/#1271) → build ✅ (#1275) → matrix pulls the real RC (installer#21 + this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)