### PR TITLE
ci(release): Discord ping when the RC is validated and waiting promote approval

### DIFF
--- a/.github/workflows/selfhosted-build-push.yml
+++ b/.github/workflows/selfhosted-build-push.yml
@@ -712,6 +712,53 @@ jobs:
                   done < /tmp/open-shas.txt
                   echo "::notice::Cleared release-freeze-eligible to success on all open PRs (freeze OFF)"
 
+    # The happy path was SILENT: matrix goes green, promote sits waiting
+    # for 3 reviewers, and nobody knows unless they watch the run (GitHub
+    # only notifies the environment reviewers, not the Discord channel).
+    # On 2026-06-05 the validated RC waited at the gate with zero channel
+    # visibility. Fires as soon as the matrix succeeds — promote is still
+    # `waiting` at that point, so this is the "come approve it" ping.
+    # Skipped on hotfix (the gate is bypassed there; nothing to approve).
+    notify-discord-rc-ready:
+        name: Notify Discord (RC validated — waiting promote approval)
+        needs:
+            - plan-release
+            - build-and-push
+            - e2e-matrix
+        if: >-
+            !cancelled() && inputs.hotfix != true &&
+            needs.plan-release.result == 'success' &&
+            needs.build-and-push.result == 'success' &&
+            needs.e2e-matrix.result == 'success'
+        runs-on: ubuntu-latest
+        permissions: {}
+        steps:
+            - name: Check Discord webhook configuration
+              id: discord-webhook
+              run: |
+                  # Same fallback chain as the failure notifier.
+                  if [ -n "${{ secrets.DISCORD_WEBHOOK_INTERNAL || secrets.DISCORD_WEBHOOK_SELFHOSTED || secrets.DISCORD_WEBHOOK }}" ]; then
+                    echo "configured=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "configured=false" >> "$GITHUB_OUTPUT"
+                  fi
+
+            - name: Notify Discord that the RC is validated
+              if: steps.discord-webhook.outputs.configured == 'true'
+              uses: sarisia/actions-status-discord@v1.16.0
+              with:
+                  webhook: ${{ secrets.DISCORD_WEBHOOK_INTERNAL || secrets.DISCORD_WEBHOOK_SELFHOSTED || secrets.DISCORD_WEBHOOK }}
+                  content: ":white_check_mark: RC validated — **waiting promote approval**"
+                  title: "Self-Hosted RC validated (matrix green)"
+                  description: |
+                      RC tag:      `${{ needs.plan-release.outputs.rc_tag }}`
+                      Will become: `${{ needs.plan-release.outputs.release_tag }}` + `:latest`
+
+                      Full e2e matrix passed against this RC. Approve (or ignore to let it expire) at:
+                      https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+                  username: "GitHub Actions"
+                  color: 0x00cc66
+
     notify-discord-failure:
         name: Notify Discord (failure only)
         needs:


### PR DESCRIPTION
## Context

Today's release flow surfaced the gap from the other side: failures alert Discord (post-#1270), but the **happy path is silent** — rc.70 went matrix-green and sat waiting for the 3 promote reviewers with zero channel visibility. GitHub only notifies the environment reviewers (web/email), not the channel.

## Change

New `notify-discord-rc-ready` job: fires the moment `plan-release` + `build-and-push` + `e2e-matrix` are all green — promote is still `waiting` at that point — posting:

> ✅ RC validated — **waiting promote approval**
> RC tag: `selfhosted-X.Y.Z-rc.N` → will become `selfhosted-X.Y.Z` + `:latest`
> link to the approval page

- Skipped on hotfix (`inputs.hotfix == true`): the gate is bypassed there, nothing to approve.
- Same webhook fallback chain (`INTERNAL || SELFHOSTED || DISCORD_WEBHOOK`) and no-environment binding as the failure notifier (post-#1270 lessons).
- `actionlint` clean.

With this, the release lifecycle is fully observable from Discord: any phase failure alerts with the phase name; a validated RC pings for approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)