### PR TITLE
feat(cockpit): review operational metrics from analytics warehouse

### DIFF
--- a/apps/api/src/controllers/__tests__/rbac-matrix.manifest.json
+++ b/apps/api/src/controllers/__tests__/rbac-matrix.manifest.json
@@ -220,6 +220,28 @@
     }
   },
   {
+    "key": "cockpit.controller.ts#operationalMetrics",
+    "httpMethod": "GET",
+    "urlPath": "/review-analytics/highlights/operational-metrics",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
+    "key": "cockpit.controller.ts#operationalOutcomesWeekly",
+    "httpMethod": "GET",
+    "urlPath": "/review-analytics/charts/operational-outcomes-weekly",
+    "expected": {
+      "owner": "allow",
+      "billing_manager": "deny",
+      "repo_admin": "allow",
+      "contributor": "deny"
+    }
+  },
+  {
     "key": "cockpit.controller.ts#prSizeChart",
     "httpMethod": "GET",
     "urlPath": "/productivity/charts/pr-size",

--- a/apps/api/src/controllers/cockpit.controller.ts
+++ b/apps/api/src/controllers/cockpit.controller.ts
@@ -248,6 +248,25 @@ export class CockpitReviewAnalyticsController {
         return this.reviewAnalytics.getNegativeVoteRateHighlight(q);
     }
 
+    @Get('/highlights/operational-metrics')
+    @ApiOperation({
+        summary:
+            'PRs processed, reviews processed and terminal review status rates current vs previous period',
+    })
+    operationalMetrics(@Query() q: CockpitRangeQuery) {
+        requireRange(q);
+        return this.reviewAnalytics.getReviewOperationalMetrics(q);
+    }
+
+    @Get('/charts/operational-outcomes-weekly')
+    @ApiOperation({
+        summary: 'Weekly review processing outcomes by terminal status',
+    })
+    operationalOutcomesWeekly(@Query() q: CockpitRangeQuery) {
+        requireRange(q);
+        return this.reviewAnalytics.getReviewOperationalMetricsWeekly(q);
+    }
+
     @Get('/highlights/ignored-criticals')
     @ApiOperation({
         summary:

--- a/apps/web/src/features/ee/cockpit/@kodusReviewTab/_components/review-cards.tsx
+++ b/apps/web/src/features/ee/cockpit/@kodusReviewTab/_components/review-cards.tsx
@@ -4,24 +4,41 @@ import { Card, CardTitle } from "@components/ui/card";
 import type {
     IgnoredCriticalsHighlight,
     NegativeVoteRateHighlight,
+    ReviewOperationalMetrics,
 } from "../../_services/analytics/review/fetch";
 import { PercentageDiff } from "../../_components/percentage-diff";
 
 const pct = (value: number) => `${Math.round(value * 100)}%`;
+const count = (value: number) => Intl.NumberFormat("en-US").format(value);
+
+const trendStatus = (trend: "improved" | "worsened" | "unchanged") => {
+    if (trend === "improved") return "good";
+    if (trend === "worsened") return "bad";
+    return "neutral";
+};
 
 const MetricCard = ({
     title,
     children,
     footer,
+    aside,
 }: React.PropsWithChildren & {
     title: string;
     footer?: React.ReactNode;
+    aside?: React.ReactNode;
 }) => (
     <Card color="lv1" className="min-h-40 justify-between gap-2 p-5">
         <CardTitle className="text-text-secondary text-xs leading-snug font-semibold">
             {title}
         </CardTitle>
-        <div className="text-3xl font-bold">{children}</div>
+        <div className="flex items-end justify-between gap-3">
+            <div className="text-3xl font-bold">{children}</div>
+            {aside && (
+                <div className="flex justify-end pb-1 text-xs font-semibold">
+                    {aside}
+                </div>
+            )}
+        </div>
         {footer && (
             <div className="text-text-tertiary text-xs leading-snug">
                 {footer}
@@ -30,16 +47,38 @@ const MetricCard = ({
     </Card>
 );
 
+const WoWDiff = ({
+    value,
+    unit,
+    trend,
+    mode,
+}: {
+    value: number;
+    unit: "%" | "pp";
+    trend: "improved" | "worsened" | "unchanged";
+    mode: React.ComponentProps<typeof PercentageDiff>["mode"];
+}) => {
+    const formattedValue = `${Math.abs(value)}${unit === "pp" ? " pp" : "%"}`;
+
+    return (
+        <PercentageDiff mode={mode} status={trendStatus(trend)}>
+            {formattedValue}
+        </PercentageDiff>
+    );
+};
+
 export const ReviewCards = ({
     sent,
     implemented,
     negativeVoteRate,
     ignoredCriticals,
+    operationalMetrics,
 }: {
     sent: number;
     implemented: number;
     negativeVoteRate: NegativeVoteRateHighlight | undefined;
     ignoredCriticals: IgnoredCriticalsHighlight | undefined;
+    operationalMetrics?: ReviewOperationalMetrics | null;
 }) => {
     const rate = sent > 0 ? implemented / sent : 0;
     const current = negativeVoteRate?.currentPeriod;
@@ -52,18 +91,43 @@ export const ReviewCards = ({
     const totalReactions =
         (current?.thumbsUp ?? 0) + (current?.thumbsDown ?? 0);
     const lowSample = totalReactions < MIN_REACTIONS_FOR_RATE;
+    const gridClassName = operationalMetrics
+        ? "grid grid-cols-1 gap-2 md:grid-cols-2 xl:grid-cols-5"
+        : "grid grid-cols-1 gap-2 md:grid-cols-2 xl:grid-cols-4";
+    const formattedImplemented = count(implemented);
+    const formattedSent = count(sent);
+    const suggestionsFooter = `${formattedImplemented} of ${formattedSent} suggestions implemented`;
 
     return (
-        <div className="grid grid-cols-4 gap-2">
-            <MetricCard
-                title="Implementation rate"
-                footer={`${implemented} of ${sent} suggestions implemented`}>
+        <div className={gridClassName}>
+            <MetricCard title="Implementation rate" footer={suggestionsFooter}>
                 {pct(rate)}
             </MetricCard>
 
             <MetricCard title="Suggestions sent" footer="in this period">
-                {sent}
+                {count(sent)}
             </MetricCard>
+
+            {operationalMetrics && (
+                <MetricCard
+                    title="PRs processed"
+                    footer={`${count(operationalMetrics.previousPeriod.processedPRs)} previous period`}
+                    aside={
+                        <WoWDiff
+                            value={
+                                operationalMetrics.comparison.processedPRs
+                                    .percentageChange
+                            }
+                            unit="%"
+                            trend={
+                                operationalMetrics.comparison.processedPRs.trend
+                            }
+                            mode="higher-is-better"
+                        />
+                    }>
+                    {count(operationalMetrics.currentPeriod.processedPRs)}
+                </MetricCard>
+            )}
 
             <MetricCard
                 title="Negative vote rate"

--- a/apps/web/src/features/ee/cockpit/@kodusReviewTab/_components/review-operational-outcomes-chart.tsx
+++ b/apps/web/src/features/ee/cockpit/@kodusReviewTab/_components/review-operational-outcomes-chart.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import {
+    Bar,
+    BarChart as RechartsBarChart,
+    CartesianGrid,
+    ResponsiveContainer,
+    Tooltip,
+    XAxis,
+    YAxis,
+} from "recharts";
+import type { TooltipContentProps } from "recharts";
+
+import { PercentageDiff } from "../../_components/percentage-diff";
+import {
+    CHART_COLORS,
+    rechartsAxisProps,
+    rechartsGridProps,
+} from "../../_components/charts/recharts-shared";
+import type {
+    ReviewOperationalMetrics,
+    ReviewOperationalMetricsWeeklyRow,
+} from "../../_services/analytics/review/fetch";
+
+type Trend = "improved" | "worsened" | "unchanged";
+type TrendMode = React.ComponentProps<typeof PercentageDiff>["mode"];
+type OutcomeKey = "successful" | "error" | "skipped";
+type ChartRow = Record<OutcomeKey, number> &
+    Record<`${OutcomeKey}Count`, number> & {
+        period: string;
+        total: number;
+    };
+
+const count = (value: number) => Intl.NumberFormat("en-US").format(value);
+const pct = (value: number) => `${Math.round(value * 100)}%`;
+const pctFromWholeNumber = (value: number) => `${Math.round(value)}%`;
+const ratioToPct = (value: number, total: number) =>
+    total > 0 ? (value / total) * 100 : 0;
+const formatWeekTick = (value: string) => {
+    const [, month, day] = value.split("-");
+    return month && day ? `${month}/${day}` : value;
+};
+
+const outcomeMeta: Record<
+    OutcomeKey,
+    { label: string; color: string; countKey: `${OutcomeKey}Count` }
+> = {
+    successful: {
+        label: "Success",
+        color: CHART_COLORS.success,
+        countKey: "successfulCount",
+    },
+    error: {
+        label: "Error",
+        color: CHART_COLORS.danger,
+        countKey: "errorCount",
+    },
+    skipped: {
+        label: "Skipped",
+        color: CHART_COLORS.warning,
+        countKey: "skippedCount",
+    },
+};
+
+const trendStatus = (trend: Trend) => {
+    if (trend === "improved") return "good";
+    if (trend === "worsened") return "bad";
+    return "neutral";
+};
+
+const Delta = ({
+    value,
+    unit,
+    trend,
+    mode,
+}: {
+    value: number;
+    unit: "%" | "pp";
+    trend: Trend;
+    mode: TrendMode;
+}) => (
+    <PercentageDiff mode={mode} status={trendStatus(trend)}>
+        {Math.abs(value)}
+        {unit === "pp" ? " pp" : "%"}
+    </PercentageDiff>
+);
+
+const OutcomesTooltip = ({
+    active,
+    payload,
+    label,
+}: TooltipContentProps<number, string>) => {
+    if (!active || !payload?.length) return null;
+
+    const row = payload[0]?.payload as ChartRow | undefined;
+    if (!row) return null;
+
+    const rows = payload.filter((entry) => (entry.value as number) > 0);
+    if (!rows.length) return null;
+
+    return (
+        <div className="bg-card-lv1 border-card-lv3 min-w-40 rounded-lg border px-3 py-2 shadow-xl">
+            <div className="text-text-primary mb-1.5 flex items-center justify-between gap-4 text-xs font-semibold">
+                <span>{label}</span>
+                <span className="text-text-tertiary font-mono">
+                    {count(row.total)}
+                </span>
+            </div>
+            {rows.map((entry) => {
+                const key = String(entry.dataKey) as OutcomeKey;
+                const meta = outcomeMeta[key];
+                const rawCount = meta ? row[meta.countKey] : 0;
+
+                return (
+                    <div
+                        key={key}
+                        className="text-text-secondary flex items-center gap-2 py-0.5 text-xs">
+                        <span
+                            className="size-2 shrink-0 rounded-xs"
+                            style={{ backgroundColor: meta?.color }}
+                        />
+                        <span className="flex-1">{meta?.label ?? key}</span>
+                        <span className="text-text-primary font-mono font-semibold">
+                            {pctFromWholeNumber(entry.value as number)}
+                        </span>
+                        <span className="text-text-tertiary font-mono">
+                            {count(rawCount)}
+                        </span>
+                    </div>
+                );
+            })}
+        </div>
+    );
+};
+
+export const ReviewOperationalOutcomesChart = ({
+    metrics,
+    weekly,
+}: {
+    metrics: ReviewOperationalMetrics;
+    weekly: ReviewOperationalMetricsWeeklyRow[];
+}) => {
+    const { currentPeriod, previousPeriod, comparison } = metrics;
+    const chartData = weekly.map((week) => ({
+        period: week.weekStart,
+        total: week.processedReviews,
+        successful: ratioToPct(week.successfulReviews, week.processedReviews),
+        error: ratioToPct(week.errorReviews, week.processedReviews),
+        skipped: ratioToPct(week.skippedReviews, week.processedReviews),
+        successfulCount: week.successfulReviews,
+        errorCount: week.errorReviews,
+        skippedCount: week.skippedReviews,
+    })) satisfies ChartRow[];
+
+    const outcomes = [
+        {
+            label: "Success",
+            color: CHART_COLORS.success,
+            count: currentPeriod.successfulReviews,
+            rate: currentPeriod.successRate,
+            delta: comparison.successRate.percentagePointChange,
+            trend: comparison.successRate.trend,
+            mode: "higher-is-better" as const,
+        },
+        {
+            label: "Error",
+            color: CHART_COLORS.danger,
+            count: currentPeriod.errorReviews,
+            rate: currentPeriod.errorRate,
+            delta: comparison.errorRate.percentagePointChange,
+            trend: comparison.errorRate.trend,
+            mode: "lower-is-better" as const,
+        },
+        {
+            label: "Skipped",
+            color: CHART_COLORS.warning,
+            count: currentPeriod.skippedReviews,
+            rate: currentPeriod.skippedRate,
+            delta: comparison.skippedRate.percentagePointChange,
+            trend: comparison.skippedRate.trend,
+            mode: "lower-is-better" as const,
+        },
+    ];
+
+    return (
+        <div className="flex flex-col gap-4">
+            <div className="flex flex-wrap items-end justify-between gap-3">
+                <div>
+                    <div className="text-text-secondary text-xs font-semibold">
+                        Reviews processed
+                    </div>
+                    <div className="mt-1 flex items-baseline gap-3">
+                        <span className="text-2xl font-bold">
+                            {count(currentPeriod.processedReviews)}
+                        </span>
+                        <span className="text-text-tertiary text-xs">
+                            {count(previousPeriod.processedReviews)} previous
+                        </span>
+                    </div>
+                </div>
+                <div className="flex justify-end text-xs font-semibold">
+                    <Delta
+                        value={comparison.processedReviews.percentageChange}
+                        unit="%"
+                        trend={comparison.processedReviews.trend}
+                        mode="higher-is-better"
+                    />
+                </div>
+            </div>
+
+            <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_18rem]">
+                <ResponsiveContainer width="100%" height={240}>
+                    <RechartsBarChart
+                        data={chartData}
+                        margin={{ top: 8, right: 12, left: -12, bottom: 0 }}>
+                        <CartesianGrid {...rechartsGridProps} />
+                        <XAxis
+                            dataKey="period"
+                            tickMargin={10}
+                            tickFormatter={(value) =>
+                                formatWeekTick(String(value))
+                            }
+                            {...rechartsAxisProps}
+                        />
+                        <YAxis
+                            domain={[0, 100]}
+                            ticks={[0, 25, 50, 75, 100]}
+                            tickFormatter={(value) => `${Number(value)}%`}
+                            {...rechartsAxisProps}
+                        />
+                        <Tooltip
+                            cursor={{ fill: "#30304b22" }}
+                            content={<OutcomesTooltip />}
+                        />
+                        <Bar
+                            dataKey="successful"
+                            name="Success"
+                            stackId="reviews"
+                            fill={CHART_COLORS.success}
+                            radius={[0, 0, 5, 5]}
+                        />
+                        <Bar
+                            dataKey="error"
+                            name="Error"
+                            stackId="reviews"
+                            fill={CHART_COLORS.danger}
+                        />
+                        <Bar
+                            dataKey="skipped"
+                            name="Skipped"
+                            stackId="reviews"
+                            fill={CHART_COLORS.warning}
+                            radius={[5, 5, 0, 0]}
+                        />
+                    </RechartsBarChart>
+                </ResponsiveContainer>
+
+                <div className="divide-card-lv3/70 flex flex-col justify-center divide-y">
+                    {outcomes.map((outcome) => (
+                        <div
+                            key={outcome.label}
+                            className="flex items-center justify-between gap-4 py-2">
+                            <div className="min-w-0">
+                                <div className="text-text-secondary flex items-center gap-2 text-xs font-semibold">
+                                    <span
+                                        className="size-2 rounded-xs"
+                                        style={{
+                                            backgroundColor: outcome.color,
+                                        }}
+                                    />
+                                    {outcome.label}
+                                </div>
+                                <div className="text-text-tertiary mt-1 text-xs">
+                                    {count(outcome.count)} reviews
+                                </div>
+                            </div>
+                            <div className="text-right">
+                                <div className="text-sm font-bold">
+                                    {pct(outcome.rate)}
+                                </div>
+                                <div className="mt-1 flex justify-end text-xs font-semibold">
+                                    <Delta
+                                        value={outcome.delta}
+                                        unit="pp"
+                                        trend={outcome.trend}
+                                        mode={outcome.mode}
+                                    />
+                                </div>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+};

--- a/apps/web/src/features/ee/cockpit/@kodusReviewTab/_components/review-section.tsx
+++ b/apps/web/src/features/ee/cockpit/@kodusReviewTab/_components/review-section.tsx
@@ -6,18 +6,21 @@ import {
     CardHeader,
     CardTitle,
 } from "@components/ui/card";
+import { cn } from "src/core/utils/components";
 
 export const ReviewSection = ({
     title,
     description,
     footer,
+    className,
     children,
 }: React.PropsWithChildren & {
     title: string;
     description?: string;
     footer?: string;
+    className?: string;
 }) => (
-    <Card color="lv1">
+    <Card color="lv1" className={cn("h-full", className)}>
         <CardHeader>
             <CardTitle className="text-sm">{title}</CardTitle>
             {description && (

--- a/apps/web/src/features/ee/cockpit/@kodusReviewTab/page.tsx
+++ b/apps/web/src/features/ee/cockpit/@kodusReviewTab/page.tsx
@@ -9,12 +9,15 @@ import {
     getNegativeFeedbackByCategory,
     getNegativeFeedbackWeekly,
     getNegativeVoteRate,
+    getReviewOperationalMetrics,
+    getReviewOperationalOutcomesWeekly,
     getRepositoriesHealth,
 } from "../_services/analytics/review/fetch";
 import { FeedbackSection } from "./_components/feedback-section";
 import { RateByCategoryChart } from "./_components/rate-by-category-chart";
 import { RateBySeverityChart } from "./_components/rate-by-severity-chart";
 import { ReviewCards } from "./_components/review-cards";
+import { ReviewOperationalOutcomesChart } from "./_components/review-operational-outcomes-chart";
 import { ReviewSection } from "./_components/review-section";
 import { RepositoriesHealthTable } from "./_components/repositories-health-table";
 import { RulesHealthTable } from "./_components/rules-health-table";
@@ -32,6 +35,8 @@ export default async function KodusReviewTab() {
         negativeByCategory,
         negativeWeekly,
         negativeVoteRate,
+        operationalMetrics,
+        operationalWeekly,
         repositoriesHealth,
         rulesHealth,
     ] = await Promise.all([
@@ -42,6 +47,12 @@ export default async function KodusReviewTab() {
         getNegativeFeedbackByCategory(params).then(extractApiData),
         getNegativeFeedbackWeekly(params).then(extractApiData),
         getNegativeVoteRate(params).then(extractApiData),
+        getReviewOperationalMetrics(params)
+            .then(extractApiData)
+            .catch(() => null),
+        getReviewOperationalOutcomesWeekly(params)
+            .then(extractApiData)
+            .catch(() => null),
         getRepositoriesHealth(params).then(extractApiData),
         // rules health merges Mongo metadata — tolerate failures without
         // taking the whole tab down.
@@ -65,7 +76,19 @@ export default async function KodusReviewTab() {
                 implemented={totals.implemented}
                 negativeVoteRate={negativeVoteRate}
                 ignoredCriticals={ignoredCriticals}
+                operationalMetrics={operationalMetrics}
             />
+
+            {operationalMetrics && operationalWeekly?.length ? (
+                <ReviewSection
+                    title="Review processing outcomes"
+                    description="weekly composition · success, error, skipped">
+                    <ReviewOperationalOutcomesChart
+                        metrics={operationalMetrics}
+                        weekly={operationalWeekly}
+                    />
+                </ReviewSection>
+            ) : null}
 
             <ReviewSection
                 title="Implementation rate — week over week"
@@ -80,7 +103,7 @@ export default async function KodusReviewTab() {
                     instead of a flat list of individual findings. */}
                 <section
                     id="themes-by-category"
-                    className="target:ring-primary-light/60 scroll-mt-24 rounded-xl transition-shadow target:ring-2">
+                    className="target:ring-primary-light/60 h-full scroll-mt-24 rounded-xl transition-shadow target:ring-2">
                     <ReviewSection
                         title="Implementation rate by category"
                         description="sent vs. implemented · click a theme to see its PRs">

--- a/apps/web/src/features/ee/cockpit/_services/analytics/review/fetch.ts
+++ b/apps/web/src/features/ee/cockpit/_services/analytics/review/fetch.ts
@@ -108,6 +108,59 @@ export type NegativeVoteRateHighlight = {
     };
 };
 
+export type ReviewOperationalMetrics = {
+    currentPeriod: {
+        processedPRs: number;
+        processedReviews: number;
+        successfulReviews: number;
+        errorReviews: number;
+        skippedReviews: number;
+        successRate: number;
+        errorRate: number;
+        skippedRate: number;
+    };
+    previousPeriod: {
+        processedPRs: number;
+        processedReviews: number;
+        successfulReviews: number;
+        errorReviews: number;
+        skippedReviews: number;
+        successRate: number;
+        errorRate: number;
+        skippedRate: number;
+    };
+    comparison: {
+        processedPRs: {
+            percentageChange: number;
+            trend: "improved" | "worsened" | "unchanged";
+        };
+        processedReviews: {
+            percentageChange: number;
+            trend: "improved" | "worsened" | "unchanged";
+        };
+        successRate: {
+            percentageChange: number;
+            percentagePointChange: number;
+            trend: "improved" | "worsened" | "unchanged";
+        };
+        errorRate: {
+            percentageChange: number;
+            percentagePointChange: number;
+            trend: "improved" | "worsened" | "unchanged";
+        };
+        skippedRate: {
+            percentageChange: number;
+            percentagePointChange: number;
+            trend: "improved" | "worsened" | "unchanged";
+        };
+    };
+};
+
+export type ReviewOperationalMetricsWeeklyRow =
+    ReviewOperationalMetrics["currentPeriod"] & {
+        weekStart: string;
+    };
+
 const REVIEW_TAGS: { next: { tags: string[] } } = {
     next: {
         tags: [
@@ -168,5 +221,17 @@ export const getNegativeFeedbackWeekly = (params: AnalyticsParams) =>
 export const getNegativeVoteRate = (params: AnalyticsParams) =>
     analyticsFetch<NegativeVoteRateHighlight>(
         "/review-analytics/highlights/negative-vote-rate",
+        { params, ...REVIEW_TAGS },
+    );
+
+export const getReviewOperationalMetrics = (params: AnalyticsParams) =>
+    analyticsFetch<ReviewOperationalMetrics>(
+        "/review-analytics/highlights/operational-metrics",
+        { params, ...REVIEW_TAGS },
+    );
+
+export const getReviewOperationalOutcomesWeekly = (params: AnalyticsParams) =>
+    analyticsFetch<ReviewOperationalMetricsWeeklyRow[]>(
+        "/review-analytics/charts/operational-outcomes-weekly",
         { params, ...REVIEW_TAGS },
     );

--- a/apps/worker/src/cron/analytics-ingestion.cron.ts
+++ b/apps/worker/src/cron/analytics-ingestion.cron.ts
@@ -1,13 +1,14 @@
-import { Injectable, Logger } from '@nestjs/common';
+import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 
 import {
     FeedbackIngestionService,
     PullRequestIngestionService,
+    ReviewOperationalIngestionService,
 } from '@libs/ee/analytics-warehouse';
 
 /**
- * Cron wrapper that drives `PullRequestIngestionService` on a schedule.
+ * Cron wrapper that drives cockpit warehouse ingestion on a schedule.
  * Interval is tunable via `ANALYTICS_INGESTION_CRON` (standard cron
  * expression). Default = every 15 minutes.
  *
@@ -18,14 +19,28 @@ import {
  * guard as a cheap mutex so we don't stack up runs on a single node.
  */
 @Injectable()
-export class AnalyticsIngestionCron {
+export class AnalyticsIngestionCron implements OnApplicationBootstrap {
     private readonly logger = new Logger(AnalyticsIngestionCron.name);
     private running = false;
 
     constructor(
         private readonly ingestion: PullRequestIngestionService,
         private readonly feedbackIngestion: FeedbackIngestionService,
+        private readonly reviewOperationalIngestion: ReviewOperationalIngestionService,
     ) {}
+
+    onApplicationBootstrap(): void {
+        if (
+            process.env.ANALYTICS_INGESTION_DISABLED === 'true' ||
+            process.env.ANALYTICS_INGESTION_RUN_ON_BOOT === 'false'
+        ) {
+            return;
+        }
+
+        setImmediate(() => {
+            void this.runAll('startup');
+        });
+    }
 
     // `??` only swaps null/undefined — but docker-compose sets the var
     // as an empty string when unset (`${VAR:-}`), which would slip
@@ -37,12 +52,16 @@ export class AnalyticsIngestionCron {
         { name: 'analytics-ingestion' },
     )
     async handle(): Promise<void> {
+        await this.runAll('cron');
+    }
+
+    private async runAll(trigger: 'cron' | 'startup'): Promise<void> {
         if (process.env.ANALYTICS_INGESTION_DISABLED === 'true') {
             return;
         }
         if (this.running) {
             this.logger.warn(
-                'skipping analytics ingestion — previous run still in flight',
+                `skipping analytics ingestion (${trigger}) — previous run still in flight`,
             );
             return;
         }
@@ -50,10 +69,18 @@ export class AnalyticsIngestionCron {
         this.running = true;
         const start = Date.now();
         try {
-            const res = await this.ingestion.run();
-            this.logger.log(
-                `analytics ingestion done in ${Date.now() - start}ms — ${JSON.stringify(res)}`,
-            );
+            try {
+                const res = await this.ingestion.run();
+                this.logger.log(
+                    `analytics ingestion (${trigger}) done in ${Date.now() - start}ms — ${JSON.stringify(res)}`,
+                );
+            } catch (err) {
+                this.logger.error(
+                    `analytics ingestion (${trigger}) failed: ${err instanceof Error ? err.message : String(err)}`,
+                    err instanceof Error ? err.stack : undefined,
+                );
+            }
+
             // Feedback is a much lighter pass (flat docs, no children);
             // run it on the same tick so both stay equally fresh. Its
             // failure must not mask a successful PR ingestion above.
@@ -68,11 +95,18 @@ export class AnalyticsIngestionCron {
                     fbErr instanceof Error ? fbErr.stack : undefined,
                 );
             }
-        } catch (err) {
-            this.logger.error(
-                `analytics ingestion failed: ${err instanceof Error ? err.message : String(err)}`,
-                err instanceof Error ? err.stack : undefined,
-            );
+
+            try {
+                const ops = await this.reviewOperationalIngestion.run();
+                this.logger.log(
+                    `review operational ingestion done — ${JSON.stringify(ops)}`,
+                );
+            } catch (opsErr) {
+                this.logger.error(
+                    `review operational ingestion failed: ${opsErr instanceof Error ? opsErr.message : String(opsErr)}`,
+                    opsErr instanceof Error ? opsErr.stack : undefined,
+                );
+            }
         } finally {
             this.running = false;
         }

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -44,6 +44,26 @@ services:
         environment:
             - API_CLOUD_MODE=false
             - COMPONENT_TYPE=worker
+            - WORKER_ROLE=code-review
+        depends_on:
+            db_postgres:
+                condition: service_healthy
+            db_mongodb:
+                condition: service_healthy
+        networks:
+            - kodus-backend-services
+
+    worker-analytics:
+        image: ghcr.io/kodustech/kodus-ai-worker:${KODUS_VERSION:-latest}
+        container_name: kodus_analytics_worker_prod
+        restart: unless-stopped
+        command: node dist/apps/worker/main.js
+        env_file:
+            - ${ENV_FILE:-.env.prod}
+        environment:
+            - API_CLOUD_MODE=false
+            - COMPONENT_TYPE=worker
+            - WORKER_ROLE=analytics
         depends_on:
             db_postgres:
                 condition: service_healthy

--- a/libs/cockpit/domain/contracts/cockpit-review-analytics.service.contract.ts
+++ b/libs/cockpit/domain/contracts/cockpit-review-analytics.service.contract.ts
@@ -9,6 +9,8 @@ import {
     NegativeFeedbackWeeklyRow,
     NegativeVoteRateHighlight,
     RepositoryHealthRow,
+    ReviewOperationalMetrics,
+    ReviewOperationalMetricsWeeklyRow,
     SuggestionsExplorerQuery,
     SuggestionsExplorerResult,
 } from '../types';
@@ -47,6 +49,12 @@ export interface ICockpitReviewAnalyticsService {
     getNegativeVoteRateHighlight(
         q: CockpitRangeQuery,
     ): Promise<NegativeVoteRateHighlight>;
+    getReviewOperationalMetrics(
+        q: CockpitRangeQuery,
+    ): Promise<ReviewOperationalMetrics>;
+    getReviewOperationalMetricsWeekly(
+        q: CockpitRangeQuery,
+    ): Promise<ReviewOperationalMetricsWeeklyRow[]>;
     getKodyRulesUsage(q: CockpitRangeQuery): Promise<KodyRuleUsageRow[]>;
     searchSuggestions(
         q: SuggestionsExplorerQuery,

--- a/libs/cockpit/domain/types.ts
+++ b/libs/cockpit/domain/types.ts
@@ -222,6 +222,46 @@ export type NegativeVoteRateHighlight = PeriodComparison<{
     negativeRate: number;
 }>;
 
+export interface ReviewOperationalMetricsPeriod {
+    /** Distinct PRs with a terminal review execution in the period. */
+    processedPRs: number;
+    /** Terminal review executions in the period. */
+    processedReviews: number;
+    successfulReviews: number;
+    errorReviews: number;
+    skippedReviews: number;
+    successRate: number;
+    errorRate: number;
+    skippedRate: number;
+}
+
+export interface ReviewOperationalMetricsWeeklyRow
+    extends ReviewOperationalMetricsPeriod {
+    weekStart: string;
+}
+
+export interface ReviewOperationalMetricComparison {
+    percentageChange: number;
+    trend: 'improved' | 'worsened' | 'unchanged';
+}
+
+export interface ReviewOperationalRateComparison
+    extends ReviewOperationalMetricComparison {
+    percentagePointChange: number;
+}
+
+export interface ReviewOperationalMetrics {
+    currentPeriod: ReviewOperationalMetricsPeriod;
+    previousPeriod: ReviewOperationalMetricsPeriod;
+    comparison: {
+        processedPRs: ReviewOperationalMetricComparison;
+        processedReviews: ReviewOperationalMetricComparison;
+        successRate: ReviewOperationalRateComparison;
+        errorRate: ReviewOperationalRateComparison;
+        skippedRate: ReviewOperationalRateComparison;
+    };
+}
+
 /** Warehouse usage merged with rule metadata from Mongo `kodyRules`. */
 export interface KodyRuleHealthRow extends KodyRuleUsageRow {
     title: string;

--- a/libs/cockpit/infrastructure/services/cockpit-review-analytics.service.ts
+++ b/libs/cockpit/infrastructure/services/cockpit-review-analytics.service.ts
@@ -20,6 +20,11 @@ import {
     ImplementationRateBySeverityRow,
     ImplementationRateWeeklyRow,
     RepositoryHealthRow,
+    ReviewOperationalMetricComparison,
+    ReviewOperationalMetrics,
+    ReviewOperationalMetricsPeriod,
+    ReviewOperationalMetricsWeeklyRow,
+    ReviewOperationalRateComparison,
     SuggestionsExplorerItem,
     SuggestionsExplorerQuery,
     SuggestionsExplorerResult,
@@ -496,6 +501,222 @@ export class CockpitReviewAnalyticsService
             currentPeriod: current,
             previousPeriod: previous,
             comparison,
+        };
+    }
+
+    async getReviewOperationalMetrics(
+        q: CockpitRangeQuery,
+    ): Promise<ReviewOperationalMetrics> {
+        const prev = computePreviousPeriod(q.startDate, q.endDate);
+
+        const [current, previous] = await Promise.all([
+            this.getReviewOperationalMetricsPeriod(q),
+            this.getReviewOperationalMetricsPeriod({
+                ...q,
+                startDate: prev.startDate,
+                endDate: prev.endDate,
+            }),
+        ]);
+
+        return {
+            currentPeriod: current,
+            previousPeriod: previous,
+            comparison: {
+                processedPRs: this.compareOperationalMetric(
+                    current.processedPRs,
+                    previous.processedPRs,
+                    'up',
+                ),
+                processedReviews: this.compareOperationalMetric(
+                    current.processedReviews,
+                    previous.processedReviews,
+                    'up',
+                ),
+                successRate: this.compareOperationalRate(
+                    current.successRate,
+                    previous.successRate,
+                    'up',
+                ),
+                errorRate: this.compareOperationalRate(
+                    current.errorRate,
+                    previous.errorRate,
+                    'down',
+                ),
+                skippedRate: this.compareOperationalRate(
+                    current.skippedRate,
+                    previous.skippedRate,
+                    'down',
+                ),
+            },
+        };
+    }
+
+    async getReviewOperationalMetricsWeekly(
+        q: CockpitRangeQuery,
+    ): Promise<ReviewOperationalMetricsWeeklyRow[]> {
+        const params: unknown[] = [q.organizationId, q.startDate, q.endDate];
+        const repositoryFilter = q.repository
+            ? (params.push(q.repository),
+              `AND roe."repo_full_name" = $${params.length}`)
+            : '';
+
+        const rows = (await this.ds.query(
+            // Same HashAggregate-over-PR-key rewrite as the period query: group
+            // by (week, repo, PR) once, then roll the per-PR tallies up per
+            // week. Avoids the disk-spilling COUNT(DISTINCT) sort; identical
+            // results.
+            `WITH scoped AS (
+                SELECT
+                    date_trunc('week', roe."created_at") AS week_start,
+                    roe."status",
+                    roe."repositoryId",
+                    roe."pullRequestNumber"
+                  FROM "analytics"."review_operational_executions" roe
+                 WHERE roe."organizationId" = $1
+                   AND roe."created_at" >= $2::date
+                   AND roe."created_at" < ($3::date + INTERVAL '1 day')
+                   ${repositoryFilter}
+            ),
+            per_pr AS (
+                SELECT
+                    week_start,
+                    COUNT(*) AS reviews,
+                    COUNT(*) FILTER (WHERE "status" = 'success') AS successful,
+                    COUNT(*) FILTER (WHERE "status" IN ('error', 'partial_error')) AS errored,
+                    COUNT(*) FILTER (WHERE "status" = 'skipped') AS skipped
+                  FROM scoped
+                 GROUP BY week_start, "repositoryId", "pullRequestNumber"
+            )
+            SELECT
+                to_char(week_start, 'YYYY-MM-DD') AS week_start,
+                COALESCE(SUM(reviews), 0)::int AS processed_reviews,
+                COUNT(*)::int AS processed_prs,
+                COALESCE(SUM(successful), 0)::int AS successful_reviews,
+                COALESCE(SUM(errored), 0)::int AS error_reviews,
+                COALESCE(SUM(skipped), 0)::int AS skipped_reviews
+              FROM per_pr
+             GROUP BY week_start
+             ORDER BY week_start ASC`,
+            params,
+        )) as Array<{
+            week_start: string;
+            processed_reviews: number | string | null;
+            processed_prs: number | string | null;
+            successful_reviews: number | string | null;
+            error_reviews: number | string | null;
+            skipped_reviews: number | string | null;
+        }>;
+
+        return rows.map((row) => {
+            const processedReviews = Number(row.processed_reviews ?? 0);
+            const successfulReviews = Number(row.successful_reviews ?? 0);
+            const errorReviews = Number(row.error_reviews ?? 0);
+            const skippedReviews = Number(row.skipped_reviews ?? 0);
+
+            return {
+                weekStart: row.week_start,
+                processedPRs: Number(row.processed_prs ?? 0),
+                processedReviews,
+                successfulReviews,
+                errorReviews,
+                skippedReviews,
+                successRate: this.rate(processedReviews, successfulReviews),
+                errorRate: this.rate(processedReviews, errorReviews),
+                skippedRate: this.rate(processedReviews, skippedReviews),
+            };
+        });
+    }
+
+    private async getReviewOperationalMetricsPeriod(
+        q: CockpitRangeQuery,
+    ): Promise<ReviewOperationalMetricsPeriod> {
+        const params: unknown[] = [q.organizationId, q.startDate, q.endDate];
+        const repositoryFilter = q.repository
+            ? (params.push(q.repository),
+              `AND roe."repo_full_name" = $${params.length}`)
+            : '';
+
+        const rows = (await this.ds.query(
+            // processed_prs is a distinct (repo, PR) count. Grouping by the
+            // PR key once (HashAggregate) and summing the per-PR tallies is
+            // ~4-8x faster than COUNT(DISTINCT ...), which forces a full sort
+            // that spills to disk on high-volume orgs. Results are identical.
+            `WITH scoped AS (
+                SELECT
+                    roe."status",
+                    roe."repositoryId",
+                    roe."pullRequestNumber"
+                  FROM "analytics"."review_operational_executions" roe
+                 WHERE roe."organizationId" = $1
+                   AND roe."created_at" >= $2::date
+                   AND roe."created_at" < ($3::date + INTERVAL '1 day')
+                   ${repositoryFilter}
+            ),
+            per_pr AS (
+                SELECT
+                    COUNT(*) AS reviews,
+                    COUNT(*) FILTER (WHERE "status" = 'success') AS successful,
+                    COUNT(*) FILTER (WHERE "status" IN ('error', 'partial_error')) AS errored,
+                    COUNT(*) FILTER (WHERE "status" = 'skipped') AS skipped
+                  FROM scoped
+                 GROUP BY "repositoryId", "pullRequestNumber"
+            )
+            SELECT
+                COALESCE(SUM(reviews), 0)::int AS processed_reviews,
+                COUNT(*)::int AS processed_prs,
+                COALESCE(SUM(successful), 0)::int AS successful_reviews,
+                COALESCE(SUM(errored), 0)::int AS error_reviews,
+                COALESCE(SUM(skipped), 0)::int AS skipped_reviews
+              FROM per_pr`,
+            params,
+        )) as Array<{
+            processed_reviews: number | string | null;
+            processed_prs: number | string | null;
+            successful_reviews: number | string | null;
+            error_reviews: number | string | null;
+            skipped_reviews: number | string | null;
+        }>;
+
+        const row = rows[0] ?? {
+            processed_reviews: 0,
+            processed_prs: 0,
+            successful_reviews: 0,
+            error_reviews: 0,
+            skipped_reviews: 0,
+        };
+        const processedReviews = Number(row.processed_reviews ?? 0);
+        const successfulReviews = Number(row.successful_reviews ?? 0);
+        const errorReviews = Number(row.error_reviews ?? 0);
+        const skippedReviews = Number(row.skipped_reviews ?? 0);
+
+        return {
+            processedPRs: Number(row.processed_prs ?? 0),
+            processedReviews,
+            successfulReviews,
+            errorReviews,
+            skippedReviews,
+            successRate: this.rate(processedReviews, successfulReviews),
+            errorRate: this.rate(processedReviews, errorReviews),
+            skippedRate: this.rate(processedReviews, skippedReviews),
+        };
+    }
+
+    private compareOperationalMetric(
+        current: number,
+        previous: number,
+        direction: 'up' | 'down',
+    ): ReviewOperationalMetricComparison {
+        return computeTrend(current, previous, direction);
+    }
+
+    private compareOperationalRate(
+        current: number,
+        previous: number,
+        direction: 'up' | 'down',
+    ): ReviewOperationalRateComparison {
+        return {
+            ...computeTrend(current, previous, direction),
+            percentagePointChange: this.round((current - previous) * 100),
         };
     }
 

--- a/libs/core/infrastructure/database/typeorm/migrations/2026061111000000-ReviewOperationalIngestionIndexes.ts
+++ b/libs/core/infrastructure/database/typeorm/migrations/2026061111000000-ReviewOperationalIngestionIndexes.ts
@@ -1,0 +1,79 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Source-side indexes for analytics.review_operational_executions ingestion.
+ * Cockpit still reads only the analytics schema; these indexes keep the
+ * analytics worker's historical/import cursor from repeatedly scanning OLTP.
+ */
+export class ReviewOperationalIngestionIndexes2026061111000000
+    implements MigrationInterface
+{
+    name = 'ReviewOperationalIngestionIndexes2026061111000000';
+
+    transaction = false;
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        // `CREATE INDEX CONCURRENTLY` on a large `automation_execution` can run
+        // for many minutes. A global statement_timeout would abort it midway
+        // and leave an INVALID index that `IF NOT EXISTS` then silently skips
+        // forever. Disable the statement timeout for this session and keep a
+        // bounded lock_timeout so we never wedge on the brief locks CONCURRENTLY
+        // takes. (This runs in the dedicated, short-lived migration process, so
+        // the session-level SET does not leak into the app's connection pool.)
+        await queryRunner.query(`SET statement_timeout = 0`);
+        await queryRunner.query(`SET lock_timeout = '30s'`);
+
+        // Self-heal: if a prior interrupted run left an invalid build behind,
+        // drop it first so the CREATE below actually rebuilds it.
+        await this.dropIfInvalid(
+            queryRunner,
+            'IDX_automation_exec_review_ops_watermark',
+        );
+        await queryRunner.query(`
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_automation_exec_review_ops_watermark"
+                ON "automation_execution" ("updatedAt", "uuid")
+                WHERE "pullRequestNumber" IS NOT NULL
+                  AND "repositoryId" IS NOT NULL
+                  AND "status" IN ('success', 'error', 'partial_error', 'skipped')
+        `);
+
+        await this.dropIfInvalid(queryRunner, 'IDX_repositories_external_id');
+        await queryRunner.query(`
+            CREATE INDEX CONCURRENTLY IF NOT EXISTS "IDX_repositories_external_id"
+                ON "repositories" ("external_id")
+        `);
+    }
+
+    /**
+     * Drops an index only if Postgres marked it invalid (a CONCURRENTLY build
+     * that was killed mid-flight). Issued as a top-level statement because
+     * `DROP INDEX CONCURRENTLY` cannot run inside a transaction/DO block.
+     */
+    private async dropIfInvalid(
+        queryRunner: QueryRunner,
+        indexName: string,
+    ): Promise<void> {
+        const invalid = (await queryRunner.query(
+            `SELECT 1
+               FROM pg_class c
+               JOIN pg_index i ON i.indexrelid = c.oid
+              WHERE c.relname = $1
+                AND NOT i.indisvalid`,
+            [indexName],
+        )) as unknown[];
+        if (invalid.length) {
+            await queryRunner.query(
+                `DROP INDEX CONCURRENTLY IF EXISTS "${indexName}"`,
+            );
+        }
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            DROP INDEX CONCURRENTLY IF EXISTS "IDX_repositories_external_id"
+        `);
+        await queryRunner.query(`
+            DROP INDEX CONCURRENTLY IF EXISTS "IDX_automation_exec_review_ops_watermark"
+        `);
+    }
+}

--- a/libs/ee/analytics-warehouse/entities/index.ts
+++ b/libs/ee/analytics-warehouse/entities/index.ts
@@ -5,6 +5,7 @@ import { IngestionRunEntity } from './ingestion-run.entity';
 import { IngestionWatermarkEntity } from './ingestion-watermark.entity';
 import { PullRequestOptEntity } from './pull-request-opt.entity';
 import { PullRequestTypeEntity } from './pull-request-type.entity';
+import { ReviewOperationalExecutionEntity } from './review-operational-execution.entity';
 import { SuggestionFeedbackEntity } from './suggestion-feedback.entity';
 import { SuggestionMvEntity } from './suggestion-mv.entity';
 
@@ -16,6 +17,7 @@ export {
     IngestionWatermarkEntity,
     PullRequestOptEntity,
     PullRequestTypeEntity,
+    ReviewOperationalExecutionEntity,
     SuggestionFeedbackEntity,
     SuggestionMvEntity,
 };
@@ -24,6 +26,7 @@ export const ANALYTICS_ENTITIES = [
     PullRequestOptEntity,
     SuggestionMvEntity,
     SuggestionFeedbackEntity,
+    ReviewOperationalExecutionEntity,
     CommitsViewEntity,
     PullRequestTypeEntity,
     IngestionWatermarkEntity,

--- a/libs/ee/analytics-warehouse/entities/review-operational-execution.entity.ts
+++ b/libs/ee/analytics-warehouse/entities/review-operational-execution.entity.ts
@@ -1,0 +1,56 @@
+import { Column, Entity, Index, PrimaryColumn } from 'typeorm';
+
+import { ANALYTICS_SCHEMA } from '../schema.constant';
+
+/**
+ * Terminal code-review automation executions materialized for cockpit metrics.
+ *
+ * Ingested from operational Postgres into the analytics warehouse so cockpit
+ * reads never hit OLTP tables directly.
+ */
+@Entity({ schema: ANALYTICS_SCHEMA, name: 'review_operational_executions' })
+@Index('idx_review_ops_org_created', ['organizationId', 'createdAt'])
+@Index('idx_review_ops_org_repo_created', [
+    'organizationId',
+    'repoFullName',
+    'createdAt',
+])
+@Index('idx_review_ops_org_status_created', [
+    'organizationId',
+    'status',
+    'createdAt',
+])
+export class ReviewOperationalExecutionEntity {
+    @PrimaryColumn({ name: 'automation_execution_id', type: 'uuid' })
+    automationExecutionId: string;
+
+    @Column({ name: 'organizationId', type: 'text' })
+    organizationId: string;
+
+    @Column({ name: 'team_id', type: 'uuid', nullable: true })
+    teamId: string | null;
+
+    @Column({ name: 'team_automation_id', type: 'uuid', nullable: true })
+    teamAutomationId: string | null;
+
+    @Column({ name: 'repositoryId', type: 'text', nullable: true })
+    repositoryId: string | null;
+
+    @Column({ name: 'repo_full_name', type: 'text', nullable: true })
+    repoFullName: string | null;
+
+    @Column({ name: 'pullRequestNumber', type: 'integer', nullable: true })
+    pullRequestNumber: number | null;
+
+    @Column({ name: 'status', type: 'text' })
+    status: string;
+
+    @Column({ name: 'created_at', type: 'timestamptz' })
+    createdAt: Date;
+
+    @Column({ name: 'source_updated_at', type: 'timestamptz' })
+    sourceUpdatedAt: Date;
+
+    @Column({ name: 'ingested_at', type: 'timestamptz', default: () => 'now()' })
+    ingestedAt: Date;
+}

--- a/libs/ee/analytics-warehouse/index.ts
+++ b/libs/ee/analytics-warehouse/index.ts
@@ -4,5 +4,6 @@ export * from './entities';
 export * from './ingestion/backfill-orchestrator.service';
 export * from './ingestion/feedback-ingestion.service';
 export * from './ingestion/pull-request-ingestion.service';
+export * from './ingestion/review-operational-ingestion.service';
 export * from './modules/analytics-warehouse.module';
 export * from './schema.constant';

--- a/libs/ee/analytics-warehouse/ingestion/review-operational-ingestion.service.ts
+++ b/libs/ee/analytics-warehouse/ingestion/review-operational-ingestion.service.ts
@@ -16,6 +16,14 @@ const TERMINAL_REVIEW_STATUSES = [
     'skipped',
 ] as const;
 
+// Inlined as enum literals (not a `status::text = ANY($n)` param) so the
+// predicate matches `IDX_automation_exec_review_ops_watermark`'s partial index
+// condition verbatim — otherwise the planner can't prove the match and falls
+// back to a full seq scan + on-disk sort (~50x slower on the backfill).
+const TERMINAL_REVIEW_STATUS_SQL = TERMINAL_REVIEW_STATUSES.map(
+    (status) => `'${status}'`,
+).join(', ');
+
 /**
  * Hard cap on how far back the import reaches. The cockpit date picker tops out
  * at a 3-month range and every metric compares it against the equally-long
@@ -145,7 +153,7 @@ export class ReviewOperationalIngestionService {
         organizationId: string | undefined,
         batchSize: number,
     ): Promise<ReviewOperationalSourceRow[]> {
-        const params: unknown[] = [TERMINAL_REVIEW_STATUSES, batchSize];
+        const params: unknown[] = [batchSize];
         const orgFilter = organizationId
             ? (params.push(organizationId),
               `AND t."organization_id" = $${params.length}`)
@@ -161,7 +169,7 @@ export class ReviewOperationalIngestionService {
                     ae."updatedAt" > $${updatedAtIndex}::timestamp
                     OR (
                         ae."updatedAt" = $${updatedAtIndex}::timestamp
-                        AND ae."uuid"::text > $${params.length}
+                        AND ae."uuid" > $${params.length}::uuid
                     )
                 )`;
             } else {
@@ -197,7 +205,7 @@ export class ReviewOperationalIngestionService {
                        ORDER BY r."createdAt" DESC
                        LIMIT 1
                   ) repo ON true
-                 WHERE ae."status"::text = ANY($1::text[])
+                 WHERE ae."status" IN (${TERMINAL_REVIEW_STATUS_SQL})
                    AND ae."pullRequestNumber" IS NOT NULL
                    AND ae."repositoryId" IS NOT NULL
                    -- 6-month floor: bounds the historical backfill. updatedAt
@@ -213,8 +221,8 @@ export class ReviewOperationalIngestionService {
                    )
                    ${orgFilter}
                    ${cursorFilter}
-             ORDER BY ae."updatedAt" ASC, ae."uuid"::text ASC
-             LIMIT $2`,
+             ORDER BY ae."updatedAt" ASC, ae."uuid" ASC
+             LIMIT $1`,
             params,
         )) as ReviewOperationalSourceRow[];
     }

--- a/libs/ee/analytics-warehouse/ingestion/review-operational-ingestion.service.ts
+++ b/libs/ee/analytics-warehouse/ingestion/review-operational-ingestion.service.ts
@@ -1,0 +1,378 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { InjectDataSource } from '@nestjs/typeorm';
+import { DataSource } from 'typeorm';
+
+import { ANALYTICS_DATA_SOURCE } from '../schema.constant';
+
+export const REVIEW_OPERATIONAL_INGESTION_WATERMARK =
+    'review_operational_executions';
+export const REVIEW_OPERATIONAL_INGESTION_SOURCE =
+    'review_operational_executions';
+
+const TERMINAL_REVIEW_STATUSES = [
+    'success',
+    'error',
+    'partial_error',
+    'skipped',
+] as const;
+
+/**
+ * Hard cap on how far back the import reaches. The cockpit date picker tops out
+ * at a 3-month range and every metric compares it against the equally-long
+ * previous period, so 6 months is the deepest window any read can touch.
+ * Capping here keeps the first (watermark-less) backfill from scanning and
+ * materializing the entire historical `automation_execution` corpus.
+ */
+const REVIEW_BACKFILL_WINDOW = '6 months';
+
+interface ReviewOperationalSourceRow {
+    automation_execution_id: string;
+    organization_id: string;
+    team_id: string | null;
+    team_automation_id: string | null;
+    repository_id: string | null;
+    repo_full_name: string | null;
+    pull_request_number: number | string | null;
+    status: string;
+    created_at: Date;
+    source_updated_at: string;
+}
+
+export interface ReviewOperationalIngestionOptions {
+    /** Scope to one org for replay/admin tooling. */
+    organizationId?: string;
+    /** Ignore the watermark and rescan everything. */
+    backfill?: boolean;
+    batchSize?: number;
+}
+
+export interface ReviewOperationalIngestionResult {
+    scanned: number;
+    upserted: number;
+    newWatermark: string | null;
+    durationMs: number;
+}
+
+/**
+ * Incremental sync of terminal code-review automation executions from OLTP
+ * Postgres into `analytics.review_operational_executions`.
+ *
+ * First run has no watermark, so it imports the historical corpus. Later
+ * runs advance via `(updatedAt, uuid)` and only pull changes.
+ */
+@Injectable()
+export class ReviewOperationalIngestionService {
+    private readonly logger = new Logger(
+        ReviewOperationalIngestionService.name,
+    );
+
+    constructor(
+        @InjectDataSource(ANALYTICS_DATA_SOURCE)
+        private readonly analyticsDs: DataSource,
+        @InjectDataSource()
+        private readonly appDs: DataSource,
+    ) {}
+
+    async run(
+        options: ReviewOperationalIngestionOptions = {},
+    ): Promise<ReviewOperationalIngestionResult> {
+        const batchSize = options.batchSize ?? 500;
+        const useWatermark = !options.backfill;
+        let watermark = useWatermark ? await this.readWatermark() : null;
+
+        const startedAt = Date.now();
+        const runId = await this.startRun(options.organizationId ?? null);
+
+        let scanned = 0;
+        let upserted = 0;
+        let newestUpdatedAt: string | null = watermark?.updatedAt ?? null;
+        let newestId: string | null = watermark?.id ?? null;
+
+        try {
+            while (true) {
+                const rows = await this.fetchBatch(
+                    watermark,
+                    options.organizationId,
+                    batchSize,
+                );
+                if (!rows.length) break;
+
+                scanned += rows.length;
+                upserted += await this.writeBatch(rows);
+
+                const last = rows[rows.length - 1];
+                newestUpdatedAt = last.source_updated_at;
+                newestId = last.automation_execution_id;
+                watermark = {
+                    updatedAt: newestUpdatedAt,
+                    id: newestId,
+                };
+
+                if (useWatermark && newestUpdatedAt) {
+                    await this.writeWatermark(newestUpdatedAt, newestId);
+                }
+
+                if (rows.length < batchSize) break;
+            }
+
+            const durationMs = Date.now() - startedAt;
+            await this.completeRun(runId, 'ok', scanned, upserted, null);
+            this.logger.log(
+                `review operational ingestion done: scanned=${scanned} upserted=${upserted} ` +
+                    `total_ms=${durationMs} watermark=${newestUpdatedAt ?? 'null'}`,
+            );
+
+            return {
+                scanned,
+                upserted,
+                newWatermark: newestUpdatedAt,
+                durationMs,
+            };
+        } catch (err) {
+            await this.completeRun(
+                runId,
+                'failed',
+                scanned,
+                upserted,
+                err instanceof Error ? err.message : String(err),
+            );
+            throw err;
+        }
+    }
+
+    private async fetchBatch(
+        watermark: { updatedAt: string; id: string | null } | null,
+        organizationId: string | undefined,
+        batchSize: number,
+    ): Promise<ReviewOperationalSourceRow[]> {
+        const params: unknown[] = [TERMINAL_REVIEW_STATUSES, batchSize];
+        const orgFilter = organizationId
+            ? (params.push(organizationId),
+              `AND t."organization_id" = $${params.length}`)
+            : '';
+
+        let cursorFilter = '';
+        if (watermark?.updatedAt) {
+            params.push(watermark.updatedAt);
+            const updatedAtIndex = params.length;
+            if (watermark.id) {
+                params.push(watermark.id);
+                cursorFilter = `AND (
+                    ae."updatedAt" > $${updatedAtIndex}::timestamp
+                    OR (
+                        ae."updatedAt" = $${updatedAtIndex}::timestamp
+                        AND ae."uuid"::text > $${params.length}
+                    )
+                )`;
+            } else {
+                cursorFilter = `AND ae."updatedAt" > $${updatedAtIndex}::timestamp`;
+            }
+        }
+
+        return (await this.appDs.query(
+            `SELECT
+                    ae."uuid" AS automation_execution_id,
+                    t."organization_id"::text AS organization_id,
+                    t."uuid" AS team_id,
+                    ae."team_automation_id" AS team_automation_id,
+                    ae."repositoryId"::text AS repository_id,
+                    COALESCE(
+                        repo."full_name",
+                        ae."dataExecution"->'repository'->>'fullName',
+                        ae."dataExecution"->'repository'->>'name'
+                    )::text AS repo_full_name,
+                    ae."pullRequestNumber" AS pull_request_number,
+                    ae."status"::text AS status,
+                    ae."createdAt" AS created_at,
+                    to_char(ae."updatedAt", 'YYYY-MM-DD HH24:MI:SS.US') AS source_updated_at
+                  FROM "automation_execution" ae
+                  JOIN "team_automations" ta
+                    ON ta."uuid" = ae."team_automation_id"
+                  JOIN "teams" t
+                    ON t."uuid" = ta."teamUuid"
+                  LEFT JOIN LATERAL (
+                      SELECT r."full_name"
+                        FROM "repositories" r
+                       WHERE r."external_id" = ae."repositoryId"
+                       ORDER BY r."createdAt" DESC
+                       LIMIT 1
+                  ) repo ON true
+                 WHERE ae."status"::text = ANY($1::text[])
+                   AND ae."pullRequestNumber" IS NOT NULL
+                   AND ae."repositoryId" IS NOT NULL
+                   -- 6-month floor: bounds the historical backfill. updatedAt
+                   -- is floored too (updatedAt >= createdAt always holds) so
+                   -- the (updatedAt, uuid) index can seek to the cutoff
+                   -- instead of scanning the table from its oldest row.
+                   AND ae."createdAt" >= now() - INTERVAL '${REVIEW_BACKFILL_WINDOW}'
+                   AND ae."updatedAt" >= now() - INTERVAL '${REVIEW_BACKFILL_WINDOW}'
+                   AND EXISTS (
+                       SELECT 1
+                         FROM "code_review_execution" cre
+                        WHERE cre."automation_execution_id" = ae."uuid"
+                   )
+                   ${orgFilter}
+                   ${cursorFilter}
+             ORDER BY ae."updatedAt" ASC, ae."uuid"::text ASC
+             LIMIT $2`,
+            params,
+        )) as ReviewOperationalSourceRow[];
+    }
+
+    private async writeBatch(
+        rows: ReviewOperationalSourceRow[],
+    ): Promise<number> {
+        if (!rows.length) return 0;
+
+        const params: unknown[] = [];
+        const values = rows
+            .map((row) => {
+                const offset = params.length;
+                params.push(
+                    row.automation_execution_id,
+                    row.organization_id,
+                    row.team_id,
+                    row.team_automation_id,
+                    row.repository_id,
+                    row.repo_full_name,
+                    row.pull_request_number != null
+                        ? Number(row.pull_request_number)
+                        : null,
+                    row.status,
+                    row.created_at,
+                    row.source_updated_at,
+                );
+                return `($${offset + 1}, $${offset + 2}, $${offset + 3}, $${offset + 4}, $${offset + 5}, $${offset + 6}, $${offset + 7}, $${offset + 8}, $${offset + 9}, $${offset + 10})`;
+            })
+            .join(', ');
+
+        await this.analyticsDs.transaction(async (manager) => {
+            await manager.query(
+                `INSERT INTO "analytics"."review_operational_executions" (
+                        "automation_execution_id", "organizationId",
+                        "team_id", "team_automation_id",
+                        "repositoryId", "repo_full_name", "pullRequestNumber",
+                        "status", "created_at", "source_updated_at"
+                     ) VALUES ${values}
+                     ON CONFLICT ("automation_execution_id") DO UPDATE SET
+                        "organizationId" = EXCLUDED."organizationId",
+                        "team_id" = EXCLUDED."team_id",
+                        "team_automation_id" = EXCLUDED."team_automation_id",
+                        "repositoryId" = EXCLUDED."repositoryId",
+                        "repo_full_name" = EXCLUDED."repo_full_name",
+                        "pullRequestNumber" = EXCLUDED."pullRequestNumber",
+                        "status" = EXCLUDED."status",
+                        "created_at" = EXCLUDED."created_at",
+                        "source_updated_at" = EXCLUDED."source_updated_at",
+                        "ingested_at" = now()`,
+                params,
+            );
+        });
+        return rows.length;
+    }
+
+    async readWatermark(): Promise<{
+        updatedAt: string;
+        id: string | null;
+    } | null> {
+        const rows = (await this.analyticsDs.query(
+            `SELECT
+                to_char("last_source_updated_at", 'YYYY-MM-DD HH24:MI:SS.US') AS "last_source_updated_at",
+                "last_source_id"
+             FROM "analytics"."watermarks" WHERE "table_name" = $1`,
+            [REVIEW_OPERATIONAL_INGESTION_WATERMARK],
+        )) as Array<{
+            last_source_updated_at: string | null;
+            last_source_id: string | null;
+        }>;
+        const row = rows[0];
+        if (!row?.last_source_updated_at) return null;
+        return {
+            updatedAt: row.last_source_updated_at,
+            id: row.last_source_id ?? null,
+        };
+    }
+
+    private async writeWatermark(
+        at: string | Date,
+        id: string | null,
+    ): Promise<void> {
+        await this.analyticsDs.query(
+            `INSERT INTO "analytics"."watermarks" (
+                "table_name", "last_source_updated_at", "last_source_id",
+                "last_run_at", "last_status", "last_error"
+             ) VALUES ($1, $2, $3, now(), 'ok', NULL)
+             ON CONFLICT ("table_name") DO UPDATE SET
+                "last_source_updated_at" = CASE
+                    WHEN EXCLUDED."last_source_updated_at" > COALESCE(
+                        "analytics"."watermarks"."last_source_updated_at",
+                        'epoch'::timestamptz
+                    )
+                    THEN EXCLUDED."last_source_updated_at"
+                    WHEN EXCLUDED."last_source_updated_at" = "analytics"."watermarks"."last_source_updated_at"
+                     AND COALESCE(EXCLUDED."last_source_id", '') > COALESCE(
+                        "analytics"."watermarks"."last_source_id",
+                        ''
+                     )
+                    THEN EXCLUDED."last_source_updated_at"
+                    ELSE "analytics"."watermarks"."last_source_updated_at"
+                END,
+                "last_source_id" = CASE
+                    WHEN EXCLUDED."last_source_updated_at" > COALESCE(
+                        "analytics"."watermarks"."last_source_updated_at",
+                        'epoch'::timestamptz
+                    )
+                    THEN EXCLUDED."last_source_id"
+                    WHEN EXCLUDED."last_source_updated_at" = "analytics"."watermarks"."last_source_updated_at"
+                     AND COALESCE(EXCLUDED."last_source_id", '') > COALESCE(
+                        "analytics"."watermarks"."last_source_id",
+                        ''
+                     )
+                    THEN EXCLUDED."last_source_id"
+                    ELSE "analytics"."watermarks"."last_source_id"
+                END,
+                "last_run_at" = now(),
+                "last_status" = EXCLUDED."last_status",
+                "last_error" = NULL`,
+            [REVIEW_OPERATIONAL_INGESTION_WATERMARK, at, id],
+        );
+    }
+
+    private async startRun(
+        organizationId: string | null,
+    ): Promise<string | null> {
+        try {
+            const rows = (await this.analyticsDs.query(
+                `INSERT INTO "analytics"."ingestion_runs" (
+                    "source", "mode", "status", "organizationId"
+                 ) VALUES ($1, 'incremental', 'running', $2)
+                 RETURNING "id"`,
+                [REVIEW_OPERATIONAL_INGESTION_SOURCE, organizationId],
+            )) as Array<{ id: string | number }>;
+            return rows[0]?.id != null ? String(rows[0].id) : null;
+        } catch {
+            return null;
+        }
+    }
+
+    private async completeRun(
+        runId: string | null,
+        status: 'ok' | 'failed',
+        scanned: number,
+        upserted: number,
+        error: string | null,
+    ): Promise<void> {
+        if (!runId) return;
+        try {
+            await this.analyticsDs.query(
+                `UPDATE "analytics"."ingestion_runs"
+                    SET "status" = $2, "finished_at" = now(),
+                        "scanned" = $3, "prs_upserted" = $4, "error" = $5
+                  WHERE "id" = $1`,
+                [runId, status, scanned, upserted, error],
+            );
+        } catch {
+            // auxiliary table - never fail the run because of it
+        }
+    }
+}

--- a/libs/ee/analytics-warehouse/migrations/2026061110000000-AddReviewOperationalExecutions.ts
+++ b/libs/ee/analytics-warehouse/migrations/2026061110000000-AddReviewOperationalExecutions.ts
@@ -1,0 +1,52 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Materialized terminal review executions for cockpit operational metrics.
+ * This keeps cockpit reads on the analytics schema while the analytics worker
+ * owns OLTP extraction and incremental sync.
+ */
+export class AddReviewOperationalExecutions2026061110000000
+    implements MigrationInterface
+{
+    name = 'AddReviewOperationalExecutions2026061110000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            CREATE TABLE IF NOT EXISTS "analytics"."review_operational_executions" (
+                "automation_execution_id" uuid PRIMARY KEY,
+                "organizationId" text NOT NULL,
+                "team_id" uuid,
+                "team_automation_id" uuid,
+                "repositoryId" text,
+                "repo_full_name" text,
+                "pullRequestNumber" integer,
+                "status" text NOT NULL,
+                "created_at" timestamptz NOT NULL,
+                "source_updated_at" timestamptz NOT NULL,
+                "ingested_at" timestamptz NOT NULL DEFAULT now()
+            )
+        `);
+        await queryRunner.query(`
+            CREATE INDEX IF NOT EXISTS "idx_review_ops_org_created"
+                ON "analytics"."review_operational_executions" ("organizationId", "created_at")
+        `);
+        await queryRunner.query(`
+            CREATE INDEX IF NOT EXISTS "idx_review_ops_org_repo_created"
+                ON "analytics"."review_operational_executions" ("organizationId", "repo_full_name", "created_at")
+        `);
+        await queryRunner.query(`
+            CREATE INDEX IF NOT EXISTS "idx_review_ops_org_status_created"
+                ON "analytics"."review_operational_executions" ("organizationId", "status", "created_at")
+        `);
+        await queryRunner.query(`
+            CREATE INDEX IF NOT EXISTS "idx_review_ops_source_watermark"
+                ON "analytics"."review_operational_executions" ("source_updated_at", "automation_execution_id")
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(
+            `DROP TABLE IF EXISTS "analytics"."review_operational_executions"`,
+        );
+    }
+}

--- a/libs/ee/analytics-warehouse/modules/analytics-warehouse.module.ts
+++ b/libs/ee/analytics-warehouse/modules/analytics-warehouse.module.ts
@@ -18,6 +18,7 @@ import { ANALYTICS_ENTITIES } from '../entities';
 import { BackfillOrchestratorService } from '../ingestion/backfill-orchestrator.service';
 import { FeedbackIngestionService } from '../ingestion/feedback-ingestion.service';
 import { PullRequestIngestionService } from '../ingestion/pull-request-ingestion.service';
+import { ReviewOperationalIngestionService } from '../ingestion/review-operational-ingestion.service';
 import { AnalyticsTypeORMFactory } from '../infrastructure/typeORM.factory';
 import { ANALYTICS_DATA_SOURCE } from '../schema.constant';
 
@@ -67,6 +68,7 @@ export class AnalyticsWarehouseModule {
             providers: [
                 PullRequestIngestionService,
                 FeedbackIngestionService,
+                ReviewOperationalIngestionService,
                 BackfillOrchestratorService,
                 PullRequestClassifierService,
             ],
@@ -74,6 +76,7 @@ export class AnalyticsWarehouseModule {
                 TypeOrmModule,
                 PullRequestIngestionService,
                 FeedbackIngestionService,
+                ReviewOperationalIngestionService,
                 BackfillOrchestratorService,
                 PullRequestClassifierService,
             ],

--- a/test/unit/analytics/review-operational-ingestion.service.spec.ts
+++ b/test/unit/analytics/review-operational-ingestion.service.spec.ts
@@ -1,0 +1,181 @@
+import {
+    REVIEW_OPERATIONAL_INGESTION_WATERMARK,
+    ReviewOperationalIngestionService,
+} from '@libs/ee/analytics-warehouse/ingestion/review-operational-ingestion.service';
+
+interface QueryCall {
+    sql: string;
+    params?: unknown[];
+}
+
+function makeManager() {
+    const calls: QueryCall[] = [];
+    return {
+        query: jest.fn(async (sql: string, params?: unknown[]) => {
+            calls.push({ sql, params });
+            return [];
+        }),
+        calls,
+    };
+}
+
+function makeAnalyticsDs(opts?: {
+    watermarkRow?: {
+        last_source_updated_at: string | null;
+        last_source_id: string | null;
+    } | null;
+}) {
+    const calls: QueryCall[] = [];
+    const managers: ReturnType<typeof makeManager>[] = [];
+    const ds = {
+        query: jest.fn(async (sql: string, params?: unknown[]) => {
+            calls.push({ sql, params });
+            if (sql.includes('FROM "analytics"."watermarks"')) {
+                return opts?.watermarkRow ? [opts.watermarkRow] : [];
+            }
+            if (sql.includes('INSERT INTO "analytics"."ingestion_runs"')) {
+                return [{ id: '1' }];
+            }
+            return [];
+        }),
+        transaction: jest.fn(async (cb: (manager: unknown) => unknown) => {
+            const manager = makeManager();
+            managers.push(manager);
+            return cb(manager);
+        }),
+    };
+    return { ds, calls, managers };
+}
+
+function makeAppDs(batches: unknown[][]) {
+    const calls: QueryCall[] = [];
+    const ds = {
+        query: jest.fn(async (sql: string, params?: unknown[]) => {
+            calls.push({ sql, params });
+            return batches.shift() ?? [];
+        }),
+    };
+    return { ds, calls };
+}
+
+describe('ReviewOperationalIngestionService.run()', () => {
+    it('imports terminal review executions into analytics and advances the watermark', async () => {
+        const sourceUpdatedAt = '2026-06-10 10:00:00.123456';
+        const { ds: analyticsDs, calls: analyticsCalls, managers } =
+            makeAnalyticsDs();
+        const { ds: appDs, calls: appCalls } = makeAppDs([
+            [
+                {
+                    automation_execution_id:
+                        '11111111-1111-1111-1111-111111111111',
+                    organization_id: 'org-1',
+                    team_id: '22222222-2222-2222-2222-222222222222',
+                    team_automation_id:
+                        '33333333-3333-3333-3333-333333333333',
+                    repository_id: 'repo-1',
+                    repo_full_name: 'org/repo',
+                    pull_request_number: 123,
+                    status: 'success',
+                    created_at: new Date('2026-06-10T09:00:00Z'),
+                    source_updated_at: sourceUpdatedAt,
+                },
+            ],
+        ]);
+        const service = new ReviewOperationalIngestionService(
+            analyticsDs as never,
+            appDs as never,
+        );
+
+        const result = await service.run({ batchSize: 10 });
+
+        expect(result).toMatchObject({
+            scanned: 1,
+            upserted: 1,
+            newWatermark: sourceUpdatedAt,
+        });
+
+        expect(appCalls[0].sql).toContain('FROM "automation_execution" ae');
+        expect(appCalls[0].sql).toContain('"code_review_execution" cre');
+        expect(appCalls[0].sql).toContain('ae."status"::text = ANY');
+        // 6-month backfill floor on both createdAt and updatedAt.
+        expect(appCalls[0].sql).toContain(
+            `ae."createdAt" >= now() - INTERVAL '6 months'`,
+        );
+        expect(appCalls[0].sql).toContain(
+            `ae."updatedAt" >= now() - INTERVAL '6 months'`,
+        );
+
+        const writeCall = managers[0].calls[0];
+        expect(writeCall.sql).toContain(
+            'INSERT INTO "analytics"."review_operational_executions"',
+        );
+        expect(writeCall.params?.[1]).toBe('org-1');
+        expect(writeCall.params?.[5]).toBe('org/repo');
+
+        const watermarkCall = analyticsCalls.find((call) =>
+            call.sql.includes('INSERT INTO "analytics"."watermarks"'),
+        );
+        expect(watermarkCall?.params).toEqual([
+            REVIEW_OPERATIONAL_INGESTION_WATERMARK,
+            sourceUpdatedAt,
+            '11111111-1111-1111-1111-111111111111',
+        ]);
+    });
+
+    it('resumes from tuple watermark when one already exists', async () => {
+        const watermarkAt = '2026-06-10 10:00:00.123456';
+        const { ds: analyticsDs } = makeAnalyticsDs({
+            watermarkRow: {
+                last_source_updated_at: watermarkAt,
+                last_source_id: '11111111-1111-1111-1111-111111111111',
+            },
+        });
+        const { ds: appDs, calls: appCalls } = makeAppDs([[]]);
+        const service = new ReviewOperationalIngestionService(
+            analyticsDs as never,
+            appDs as never,
+        );
+
+        await service.run();
+
+        expect(appCalls[0].sql).toContain('ae."updatedAt" > $3::timestamp');
+        expect(appCalls[0].sql).toContain('ae."uuid"::text > $4');
+        expect(appCalls[0].params).toEqual([
+            ['success', 'error', 'partial_error', 'skipped'],
+            500,
+            watermarkAt,
+            '11111111-1111-1111-1111-111111111111',
+        ]);
+    });
+
+    it('keeps the greatest tuple when advancing the watermark at the same timestamp', async () => {
+        const { ds: analyticsDs, calls } = makeAnalyticsDs();
+        const { ds: appDs } = makeAppDs([]);
+        const service = new ReviewOperationalIngestionService(
+            analyticsDs as never,
+            appDs as never,
+        );
+
+        await (
+            service as unknown as {
+                writeWatermark: (
+                    at: Date,
+                    id: string | null,
+                ) => Promise<void>;
+            }
+        ).writeWatermark(
+            new Date('2026-06-10T10:00:00Z'),
+            '22222222-2222-2222-2222-222222222222',
+        );
+
+        const watermarkCall = calls.find((call) =>
+            call.sql.includes('INSERT INTO "analytics"."watermarks"'),
+        );
+        expect(watermarkCall?.sql).toContain(
+            'EXCLUDED."last_source_updated_at" = "analytics"."watermarks"."last_source_updated_at"',
+        );
+        expect(watermarkCall?.sql).toContain(
+            'COALESCE(EXCLUDED."last_source_id", \'\') > COALESCE',
+        );
+    });
+});

--- a/test/unit/analytics/review-operational-ingestion.service.spec.ts
+++ b/test/unit/analytics/review-operational-ingestion.service.spec.ts
@@ -96,7 +96,13 @@ describe('ReviewOperationalIngestionService.run()', () => {
 
         expect(appCalls[0].sql).toContain('FROM "automation_execution" ae');
         expect(appCalls[0].sql).toContain('"code_review_execution" cre');
-        expect(appCalls[0].sql).toContain('ae."status"::text = ANY');
+        // statuses inlined as enum literals (matches the partial index predicate)
+        expect(appCalls[0].sql).toContain(
+            `ae."status" IN ('success', 'error', 'partial_error', 'skipped')`,
+        );
+        expect(appCalls[0].sql).not.toContain('::text = ANY');
+        // native uuid ordering (no ::text cast) so the index satisfies ORDER BY
+        expect(appCalls[0].sql).toContain('ORDER BY ae."updatedAt" ASC, ae."uuid" ASC');
         // 6-month backfill floor on both createdAt and updatedAt.
         expect(appCalls[0].sql).toContain(
             `ae."createdAt" >= now() - INTERVAL '6 months'`,
@@ -138,10 +144,9 @@ describe('ReviewOperationalIngestionService.run()', () => {
 
         await service.run();
 
-        expect(appCalls[0].sql).toContain('ae."updatedAt" > $3::timestamp');
-        expect(appCalls[0].sql).toContain('ae."uuid"::text > $4');
+        expect(appCalls[0].sql).toContain('ae."updatedAt" > $2::timestamp');
+        expect(appCalls[0].sql).toContain('ae."uuid" > $3::uuid');
         expect(appCalls[0].params).toEqual([
-            ['success', 'error', 'partial_error', 'skipped'],
             500,
             watermarkAt,
             '11111111-1111-1111-1111-111111111111',

--- a/test/unit/cockpit/cockpit-review-analytics.service.spec.ts
+++ b/test/unit/cockpit/cockpit-review-analytics.service.spec.ts
@@ -15,9 +15,11 @@ describe('CockpitReviewAnalyticsService', () => {
 
     beforeEach(() => {
         query = jest.fn().mockResolvedValue([]);
-        service = new CockpitReviewAnalyticsService({
-            query,
-        } as unknown as DataSource);
+        service = new CockpitReviewAnalyticsService(
+            {
+                query,
+            } as unknown as DataSource,
+        );
     });
 
     describe('getImplementationRateWeekly', () => {
@@ -194,6 +196,161 @@ describe('CockpitReviewAnalyticsService', () => {
                     lastTriggeredAt: '2026-05-22T10:00:00Z',
                 },
             ]);
+        });
+    });
+
+    describe('getReviewOperationalMetrics', () => {
+        it('compares processed PRs, review volume and terminal status rates', async () => {
+            query
+                .mockResolvedValueOnce([
+                    {
+                        processed_prs: 10,
+                        processed_reviews: 20,
+                        successful_reviews: 14,
+                        error_reviews: 4,
+                        skipped_reviews: 2,
+                    },
+                ])
+                .mockResolvedValueOnce([
+                    {
+                        processed_prs: 5,
+                        processed_reviews: 10,
+                        successful_reviews: 8,
+                        error_reviews: 1,
+                        skipped_reviews: 1,
+                    },
+                ]);
+
+            const res = await service.getReviewOperationalMetrics(baseQuery);
+
+            const [sql, params] = query.mock.calls[0];
+            expect(sql).toContain(
+                '"analytics"."review_operational_executions" roe',
+            );
+            expect(sql).toContain('roe."organizationId" = $1');
+            expect(sql).not.toContain('"automation_execution"');
+            expect(sql).not.toContain('"code_review_execution"');
+            expect(params).toEqual(['org-1', '2026-03-01', '2026-06-01']);
+
+            expect(res.currentPeriod).toEqual({
+                processedPRs: 10,
+                processedReviews: 20,
+                successfulReviews: 14,
+                errorReviews: 4,
+                skippedReviews: 2,
+                successRate: 0.7,
+                errorRate: 0.2,
+                skippedRate: 0.1,
+            });
+            expect(res.previousPeriod.successRate).toBe(0.8);
+            expect(res.comparison.processedPRs).toEqual({
+                percentageChange: 100,
+                trend: 'improved',
+            });
+            expect(res.comparison.successRate).toEqual({
+                percentageChange: -12.5,
+                percentagePointChange: -10,
+                trend: 'worsened',
+            });
+            expect(res.comparison.errorRate).toEqual({
+                percentageChange: 100,
+                percentagePointChange: 10,
+                trend: 'worsened',
+            });
+            expect(res.comparison.skippedRate).toEqual({
+                percentageChange: 0,
+                percentagePointChange: 0,
+                trend: 'unchanged',
+            });
+        });
+
+        it('applies the repository filter against repository full name', async () => {
+            await service.getReviewOperationalMetrics({
+                ...baseQuery,
+                repository: 'org/repo',
+            });
+
+            const [sql, params] = query.mock.calls[0];
+            expect(sql).toContain('roe."repo_full_name" = $4');
+            expect(sql).not.toContain('FROM "repositories"');
+            expect(params[3]).toBe('org/repo');
+        });
+    });
+
+    describe('getReviewOperationalMetricsWeekly', () => {
+        it('groups operational outcomes by week and derives rates', async () => {
+            query.mockResolvedValue([
+                {
+                    week_start: '2026-05-04',
+                    processed_prs: 4,
+                    processed_reviews: 10,
+                    successful_reviews: 6,
+                    error_reviews: 1,
+                    skipped_reviews: 3,
+                },
+                {
+                    week_start: '2026-05-11',
+                    processed_prs: 8,
+                    processed_reviews: 20,
+                    successful_reviews: 12,
+                    error_reviews: 4,
+                    skipped_reviews: 4,
+                },
+            ]);
+
+            const rows =
+                await service.getReviewOperationalMetricsWeekly(baseQuery);
+
+            const [sql, params] = query.mock.calls[0];
+            expect(sql).toContain(`date_trunc('week', roe."created_at")`);
+            expect(sql).toContain(
+                'GROUP BY week_start, "repositoryId", "pullRequestNumber"',
+            );
+            expect(sql).toContain('ORDER BY week_start ASC');
+            // distinct-PR count is now a HashAggregate roll-up, not COUNT(DISTINCT)
+            expect(sql).not.toContain('COUNT(DISTINCT');
+            expect(sql).toContain(
+                '"analytics"."review_operational_executions" roe',
+            );
+            expect(sql).not.toContain('"code_review_execution"');
+            expect(params).toEqual(['org-1', '2026-03-01', '2026-06-01']);
+
+            expect(rows).toEqual([
+                {
+                    weekStart: '2026-05-04',
+                    processedPRs: 4,
+                    processedReviews: 10,
+                    successfulReviews: 6,
+                    errorReviews: 1,
+                    skippedReviews: 3,
+                    successRate: 0.6,
+                    errorRate: 0.1,
+                    skippedRate: 0.3,
+                },
+                {
+                    weekStart: '2026-05-11',
+                    processedPRs: 8,
+                    processedReviews: 20,
+                    successfulReviews: 12,
+                    errorReviews: 4,
+                    skippedReviews: 4,
+                    successRate: 0.6,
+                    errorRate: 0.2,
+                    skippedRate: 0.2,
+                },
+            ]);
+        });
+
+        it('applies the repository filter to weekly operational outcomes', async () => {
+            await service.getReviewOperationalMetricsWeekly({
+                ...baseQuery,
+                repository: 'org/repo',
+            });
+
+            const [sql, params] = query.mock.calls[0];
+            expect(sql).toContain('roe."repo_full_name" = $4');
+            expect(sql).not.toContain('FROM "repositories"');
+            expect(params[3]).toBe('org/repo');
         });
     });
 


### PR DESCRIPTION
## What

Completes the new review cockpit by adding the operational metrics left out of the original PR, and fixes the read path to go through the **analytics schema** instead of querying OLTP directly.

### 1. Review volume & error metrics
- **PRs processed**, **reviews processed**, and terminal-status rates (**success / error / skipped**), current vs previous period.
- A weekly stacked **"Review processing outcomes"** chart.

### 2. Reads now go through the analytics warehouse (not OLTP)
- New `ReviewOperationalIngestionService` runs on the `WORKER_ROLE=analytics` worker (existing ingestion cron) and extracts terminal code-review executions from OLTP into `analytics.review_operational_executions`.
- Cockpit endpoints read **only** from the analytics schema — no direct OLTP/`code_review_execution`/`repositories` access on the read path (asserted in tests).
- Incremental, watermark-driven sync; first run backfills history, **capped at 6 months** (the deepest window the cockpit date picker can reach: 3-month max range × previous-period comparison).

## Performance
The distinct-PR count was rewritten from `COUNT(DISTINCT (repo, pr))` — a full sort that spills to disk on large orgs — to a `GROUP BY` HashAggregate roll-up. Measured on a real 219k-row single-org dataset:

| query | before | after |
|---|---|---|
| operational metrics (period) | ~625ms | **~75ms** |
| operational outcomes (weekly) | ~546ms | **~237ms** |

Counts verified **identical** to the old query (0 divergence across all aggregates and per-week).

## Hardening
- OLTP index migration sets `statement_timeout = 0` + bounded `lock_timeout`, and **self-heals** an invalid index left behind by an interrupted `CREATE INDEX CONCURRENTLY` (instead of silently skipping it via `IF NOT EXISTS`).

## ⚠️ Deploy preconditions — please review @Wellington01
1. **`RUN_MIGRATIONS=true` on the API service** (per-service, **not** global — the workers share the same `env_file` and must not race the migrations). This runs OLTP indexes + ensure-schema + the new warehouse migration.
2. **The `WORKER_ROLE=analytics` worker must be running.** Added here in `docker-compose.prod.yml`, but the self-hosted **kodus-installer** compose must ship it too, or no ingestion runs.
3. **Cloud only:** consider pre-creating the OLTP indexes out-of-band — `CREATE INDEX CONCURRENTLY` on a large `automation_execution` runs in the API entrypoint and can delay startup.
4. First analytics-worker boot runs the backfill; the table is empty until it finishes. The tab degrades gracefully (operational cards just don't render until data exists).

## Tests
- 189 cockpit + analytics unit tests passing; query-rewrite correctness verified against a real dataset; full suite green via pre-push hook (4198 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)