### PR TITLE
fix(boot): serialize prod migrations across replicas (advisory lock)

### DIFF
--- a/docker/prod-entrypoint.sh
+++ b/docker/prod-entrypoint.sh
@@ -52,27 +52,39 @@ RUN_MIGRATIONS="${RUN_MIGRATIONS:-false}"
 RUN_SEEDS="${RUN_SEEDS:-false}"
 
 if [ "$RUN_MIGRATIONS" = "true" ]; then
-  echo "▶ Running OLTP migrations (PROD)..."
-  # Use node with compiled migrations in prod
-  if [ -f "dist/libs/core/infrastructure/database/typeorm/ormconfig.js" ]; then
-      npm run migration:run:prod
+  # Run OLTP + analytics migrations under a Postgres advisory lock so the
+  # replicas that share this entrypoint (api / worker / webhooks) don't run
+  # them concurrently. Without serialization they race on CREATE TYPE
+  # (duplicate key pg_type_typname_nsp_index) -> migration fails -> set -e
+  # crashes the container -> CrashLoopBackOff churns the boot and the analytics
+  # warehouse (migrated after OLTP) is left uncreated -> /cockpit/validate 500.
+  if [ -f "scripts/run-migrations-with-lock.cjs" ]; then
+      echo "▶ Running migrations under advisory lock (PROD)..."
+      node -r ./tsconfig-paths-bootstrap.js scripts/run-migrations-with-lock.cjs
   else
-      echo "⚠️ Migration config not found at dist/libs/core/infrastructure/database/typeorm/ormconfig.js. Skipping."
-  fi
+      # Fallback: legacy un-serialized path (only if the lock runner is absent
+      # from the image — keeps boot working no matter what).
+      echo "▶ Running OLTP migrations (PROD)..."
+      if [ -f "dist/libs/core/infrastructure/database/typeorm/ormconfig.js" ]; then
+          npm run migration:run:prod
+      else
+          echo "⚠️ Migration config not found at dist/libs/core/infrastructure/database/typeorm/ormconfig.js. Skipping."
+      fi
 
-  echo "▶ Ensuring analytics schema exists (PROD)..."
-  # See dev-entrypoint.sh for rationale. Idempotent.
-  if [ -f "dist/scripts/analytics/ensure-schema.cli.js" ]; then
-      npm run analytics:ensure-schema:prod
-  else
-      echo "⚠️ ensure-schema CLI not found in dist/. Skipping (migration may fail on first boot)."
-  fi
+      echo "▶ Ensuring analytics schema exists (PROD)..."
+      # See dev-entrypoint.sh for rationale. Idempotent.
+      if [ -f "dist/scripts/analytics/ensure-schema.cli.js" ]; then
+          npm run analytics:ensure-schema:prod
+      else
+          echo "⚠️ ensure-schema CLI not found in dist/. Skipping (migration may fail on first boot)."
+      fi
 
-  echo "▶ Running analytics warehouse migrations (PROD)..."
-  if [ -f "dist/libs/ee/analytics-warehouse/infrastructure/ormconfig.js" ]; then
-      npm run analytics:migration:run:prod
-  else
-      echo "⚠️ Analytics ormconfig not found at dist/libs/ee/analytics-warehouse/infrastructure/ormconfig.js. Skipping."
+      echo "▶ Running analytics warehouse migrations (PROD)..."
+      if [ -f "dist/libs/ee/analytics-warehouse/infrastructure/ormconfig.js" ]; then
+          npm run analytics:migration:run:prod
+      else
+          echo "⚠️ Analytics ormconfig not found at dist/libs/ee/analytics-warehouse/infrastructure/ormconfig.js. Skipping."
+      fi
   fi
 
   # MCP manager owns its own schema and runs its migration from a

