### PR TITLE
docs: add changelog page

### DIFF
--- a/docs/.mintignore
+++ b/docs/.mintignore
@@ -1,0 +1,11 @@
+# Internal planning and research notes
+PLANO_MELHORIAS_DOCS.md
+PR_CHEATSHEET.md
+README.md
+diferencas-concorrentes.md
+estudo-harness.md
+gap-analysis-harness.md
+github_issue_response.md
+
+# Source diagrams used for editing, not public docs pages
+*.excalidraw

--- a/docs/changelog/index.mdx
+++ b/docs/changelog/index.mdx
@@ -3,102 +3,172 @@ title: "Changelog"
 description: "Latest Kodus updates and improvements."
 ---
 
-export const ChangelogRelease = () => (
-  <>
-    <a id="kodus-changelog-rss-action" className="kodus-changelog-rss" href="/changelog.xml" aria-label="RSS feed">
-      <svg aria-hidden="true" viewBox="0 0 24 24">
+<a id="kodus-changelog-rss-action" className="kodus-changelog-rss" href="/changelog.xml" aria-label="RSS feed">
+    <svg aria-hidden="true" viewBox="0 0 24 24">
         <path d="M4 5.5a14.5 14.5 0 0 1 14.5 14.5" />
         <path d="M4 10.5a9.5 9.5 0 0 1 9.5 9.5" />
-        <circle cx="5" cy="19" r="1" />
-      </svg>
-    </a>
+        <path d="M5 19h.01" />
+    </svg>
+</a>
 
-    <article className="kodus-changelog-release">
-      <aside className="kodus-changelog-meta">
-        <time className="kodus-changelog-date" dateTime="2026-06-08">June 8, 2026</time>
-      </aside>
-
-    <div className="kodus-changelog-content">
-      <section className="kodus-changelog-section">
-        <h2 className="kodus-changelog-section-label">What's new</h2>
-
-        <div className="kodus-changelog-item">
-          <h3 className="kodus-changelog-title">Moonshot Kimi support for BYOK</h3>
-
-          <p className="kodus-changelog-copy">We added support for Moonshot as a provider, compatible with the Anthropic API.</p>
-
-          <p className="kodus-changelog-copy">You can now use the Kimi Coding Plan model in BYOK setups. To configure it, set the <code className="kodus-changelog-code">API_MOONSHOT_API_KEY</code> key and select the model in the organization preferences.</p>
-
-          <p className="kodus-changelog-copy">See the <a className="kodus-changelog-link" href="https://docs.kodus.io/knowledge_base/en/how-to-use-moonshot-with-kodus">Moonshot (Kimi)</a> documentation for more setup details.</p>
+<div className="kodus-changelog-shell">
+    <div className="kodus-changelog-release">
+        <div className="kodus-changelog-meta">
+            <span className="kodus-changelog-date">June 8, 2026</span>
         </div>
 
-        <div className="kodus-changelog-item">
-          <h3 className="kodus-changelog-title">Monthly token usage control</h3>
+        <div className="kodus-changelog-content">
+            <div className="kodus-changelog-section">
+                <div role="heading" aria-level="2" className="kodus-changelog-section-label">What's new</div>
 
-          <p className="kodus-changelog-copy">Organizations can now set monthly token consumption limits per model.</p>
+                <div className="kodus-changelog-item kodus-changelog-filterable filter-ai-engine filter-byok">
+                    <div role="heading" aria-level="3" className="kodus-changelog-title">Moonshot Kimi support for BYOK</div>
+                    <p className="kodus-changelog-copy">We added support for Moonshot as a provider, compatible with the Anthropic API.</p>
+                    <p className="kodus-changelog-copy">You can now use the Kimi Coding Plan model in BYOK setups. To configure it, set the <code className="kodus-changelog-code">API_MOONSHOT_API_KEY</code> key and select the model in the organization preferences.</p>
+                    <p className="kodus-changelog-copy">See the <a className="kodus-changelog-link" href="https://docs.kodus.io/knowledge_base/en/how-to-use-moonshot-with-kodus">Moonshot (Kimi)</a> documentation for more setup details.</p>
+                </div>
 
-          <p className="kodus-changelog-copy">Usage is shown in real time in the interface, with a progress bar. When usage reaches 80% of the limit, the team receives an email alert. If the limit is reached, additional reviews can be blocked automatically.</p>
+                <div className="kodus-changelog-item kodus-changelog-filterable filter-byok">
+                    <div role="heading" aria-level="3" className="kodus-changelog-title">Monthly token usage control</div>
+                    <p className="kodus-changelog-copy">Organizations can now set monthly token consumption limits per model.</p>
+                    <p className="kodus-changelog-copy">Usage is shown in real time in the interface, with a progress bar. When usage reaches 80% of the limit, the team receives an email alert. If the limit is reached, additional reviews can be blocked automatically.</p>
+                    <video autoPlay loop muted playsInline preload="auto" className="kodus-changelog-video">
+                        <source src="/videos/token-usage.mp4" type="video/mp4" />
+                    </video>
+                    <p className="kodus-changelog-copy">See the <a className="kodus-changelog-link" href="https://docs.kodus.io/how_to_use/en/spend-limit">Monthly Spend Limit</a> documentation for more setup details.</p>
+                </div>
+            </div>
 
-          <video autoPlay loop muted playsInline preload="auto" className="kodus-changelog-video">
-            <source src="/videos/token-usage.mp4" type="video/mp4" />
-          </video>
+            <div className="kodus-changelog-section">
+                <div role="heading" aria-level="2" className="kodus-changelog-section-label">Improvements</div>
 
-          <p className="kodus-changelog-copy">See the <a className="kodus-changelog-link" href="https://docs.kodus.io/how_to_use/en/spend-limit">Monthly Spend Limit</a> documentation for more setup details.</p>
+                <div className="kodus-changelog-item kodus-changelog-filterable filter-ai-engine">
+                    <div role="heading" aria-level="3" className="kodus-changelog-title">More resilient review agent</div>
+                    <p className="kodus-changelog-copy">The review engine now handles empty or malformed LLM responses better.</p>
+                    <p className="kodus-changelog-copy">This reduces loops in edge cases and helps ensure valid suggestions continue to be delivered even when the provider returns an unexpected response.</p>
+                </div>
+
+                <div className="kodus-changelog-item kodus-changelog-filterable filter-self-hosted">
+                    <div role="heading" aria-level="3" className="kodus-changelog-title">Telemetry for self-hosted environments</div>
+                    <p className="kodus-changelog-copy">On-premise installations now automatically report health metrics, such as heartbeat, and usage data.</p>
+                    <p className="kodus-changelog-copy">The goal is to make diagnosis and support easier without exposing sensitive customer data.</p>
+                </div>
+
+                <div className="kodus-changelog-item kodus-changelog-filterable filter-ai-engine">
+                    <div role="heading" aria-level="3" className="kodus-changelog-title">Faster Kody Rules</div>
+                    <p className="kodus-changelog-copy">We improved the loading and synchronization of custom rules.</p>
+                    <p className="kodus-changelog-copy">We also fixed the count of orphaned rules and made partial updates safer against race conditions.</p>
+                </div>
+
+                <div className="kodus-changelog-item kodus-changelog-filterable filter-git-provider">
+                    <div role="heading" aria-level="3" className="kodus-changelog-title">GitLab compatibility improvements</div>
+                    <ul className="kodus-changelog-list">
+                        <li>Support for GitLab 13.x in comment webhooks</li>
+                        <li>Diff fallback for versions earlier than 15.7</li>
+                        <li>Fixes for discussion threads and replies scoped by discussionId</li>
+                        <li>Self-hosted development environment documentation</li>
+                    </ul>
+                </div>
+            </div>
+
+            <div className="kodus-changelog-section">
+                <div role="heading" aria-level="2" className="kodus-changelog-section-label">Fixes</div>
+
+                <div className="kodus-changelog-fix-list">
+                    <div className="kodus-changelog-fix kodus-changelog-filterable filter-git-provider filter-security">
+                        <p className="kodus-changelog-copy"><strong className="kodus-changelog-fix-label">GitHub:</strong> suspended users no longer appear in the member list for license assignment.</p>
+                    </div>
+
+                    <div className="kodus-changelog-fix kodus-changelog-filterable filter-git-provider">
+                        <p className="kodus-changelog-copy"><strong className="kodus-changelog-fix-label">Update Connection:</strong> integration reauthentication now correctly clears the previous configuration.</p>
+                    </div>
+
+                    <div className="kodus-changelog-fix kodus-changelog-filterable filter-ai-engine">
+                        <p className="kodus-changelog-copy"><strong className="kodus-changelog-fix-label">Integration reset:</strong> Kody Rules linked to the repo/directory are now removed automatically.</p>
+                    </div>
+
+                    <div className="kodus-changelog-fix kodus-changelog-filterable">
+                        <p className="kodus-changelog-copy"><strong className="kodus-changelog-fix-label">Release Freeze:</strong> eligibility notifications only appear when the freeze is active.</p>
+                    </div>
+                </div>
+            </div>
+
+            <p className="kodus-changelog-empty">No changelog entries for this filter yet.</p>
         </div>
-      </section>
 
-      <section className="kodus-changelog-section">
-        <h2 className="kodus-changelog-section-label">Improvements</h2>
-
-        <div className="kodus-changelog-item">
-          <h3 className="kodus-changelog-title">More resilient review agent</h3>
-
-          <p className="kodus-changelog-copy">The review engine now handles empty or malformed LLM responses better.</p>
-
-          <p className="kodus-changelog-copy">This reduces loops in edge cases and helps ensure valid suggestions continue to be delivered even when the provider returns an unexpected response.</p>
+        <div className="kodus-changelog-filter-sidebar">
+            <div className="kodus-changelog-filter-panel" aria-label="Changelog filters">
+                <p className="kodus-changelog-filter-heading">Filters</p>
+                <div className="kodus-changelog-filter-options">
+                    <label className="kodus-changelog-filter-button">
+                        <input className="kodus-changelog-filter-control" type="checkbox" id="kodus-filter-security" />
+                        <span>Security</span>
+                    </label>
+                    <label className="kodus-changelog-filter-button">
+                        <input className="kodus-changelog-filter-control" type="checkbox" id="kodus-filter-byok" />
+                        <span>BYOK</span>
+                    </label>
+                    <label className="kodus-changelog-filter-button">
+                        <input className="kodus-changelog-filter-control" type="checkbox" id="kodus-filter-ai-engine" />
+                        <span>AI Engine</span>
+                    </label>
+                    <label className="kodus-changelog-filter-button">
+                        <input className="kodus-changelog-filter-control" type="checkbox" id="kodus-filter-self-hosted" />
+                        <span>Self-hosted</span>
+                    </label>
+                    <label className="kodus-changelog-filter-button">
+                        <input className="kodus-changelog-filter-control" type="checkbox" id="kodus-filter-git-provider" />
+                        <span>Git Provider</span>
+                    </label>
+                </div>
+            </div>
         </div>
-
-        <div className="kodus-changelog-item">
-          <h3 className="kodus-changelog-title">Telemetry for self-hosted environments</h3>
-
-          <p className="kodus-changelog-copy">On-premise installations now automatically report health metrics, such as heartbeat, and usage data.</p>
-
-          <p className="kodus-changelog-copy">The goal is to make diagnosis and support easier without exposing sensitive customer data.</p>
-        </div>
-
-        <div className="kodus-changelog-item">
-          <h3 className="kodus-changelog-title">Faster Kody Rules</h3>
-
-          <p className="kodus-changelog-copy">We improved the loading and synchronization of custom rules.</p>
-
-          <p className="kodus-changelog-copy">We also fixed the count of orphaned rules and made partial updates safer against race conditions.</p>
-        </div>
-
-        <div className="kodus-changelog-item">
-          <h3 className="kodus-changelog-title">GitLab compatibility improvements</h3>
-
-          <ul className="kodus-changelog-list">
-            <li>Support for GitLab 13.x in comment webhooks</li>
-            <li>Diff fallback for versions earlier than 15.7</li>
-            <li>Fixes for discussion threads and replies scoped by discussionId</li>
-            <li>Self-hosted development environment documentation</li>
-          </ul>
-        </div>
-      </section>
-
-      <section className="kodus-changelog-section">
-        <h2 className="kodus-changelog-section-label">Fixes</h2>
-
-        <ul className="kodus-changelog-list">
-          <li>GitHub: suspended users no longer appear in the member list for license assignment.</li>
-          <li>Update Connection: integration reauthentication now correctly clears the previous configuration.</li>
-          <li>Integration reset: Kody Rules linked to the repo/directory are now removed automatically.</li>
-          <li>Release Freeze: eligibility notifications only appear when the freeze is active.</li>
-        </ul>
-      </section>
     </div>
-    </article>
-  </>
-);
+</div>
 
