### PR TITLE
fix: disconnecting a git provider leaves stale integration rows that break reconnect

### DIFF
--- a/libs/integrations/infrastructure/adapters/repositories/authIntegration.repository.ts
+++ b/libs/integrations/infrastructure/adapters/repositories/authIntegration.repository.ts
@@ -236,6 +236,9 @@ export class AuthIntegrationRepository implements IAuthIntegrationRepository {
             await this.authIntegrationRepository.delete(uuid);
         } catch (error) {
             console.log(error);
+            // Surface the failure so callers don't report a successful
+            // disconnect while the auth integration row is still in place.
+            throw error;
         }
     }
 

--- a/libs/integrations/infrastructure/adapters/repositories/integration.repository.ts
+++ b/libs/integrations/infrastructure/adapters/repositories/integration.repository.ts
@@ -254,6 +254,10 @@ export class IntegrationRepository implements IIntegrationRepository {
             await this.integrationRepository.delete(uuid);
         } catch (error) {
             console.log(error);
+            // Swallowing this error leaves a stale active integration behind
+            // (e.g. when a remaining integration_config still references it),
+            // which breaks reconnecting the provider later.
+            throw error;
         }
     }
 

--- a/libs/integrations/infrastructure/adapters/repositories/integrationConfig.repository.ts
+++ b/libs/integrations/infrastructure/adapters/repositories/integrationConfig.repository.ts
@@ -392,6 +392,9 @@ export class IntegrationConfigRepository implements IIntegrationConfigRepository
             await this.integrationConfigRepository.delete(uuid);
         } catch (error) {
             console.log(error);
+            // Surface the failure so the integration delete that depends on
+            // these rows being gone doesn't proceed against a stale config.
+            throw error;
         }
     }
 }