--- a/scripts/run-migrations-with-lock.cjs
+++ b/scripts/run-migrations-with-lock.cjs
@@ -1,0 +1,158 @@
+'use strict';
+
+/*
+ * Serialize production DB migrations across replicas via a Postgres
+ * session-level advisory lock.
+ *
+ * Why: in self-hosted, api / worker / webhooks all boot with
+ * RUN_MIGRATIONS=true and otherwise run the migration steps concurrently.
+ * They then race on `CREATE TYPE` and one loses with
+ * `duplicate key value violates unique constraint "pg_type_typname_nsp_index"`.
+ * Under `set -e` that crashes the container -> CrashLoopBackOff churns the
+ * first boot, and because the analytics-warehouse migration runs AFTER the
+ * OLTP one in the same entrypoint, the warehouse is left uncreated during the
+ * window -> /cockpit/validate returns 500.
+ *
+ * Fix: hold ONE advisory lock on the OLTP database for the whole migration
+ * sequence. Concurrent replicas block on `pg_advisory_lock`, then enter and
+ * find every migration already applied -> fast no-op. The lock lives on a
+ * dedicated QueryRunner connection so it is held deterministically until we
+ * release it.
+ *
+ * Fail-open: if we cannot acquire the lock (e.g. the OLTP DataSource can't be
+ * loaded/connected for the lock connection) we log and still run the
+ * migrations, so this is never worse than the previous un-serialized path.
+ */
+
+const { execFileSync } = require('node:child_process');
+const fs = require('node:fs');
+const path = require('node:path');
+
+// dist lives under the working directory (/usr/src/app), NOT next to this
+// script in scripts/ — resolve from cwd so `require` finds the compiled
+// OLTP DataSource regardless of where node is invoked from.
+const OLTP_ORMCONFIG = path.resolve(
+    process.cwd(),
+    'dist/libs/core/infrastructure/database/typeorm/ormconfig.js',
+);
+
+// Fixed key shared by every replica. High constant chosen to avoid colliding
+// with the app's runtime advisory locks (DistributedLockService hashes keys).
+const LOCK_KEY = '4242042000';
+
+// [human label, package.json script, dist guard file]. Mirrors the order the
+// prod entrypoint used inline; each step is skipped if its dist artifact is
+// absent (same behaviour as before).
+const STEPS = [
+    [
+        'Running OLTP migrations (PROD)',
+        'migration:run:prod',
+        'dist/libs/core/infrastructure/database/typeorm/ormconfig.js',
+    ],
+    [
+        'Ensuring analytics schema exists (PROD)',
+        'analytics:ensure-schema:prod',
+        'dist/scripts/analytics/ensure-schema.cli.js',
+    ],
+    [
+        'Running analytics warehouse migrations (PROD)',
+        'analytics:migration:run:prod',
+        'dist/libs/ee/analytics-warehouse/infrastructure/ormconfig.js',
+    ],
+];
+
+function runSteps() {
+    for (const [label, script, guard] of STEPS) {
+        if (!fs.existsSync(guard)) {
+            console.log(`⚠️  ${label}: ${guard} not found in dist; skipping.`);
+            continue;
+        }
+        console.log(`▶ ${label}...`);
+        execFileSync('npm', ['run', script], { stdio: 'inherit' });
+    }
+}
+
+async function main() {
+    let dataSource;
+    let queryRunner;
+    let locked = false;
+
+    try {
+        ({ dataSourceInstance: dataSource } = require(OLTP_ORMCONFIG));
+        if (!dataSource.isInitialized) {
+            await dataSource.initialize();
+        }
+        queryRunner = dataSource.createQueryRunner();
+        await queryRunner.connect();
+        console.log(`▶ Acquiring migration advisory lock (${LOCK_KEY})...`);
+        // Poll with pg_try_advisory_lock instead of a blocking
+        // pg_advisory_lock: a blocked pg_advisory_lock keeps a snapshot open
+        // for the whole wait, which stalls `CREATE INDEX CONCURRENTLY` in the
+        // replica that IS migrating (CIC waits for all older snapshots) — a
+        // logical deadlock. Polling releases the snapshot between attempts so
+        // the migrating replica can finish.
+        const deadlineMs = 20 * 60 * 1000; // safety cap
+        const startedAt = Date.now();
+        for (;;) {
+            const rows = await queryRunner.query(
+                'SELECT pg_try_advisory_lock($1::bigint) AS locked',
+                [LOCK_KEY],
+            );
+            const got = rows && rows[0] && rows[0].locked;
+            if (got === true || got === 't') {
+                locked = true;
+                console.log(
+                    '  - lock acquired; this replica runs migrations, others wait.',
+                );
+                break;
+            }
+            if (Date.now() - startedAt > deadlineMs) {
+                console.warn(
+                    '⚠️  Timed out waiting for the migration lock; ' +
+                        'proceeding WITHOUT it (fail-open).',
+                );
+                break;
+            }
+            await new Promise((resolve) => setTimeout(resolve, 3000));
+        }
+    } catch (err) {
+        console.warn(
+            `⚠️  Migration advisory lock unavailable (${err && err.message}); ` +
+                'running migrations WITHOUT serialization (fail-open).',
+        );
+    }
+
+    try {
+        runSteps();
+    } finally {
+        if (locked) {
+            try {
+                await queryRunner.query(
+                    'SELECT pg_advisory_unlock($1::bigint)',
+                    [LOCK_KEY],
+                );
+            } catch (_) {
+                /* lock auto-releases when the connection closes below */
+            }
+        }
+        try {
+            if (queryRunner) await queryRunner.release();
+        } catch (_) {
+            /* ignore */
+        }
+        try {
+            if (dataSource && dataSource.isInitialized) {
+                await dataSource.destroy();
+            }
+        } catch (_) {
+            /* ignore */
+        }
+    }
+}
+
+main()
+    .then(() => process.exit(0))
+    .catch((err) => {
+        console.error('Migration runner failed:', err);
+        process.exit(1);
+    });


