### PR TITLE
test(e2e): round-robin GitHub cells across a bot-account token pool

### DIFF
--- a/.github/workflows/e2e-cloud.yml
+++ b/.github/workflows/e2e-cloud.yml
@@ -216,6 +216,11 @@ jobs:
                   # Provider tokens — cells without the right token are
                   # skipped (target.sh passes --skip-missing-tokens).
                   GH_TEST_TOKEN: ${{ secrets.GH_TEST_TOKEN }}
+                  # Extra bot-account tokens for the round-robin pool (see
+                  # tests/e2e/lib/github-token-pool.ts). Optional — the pool
+                  # collapses to GH_TEST_TOKEN alone when these are unset.
+                  GH_TEST_TOKEN_2: ${{ secrets.GH_TEST_TOKEN_2 }}
+                  GH_TEST_TOKEN_3: ${{ secrets.GH_TEST_TOKEN_3 }}
                   GH_TEST_REPO: ${{ secrets.GH_TEST_REPO }}
                   GH_TEST_REPO_CLOUD: ${{ secrets.GH_TEST_REPO_CLOUD }}
                   GH_TEST_PR_NUMBER: ${{ secrets.GH_TEST_PR_NUMBER }}

--- a/tests/e2e/lib/__tests__/github-token-pool.test.ts
+++ b/tests/e2e/lib/__tests__/github-token-pool.test.ts
@@ -1,0 +1,57 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+
+import {
+    githubTokenPool,
+    makeGithubTokenPicker,
+} from "../github-token-pool.js";
+
+const env = (o: Record<string, string>) => o as NodeJS.ProcessEnv;
+
+test("collapses to a single token when only GH_TEST_TOKEN is set", () => {
+    assert.deepEqual(githubTokenPool(env({ GH_TEST_TOKEN: "a" })), ["a"]);
+});
+
+test("collects numbered siblings GH_TEST_TOKEN_2..N in order", () => {
+    assert.deepEqual(
+        githubTokenPool(
+            env({ GH_TEST_TOKEN: "a", GH_TEST_TOKEN_2: "b", GH_TEST_TOKEN_3: "c" }),
+        ),
+        ["a", "b", "c"],
+    );
+});
+
+test("GH_TEST_TOKENS list takes precedence and splits on comma/space/newline", () => {
+    assert.deepEqual(
+        githubTokenPool(
+            env({ GH_TEST_TOKENS: "x, y\nz", GH_TEST_TOKEN: "ignored" }),
+        ),
+        ["x", "y", "z"],
+    );
+});
+
+test("dedupes repeated tokens (same secret pasted twice)", () => {
+    assert.deepEqual(
+        githubTokenPool(env({ GH_TEST_TOKEN: "a", GH_TEST_TOKEN_2: "a" })),
+        ["a"],
+    );
+});
+
+test("empty env yields an empty pool (picker returns no token)", () => {
+    assert.deepEqual(githubTokenPool(env({})), []);
+    assert.deepEqual(makeGithubTokenPicker(env({}))(), {
+        token: undefined,
+        slot: 0,
+        size: 0,
+    });
+});
+
+test("picker round-robins tokens and reports a 1-based slot", () => {
+    const pick = makeGithubTokenPicker(
+        env({ GH_TEST_TOKEN: "a", GH_TEST_TOKEN_2: "b", GH_TEST_TOKEN_3: "c" }),
+    );
+    assert.deepEqual(
+        [pick(), pick(), pick(), pick()].map((a) => `${a.token}:${a.slot}/${a.size}`),
+        ["a:1/3", "b:2/3", "c:3/3", "a:1/3"],
+    );
+});

