### PR TITLE
fix(kody-rules): repo-scope authz enforcement and rules screen  UX fixes

### DIFF
--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/kody-rules/_components/_page.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/kody-rules/_components/_page.tsx
@@ -363,41 +363,47 @@ const KodyRulesPageContent = () => {
                 : statusFilteredRules;
 
         // Popover filters: origin (Auto-sync / Onboard / Kody-generated /
-        // manual) and severity. Origin only applies to standard rules
-        // (memories don't have these origins).
-        const listFilteredRules = bannerFilteredRules.filter((rule) => {
-            const passesOrigin =
-                ruleType !== KodyRulesType.STANDARD ||
-                matchesOriginFilter(rule as KodyRule, listFilters);
-            const passesSeverity =
-                ruleType !== KodyRulesType.STANDARD ||
-                matchesSeverityFilter(rule as KodyRule, listFilters);
-            const passesSyncErrors =
-                ruleType !== KodyRulesType.STANDARD ||
-                matchesSyncErrorsFilter(rule as KodyRule, listFilters);
-            const passesPausedOnly =
-                ruleType !== KodyRulesType.STANDARD ||
-                matchesPausedOnlyFilter(rule as KodyRule, listFilters);
-            const passesKodySync =
-                ruleType !== KodyRulesType.STANDARD ||
-                matchesKodySyncFilter(rule as KodyRule, listFilters);
-            return (
-                passesOrigin &&
-                passesSeverity &&
-                passesSyncErrors &&
-                passesPausedOnly &&
-                passesKodySync
-            );
-        });
+        // manual), sync state, paused-only — everything EXCEPT severity,
+        // which is applied last (below) so the heatmap can count this
+        // pool. Origin only applies to standard rules (memories don't
+        // have these origins).
+        const nonSeverityFilteredRules = bannerFilteredRules.filter(
+            (rule) => {
+                const passesOrigin =
+                    ruleType !== KodyRulesType.STANDARD ||
+                    matchesOriginFilter(rule as KodyRule, listFilters);
+                const passesSyncErrors =
+                    ruleType !== KodyRulesType.STANDARD ||
+                    matchesSyncErrorsFilter(rule as KodyRule, listFilters);
+                const passesPausedOnly =
+                    ruleType !== KodyRulesType.STANDARD ||
+                    matchesPausedOnlyFilter(rule as KodyRule, listFilters);
+                const passesKodySync =
+                    ruleType !== KodyRulesType.STANDARD ||
+                    matchesKodySyncFilter(rule as KodyRule, listFilters);
+                return (
+                    passesOrigin &&
+                    passesSyncErrors &&
+                    passesPausedOnly &&
+                    passesKodySync
+                );
+            },
+        );
 
         const filterQueryLowercase = filterQuery.toLowerCase();
         const queryFilteredRules = !filterQuery
-            ? listFilteredRules
-            : listFilteredRules.filter((rule) =>
+            ? nonSeverityFilteredRules
+            : nonSeverityFilteredRules.filter((rule) =>
                 matchesTextQuery(rule as KodyRule, filterQueryLowercase),
             );
 
-        const rulesToDisplay = [...queryFilteredRules].sort((x, y) =>
+        const listFilteredRules = queryFilteredRules.filter(
+            (rule) =>
+                ruleType !== KodyRulesType.STANDARD ||
+                matchesSeverityFilter(rule as KodyRule, listFilters),
+        );
+
+        const rulesToDisplay = [...listFilteredRules].sort((x, y) =>
             compareRules(x as KodyRule, y as KodyRule, sortOption),
         );
 
@@ -407,16 +413,19 @@ const KodyRulesPageContent = () => {
             inheritedRepoRulesByType.length > 0 ||
             inheritedDirectoryRulesByType.length > 0;
 
-        // Severity distribution computed BEFORE severity filtering so the
-        // heatmap counters always reflect the full pool (otherwise clicking
-        // "Critical" would zero out the High/Medium/Low counters).
+        // Severity distribution over the pool with every OTHER filter
+        // (origin, sync, paused, text query) already applied, but NOT the
+        // severity selection itself: each chip must match the cards on
+        // screen when other filters are active (e.g. Origin: Library → "2
+        // High", not the unfiltered "4 High"), while clicking "Critical"
+        // still must not zero out the High/Medium/Low counters.
         const severityCounts: Record<string, number> = {
             critical: 0,
             high: 0,
             medium: 0,
             low: 0,
         };
-        for (const rule of bannerFilteredRules) {
+        for (const rule of queryFilteredRules) {
             const sev = (rule as KodyRule).severity?.toLowerCase();
             if (sev && severityCounts[sev] !== undefined) {
                 severityCounts[sev] += 1;

--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/kody-rules/_components/_page.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/kody-rules/_components/_page.tsx
@@ -30,6 +30,7 @@ import {
 import { usePermission } from "@services/permissions/hooks";
 import { Action, ResourceType } from "@services/permissions/types";
 import { useQueryClient } from "@tanstack/react-query";
+import { isAxiosError } from "axios";
 import { BellRing, PlusIcon } from "lucide-react";
 import { PageBoundary } from "src/core/components/page-boundary";
 import { useSelectedTeamId } from "src/core/providers/selected-team-context";
@@ -95,6 +96,21 @@ const isRulePendingCentralizedChange = (rule: KodyRule) => {
         KodyRuleCentralizedStatus.PENDING_DELETE
     );
 };
+
+// A 403 means the backend policy rejected the mutation (e.g. a repo admin
+// acting on rules outside their assigned repos) — retrying will never
+// succeed, so surface the real cause instead of the generic "try again".
+const bulkActionErrorToast = (
+    action: "pause" | "resume" | "delete",
+    error: unknown,
+) => ({
+    title: `Could not ${action} rules`,
+    description:
+        isAxiosError(error) && error.response?.status === 403
+            ? `You don't have permission to ${action} rules in this scope.`
+            : "Please try again in a moment.",
+    variant: "danger" as const,
+});
 
 
 const KodyRulesPageContent = () => {
@@ -553,11 +569,7 @@ const KodyRulesPageContent = () => {
                 await refreshRulesList();
             } catch (error) {
                 console.error("Failed to bulk delete rules", error);
-                toast({
-                    title: "Could not delete rules",
-                    description: "Please try again in a moment.",
-                    variant: "danger",
-                });
+                toast(bulkActionErrorToast("delete", error));
             }
         },
     );
@@ -601,11 +613,7 @@ const KodyRulesPageContent = () => {
                 await refreshRulesList();
             } catch (error) {
                 console.error("Failed to bulk pause rules", error);
-                toast({
-                    title: "Could not pause rules",
-                    description: "Please try again in a moment.",
-                    variant: "danger",
-                });
+                toast(bulkActionErrorToast("pause", error));
             }
         },
     );
@@ -629,11 +637,7 @@ const KodyRulesPageContent = () => {
                 await refreshRulesList();
             } catch (error) {
                 console.error("Failed to bulk resume rules", error);
-                toast({
-                    title: "Could not resume rules",
-                    description: "Please try again in a moment.",
-                    variant: "danger",
-                });
+                toast(bulkActionErrorToast("resume", error));
             }
         },
     );
@@ -954,20 +958,26 @@ const KodyRulesPageContent = () => {
                             {renderPendingMergeFilter(
                                 reviewRulesState.pendingCentralizedCount,
                             )}
-                            <BulkActionToolbar
-                                selectedCount={selection.size}
-                                eligibleCount={eligibleSelectableIds.length}
-                                pauseableCount={pauseableIds.length}
-                                resumableCount={resumableIds.length}
-                                isDeleting={isBulkDeleting}
-                                isPausing={isBulkPausing}
-                                isResuming={isBulkResuming}
-                                onSelectAll={selectAllVisible}
-                                onClear={clearSelection}
-                                onDelete={handleBulkDelete}
-                                onPause={handleBulkPause}
-                                onResume={handleBulkResume}
-                            />
+                            {/* Bulk actions are mutations — without Update
+                                permission on this scope (e.g. repo admin on
+                                the Global page) the backend rejects them all,
+                                so don't offer selection at all. */}
+                            {canEdit && (
+                                <BulkActionToolbar
+                                    selectedCount={selection.size}
+                                    eligibleCount={eligibleSelectableIds.length}
+                                    pauseableCount={pauseableIds.length}
+                                    resumableCount={resumableIds.length}
+                                    isDeleting={isBulkDeleting}
+                                    isPausing={isBulkPausing}
+                                    isResuming={isBulkResuming}
+                                    onSelectAll={selectAllVisible}
+                                    onClear={clearSelection}
+                                    onDelete={handleBulkDelete}
+                                    onPause={handleBulkPause}
+                                    onResume={handleBulkResume}
+                                />
+                            )}
                             {(() => {
                                 const empty =
                                     !reviewRulesState.rulesToDisplay.length;
@@ -979,11 +989,17 @@ const KodyRulesPageContent = () => {
                                             }
                                             tab="review-rules"
                                             onAnyChange={refreshRulesList}
-                                            bulkSelection={{
-                                                selection,
-                                                onToggle: toggleSelection,
-                                                isEligible: isBulkEligible,
-                                            }}
+                                            bulkSelection={
+                                                canEdit
+                                                    ? {
+                                                          selection,
+                                                          onToggle:
+                                                              toggleSelection,
+                                                          isEligible:
+                                                              isBulkEligible,
+                                                      }
+                                                    : undefined
+                                            }
                                             syncEnabledForRepo={
                                                 isGlobalView
                                                     ? undefined

--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/kody-rules/_components/item.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/kody-rules/_components/item.tsx
@@ -5,7 +5,6 @@ import { Badge } from "@components/ui/badge";
 import { Button } from "@components/ui/button";
 import { Card, CardContent, CardHeader } from "@components/ui/card";
 import { Heading } from "@components/ui/heading";
-import { Link } from "@components/ui/link";
 import { magicModal } from "@components/ui/magic-modal";
 import { Section } from "@components/ui/section";
 import { Separator } from "@components/ui/separator";
@@ -24,12 +23,12 @@ import { usePermission } from "@services/permissions/hooks";
 import { Action, ResourceType } from "@services/permissions/types";
 import { EditIcon, EyeIcon, PlayIcon, TrashIcon } from "lucide-react";
 import { SuggestionsModal } from "src/app/(app)/library/kody-rules/_components/suggestions-modal";
-import { useSelectedTeamId } from "src/core/providers/selected-team-context";
-import { addSearchParamsToUrl } from "src/core/utils/url";
 
 import { OriginBadge } from "./origin-badge";
 
 import { DeleteKodyRuleConfirmationModal } from "../../../_components/delete-confirmation-modal";
+import { KodyRuleAddOrUpdateItemModal } from "../../../_components/modal";
+import { useFullCodeReviewConfig } from "../../../../_components/context";
 import { useCodeReviewRouteParams } from "../../../../_hooks";
 import { ExternalReferencesDisplay } from "../../pr-summary/_components/external-references-display";
 import { changeStatusKodyRules } from "@services/kodyRules/fetch";
@@ -39,14 +38,12 @@ import { useAsyncAction } from "@hooks/use-async-action";
 
 export const KodyRuleItem = ({
     rule,
-    tab,
     onAnyChange,
     showSuggestionsButton = false,
     selection,
     syncEnabledForRepo,
 }: {
     rule: KodyRuleWithInheritanceDetails;
-    tab: "review-rules" | "memories";
     onAnyChange: () => void;
     showSuggestionsButton?: boolean;
     /** Repo's `ideRulesSyncEnabled`; forwarded to OriginBadge so it can
@@ -62,7 +59,7 @@ export const KodyRuleItem = ({
     };
 }) => {
     const { repositoryId, directoryId } = useCodeReviewRouteParams();
-    const { teamId } = useSelectedTeamId();
+    const config = useFullCodeReviewConfig();
     const canEdit = usePermission(
         Action.Update,
         ResourceType.KodyRules,
@@ -90,6 +87,27 @@ export const KodyRuleItem = ({
                 : null;
     const entityLabel = isMemory ? "memory" : "rule";
     const isPaused = rule.status === KodyRulesStatus.PAUSED;
+
+    // Opens the edit/view modal in place — same pattern Delete and "New
+    // rule" already use — instead of navigating to the sibling
+    // /kody-rules/[id] page. The route round-trip unmounted the whole
+    // list into a full-page skeleton twice (open and close) and lost the
+    // scroll position (#1274). The [id] route stays for deep links.
+    const handleOpenRuleModal = async () => {
+        const directory = config?.repositories
+            .find((r) => r.id === repositoryId)
+            ?.directories?.find((d) => d.id === directoryId);
+
+        const response = await magicModal.show(() => (
+            <KodyRuleAddOrUpdateItemModal
+                rule={rule}
+                repositoryId={repositoryId}
+                directory={directory}
+                canEdit={canEdit}
+            />
+        ));
+        if (response) onAnyChange?.();
+    };
 
     const [handleResume, { loading: isResuming }] = useAsyncAction(async () => {
         if (!rule.uuid) return;
@@ -260,28 +278,22 @@ export const KodyRuleItem = ({
                         </Button>
                     )}
 
-                    <Link
-                        href={addSearchParamsToUrl(
-                            `/settings/code-review/${repositoryId}/kody-rules/${rule.uuid}`,
-                            { directoryId, teamId, tab },
-                        )}>
-                        <Button
-                            decorative
-                            size="icon-md"
-                            variant="secondary"
-                            aria-label={
-                                !canEdit || isInherited
-                                    ? "View " + entityLabel + " details"
-                                    : "Edit " + entityLabel
-                            }
-                            className="size-9">
-                            {!canEdit || isInherited ? (
-                                <EyeIcon aria-hidden />
-                            ) : (
-                                <EditIcon aria-hidden />
-                            )}
-                        </Button>
-                    </Link>
+                    <Button
+                        size="icon-md"
+                        variant="secondary"
+                        aria-label={
+                            !canEdit || isInherited
+                                ? "View " + entityLabel + " details"
+                                : "Edit " + entityLabel
+                        }
+                        className="size-9"
+                        onClick={handleOpenRuleModal}>
+                        {!canEdit || isInherited ? (
+                            <EyeIcon aria-hidden />
+                        ) : (
+                            <EditIcon aria-hidden />
+                        )}
+                    </Button>
 
                     <Button
                         size="icon-md"

--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/kody-rules/_components/list.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/kody-rules/_components/list.tsx
@@ -61,7 +61,6 @@ export const KodyRulesList = ({
                     <KodyRuleItem
                         key={rule.uuid}
                         rule={rule}
-                        tab={tab}
                         onAnyChange={onAnyChange}
                         showSuggestionsButton={tab === "review-rules"}
                         selection={selection}

--- a/apps/web/src/app/(app)/settings/code-review/_components/modal.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/_components/modal.tsx
@@ -705,7 +705,13 @@ export const KodyRuleAddOrUpdateItemModal = ({
                                                     openDelay={100}
                                                     closeDelay={200}>
                                                     <HoverCardTrigger asChild>
-                                                        <button type="button">
+                                                        {/* tabIndex -1: in view mode the rule-name input is
+                                                            disabled, so the dialog's open auto-focus would land
+                                                            on this button — and HoverCard opens on focus,
+                                                            covering the modal. Hover-only is fine for help. */}
+                                                        <button
+                                                            type="button"
+                                                            tabIndex={-1}>
                                                             <HelpCircle
                                                                 size={16}
                                                                 className="text-primary-light hover:text-primary-light/80 transition-colors"
@@ -956,7 +962,7 @@ export const KodyRuleAddOrUpdateItemModal = ({
                                             htmlFor={field.name}>
                                             Path
                                             <Tooltip>
-                                                <TooltipTrigger>
+                                                <TooltipTrigger tabIndex={-1}>
                                                     <HelpCircle
                                                         size={16}
                                                         className="text-primary-light"
@@ -1096,7 +1102,7 @@ export const KodyRuleAddOrUpdateItemModal = ({
                                         htmlFor={field.name}>
                                         Instructions
                                         <Tooltip>
-                                            <TooltipTrigger>
+                                            <TooltipTrigger tabIndex={-1}>
                                                 <HelpCircle
                                                     size={16}
                                                     className="text-primary-light"
@@ -1279,7 +1285,7 @@ export const KodyRuleAddOrUpdateItemModal = ({
                                             htmlFor={field.name}>
                                             Severity
                                             <Tooltip>
-                                                <TooltipTrigger>
+                                                <TooltipTrigger tabIndex={-1}>
                                                     <HelpCircle
                                                         size={16}
                                                         className="text-primary-light"
@@ -1431,7 +1437,7 @@ export const KodyRuleAddOrUpdateItemModal = ({
                                             <FormControl.Label className="mb-0 flex flex-row gap-1">
                                                 Inheritable
                                                 <Tooltip>
-                                                    <TooltipTrigger>
+                                                    <TooltipTrigger tabIndex={-1}>
                                                         <HelpCircle
                                                             size={16}
                                                             className="text-primary-light"

--- a/apps/web/src/core/components/ui/button.tsx
+++ b/apps/web/src/core/components/ui/button.tsx
@@ -14,6 +14,7 @@ const buttonVariants = cva(
         "[&[aria-haspopup=dialog]]:ring-1",
         "button-focused:ring-3!",
         "button-hover:brightness-120 button-active:brightness-120",
+        "cursor-pointer",
         "button-loading:cursor-wait",
         "button-disabled:cursor-not-allowed group-disabled/link:cursor-not-allowed",
         "group-disabled/link:[&:hover]:brightness-100!",

--- a/libs/kodyRules/application/use-cases/create-or-update.use-case.ts
+++ b/libs/kodyRules/application/use-cases/create-or-update.use-case.ts
@@ -100,9 +100,7 @@ export class CreateOrUpdateKodyRulesUseCase {
                     user: this.request.user,
                     action: Action.Create,
                     resource: ResourceType.KodyRules,
-                    repoIds: kodyRule.repositoryId
-                        ? [kodyRule.repositoryId]
-                        : undefined,
+                    repoIds: await this.resolveAuthorizationRepoIds(kodyRule),
                 });
             }
 
@@ -207,6 +205,126 @@ export class CreateOrUpdateKodyRulesUseCase {
             });
             throw error;
         }
+    }
+
+    /**
+     * Which repo ids the mutation must be authorized against.
+     *
+     * Normally the rule's own repositoryId. Exception: an inheritance
+     * toggle (excluding/including a child scope from an inherited rule)
+     * mutates the PARENT rule document, but its effect is scoped to the
+     * toggled child — demanding write access on the parent would mean a
+     * repo admin cannot opt their own repo out of an inherited global
+     * rule ("Error disabling inheritance" 403). When the ONLY change vs
+     * the stored rule is inheritance.exclude/include, authorize against
+     * the toggled ids instead.
+     */
+    private async resolveAuthorizationRepoIds(
+        kodyRule: CreateKodyRuleDto,
+    ): Promise<string[] | undefined> {
+        const ruleScope = kodyRule.repositoryId
+            ? [kodyRule.repositoryId]
+            : undefined;
+
+        if (!kodyRule.uuid) {
+            return ruleScope;
+        }
+
+        const existing = await this.kodyRulesService.findById(kodyRule.uuid);
+        if (!existing) {
+            return ruleScope;
+        }
+
+        const toggledIds = this.getInheritanceOnlyToggledIds(
+            existing,
+            kodyRule,
+        );
+
+        return toggledIds ?? ruleScope;
+    }
+
+    /**
+     * Returns the ids added/removed in inheritance.exclude/include when
+     * those lists are the ONLY difference vs the stored rule, or null
+     * when anything else changed (callers then authorize against the
+     * rule's own scope, as before).
+     *
+     * The service update is a merge (`{...existingRule, ...kodyRule}`),
+     * so every key PRESENT in the payload can overwrite the stored value
+     * — compare them all, not a fixed whitelist. `inheritable` is
+     * rule-wide (affects every repo), so flipping it is NOT a per-repo
+     * toggle.
+     */
+    private getInheritanceOnlyToggledIds(
+        existing: Partial<IKodyRule>,
+        incoming: CreateKodyRuleDto,
+    ): string[] | null {
+        // Args of the request that aren't rule content, plus the lists we
+        // diff explicitly below.
+        const ignoredKeys = new Set([
+            'uuid',
+            'inheritance',
+            'teamId',
+            'createdAt',
+            'updatedAt',
+        ]);
+
+        const normalized = (value: unknown) =>
+            JSON.stringify(value ?? null);
+
+        for (const key of Object.keys(incoming)) {
+            if (ignoredKeys.has(key)) {
+                continue;
+            }
+            if (
+                normalized((incoming as any)[key]) !==
+                normalized((existing as any)[key])
+            ) {
+                return null;
+            }
+        }
+
+        const existingInheritance = existing.inheritance ?? {
+            inheritable: true,
+            exclude: [],
+            include: [],
+        };
+        const incomingInheritance = incoming.inheritance ?? {
+            inheritable: true,
+            exclude: [],
+            include: [],
+        };
+
+        if (
+            (existingInheritance.inheritable ?? true) !==
+            (incomingInheritance.inheritable ?? true)
+        ) {
+            return null;
+        }
+
+        const symmetricDiff = (a: string[] = [], b: string[] = []) => {
+            const setA = new Set(a);
+            const setB = new Set(b);
+            return [
+                ...a.filter((id) => !setB.has(id)),
+                ...b.filter((id) => !setA.has(id)),
+            ];
+        };
+
+        const toggledIds = [
+            ...new Set([
+                ...symmetricDiff(
+                    existingInheritance.exclude,
+                    incomingInheritance.exclude,
+                ),
+                ...symmetricDiff(
+                    existingInheritance.include,
+                    incomingInheritance.include,
+                ),
+            ]),
+        ];
+
+        return toggledIds.length > 0 ? toggledIds : null;
     }
 
     private async createCentralizedMutationIfEnabled(

--- a/libs/kodyRules/application/use-cases/delete-rule-in-organization-by-id.use-case.ts
+++ b/libs/kodyRules/application/use-cases/delete-rule-in-organization-by-id.use-case.ts
@@ -13,6 +13,11 @@ import {
 import { buildKodyRuleCentralizedMutationRequest } from '@libs/centralized-config/utils/kody-rules-centralized-pr.builder';
 import { UserRequest } from '@libs/core/infrastructure/config/types/http/user-request.type';
 import {
+    Action,
+    ResourceType,
+} from '@libs/identity/domain/permissions/enums/permissions.enum';
+import { AuthorizationService } from '@libs/identity/infrastructure/adapters/services/permissions/authorization.service';
+import {
     KodyRuleCentralizedStatus,
     KodyRulesStatus,
     KodyRulesType,
@@ -32,6 +37,8 @@ export class DeleteRuleInOrganizationByIdKodyRulesUseCase {
         private readonly kodyRulesService: IKodyRulesService,
 
         private readonly centralizedConfigPrService: CentralizedConfigPrService,
+
+        private readonly authorizationService: AuthorizationService,
     ) {}
 
     async execute(
@@ -52,6 +59,27 @@ export class DeleteRuleInOrganizationByIdKodyRulesUseCase {
                 actor?.teamId || requestUser?.team?.uuid || requestUser?.teamId;
 
             const existingRule = await this.kodyRulesService.findById(ruleId);
+
+            // The controller guard is type-level only — it cannot see which
+            // repository the rule belongs to. Enforce repo scope here (same
+            // contract as ChangeStatusKodyRulesUseCase): a repo-scoped role
+            // may only delete rules of its assigned repositories; rules
+            // without a repositoryId (org-wide/global) stay owner-only.
+            // Machine flows (sync, or no request context) are exempt.
+            if (
+                existingRule &&
+                actor?.source !== 'sync' &&
+                this.request?.user
+            ) {
+                await this.authorizationService.ensure({
+                    user: this.request.user,
+                    action: Action.Delete,
+                    resource: ResourceType.KodyRules,
+                    repoIds: existingRule.repositoryId
+                        ? [existingRule.repositoryId]
+                        : undefined,
+                });
+            }
 
             if (existingRule && actor?.source !== 'sync') {
                 const pr =

--- a/libs/kodyRules/application/use-cases/delete-rule-in-organization-by-id.use-case.ts
+++ b/libs/kodyRules/application/use-cases/delete-rule-in-organization-by-id.use-case.ts
@@ -54,7 +54,7 @@ export class DeleteRuleInOrganizationByIdKodyRulesUseCase {
         try {
             const requestUser = this.request?.user as any;
             const organizationId =
-                actor?.organizationId || requestUser.organization.uuid;
+                actor?.organizationId || requestUser?.organization?.uuid;
             const teamId =
                 actor?.teamId || requestUser?.team?.uuid || requestUser?.teamId;
 
@@ -142,8 +142,8 @@ export class DeleteRuleInOrganizationByIdKodyRulesUseCase {
                             },
                         } as any,
                         {
-                            userId: actor?.userId || requestUser.uuid,
-                            userEmail: actor?.userEmail || requestUser.email,
+                            userId: actor?.userId || requestUser?.uuid,
+                            userEmail: actor?.userEmail || requestUser?.email,
                         },
                     );
 
@@ -157,8 +157,8 @@ export class DeleteRuleInOrganizationByIdKodyRulesUseCase {
                 },
                 ruleId,
                 {
-                    userId: actor?.userId || requestUser.uuid,
-                    userEmail: actor?.userEmail || requestUser.email,
+                    userId: actor?.userId || requestUser?.uuid,
+                    userEmail: actor?.userEmail || requestUser?.email,
                 },
             );
         } catch (error) {
@@ -169,7 +169,7 @@ export class DeleteRuleInOrganizationByIdKodyRulesUseCase {
                 metadata: {
                     organizationId:
                         actor?.organizationId ||
-                        this.request.user.organization.uuid,
+                        this.request?.user?.organization?.uuid,
                     ruleId,
                 },
             });

--- a/libs/kodyRules/application/use-cases/manage-imported-kody-rules.use-case.ts
+++ b/libs/kodyRules/application/use-cases/manage-imported-kody-rules.use-case.ts
@@ -1,7 +1,19 @@
 import { createLogger } from '@kodus/flow';
-import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+    BadRequestException,
+    Inject,
+    Injectable,
+    Optional,
+} from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
 
 import { OrganizationAndTeamData } from '@libs/core/infrastructure/config/types/general/organizationAndTeamData';
+import { UserRequest } from '@libs/core/infrastructure/config/types/http/user-request.type';
+import {
+    Action,
+    ResourceType,
+} from '@libs/identity/domain/permissions/enums/permissions.enum';
+import { AuthorizationService } from '@libs/identity/infrastructure/adapters/services/permissions/authorization.service';
 import { KodyRulesSyncService } from '../../infrastructure/adapters/services/kodyRulesSync.service';
 
 /**
@@ -18,7 +30,13 @@ export class ManageImportedKodyRulesUseCase {
         ManageImportedKodyRulesUseCase.name,
     );
 
-    constructor(private readonly syncService: KodyRulesSyncService) {}
+    constructor(
+        private readonly syncService: KodyRulesSyncService,
+        private readonly authorizationService: AuthorizationService,
+        @Optional()
+        @Inject(REQUEST)
+        private readonly request: UserRequest,
+    ) {}
 
     async execute(params: {
         organizationAndTeamData: OrganizationAndTeamData;
@@ -42,6 +60,19 @@ export class ManageImportedKodyRulesUseCase {
             throw new BadRequestException(
                 `action must be one of pause | resume | delete (got "${action}")`,
             );
+        }
+
+        // The endpoint guard only checks Update on kody_rules at the type
+        // level; the body's repositoryId decides WHICH repo gets bulk
+        // pause/resume/purge, so verify it against the user's assigned
+        // repositories. Machine flows (no request context) are exempt.
+        if (this.request?.user) {
+            await this.authorizationService.ensure({
+                user: this.request.user,
+                action: Action.Update,
+                resource: ResourceType.KodyRules,
+                repoIds: [repositoryId],
+            });
         }
 
         switch (action) {

--- a/test/unit/code-review/utils/pr-link-route-coverage.spec.ts
+++ b/test/unit/code-review/utils/pr-link-route-coverage.spec.ts
@@ -1,0 +1,238 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { buildKodyRuleLink } from '@libs/code-review/utils/build-kody-rule-link';
+import { buildKodyRuleAppLink } from '@libs/ee/kodyRules/utils/build-rule-link';
+import { KodyRulesStatus } from '@libs/kodyRules/domain/interfaces/kodyRules.interface';
+
+/**
+ * Every external app link Kody pastes into a PR must land on a real web
+ * route — a dead link in a PR comment is invisible to unit tests of the
+ * builders alone (they only check the string shape). This spec closes
+ * the loop: it generates every link VARIATION the backend can emit into
+ * a PR (both rule-link builders + the static links hardcoded in PR
+ * comment templates) and asserts each pathname resolves against the
+ * actual Next.js App Router tree in apps/web/src/app.
+ *
+ * If someone moves/removes a route the links depend on (e.g. the
+ * /kody-rules/[id] deep-link page), this fails at unit-test time
+ * instead of as a customer-reported dead link (see the David B /
+ * directory-scoped incident in build-kody-rule-link.ts).
+ */
+
+const APP_DIR = path.resolve(__dirname, '../../../../apps/web/src/app');
+
+const PAGE_FILE = /^page\.(tsx|jsx|ts|js)$/;
+const LAYOUT_FILE = /^layout\.(tsx|jsx|ts|js)$/;
+
+const readEntries = (dir: string) =>
+    fs.existsSync(dir) ? fs.readdirSync(dir, { withFileTypes: true }) : [];
+
+/** A directory renders a page if it has page.tsx, a route group that
+ *  does, or is a parallel-routes container (layout + @slot pages). */
+const dirRendersPage = (dir: string): boolean => {
+    const entries = readEntries(dir);
+
+    if (entries.some((e) => e.isFile() && PAGE_FILE.test(e.name))) {
+        return true;
+    }
+
+    // route groups are transparent: (group)/page.tsx serves this path
+    if (
+        entries.some(
+            (e) =>
+                e.isDirectory() &&
+                e.name.startsWith('(') &&
+                dirRendersPage(path.join(dir, e.name)),
+        )
+    ) {
+        return true;
+    }
+
+    // parallel routes: layout.tsx + at least one @slot rendering a page
+    const hasLayout = entries.some(
+        (e) => e.isFile() && LAYOUT_FILE.test(e.name),
+    );
+    if (hasLayout) {
+        return entries.some(
+            (e) =>
+                e.isDirectory() &&
+                e.name.startsWith('@') &&
+                dirRendersPage(path.join(dir, e.name)),
+        );
+    }
+
+    return false;
+};
+
+const matchSegments = (dir: string, segments: string[]): boolean => {
+    if (segments.length === 0) {
+        return dirRendersPage(dir);
+    }
+
+    const [head, ...rest] = segments;
+
+    for (const entry of readEntries(dir)) {
+        if (!entry.isDirectory()) {
+            continue;
+        }
+        const child = path.join(dir, entry.name);
+
+        // route groups don't consume a URL segment
+        if (entry.name.startsWith('(')) {
+            if (matchSegments(child, segments)) {
+                return true;
+            }
+            continue;
+        }
+
+        // parallel route slots don't map to URL segments
+        if (entry.name.startsWith('@')) {
+            continue;
+        }
+
+        const isDynamic =
+            entry.name.startsWith('[') && entry.name.endsWith(']');
+        if (entry.name === head || isDynamic) {
+            if (matchSegments(child, rest)) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+};
+
+const routeExists = (pathname: string): boolean => {
+    const segments = pathname.split('/').filter(Boolean);
+    return matchSegments(APP_DIR, segments);
+};
+
+const pathnameOf = (url: string): string => new URL(url).pathname;
+
+const BASE = 'https://app.kodus.io';
+
+describe('PR external links → web route coverage', () => {
+    it('sanity: the route matcher resolves a known route and rejects garbage', () => {
+        expect(routeExists('/settings')).toBe(true);
+        expect(routeExists('/definitely/not/a/route')).toBe(false);
+    });
+
+    describe('buildKodyRuleLink (file-level, PR-level and agent review pipelines)', () => {
+        const variations: Array<{ name: string; url: string }> = [
+            {
+                name: 'global rule, no extras',
+                url: buildKodyRuleLink(BASE, 'rule-1', {}),
+            },
+            {
+                name: 'global rule with teamId',
+                url: buildKodyRuleLink(
+                    BASE,
+                    'rule-1',
+                    { repositoryId: 'global' },
+                    { teamId: 'team-1' },
+                ),
+            },
+            {
+                name: 'repo-level rule',
+                url: buildKodyRuleLink(
+                    BASE,
+                    'rule-1',
+                    { repositoryId: '1190062595' },
+                    { teamId: 'team-1' },
+                ),
+            },
+            {
+                name: 'directory-scoped rule (David B bug shape)',
+                url: buildKodyRuleLink(
+                    BASE,
+                    'rule-1',
+                    { repositoryId: '1190062595', directoryId: 'dir-1' },
+                    { teamId: 'team-1' },
+                ),
+            },
+        ];
+
+        it.each(variations)('$name resolves to a real route', ({ url }) => {
+            expect(routeExists(pathnameOf(url))).toBe(true);
+        });
+    });
+
+    describe('buildKodyRuleAppLink (kodyRules service + MCP tools)', () => {
+        const variations: Array<{ name: string; url: string }> = [
+            {
+                name: 'active rule deep link (review-rules tab)',
+                url: buildKodyRuleAppLink({
+                    repositoryId: '1190062595',
+                    ruleId: 'rule-1',
+                    teamId: 'team-1',
+                    tab: 'review-rules',
+                    baseUrl: BASE,
+                }),
+            },
+            {
+                name: 'active memory deep link (memories tab)',
+                url: buildKodyRuleAppLink({
+                    repositoryId: 'global',
+                    ruleId: 'rule-1',
+                    tab: 'memories',
+                    baseUrl: BASE,
+                }),
+            },
+            {
+                name: 'pending rule → list page fallback',
+                url: buildKodyRuleAppLink({
+                    repositoryId: '1190062595',
+                    ruleId: 'rule-1',
+                    status: KodyRulesStatus.PENDING,
+                    tab: 'review-rules',
+                    baseUrl: BASE,
+                }),
+            },
+            {
+                name: 'missing ruleId → list page fallback',
+                url: buildKodyRuleAppLink({
+                    repositoryId: null,
+                    ruleId: undefined,
+                    tab: 'review-rules',
+                    baseUrl: BASE,
+                }),
+            },
+        ];
+
+        it.each(variations)('$name resolves to a real route', ({ url }) => {
+            expect(routeExists(pathnameOf(url))).toBe(true);
+        });
+    });
+
+    describe('static links hardcoded in PR comment templates', () => {
+        // Keep in sync with the templates; each entry names its source so a
+        // failure points straight at the comment that would ship the dead
+        // link.
+        const staticLinks: Array<{ source: string; pathname: string }> = [
+            {
+                source: 'commentManager.service.ts (review dashboard link)',
+                pathname: '/pull-requests',
+            },
+            {
+                source: 'commentManager.service.ts (configurationLink)',
+                pathname: '/settings/code-review/global/general',
+            },
+            {
+                source: 'validate-prerequisites.stage.ts (plan expired ×2)',
+                pathname: '/settings/subscription',
+            },
+            {
+                source: 'validate-prerequisites.stage.ts (BYOK missing)',
+                pathname: '/organization/byok',
+            },
+        ];
+
+        it.each(staticLinks)(
+            '$source → $pathname resolves to a real route',
+            ({ pathname }) => {
+                expect(routeExists(pathname)).toBe(true);
+            },
+        );
+    });
+});

--- a/test/unit/kodyRules/use-cases/create-or-update-inheritance-authz.use-case.spec.ts
+++ b/test/unit/kodyRules/use-cases/create-or-update-inheritance-authz.use-case.spec.ts
@@ -1,0 +1,270 @@
+import { ForbiddenException } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { ContextReferenceDetectionService } from '@libs/ai-engine/infrastructure/adapters/services/context/context-reference-detection.service';
+import { CentralizedConfigPrService } from '@libs/centralized-config/infrastructure/adapters/services/centralized-config-pr.service';
+import {
+    CONTEXT_RESOLUTION_SERVICE_TOKEN,
+    IContextResolutionService,
+} from '@libs/core/context-resolution/domain/contracts/context-resolution.service.contract';
+import { STATUS } from '@libs/core/infrastructure/config/types/database/status.type';
+import { PERMISSIONS_SERVICE_TOKEN } from '@libs/identity/domain/permissions/contracts/permissions.service.contract';
+import { Role } from '@libs/identity/domain/permissions/enums/permissions.enum';
+import { AuthorizationService } from '@libs/identity/infrastructure/adapters/services/permissions/authorization.service';
+import { PermissionsAbilityFactory } from '@libs/identity/infrastructure/adapters/services/permissions/permissionsAbility.factory';
+import { CreateOrUpdateKodyRulesUseCase } from '@libs/kodyRules/application/use-cases/create-or-update.use-case';
+import {
+    IKodyRulesService,
+    KODY_RULES_SERVICE_TOKEN,
+} from '@libs/kodyRules/domain/contracts/kodyRules.service.contract';
+import {
+    KodyRulesOrigin,
+    KodyRulesStatus,
+    KodyRulesType,
+} from '@libs/kodyRules/domain/interfaces/kodyRules.interface';
+
+jest.mock('@kodus/flow', () => ({
+    createLogger: () => ({
+        log: jest.fn(),
+        error: jest.fn(),
+        warn: jest.fn(),
+        debug: jest.fn(),
+    }),
+}));
+
+/**
+ * Inheritance-toggle authorization (issue: "Error disabling inheritance").
+ *
+ * Excluding/including a child scope from an inherited rule mutates the
+ * PARENT (e.g. global) rule document, but its effect is scoped to the
+ * toggled child. Authorizing it against the parent's repositoryId means a
+ * repo admin cannot opt their own repo out of an inherited global rule —
+ * the toggle 403s. When the ONLY change is inheritance.exclude/include,
+ * the use case must authorize against the toggled ids instead. Any other
+ * change to a global rule must keep requiring write on the parent scope.
+ *
+ * Real AuthorizationService + ability factory (only the permissions
+ * repository is mocked) so the tests prove the actual policy outcome.
+ */
+describe('CreateOrUpdateKodyRulesUseCase — inheritance toggle authz', () => {
+    const kodyRulesServiceMock = {
+        createOrUpdate: jest.fn(),
+        findById: jest.fn(),
+        updateRuleReferences: jest.fn(),
+    } as unknown as jest.Mocked<IKodyRulesService>;
+
+    const centralizedConfigPrServiceMock = {
+        createMutationPullRequestIfEnabled: jest.fn(),
+        getCentralizedRepositoryIfEnabled: jest.fn().mockResolvedValue(null),
+        resolveRepositoryFolderName: jest.fn(),
+        buildCentralizedPath: jest.fn(),
+        sanitizeFileName: jest.fn(),
+    };
+
+    // repo_admin assigned ONLY to repo-a.
+    const permissionsServiceMock = {
+        findOne: jest.fn(),
+    };
+
+    const repoAdminUser = {
+        uuid: 'user-1',
+        email: 'dev@kodus.io',
+        role: Role.REPO_ADMIN,
+        status: STATUS.ACTIVE,
+        organization: { uuid: 'org-1' },
+        team: { uuid: 'team-1' },
+    };
+
+    const ownerUser = {
+        ...repoAdminUser,
+        role: Role.OWNER,
+    };
+
+    // The global rule as stored; the toggle sends this back verbatim with
+    // only inheritance.exclude changed (mirrors handleDisableInherited in
+    // apps/web modal.tsx).
+    const existingGlobalRule = {
+        uuid: 'rule-1',
+        title: 'Avoid mixed concerns in one PR',
+        rule: 'Do not combine mechanical changes with behavioral changes.',
+        path: '',
+        severity: 'high',
+        scope: 'file',
+        status: KodyRulesStatus.ACTIVE,
+        type: KodyRulesType.STANDARD,
+        origin: KodyRulesOrigin.USER,
+        repositoryId: 'global',
+        examples: [],
+        inheritance: {
+            inheritable: true,
+            exclude: [],
+            include: [],
+        },
+    };
+
+    const toggleDto = (overrides: Record<string, unknown>) =>
+        ({
+            ...existingGlobalRule,
+            ...overrides,
+        }) as any;
+
+    const buildUseCase = async (user: Record<string, unknown>) => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                CreateOrUpdateKodyRulesUseCase,
+                AuthorizationService,
+                PermissionsAbilityFactory,
+                {
+                    provide: PERMISSIONS_SERVICE_TOKEN,
+                    useValue: permissionsServiceMock,
+                },
+                {
+                    provide: KODY_RULES_SERVICE_TOKEN,
+                    useValue: kodyRulesServiceMock,
+                },
+                {
+                    provide: CONTEXT_RESOLUTION_SERVICE_TOKEN,
+                    useValue: {
+                        getTeamIdByOrganizationAndRepository: jest.fn(),
+                        getRepositoryNameByOrganizationAndRepository:
+                            jest.fn(),
+                    } as Partial<IContextResolutionService>,
+                },
+                {
+                    provide: ContextReferenceDetectionService,
+                    useValue: { detectAndSaveReferences: jest.fn() },
+                },
+                {
+                    provide: CentralizedConfigPrService,
+                    useValue: centralizedConfigPrServiceMock,
+                },
+                {
+                    provide: REQUEST,
+                    useValue: { user },
+                },
+            ],
+        }).compile();
+
+        return module.get(CreateOrUpdateKodyRulesUseCase);
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        permissionsServiceMock.findOne.mockResolvedValue({
+            permissions: { assignedRepositoryIds: ['repo-a'] },
+        });
+        centralizedConfigPrServiceMock.getCentralizedRepositoryIfEnabled.mockResolvedValue(
+            null,
+        );
+        centralizedConfigPrServiceMock.createMutationPullRequestIfEnabled.mockResolvedValue(
+            { mode: 'direct' },
+        );
+        kodyRulesServiceMock.findById.mockResolvedValue(
+            existingGlobalRule as any,
+        );
+        kodyRulesServiceMock.createOrUpdate.mockResolvedValue({
+            ...existingGlobalRule,
+        } as any);
+    });
+
+    it('allows a repo admin to exclude their assigned repo from an inherited global rule', async () => {
+        const useCase = await buildUseCase(repoAdminUser);
+
+        const dto = toggleDto({
+            inheritance: { inheritable: true, exclude: ['repo-a'], include: [] },
+        });
+
+        await expect(useCase.execute(dto, 'org-1')).resolves.toBeDefined();
+
+        expect(kodyRulesServiceMock.createOrUpdate).toHaveBeenCalled();
+    });
+
+    it('allows a repo admin to re-enable inheritance for their assigned repo', async () => {
+        const useCase = await buildUseCase(repoAdminUser);
+        kodyRulesServiceMock.findById.mockResolvedValue({
+            ...existingGlobalRule,
+            inheritance: {
+                inheritable: true,
+                exclude: ['repo-a'],
+                include: [],
+            },
+        } as any);
+
+        const dto = toggleDto({
+            inheritance: { inheritable: true, exclude: [], include: [] },
+        });
+
+        await expect(useCase.execute(dto, 'org-1')).resolves.toBeDefined();
+
+        expect(kodyRulesServiceMock.createOrUpdate).toHaveBeenCalled();
+    });
+
+    it('denies a repo admin toggling a repository they are not assigned to', async () => {
+        const useCase = await buildUseCase(repoAdminUser);
+
+        const dto = toggleDto({
+            inheritance: { inheritable: true, exclude: ['repo-b'], include: [] },
+        });
+
+        await expect(useCase.execute(dto, 'org-1')).rejects.toThrow(
+            ForbiddenException,
+        );
+
+        expect(kodyRulesServiceMock.createOrUpdate).not.toHaveBeenCalled();
+    });
+
+    it('denies a repo admin smuggling content changes alongside the toggle', async () => {
+        const useCase = await buildUseCase(repoAdminUser);
+
+        const dto = toggleDto({
+            title: 'Changed title',
+            inheritance: { inheritable: true, exclude: ['repo-a'], include: [] },
+        });
+
+        await expect(useCase.execute(dto, 'org-1')).rejects.toThrow(
+            ForbiddenException,
+        );
+
+        expect(kodyRulesServiceMock.createOrUpdate).not.toHaveBeenCalled();
+    });
+
+    it('denies a repo admin flipping rule-wide inheritable via the toggle path', async () => {
+        const useCase = await buildUseCase(repoAdminUser);
+
+        const dto = toggleDto({
+            inheritance: { inheritable: false, exclude: ['repo-a'], include: [] },
+        });
+
+        await expect(useCase.execute(dto, 'org-1')).rejects.toThrow(
+            ForbiddenException,
+        );
+
+        expect(kodyRulesServiceMock.createOrUpdate).not.toHaveBeenCalled();
+    });
+
+    it('still denies a repo admin editing a global rule outright', async () => {
+        const useCase = await buildUseCase(repoAdminUser);
+
+        const dto = toggleDto({ title: 'New global title' });
+
+        await expect(useCase.execute(dto, 'org-1')).rejects.toThrow(
+            ForbiddenException,
+        );
+
+        expect(kodyRulesServiceMock.createOrUpdate).not.toHaveBeenCalled();
+    });
+
+    it('keeps the owner able to edit global rules and toggles alike', async () => {
+        const useCase = await buildUseCase(ownerUser);
+
+        const dto = toggleDto({
+            title: 'Owner edit',
+            inheritance: { inheritable: true, exclude: ['repo-b'], include: [] },
+        });
+
+        await expect(useCase.execute(dto, 'org-1')).resolves.toBeDefined();
+
+        expect(kodyRulesServiceMock.createOrUpdate).toHaveBeenCalled();
+    });
+});

--- a/test/unit/kodyRules/use-cases/delete-rule-in-organization-by-id.use-case.spec.ts
+++ b/test/unit/kodyRules/use-cases/delete-rule-in-organization-by-id.use-case.spec.ts
@@ -1,3 +1,4 @@
+import { ForbiddenException } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
 import { Test, TestingModule } from '@nestjs/testing';
 
@@ -5,6 +6,11 @@ import {
     CentralizedConfigPrService,
     CentralizedPrMetadata,
 } from '@libs/centralized-config/infrastructure/adapters/services/centralized-config-pr.service';
+import { STATUS } from '@libs/core/infrastructure/config/types/database/status.type';
+import { PERMISSIONS_SERVICE_TOKEN } from '@libs/identity/domain/permissions/contracts/permissions.service.contract';
+import { Role } from '@libs/identity/domain/permissions/enums/permissions.enum';
+import { AuthorizationService } from '@libs/identity/infrastructure/adapters/services/permissions/authorization.service';
+import { PermissionsAbilityFactory } from '@libs/identity/infrastructure/adapters/services/permissions/permissionsAbility.factory';
 import { DeleteRuleInOrganizationByIdKodyRulesUseCase } from '@libs/kodyRules/application/use-cases/delete-rule-in-organization-by-id.use-case';
 import {
     IKodyRulesService,
@@ -55,6 +61,10 @@ describe('DeleteRuleInOrganizationByIdKodyRulesUseCase', () => {
                 {
                     provide: CentralizedConfigPrService,
                     useValue: centralizedConfigPrServiceMock,
+                },
+                {
+                    provide: AuthorizationService,
+                    useValue: { ensure: jest.fn().mockResolvedValue(undefined) },
                 },
                 {
                     provide: REQUEST,
@@ -150,5 +160,174 @@ describe('DeleteRuleInOrganizationByIdKodyRulesUseCase', () => {
             },
         );
         expect(result).toBe(true);
+    });
+});
+
+/**
+ * Repo-scope enforcement. The controller guard (`checkPermissions`) is
+ * type-level only — it cannot know which repository the rule belongs to —
+ * so the use case must enforce it, the same contract
+ * `ChangeStatusKodyRulesUseCase` already honors via
+ * `authorizationService.ensure`. These tests wire the REAL
+ * AuthorizationService + PermissionsAbilityFactory (only the permissions
+ * repository is mocked) so they prove the actual policy outcome.
+ */
+describe('DeleteRuleInOrganizationByIdKodyRulesUseCase — repo scope', () => {
+    const kodyRulesServiceMock = {
+        findById: jest.fn(),
+        createOrUpdate: jest.fn(),
+        deleteRuleWithLogging: jest.fn(),
+    } as unknown as jest.Mocked<IKodyRulesService>;
+
+    const centralizedConfigPrServiceMock = {
+        createMutationPullRequestIfEnabled: jest.fn(),
+    };
+
+    // repo_admin assigned ONLY to repo-a.
+    const permissionsServiceMock = {
+        findOne: jest.fn(),
+    };
+
+    const repoAdminUser = {
+        uuid: 'user-1',
+        email: 'dev@kodus.io',
+        role: Role.REPO_ADMIN,
+        status: STATUS.ACTIVE,
+        organization: { uuid: 'org-1' },
+    };
+
+    const ownerUser = {
+        ...repoAdminUser,
+        role: Role.OWNER,
+    };
+
+    const buildUseCase = async (user: Record<string, unknown> | null) => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                DeleteRuleInOrganizationByIdKodyRulesUseCase,
+                AuthorizationService,
+                PermissionsAbilityFactory,
+                {
+                    provide: PERMISSIONS_SERVICE_TOKEN,
+                    useValue: permissionsServiceMock,
+                },
+                {
+                    provide: KODY_RULES_SERVICE_TOKEN,
+                    useValue: kodyRulesServiceMock,
+                },
+                {
+                    provide: CentralizedConfigPrService,
+                    useValue: centralizedConfigPrServiceMock,
+                },
+                {
+                    provide: REQUEST,
+                    useValue: user ? { user } : undefined,
+                },
+            ],
+        }).compile();
+
+        return module.get(DeleteRuleInOrganizationByIdKodyRulesUseCase);
+    };
+
+    const ruleIn = (repositoryId: string) => ({
+        uuid: 'rule-1',
+        title: 'Some rule',
+        rule: 'Do X',
+        type: KodyRulesType.STANDARD,
+        repositoryId,
+        status: KodyRulesStatus.ACTIVE,
+    });
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        permissionsServiceMock.findOne.mockResolvedValue({
+            permissions: { assignedRepositoryIds: ['repo-a'] },
+        });
+        centralizedConfigPrServiceMock.createMutationPullRequestIfEnabled.mockResolvedValue(
+            { mode: 'direct' },
+        );
+        kodyRulesServiceMock.deleteRuleWithLogging.mockResolvedValue(true);
+    });
+
+    it('denies a repo admin deleting a rule from a repository they are not assigned to', async () => {
+        const useCase = await buildUseCase(repoAdminUser);
+        kodyRulesServiceMock.findById.mockResolvedValue(
+            ruleIn('repo-b') as any,
+        );
+
+        await expect(
+            useCase.execute('rule-1', { source: 'web' }),
+        ).rejects.toThrow(ForbiddenException);
+
+        expect(
+            kodyRulesServiceMock.deleteRuleWithLogging,
+        ).not.toHaveBeenCalled();
+        expect(
+            centralizedConfigPrServiceMock.createMutationPullRequestIfEnabled,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('denies a repo admin deleting a global rule', async () => {
+        const useCase = await buildUseCase(repoAdminUser);
+        kodyRulesServiceMock.findById.mockResolvedValue(
+            ruleIn('global') as any,
+        );
+
+        await expect(
+            useCase.execute('rule-1', { source: 'web' }),
+        ).rejects.toThrow(ForbiddenException);
+
+        expect(
+            kodyRulesServiceMock.deleteRuleWithLogging,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('allows a repo admin to delete a rule in an assigned repository', async () => {
+        const useCase = await buildUseCase(repoAdminUser);
+        kodyRulesServiceMock.findById.mockResolvedValue(
+            ruleIn('repo-a') as any,
+        );
+
+        await expect(
+            useCase.execute('rule-1', { source: 'web' }),
+        ).resolves.toBe(true);
+
+        expect(kodyRulesServiceMock.deleteRuleWithLogging).toHaveBeenCalledWith(
+            { organizationId: 'org-1' },
+            'rule-1',
+            { userId: 'user-1', userEmail: 'dev@kodus.io' },
+        );
+    });
+
+    it('allows the owner to delete a rule in any repository', async () => {
+        const useCase = await buildUseCase(ownerUser);
+        kodyRulesServiceMock.findById.mockResolvedValue(
+            ruleIn('repo-b') as any,
+        );
+
+        await expect(
+            useCase.execute('rule-1', { source: 'web' }),
+        ).resolves.toBe(true);
+
+        expect(kodyRulesServiceMock.deleteRuleWithLogging).toHaveBeenCalled();
+    });
+
+    it('keeps machine sync deletions working without a request context', async () => {
+        const useCase = await buildUseCase(null);
+        kodyRulesServiceMock.findById.mockResolvedValue(
+            ruleIn('repo-b') as any,
+        );
+
+        await expect(
+            useCase.execute('rule-1', {
+                source: 'sync',
+                organizationId: 'org-1',
+                teamId: 'team-1',
+                userId: 'kody-system',
+                userEmail: 'kody@kodus.io',
+            }),
+        ).resolves.toBe(true);
+
+        expect(kodyRulesServiceMock.deleteRuleWithLogging).toHaveBeenCalled();
     });
 });

--- a/test/unit/kodyRules/use-cases/manage-imported-kody-rules.use-case.spec.ts
+++ b/test/unit/kodyRules/use-cases/manage-imported-kody-rules.use-case.spec.ts
@@ -1,0 +1,172 @@
+import { ForbiddenException } from '@nestjs/common';
+import { REQUEST } from '@nestjs/core';
+import { Test, TestingModule } from '@nestjs/testing';
+
+import { STATUS } from '@libs/core/infrastructure/config/types/database/status.type';
+import { PERMISSIONS_SERVICE_TOKEN } from '@libs/identity/domain/permissions/contracts/permissions.service.contract';
+import { Role } from '@libs/identity/domain/permissions/enums/permissions.enum';
+import { AuthorizationService } from '@libs/identity/infrastructure/adapters/services/permissions/authorization.service';
+import { PermissionsAbilityFactory } from '@libs/identity/infrastructure/adapters/services/permissions/permissionsAbility.factory';
+import { ManageImportedKodyRulesUseCase } from '@libs/kodyRules/application/use-cases/manage-imported-kody-rules.use-case';
+import { KodyRulesSyncService } from '@libs/kodyRules/infrastructure/adapters/services/kodyRulesSync.service';
+
+/**
+ * Repo-scope enforcement for `POST /kody-rules/imported/manage`.
+ *
+ * The endpoint guard only checks Update on kody_rules at the type level;
+ * the `repositoryId` in the body is what decides WHICH repo gets its
+ * IDE-synced rules paused/resumed/purged in bulk, so the use case must
+ * verify it against the user's assigned repositories. Real
+ * AuthorizationService + ability factory (only the permissions repository
+ * is mocked) so the tests prove the actual policy outcome.
+ */
+describe('ManageImportedKodyRulesUseCase — repo scope', () => {
+    const counts = { active: 0, paused: 2, deleted: 0, pinned: 0 };
+
+    const syncServiceMock = {
+        pauseAllIdeSyncRulesForRepository: jest.fn(),
+        resumeAllIdeSyncRulesForRepository: jest.fn(),
+        purgeAllIdeSyncRulesForRepository: jest.fn(),
+        countIdeSyncRulesForRepository: jest.fn().mockResolvedValue(counts),
+    };
+
+    // repo_admin assigned ONLY to repo-a.
+    const permissionsServiceMock = {
+        findOne: jest.fn(),
+    };
+
+    const repoAdminUser = {
+        uuid: 'user-1',
+        email: 'dev@kodus.io',
+        role: Role.REPO_ADMIN,
+        status: STATUS.ACTIVE,
+        organization: { uuid: 'org-1' },
+    };
+
+    const ownerUser = {
+        ...repoAdminUser,
+        role: Role.OWNER,
+    };
+
+    const organizationAndTeamData = {
+        organizationId: 'org-1',
+        teamId: 'team-1',
+    };
+
+    const buildUseCase = async (user: Record<string, unknown> | null) => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                ManageImportedKodyRulesUseCase,
+                AuthorizationService,
+                PermissionsAbilityFactory,
+                {
+                    provide: PERMISSIONS_SERVICE_TOKEN,
+                    useValue: permissionsServiceMock,
+                },
+                {
+                    provide: KodyRulesSyncService,
+                    useValue: syncServiceMock,
+                },
+                {
+                    provide: REQUEST,
+                    useValue: user ? { user } : undefined,
+                },
+            ],
+        }).compile();
+
+        return module.get(ManageImportedKodyRulesUseCase);
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        permissionsServiceMock.findOne.mockResolvedValue({
+            permissions: { assignedRepositoryIds: ['repo-a'] },
+        });
+        syncServiceMock.countIdeSyncRulesForRepository.mockResolvedValue(
+            counts,
+        );
+    });
+
+    it('denies a repo admin pausing imported rules of a repository they are not assigned to', async () => {
+        const useCase = await buildUseCase(repoAdminUser);
+
+        await expect(
+            useCase.execute({
+                organizationAndTeamData,
+                repositoryId: 'repo-b',
+                action: 'pause',
+            }),
+        ).rejects.toThrow(ForbiddenException);
+
+        expect(
+            syncServiceMock.pauseAllIdeSyncRulesForRepository,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('denies a repo admin bulk-deleting imported rules of a repository they are not assigned to', async () => {
+        const useCase = await buildUseCase(repoAdminUser);
+
+        await expect(
+            useCase.execute({
+                organizationAndTeamData,
+                repositoryId: 'repo-b',
+                action: 'delete',
+            }),
+        ).rejects.toThrow(ForbiddenException);
+
+        expect(
+            syncServiceMock.purgeAllIdeSyncRulesForRepository,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('allows a repo admin to pause imported rules of an assigned repository', async () => {
+        const useCase = await buildUseCase(repoAdminUser);
+
+        const result = await useCase.execute({
+            organizationAndTeamData,
+            repositoryId: 'repo-a',
+            action: 'pause',
+        });
+
+        expect(
+            syncServiceMock.pauseAllIdeSyncRulesForRepository,
+        ).toHaveBeenCalledWith({
+            organizationAndTeamData,
+            repositoryId: 'repo-a',
+        });
+        expect(result).toEqual({ action: 'pause', counts });
+    });
+
+    it('allows the owner to manage imported rules of any repository', async () => {
+        const useCase = await buildUseCase(ownerUser);
+
+        const result = await useCase.execute({
+            organizationAndTeamData,
+            repositoryId: 'repo-b',
+            action: 'resume',
+        });
+
+        expect(
+            syncServiceMock.resumeAllIdeSyncRulesForRepository,
+        ).toHaveBeenCalledWith({
+            organizationAndTeamData,
+            repositoryId: 'repo-b',
+        });
+        expect(result).toEqual({ action: 'resume', counts });
+    });
+
+    it('keeps machine flows working without a request context', async () => {
+        const useCase = await buildUseCase(null);
+
+        const result = await useCase.execute({
+            organizationAndTeamData,
+            repositoryId: 'repo-b',
+            action: 'pause',
+        });
+
+        expect(
+            syncServiceMock.pauseAllIdeSyncRulesForRepository,
+        ).toHaveBeenCalled();
+        expect(result).toEqual({ action: 'pause', counts });
+    });
+});


### PR DESCRIPTION
Closes #1274

## What

Security and UX fixes for the Kody Rules screen and its backend, found while investigating #1274 and the repo_admin permission reports.

### Backend — repo-scope authorization (`fix(kody-rules)`)
The kody-rules controller guards are type-level only; repo-scope enforcement is each use case's job, and three skipped it:

- **Delete by id**: any repo_admin could delete any rule in the org (other repos, global) by id. Now `ensure(Delete)` against the rule's repositoryId; sync/machine flows stay exempt.
- **`POST /kody-rules/imported/manage`**: bulk pause/resume/purge accepted any repositoryId in the body. Now `ensure(Update)` against it.
- **Inheritance toggle**: excluding your own repo from an inherited global rule writes to the global rule document, so repo_admin got 403 ("Error disabling inheritance"). When the only change is `inheritance.exclude/include`, authorization now targets the toggled repo ids; any content change still requires write on the rule's own scope.

### Frontend — `fix(web)`
- **#1274**: the card's edit/view button navigated to the sibling `/kody-rules/[id]` page (full-page skeleton on open and close, scroll lost). It now opens the modal in place, same pattern as Delete/"New rule". The `[id]` route is untouched for PR-comment/MCP deep links.
- Bulk toolbar and selection checkboxes only render with Update permission on the scope; 403s get their own toast copy instead of "try again".
- Severity heatmap chips now respect the other active filters (with `Origin: Library` the chip said "4 High" while the list showed 2).
- Help "?" tooltips no longer auto-open over the modal in view mode; buttons get `cursor: pointer`.

### Tests
- 19 new authz tests using the real `AuthorizationService` + ability factory (abuse paths included).
- New `pr-link-route-coverage.spec.ts`: every link variation Kody pastes into PRs (both builders + static template links) must resolve against the actual Next.js route tree — a moved route now fails at unit-test time instead of as a dead link.

## Validation
- 49 suites / 416 tests green (kodyRules, centralized, RBAC, links)
- Live Playwright on the local stack as owner and repo_admin: modal open/close without skeleton, inheritance toggle 403→201 round-trip, memories flow, all 7 deep-link variations + 4 static links

🤖 Generated with [Claude Code](https://claude.com/claude-code)