### PR TITLE
fix(e2e): resolve self-hosted API hostname so SSO + RBAC web scenarios pass

### DIFF
--- a/docker/sso-e2e/droplet/Caddyfile.internal.tpl
+++ b/docker/sso-e2e/droplet/Caddyfile.internal.tpl
@@ -40,7 +40,7 @@ app.${BASE} {
 
 api.${BASE} {
     tls internal
-    reverse_proxy kodus-api:3001 {
+    reverse_proxy api:3001 {
         import proxy_common
     }
 }

--- a/docker/sso-e2e/droplet/Caddyfile.tpl
+++ b/docker/sso-e2e/droplet/Caddyfile.tpl
@@ -46,7 +46,7 @@ app.${BASE} {
 }
 
 api.${BASE} {
-    reverse_proxy kodus-api:3001 {
+    reverse_proxy api:3001 {
         import proxy_common
     }
 }

--- a/scripts/sso-e2e/droplet/bootstrap-multi-user.sh
+++ b/scripts/sso-e2e/droplet/bootstrap-multi-user.sh
@@ -96,9 +96,9 @@ env_set() {
     fi
 }
 CURR_HOSTNAME=$(grep -E '^WEB_HOSTNAME_API=' /opt/kodus-installer/.env | head -1 | cut -d= -f2-)
-if [ "${CURR_HOSTNAME}" != "kodus-api" ]; then
-    echo "==> repairing WEB_HOSTNAME_API (was '${CURR_HOSTNAME}') -> kodus-api" >&2
-    env_set WEB_HOSTNAME_API "kodus-api"
+if [ "${CURR_HOSTNAME}" != "api" ]; then
+    echo "==> repairing WEB_HOSTNAME_API (was '${CURR_HOSTNAME}') -> api" >&2
+    env_set WEB_HOSTNAME_API "api"
     env_set WEB_PORT_API "3001"
     cd /opt/kodus-installer && docker compose -p kodus-installer -f docker-compose.yml up -d --force-recreate kodus-web
 fi

--- a/scripts/sso-e2e/droplet/provision.sh
+++ b/scripts/sso-e2e/droplet/provision.sh
@@ -9,7 +9,7 @@
 #      so secrets live in one place (~/.kodus-dev/config).
 #   2. Layers Caddy + Keycloak on top via docker/sso-e2e/droplet/compose.yml.
 #      Caddy fronts three sslip.io hostnames:
-#          api.<IP>.sslip.io  → kodus-api:3001
+#          api.<IP>.sslip.io  → api:3001
 #          app.<IP>.sslip.io  → kodus-web-prod:3000
 #          kc.<IP>.sslip.io   → kc-sso-e2e:8080
 #      with Let's Encrypt auto-issued certs (HTTP-01 over port 80).
@@ -189,7 +189,11 @@ env_set NEXTAUTH_URL "${APP_BASE_URL}"
 # sign-in form's /auth/sso/check call). The public API origin lives
 # in API_URL above for cookie-domain / SAML purposes — those code
 # paths read API_URL directly, not WEB_HOSTNAME_API.
-env_set WEB_HOSTNAME_API "kodus-api"
+# Use the compose SERVICE name `api` (Docker DNS always resolves it on the
+# shared network) — NOT the literal `kodus-api`, which matches neither the
+# service (`api`) nor the container (`kodus_api`, GLOBAL_API_CONTAINER_NAME's
+# installer default) and so 502s every web→API server-side call.
+env_set WEB_HOSTNAME_API "api"
 env_set WEB_PORT_API "3001"
 # kodus-installer defaults API_NODE_ENV to "development" for the
 # self-hosted dev experience. The SSO cookie code path explicitly

--- a/tests/e2e/provisioning/self-hosted/vm.sh
+++ b/tests/e2e/provisioning/self-hosted/vm.sh
@@ -333,7 +333,15 @@ env_set() {
     fi
 }
 env_set IMAGE_TAG "$IMAGE_TAG"
-env_set WEB_HOSTNAME_API "kodus-api"
+# Point the web's server-side API calls (next-auth authorize → /auth/login,
+# used by rbac-frontend-routes / rbac-ui-render) at the compose SERVICE name
+# `api`, which Docker DNS always resolves on the shared network regardless of
+# container_name. The old literal `kodus-api` matched neither the service
+# (`api`) nor the actual container (`kodus_api` once GLOBAL_API_CONTAINER_NAME
+# is set), so authorize() got ENOTFOUND → returned null → the next-auth login
+# 302'd with no session → both RBAC web scenarios failed on self-hosted only
+# (cloud passes: it reaches the API over the public URL, not a docker host).
+env_set WEB_HOSTNAME_API "api"
 env_set WEB_PORT_API "3001"
 env_set NEXTAUTH_URL "http://$SERVER_IP:3000"
 # Webhook URL env var names are INCONSISTENT across providers in the app:
@@ -405,7 +413,7 @@ done
 
 if [ ${#HEALTH_FAILED[@]} -gt 0 ]; then
     err "Health check failed for: ${HEALTH_FAILED[*]}"
-    ssh_vm "cd /opt/kodus-installer && docker compose logs api worker webhooks --tail 80 --no-color" || true
+    ssh_vm "cd /opt/kodus-installer && docker compose logs api kodus-web worker webhooks --tail 80 --no-color" || true
     exit 1
 fi
 
@@ -468,7 +476,7 @@ set -e
 # agent actually received the rule. Best-effort: never fail the run on this.
 PROV="${TARGET_FILTER_PROVIDER:-unknown}"
 mkdir -p "$E2E_ROOT/evidence"
-ssh_vm "cd /opt/kodus-installer && docker compose logs api worker webhooks --tail 2000 --no-color" \
+ssh_vm "cd /opt/kodus-installer && docker compose logs api kodus-web worker webhooks --tail 2000 --no-color" \
     > "$E2E_ROOT/evidence/droplet-logs-${PROV}.txt" 2>&1 \
     && ok "Captured droplet logs → evidence/droplet-logs-${PROV}.txt" \
     || warn "Could not capture droplet logs"


### PR DESCRIPTION
## Why

The self-hosted release matrix has been failing on a single cell — `github × license-paid` — which blocks promotion (e.g. `selfhosted-2.1.18-rc.75` never became `selfhosted-2.1.18`). That cell fails on exactly four scenarios; the review engine itself passes everywhere:

- `rbac-frontend-routes`, `rbac-ui-render`
- `sso-cookie-domain`, `sso-multi-user`

All four share **one root cause**, not four flakes.

## Root cause

The harness hardcoded the API hostname as **`kodus-api`** (hyphen) for the web→API path and the SSO Caddy overlay. But the real installer container is **`kodus_api`** (underscore — `GLOBAL_API_CONTAINER_NAME`'s installer default, synced from this repo's `.env.example`/`.env.schema`) and the compose **service** is `api`. `kodus-api` resolves to *neither*:

- **RBAC**: the web's next-auth `authorize()` calls `http://kodus-api:3001/auth/login` → ENOTFOUND → returns `null` → the login **302s with no session**. Passes on cloud because there the web reaches the API over the public HTTPS URL, not a docker hostname — green-on-cloud / red-on-self-hosted was the tell.
- **SSO**: the overlay Caddy `reverse_proxy kodus-api:3001` never resolves → **"API never answered over Caddy internal-CA TLS"** at the TLS-wait step, before any assertion runs (hence "no [sso-e2e] FAIL line").

## Fix

Point every harness reference at the compose **service name `api`**, which Docker DNS always resolves on the shared network regardless of `container_name`:

- `tests/e2e/provisioning/self-hosted/vm.sh` — `WEB_HOSTNAME_API` → `api`; also **add `kodus-web` to the droplet log capture** (only `api/worker/webhooks` were captured, so the web-side 302 was invisible in evidence).
- `docker/sso-e2e/droplet/Caddyfile.tpl` + `Caddyfile.internal.tpl` — API upstream → `api:3001`.
- `scripts/sso-e2e/droplet/provision.sh` + `bootstrap-multi-user.sh` — `WEB_HOSTNAME_API` / repair → `api`.

The **local** lvh.me harness (`docker/sso-e2e/*`, `scripts/sso-e2e/run.sh`) builds its own api container literally named `kodus-api` and is intentionally left untouched.

## Risk

Low — test-harness only, cannot affect product or prod. `api` is the documented compose service name.

## Test plan

⚠️ **Not yet validated live** — these paths only run on a provisioned DigitalOcean droplet, not locally. Validated statically (YAML + `bash -n` + log cross-reference).

To validate without merging, dispatch the matrix against this branch on the github cell using the existing RC image:

```
gh workflow run e2e-self-hosted-matrix.yml --ref fix/e2e-selfhosted-api-hostname \
  -f image_tag=2.1.18-rc.75 -f only_provider=github
```

Caveat: this unblocks the API-over-TLS gate for SSO; the downstream Keycloak/SAML steps never ran in the failing matrix, so a later-stage failure could still surface that we haven't seen yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)