--- a/tests/e2e/lib/github-token-pool.ts
+++ b/tests/e2e/lib/github-token-pool.ts
@@ -1,0 +1,72 @@
+/**
+ * GitHub e2e token pool.
+ *
+ * GitHub's rate limits — both the 5k/h primary budget and (worse for us) the
+ * per-account *secondary* limits on content creation (branches/PRs/comments) —
+ * are charged PER ACCOUNT. The matrix runs ~dozens of GitHub cells through a
+ * single bot token, so one account's budget is the ceiling for the whole run;
+ * when it trips we get `HTTP 403` / opaque `items is not iterable` failures.
+ *
+ * Spreading the cells across several bot accounts multiplies both budgets
+ * linearly. This module just resolves the available tokens; the runner does
+ * the round-robin assignment per GitHub cell.
+ *
+ * Sources, in priority order:
+ *   1. `GH_TEST_TOKENS` — a single secret holding a comma/space/newline list
+ *      (easiest to manage as one secret).
+ *   2. `GH_TEST_TOKEN` + `GH_TEST_TOKEN_2..N` — the base token plus numbered
+ *      siblings, one per extra bot account.
+ *
+ * Always backward compatible: with only `GH_TEST_TOKEN` set, the pool is a
+ * single token and behaviour is identical to before.
+ */
+
+const MAX_NUMBERED = 9;
+
+function dedupe(tokens: string[]): string[] {
+    return [...new Set(tokens.map((t) => t.trim()).filter(Boolean))];
+}
+
+export function githubTokenPool(
+    env: NodeJS.ProcessEnv = process.env,
+): string[] {
+    const list = env.GH_TEST_TOKENS?.split(/[\s,]+/);
+    if (list && dedupe(list).length > 0) {
+        return dedupe(list);
+    }
+
+    const numbered: string[] = [];
+    if (env.GH_TEST_TOKEN) numbered.push(env.GH_TEST_TOKEN);
+    for (let i = 2; i <= MAX_NUMBERED; i++) {
+        const v = env[`GH_TEST_TOKEN_${i}`];
+        if (v) numbered.push(v);
+    }
+    return dedupe(numbered);
+}
+
+export interface GithubTokenAssignment {
+    /** The token to use, or undefined when no pool is configured (caller
+     *  falls back to the provider's own requireEnv("GH_TEST_TOKEN")). */
+    token: string | undefined;
+    /** 1-based slot for logging (0 when the pool is empty). */
+    slot: number;
+    /** Pool size — `size > 1` is the only case worth logging. */
+    size: number;
+}
+
+/**
+ * Round-robin picker over the pool. Returns the next assignment (token + slot)
+ * each call, so the runner can both use the token and log WHICH account it
+ * rotated to (the slot, never the secret).
+ */
+export function makeGithubTokenPicker(
+    env: NodeJS.ProcessEnv = process.env,
+): () => GithubTokenAssignment {
+    const pool = githubTokenPool(env);
+    let i = 0;
+    return () => {
+        if (!pool.length) return { token: undefined, slot: 0, size: 0 };
+        const slot = i++ % pool.length;
+        return { token: pool[slot], slot: slot + 1, size: pool.length };
+    };
+}

--- a/tests/e2e/lib/runner.ts
+++ b/tests/e2e/lib/runner.ts
@@ -14,6 +14,7 @@ import type {
 } from "./types.js";
 import { ScenarioSkipError } from "./types.js";
 import { makeProvider } from "../providers/index.js";
+import { makeGithubTokenPicker } from "./github-token-pool.js";
 import {
     finishOnboarding,
     login,
@@ -420,6 +421,10 @@ export async function runMatrix(opts: RunOptions): Promise<RunOutcome> {
         }
     }
 