-<ChangelogRelease />
+<script>
+{`
+(() => {
+    const filterSelector = ".kodus-changelog-filter-control";
+    const itemSelector = ".kodus-changelog-filterable";
+    const sectionSelector = ".kodus-changelog-section";
+
+    const applyChangelogFilters = () => {
+        const root = document.querySelector(".kodus-changelog-shell");
+
+        if (!root) {
+            return;
+        }
+
+        const selectedFilters = Array.from(root.querySelectorAll(filterSelector))
+            .filter((input) => input.checked)
+            .map((input) => input.id.replace("kodus-filter-", "filter-"));
+
+        const isFiltered = selectedFilters.length > 0;
+
+        root.querySelectorAll(filterSelector).forEach((input) => {
+            input.closest(".kodus-changelog-filter-button")?.classList.toggle("is-selected", input.checked);
+        });
+
+        root.querySelectorAll(itemSelector).forEach((item) => {
+            const shouldShow = !isFiltered || selectedFilters.some((filter) => item.classList.contains(filter));
+            item.hidden = !shouldShow;
+        });
+
+        root.querySelectorAll(sectionSelector).forEach((section) => {
+            const hasVisibleItems = Array.from(section.querySelectorAll(itemSelector)).some((item) => !item.hidden);
+            section.hidden = isFiltered && !hasVisibleItems;
+        });
+    };
+
+    document.addEventListener("change", (event) => {
+        if (event.target.matches(filterSelector)) {
+            applyChangelogFilters();
+        }
+    });
+
+    window.addEventListener("pageshow", applyChangelogFilters);
+    requestAnimationFrame(applyChangelogFilters);
+})();
+`}
+</script>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -29,8 +29,7 @@
                                 "group": "Getting Started",
                                 "pages": [
                                     "how_to_use/en/overview",
-                                    "how_to_use/en/quickstart",
-                                    "changelog/index"
+                                    "how_to_use/en/quickstart"
                                 ]
                             },
                             {
@@ -323,8 +322,7 @@
                                 "group": "Comenzando",
                                 "pages": [
                                     "how_to_use/es/overview",
-                                    "how_to_use/es/quickstart",
-                                    "changelog/index"
+                                    "how_to_use/es/quickstart"
                                 ]
                             },
                             {
@@ -616,8 +614,7 @@
                                 "group": "Primeiros Passos",
                                 "pages": [
                                     "how_to_use/pt-br/overview",
-                                    "how_to_use/pt-br/quickstart",
-                                    "changelog/index"
+                                    "how_to_use/pt-br/quickstart"
                                 ]
                             },
                             {
@@ -909,8 +906,7 @@
                                 "group": "はじめに",
                                 "pages": [
                                     "how_to_use/ja/overview",
-                                    "how_to_use/ja/quickstart",
-                                    "changelog/index"
+                                    "how_to_use/ja/quickstart"
                                 ]
                             },
                             {
@@ -1202,8 +1198,7 @@
                                 "group": "快速开始",
                                 "pages": [
                                     "how_to_use/zh/overview",
-                                    "how_to_use/zh/quickstart",
-                                    "changelog/index"
+                                    "how_to_use/zh/quickstart"
                                 ]
                             },
                             {

--- a/docs/style.css
+++ b/docs/style.css
@@ -6,6 +6,24 @@ body:has(.kodus-changelog-release) div.ml-4.flex.text-sm.leading-6.whitespace-no
     display: none;
 }
 
