### PR TITLE
fix(e2e): settle 120s before retrying absence-shaped failures (deploy/worker rollout window)

### DIFF
--- a/tests/e2e/lib/__tests__/transient-failure.test.ts
+++ b/tests/e2e/lib/__tests__/transient-failure.test.ts
@@ -1,6 +1,6 @@
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
-import { isTransientFailure } from "../runner.js";
+import { absenceRetryDelayMs, isTransientFailure } from "../runner.js";
 
 // The retry classifier decides which cell failures get ONE automatic
 // re-run. The split is ABSENCE/NETWORK (retry — a lost webhook or provider
@@ -52,4 +52,27 @@ test("isTransientFailure: deterministic mismatches do NOT retry", () => {
 test("isTransientFailure: tolerates empty/undefined", () => {
     assert.equal(isTransientFailure(""), false);
     assert.equal(isTransientFailure(undefined as unknown as string), false);
+});
+
+test("absenceRetryDelayMs: review-never-started shapes get the 120s settle", () => {
+    const absent = [
+        "[provider:github] No kody-codereview status comment on PR #23 within 60s — review pipeline likely never started (check droplet worker logs and the webhook delivery list).",
+        "Assertion failed: No review activity on PR https://gitlab.com/x/-/merge_requests/79 within timeout",
+        "Expected a real review for license=trial but none arrived within 900s.",
+    ];
+    for (const msg of absent) {
+        assert.equal(absenceRetryDelayMs(msg), 120_000, msg.slice(0, 60));
+    }
+});
+
+test("absenceRetryDelayMs: transport noise retries immediately (0ms)", () => {
+    const transport = [
+        "TypeError: fetch failed",
+        "HTTP 502\n<html>Bad Gateway</html>",
+        "request to https://qa.web.kodus.io failed, reason: ECONNRESET",
+    ];
+    for (const msg of transport) {
+        assert.equal(absenceRetryDelayMs(msg), 0, msg.slice(0, 60));
+    }
+    assert.equal(absenceRetryDelayMs(""), 0);
 });

--- a/tests/e2e/lib/runner.ts
+++ b/tests/e2e/lib/runner.ts
@@ -317,6 +317,28 @@ export function isTransientFailure(message: string): boolean {
     return TRANSIENT_FAILURE_PATTERNS.some((re) => re.test(message ?? ""));
 }
 
+// ABSENCE failures (an expected event never materialized — review never
+// started, comment never arrived) get a settle delay before the retry.
+// Rationale: the per-deploy matrix starts ~5s after the GitOps infra PR,
+// and the version gate only proves the API converged — the WORKERS are
+// still rolling when the first review scenario fires its webhook. The
+// webhook lands (200), the job dies with the old worker, and an IMMEDIATE
+// retry falls inside the same rollout window: run 27021874607 had PRs
+// #22+#23 (attempt + instant retry, 15:16–15:19) with zero comments while
+// PR #24 one minute later reviewed fine. Two minutes covers the observed
+// worker-cycle gap. Pure transport noise (5xx/ECONNRESET/fetch failed)
+// keeps the instant retry — waiting buys nothing there.
+const ABSENCE_FAILURE_PATTERNS: RegExp[] = [
+    /no review activity|none arrived|never arrived|never (reached|registered|woke|started)|did not (arrive|appear|start)/i,
+    /No .* (comment|review|status) on (PR|MR)/i,
+];
+
+export function absenceRetryDelayMs(message: string): number {
+    return ABSENCE_FAILURE_PATTERNS.some((re) => re.test(message ?? ""))
+        ? 120_000
+        : 0;
+}
+
 export async function runMatrix(opts: RunOptions): Promise<RunOutcome> {
     const startedAt = new Date().toISOString();
     const results: ScenarioResult[] = [];
@@ -530,9 +552,13 @@ export async function runMatrix(opts: RunOptions): Promise<RunOutcome> {
                         isTransientFailure(e.message)
                     ) {
                         retriedAfter = e.message;
+                        const settleMs = absenceRetryDelayMs(e.message);
                         log.info(
-                            `RETRY ${cellLabel}: transient failure shape, re-running once (${e.message.slice(0, 160)})`,
+                            `RETRY ${cellLabel}: transient failure shape, re-running once${settleMs ? ` after a ${settleMs / 1000}s settle (absence shape — likely a deploy/worker rollout window)` : ""} (${e.message.slice(0, 160)})`,
                         );
+                        if (settleMs) {
+                            await new Promise((r) => setTimeout(r, settleMs));
+                        }
                         continue;
                     }
                     log.err(`FAIL  ${cellLabel}: ${e.message}`);


### PR DESCRIPTION
## Context

Run [27021874607](https://github.com/kodustech/kodus-ai/actions/runs/27021874607) (per-deploy matrix for #1275's merge) failed `code-review-basic × cloud × github × paid` twice in a row: PRs #22 and #23 on `tiny-url-cloud-paid` got **zero** Kody comments, while PR #24 — opened one minute later by the next scenario — reviewed fine.

Repo isolation was working (right repo, right org). The failure window (15:16–15:19) sits right after the QA GitOps deploy: the matrix job starts ~5s after the infra PR and the readiness gate only proves the **API** converged — the **workers** are still rolling. A review webhook that lands mid-rollout returns 200 and dies with the old worker. The runner's retry is immediate, so both attempts fell inside the same rollout window.

## Fix

`absenceRetryDelayMs()`: transient failures with an **absence** shape ("review pipeline likely never started", "no review activity", "none arrived") now wait **120s** before their single retry — enough to clear the observed worker-cycle gap. Pure transport noise (5xx/ECONNRESET/fetch failed) keeps the instant retry, where waiting buys nothing.

Worst case cost: +2 min on a cell that was going to fail anyway; zero cost on green runs.

## Validation

- 67/67 unit tests (2 new: absence shapes → 120s, transport shapes → 0ms), typecheck clean.
- Real-world replay: with this change, attempt 1 fails at 15:17:51 → settle until 15:19:51 → retry opens its PR after the window where PR #24 (15:19:33) already reviewed successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)