+    // Round-robins GitHub cells across the bot-account token pool so no single
+    // account's rate limit caps the run (no-op with a single token).
+    const pickGithubToken = makeGithubTokenPicker();
+
     for (const cell of opts.cells) {
         if (cell.target !== opts.target) continue;
 
@@ -463,6 +468,18 @@ export async function runMatrix(opts: RunOptions): Promise<RunOutcome> {
 
             log.info(`RUN   ${cellLabel}`);
 
+            // Assign this GitHub run a token from the bot-account pool
+            // (round-robin). Same token across both attempts so a retry stays
+            // on the same account; other cells keep draining the other tokens.
+            const ghAssignment =
+                cell.provider === "github" ? pickGithubToken() : undefined;
+            const githubToken = ghAssignment?.token;
+            if (ghAssignment && ghAssignment.size > 1) {
+                log.info(
+                    `  github → token slot ${ghAssignment.slot}/${ghAssignment.size}`,
+                );
+            }
+
             // One automatic retry for TRANSIENT failure shapes (lost
             // webhook, provider hiccup, network) — see isTransientFailure.
             // Deterministic assertion mismatches ("expected deny, got
@@ -477,6 +494,7 @@ export async function runMatrix(opts: RunOptions): Promise<RunOutcome> {
                         cell.provider,
                         cell.target,
                         tenant?.repoFullName,
+                        githubToken,
                     );
                     const scenarioArtifactDir = join(
                         artifactDir,

--- a/tests/e2e/providers/github.ts
+++ b/tests/e2e/providers/github.ts
@@ -47,9 +47,16 @@ export class GitHubProvider extends BaseProvider {
     protected readonly apiBase = "https://api.github.com";
     protected readonly existingPrNumber?: number;
 
-    constructor(opts?: { repoOverride?: string; target?: Target }) {
+    constructor(opts?: {
+        repoOverride?: string;
+        target?: Target;
+        tokenOverride?: string;
+    }) {
         super();
-        this.token = requireEnv("GH_TEST_TOKEN");
+        // tokenOverride is the round-robin token the matrix runner assigns
+        // from the bot-account pool (see lib/github-token-pool.ts). Falls back
+        // to the single GH_TEST_TOKEN when no pool is configured.
+        this.token = opts?.tokenOverride || requireEnv("GH_TEST_TOKEN");
         // Subclasses (notably GitHubAppProvider) need to target a
         // DIFFERENT repo than the PAT-driven default — the GitHub App
         // is installed scope-limited to that other repo, so any PR we

--- a/tests/e2e/providers/index.ts
+++ b/tests/e2e/providers/index.ts
@@ -15,14 +15,23 @@ import { GitLabProvider } from "./gitlab.js";
 // shared repo never fans a webhook out across multiple orgs. Only the
 // GitHub PAT provider honours it; the others are already 1 org : 1 repo
 // on cloud and ignore it, and github-app is pinned to its App-bound repo.
+// `githubToken` overrides the GitHub PAT for this provider instance — the
+// matrix runner round-robins it across the bot-account pool so no single
+// account's rate limit caps the whole run (see lib/github-token-pool.ts).
+// Ignored by the non-GitHub providers and by github-app (installation auth).
 export function makeProvider(
     name: ProviderName,
     target: Target = "self-hosted",
     repoOverride?: string,
+    githubToken?: string,
 ): Provider {
     switch (name) {
         case "github":
-            return new GitHubProvider({ target, repoOverride });
+            return new GitHubProvider({
+                target,
+                repoOverride,
+                tokenOverride: githubToken,
+            });
         case "github-app":
             // App variant is cloud-only and pinned to its own App-bound repo
             // (GH_APP_TEST_REPO), so it's already repo-independent.


### PR DESCRIPTION
## Why

GitHub rate limits are charged **per account** — the 5k/h primary budget and, worse for us, the **secondary** limits on content creation (branches/PRs/comments). The whole cloud matrix runs its GitHub cells through a **single** bot token (`GH_TEST_TOKEN`), so one account's budget is the ceiling for the entire run. When it trips we get `HTTP 403` and the opaque `items is not iterable` (an unguarded PR-comment fetch on a rate-limited response) — exactly the P0 gating failures we've been seeing on `license-attribution` / `trial-managed-review`.

## What

Round-robin the GitHub cells across a **pool of bot accounts**, splitting both budgets linearly.

- `tests/e2e/lib/github-token-pool.ts` (new): resolves the pool from `GH_TEST_TOKENS` (single comma/space/newline list) **or** `GH_TEST_TOKEN` + `GH_TEST_TOKEN_2..N`; round-robin picker reports the **slot** (for logging, never the token).
- `lib/runner.ts`: each GitHub cell gets the next token (same token across the single retry, so a retry stays on the same account); logs `github → token slot i/N`.
- `makeProvider` → `GitHubProvider` gain an optional `tokenOverride` (falls back to `requireEnv("GH_TEST_TOKEN")`).
- `e2e-cloud.yml`: passes `GH_TEST_TOKEN_2/3` as env.
- Unit test for the pool/picker.

**Backward compatible:** with only `GH_TEST_TOKEN` set, the pool collapses to one token and behaviour is identical.

## Provisioning (operational — required for the pool to engage)

For each extra bot account:
1. The bot user must be a **member of the `kodus-e2e` org** (the Kodus integration binds to `orgs[0]`, so its first org must be `kodus-e2e`).
2. Fine-grained PAT: **resource owner `kodus-e2e`**, **Repository access: All repositories**, permissions **Contents / Pull requests / Issues / Webhooks = Read & write** (Metadata read is implicit). Classic equivalent: `repo` + `admin:repo_hook`. No org Administration needed — repo creation stays on `GH_REPO_ADMIN_TOKEN`.
3. Store as repo secrets `GH_TEST_TOKEN_2`, `GH_TEST_TOKEN_3` on `kodustech/kodus-ai` (NOT the QA environment — repo-level, same as `GH_TEST_TOKEN`).

## Verify after merge

Dispatch the cloud matrix and check the log for the rotation (`github → token slot 1/2`, `2/2`, …) and that the `403` / `items is not iterable` cells drop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)