+body:has(.kodus-changelog-release) #content-side-layout,
+body:has(.kodus-changelog-release) #table-of-contents-layout,
+body:has(.kodus-changelog-release) #table-of-contents {
+    display: none !important;
+}
+
+body:has(.kodus-changelog-release) #content-container {
+    max-width: none !important;
+    padding-right: 24rem !important;
+}
+
+body:has(.kodus-changelog-release) #content-area {
+    width: 100% !important;
+    max-width: 54rem !important;
+    margin-right: auto !important;
+    margin-left: 0 !important;
+}
+
 body:has(.kodus-changelog-release) header a[href*="changelog"] {
     position: relative;
     color: #faf8f6 !important;
@@ -42,8 +60,8 @@ header a[href*="changelog"]:hover svg {
 
 .kodus-changelog-release {
     display: grid;
-    grid-template-columns: minmax(8rem, 10rem) minmax(0, 1fr);
-    column-gap: 2.5rem;
+    grid-template-columns: minmax(6.5rem, 8rem) minmax(0, 36rem);
+    column-gap: 1.75rem;
     align-items: start;
     margin-top: 2.5rem;
     padding-top: 2rem;
@@ -109,6 +127,132 @@ header a[href*="changelog"]:hover svg {
 
 .kodus-changelog-content {
     min-width: 0;
+    max-width: 36rem;
+}
+
+.kodus-changelog-shell {
+    position: relative;
+}
+
+.kodus-changelog-filter-panel {
+    margin-top: 0;
+}
+
+.kodus-changelog-filter-control {
+    position: absolute;
+    inset: 0;
+    z-index: 1;
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    appearance: none;
+    border: 1px solid transparent;
+    border-radius: inherit;
+    background: transparent;
+    cursor: pointer;
+}
+
+.kodus-changelog-filter-sidebar {
+    position: fixed;
+    top: 12rem;
+    right: max(2rem, calc((100vw - 88rem) / 2 + 2rem));
+    width: 20rem;
+    z-index: 9999;
+    pointer-events: auto;
+}
+
+.kodus-changelog-filter-heading {
+    margin: 0 0 0.7rem;
+    color: #faf8f6;
+    font: inherit;
+    font-size: 0.78em;
+    font-weight: 600;
+    line-height: 1.2;
+}
+
+.kodus-changelog-filter-options {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+}
+
+.kodus-changelog-filter-button {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    min-height: 1.85rem;
+    border: 0;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.06);
+    color: inherit;
+    cursor: pointer;
+    padding: 0.24rem 0.78rem;
+    font: inherit;
+    font-size: 0.78em;
+    font-weight: 500;
+    line-height: 1;
+    white-space: nowrap;
+    user-select: none;
+    overflow: hidden;
+    transition:
+        background-color 140ms ease,
+        color 140ms ease;
+}
+
+.kodus-changelog-filter-button span {
+    position: relative;
+    z-index: 2;
+    pointer-events: none;
+}
+
+.kodus-changelog-filter-button:hover .kodus-changelog-filter-control:not(:checked) {
+    background: rgba(248, 183, 109, 0.12);
+}
+
+.kodus-changelog-filter-button:hover span {
+    color: #f8b76d;
+}
+
+.kodus-changelog-filter-button.is-selected,
+.kodus-changelog-filter-button:has(.kodus-changelog-filter-control:checked) {
+    border-color: rgba(248, 183, 109, 0.22) !important;
+    background: rgba(248, 183, 109, 0.14) !important;
+    color: #f8b76d !important;
+}
+
+.kodus-changelog-filter-control:checked {
+    border-color: rgba(248, 183, 109, 0.22) !important;
+    background: rgba(248, 183, 109, 0.14) !important;
+}
+
+.kodus-changelog-filter-control:checked + span {
+    color: #f8b76d !important;
+}
+
+.kodus-changelog-shell:has(.kodus-changelog-filter-control:checked) .kodus-changelog-filterable,
+.kodus-changelog-shell:has(.kodus-changelog-filter-control:checked) .kodus-changelog-section {
+    display: none;
+}
+
+.kodus-changelog-shell:has(#kodus-filter-security:checked) .filter-security,
+.kodus-changelog-shell:has(#kodus-filter-byok:checked) .filter-byok,
+.kodus-changelog-shell:has(#kodus-filter-ai-engine:checked) .filter-ai-engine,
+.kodus-changelog-shell:has(#kodus-filter-self-hosted:checked) .filter-self-hosted,
+.kodus-changelog-shell:has(#kodus-filter-git-provider:checked) .filter-git-provider,
+.kodus-changelog-shell:has(#kodus-filter-security:checked) .kodus-changelog-section:has(.filter-security),
+.kodus-changelog-shell:has(#kodus-filter-byok:checked) .kodus-changelog-section:has(.filter-byok),
+.kodus-changelog-shell:has(#kodus-filter-ai-engine:checked) .kodus-changelog-section:has(.filter-ai-engine),
+.kodus-changelog-shell:has(#kodus-filter-self-hosted:checked) .kodus-changelog-section:has(.filter-self-hosted),
+.kodus-changelog-shell:has(#kodus-filter-git-provider:checked) .kodus-changelog-section:has(.filter-git-provider) {
+    display: block;
+}
+
+.kodus-changelog-empty {
+    display: none;
+    margin: 0;
+    color: inherit;
+    font: inherit;
+    line-height: inherit;
 }
 
 .kodus-changelog-section + .kodus-changelog-section {
@@ -188,10 +332,62 @@ header a[href*="changelog"]:hover svg {
     margin-top: 0.5rem;
 }
 
-@container columns-container (max-width: 42rem) {
+.kodus-changelog-fix-list {
+    margin-top: 0.85rem;
+}
+
+.kodus-changelog-fix {
+    padding-left: 1.25rem;
+    position: relative;
+}
+
+.kodus-changelog-fix .kodus-changelog-copy {
+    margin-top: 0;
+}
+
+.kodus-changelog-fix-label {
+    color: #ffffff;
+    font-weight: 700;
+}
+
+.kodus-changelog-fix::before {
+    content: "";
+    position: absolute;
+    top: 0.75em;
+    left: 0.15rem;
+    width: 0.35rem;
+    height: 0.35rem;
+    border-radius: 999px;
+    background: currentColor;
+    opacity: 0.68;
+}
+
+.kodus-changelog-fix + .kodus-changelog-fix {
+    margin-top: 1.1rem;
+}
+
+@media (max-width: 1120px) {
     .kodus-changelog-release {
         grid-template-columns: 6.5rem minmax(0, 1fr);
         column-gap: 1.25rem;
+    }
+
+    .kodus-changelog-filter-sidebar {
+        grid-column: 1 / -1;
+        grid-row: 1;
+        position: static;
+        margin-bottom: 1.5rem;
+        width: auto;
+    }
+
+    .kodus-changelog-meta {
+        grid-column: 1;
+        grid-row: 2;
+    }
+
+    .kodus-changelog-content {
+        grid-column: 2;
+        grid-row: 2;
     }
 
     .kodus-changelog-rss {
@@ -202,6 +398,10 @@ header a[href*="changelog"]:hover svg {
 
 @media (prefers-color-scheme: light) {
     .kodus-changelog-title {
+        color: #111827;
+    }
+
+    .kodus-changelog-fix-label {
         color: #111827;
     }
 }


### PR DESCRIPTION
## Summary
- add the public changelog page with the June 8, 2026 release notes
- add RSS link and changelog XML feed
- add right-side multi-select changelog filters and remove the page from the docs side menu

## Validation
- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('docs/docs.json','utf8')); console.log('docs.json ok')"`
- local Mintlify preview at `http://localhost:3021/changelog`