--- a/libs/platform/application/use-cases/codeManagement/__tests__/delete-integration.use-case.spec.ts
+++ b/libs/platform/application/use-cases/codeManagement/__tests__/delete-integration.use-case.spec.ts
@@ -22,6 +22,7 @@ jest.mock('@kodus/flow', () => ({
 import { DeleteIntegrationUseCase } from '../delete-integration.use-case';
 import {
     MOCK_AUTH_INTEGRATION_UUID,
+    MOCK_INSTALLATION_CONFIG_UUID,
     MOCK_INTEGRATION_CONFIG_UUID,
     MOCK_INTEGRATION_UUID,
     MOCK_ORG_ID,
@@ -29,6 +30,7 @@ import {
     createMockAuthIntegrationService,
     createMockCodeManagementService,
     createMockEventEmitter,
+    createMockInstallationConfigEntity,
     createMockIntegrationConfigEntity,
     createMockIntegrationConfigService,
     createMockIntegrationEntity,
@@ -92,9 +94,9 @@ describe('DeleteIntegrationUseCase', () => {
     function setupIntegration(platform: string, authMode: string) {
         const integration = createMockIntegrationEntity(platform, authMode);
         mockIntegrationService.findOne.mockResolvedValue(integration);
-        mockIntegrationConfigService.findOne.mockResolvedValue(
+        mockIntegrationConfigService.find.mockResolvedValue([
             createMockIntegrationConfigEntity(),
-        );
+        ]);
         return integration;
     }
 
@@ -385,7 +387,7 @@ describe('DeleteIntegrationUseCase', () => {
 
         it('should proceed when no integration config exists', async () => {
             setupIntegration('github', 'oauth');
-            mockIntegrationConfigService.findOne.mockResolvedValue(null);
+            mockIntegrationConfigService.find.mockResolvedValue([]);
 
             await useCase.execute(executeParams);
 
@@ -394,6 +396,28 @@ describe('DeleteIntegrationUseCase', () => {
             assertAuthIntegrationDeleted();
             assertCentralizedConfigDisabled();
             expect(mockIntegrationConfigService.delete).not.toHaveBeenCalled();
+        });
+
+        it('should delete ALL configs tied to the integration, not only repositories', async () => {
+            setupIntegration('github', 'oauth');
+            mockIntegrationConfigService.find.mockResolvedValue([
+                createMockIntegrationConfigEntity(),
+                createMockInstallationConfigEntity(),
+            ]);
+
+            await useCase.execute(executeParams);
+
+            expect(mockIntegrationConfigService.find).toHaveBeenCalledWith({
+                integration: { uuid: MOCK_INTEGRATION_UUID },
+            });
+            expect(mockIntegrationConfigService.delete).toHaveBeenCalledWith(
+                MOCK_INTEGRATION_CONFIG_UUID,
+            );
+            expect(mockIntegrationConfigService.delete).toHaveBeenCalledWith(
+                MOCK_INSTALLATION_CONFIG_UUID,
+            );
+            assertIntegrationDeleted();
+            assertAuthIntegrationDeleted();
         });
     });
 });

--- a/libs/platform/application/use-cases/codeManagement/__tests__/shared-delete-mocks.ts
+++ b/libs/platform/application/use-cases/codeManagement/__tests__/shared-delete-mocks.ts
@@ -157,3 +157,13 @@ export function createMockIntegrationConfigEntity() {
         configValue: MOCK_REPOSITORIES,
     };
 }
+
+export const MOCK_INSTALLATION_CONFIG_UUID = 'integration-config-uuid-0002';
+
+export function createMockInstallationConfigEntity() {
+    return {
+        uuid: MOCK_INSTALLATION_CONFIG_UUID,
+        configKey: 'installation_github',
+        configValue: { installId: '12345', installationStatus: 'SUCCESS' },
+    };
+}

--- a/libs/platform/application/use-cases/codeManagement/delete-integration.use-case.ts
+++ b/libs/platform/application/use-cases/codeManagement/delete-integration.use-case.ts
@@ -3,7 +3,6 @@ import { Inject, Injectable } from '@nestjs/common';
 import { REQUEST } from '@nestjs/core';
 
 import { IntegrationCategory } from '@libs/core/domain/enums/integration-category.enum';
-import { IntegrationConfigKey } from '@libs/core/domain/enums/Integration-config-key.enum';
 import { ParametersKey } from '@libs/core/domain/enums/parameters-key.enum';
 import { PlatformType } from '@libs/core/domain/enums/platform-type.enum';
 import { ActionType } from '@libs/core/infrastructure/config/types/general/codeReviewSettingsLog.type';
@@ -100,13 +99,16 @@ export class DeleteIntegrationUseCase {
             });
         }
 
-        const integrationConfig = await this.integrationConfigService.findOne({
-            configKey: IntegrationConfigKey.REPOSITORIES,
+        // Delete every config tied to this integration (REPOSITORIES,
+        // INSTALLATION_GITHUB, CODE_MANAGEMENT_PAT, ...). Any row left behind
+        // violates the integration_configs.integration_id FK (ON DELETE NO
+        // ACTION) and aborts the integration delete below, leaving a stale
+        // active integration that breaks future reconnects.
+        const integrationConfigs = await this.integrationConfigService.find({
             integration: { uuid: integration.uuid },
-            team: { uuid: params.teamId },
         });
 
-        if (integrationConfig) {
+        for (const integrationConfig of integrationConfigs ?? []) {
             await this.integrationConfigService.delete(integrationConfig.uuid);
         }
 


### PR DESCRIPTION
## Problem

After disconnecting a code-management integration on the web app and reconnecting it later, the repository list can stay empty forever ("No repository found"), even though the GitHub App is installed and has repo access. Reported on Discord; reproduced by reading the disconnect/reconnect code path.

## Root cause

`DeleteIntegrationUseCase` deletes only the `REPOSITORIES` integration config before hard-deleting the integration:

- `integration_configs.integration_id` → `integrations.uuid` is `ON DELETE NO ACTION` (see the baseline migration).
- Any other `integration_configs` row tied to the integration — e.g. legacy `INSTALLATION_GITHUB` rows created by the old PENDING-installation flow, or `CODE_MANAGEMENT_PAT` — makes `integrationRepository.delete()` fail with an FK violation.
- That error is swallowed by `catch { console.log(error) }` in `IntegrationRepository.delete`, and the subsequent `authIntegrationRepository.delete()` fails (and is swallowed) the same way because the surviving integration row still references it.

Net effect: the API reports a successful disconnect, but the integration + auth integration rows survive with `status: true` and stale auth details. On the next connect attempt, `authenticateWithCodeOauth` finds that stale integration and goes down the `updateAuthIntegration` path instead of creating a fresh integration, so the org is stuck with dead credentials and `getRepositories` never returns anything again.

## Fix

- `DeleteIntegrationUseCase` now deletes **all** integration configs referencing the integration (any `configKey`), not just `REPOSITORIES`, so the FK can no longer block the integration delete.
- `IntegrationRepository.delete`, `AuthIntegrationRepository.delete` and `IntegrationConfigRepository.delete` now rethrow after logging instead of silently swallowing errors, so a genuinely failed disconnect surfaces to the caller instead of corrupting state. (These methods are only called from `DeleteIntegrationUseCase`.)

## Tests

- Updated `delete-integration.use-case.spec.ts` for the new lookup and added a case asserting that *all* configs tied to the integration are deleted (repositories + a legacy `installation_github` row) before the integration and auth integration.
- `npx jest libs/platform/application/use-cases/codeManagement/__tests__/` — 34/34 pass.
- Full unit suite (pre-push hook): 4186 passed; the only failures are the Postgres-backed integration specs that require a local `kodusdev@localhost:5432` database, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)