### PR DESCRIPTION
## Problem

Self-hosted boots **api / worker / webhooks** from the same `docker/prod-entrypoint.sh` with `RUN_MIGRATIONS=true`, so they run the migration steps **concurrently** and race on `CREATE TYPE`:

```
error: duplicate key value violates unique constraint "pg_type_typname_nsp_index"
Migration "Baseline..." failed ...
```

Under `set -e` that crashes the container → **CrashLoopBackOff churns the first boot/upgrade** (observed on a real droplet: api RestartCount=2, webhooks=2). And because the analytics-warehouse migration runs **after** the OLTP one in the same entrypoint, the warehouse is left uncreated during the window → `/cockpit/validate` **500**. The flaky `cockpit-analytics` e2e failure traces to exactly this race window.

It self-heals (a later restart wins the race), so it's not a hard outage — but it's a churny boot for every customer and it makes the analytics matrix coverage flaky.

## Fix

`scripts/run-migrations-with-lock.cjs` holds **one Postgres advisory lock** on the OLTP DB for the whole migration sequence (OLTP → ensure analytics schema → analytics warehouse). Concurrent replicas wait, then enter and find every migration already applied → fast no-op. The entrypoint calls it, with an **inline legacy fallback** if the script is somehow absent from the image, and the lock logic is **fail-open** (runs migrations anyway if the lock connection can't be established) — so this is never worse than today.

Two design points found while **testing locally against a real Postgres with two concurrent processes**:
- resolve the dist ormconfig from `process.cwd()`, not relative to `scripts/`;
- **poll with `pg_try_advisory_lock`**, not a blocking `pg_advisory_lock`: a blocked lock holds a snapshot for its whole wait, which stalls `CREATE INDEX CONCURRENTLY` in the replica that *is* migrating (CIC waits for all older snapshots) — a logical deadlock. Polling releases the snapshot between attempts.

## Validation

Local, two concurrent runners against a fresh DB:
- **before** the lock: 2nd runner failed with **3 duplicate-key errors, exit 1** (race reproduced).
- **after**: both exit **0**, **zero** duplicate-key — one runner migrates everything, the other waits then `No migrations are pending`.

## Still to validate before merge
- Full **multi-container image boot on a droplet** (script ships in image + entrypoint wiring + api/worker/webhooks together). The change is fail-open + has the inline fallback, but the image-boot integration hasn't been exercised yet. Recommend a droplet boot test (or let the next RC build exercise it) before merge.

## Related
- Pairs with #1297 (analytics fix forward-port). Once this lands, `cockpit-analytics` can be wired into the gating matrix reliably.

🤖 Generated with [Claude Code](https://claude.com/claude-code)