### PR TITLE
feat(cockpit): add scope column to Kody Rules health table

### DIFF
--- a/apps/web/src/features/ee/cockpit/@kodusReviewTab/_components/rules-columns.tsx
+++ b/apps/web/src/features/ee/cockpit/@kodusReviewTab/_components/rules-columns.tsx
@@ -21,6 +21,26 @@ export const stateMeta: Record<
     low_data: { label: "Low data", className: "bg-info/15 text-info" },
 };
 
+/** Derives the rule's scope label from its repo/folder fields. */
+function ruleScope(row: KodyRuleHealthRow): {
+    kind: "Global" | "Repo" | "Folder";
+    detail: string | null;
+} {
+    if (row.directoryPath) {
+        return { kind: "Folder", detail: row.directoryPath };
+    }
+    if (row.repositoryId) {
+        return { kind: "Repo", detail: row.repositoryName ?? row.repositoryId };
+    }
+    return { kind: "Global", detail: null };
+}
+
+const scopeClass: Record<ReturnType<typeof ruleScope>["kind"], string> = {
+    Global: "bg-card-lv3 text-text-secondary",
+    Repo: "bg-info/15 text-info",
+    Folder: "bg-warning/15 text-warning",
+};
+
 export const rulesColumns: ColumnDef<KodyRuleHealthRow>[] = [
     {
         accessorKey: "title",
@@ -32,6 +52,34 @@ export const rulesColumns: ColumnDef<KodyRuleHealthRow>[] = [
                 {row.original.title}
             </span>
         ),
+    },
+    {
+        id: "scope",
+        accessorFn: (r) => ruleScope(r).kind,
+        header: ({ column }) => (
+            <DataTableColumnHeader column={column} title="Scope" />
+        ),
+        cell: ({ row }) => {
+            const { kind, detail } = ruleScope(row.original);
+            return (
+                <span className="flex items-center gap-1.5 text-xs whitespace-nowrap">
+                    <span
+                        className={cn(
+                            "rounded-full px-2 py-0.5 text-[11px] font-bold",
+                            scopeClass[kind],
+                        )}>
+                        {kind}
+                    </span>
+                    {detail && (
+                        <span
+                            className="text-text-tertiary max-w-[180px] truncate font-mono"
+                            title={detail}>
+                            {detail}
+                        </span>
+                    )}
+                </span>
+            );
+        },
     },
     {
         accessorKey: "triggers",

--- a/apps/web/src/features/ee/cockpit/_services/analytics/review/fetch.ts
+++ b/apps/web/src/features/ee/cockpit/_services/analytics/review/fetch.ts
@@ -70,6 +70,8 @@ export type KodyRuleHealthRow = {
     title: string;
     severity: string | null;
     repositoryId: string | null;
+    repositoryName: string | null;
+    directoryPath: string | null;
     state: KodyRuleHealthState;
     triggers: number;
     implemented: number;

--- a/libs/cockpit/application/use-cases/get-kody-rules-health.use-case.ts
+++ b/libs/cockpit/application/use-cases/get-kody-rules-health.use-case.ts
@@ -86,9 +86,10 @@ export class GetKodyRulesHealthUseCase {
     ) {}
 
     async execute(q: CockpitRangeQuery): Promise<KodyRuleHealthRow[]> {
-        const [usageRows, rulesDoc] = await Promise.all([
+        const [usageRows, rulesDoc, repoNames] = await Promise.all([
             this.reviewAnalytics.getKodyRulesUsage(q),
             this.kodyRulesService.findByOrganizationId(q.organizationId),
+            this.reviewAnalytics.getRepositoryNames(q.organizationId),
         ]);
 
         const usageByRule = new Map(usageRows.map((u) => [u.ruleId, u]));
@@ -105,11 +106,21 @@ export class GetKodyRulesHealthUseCase {
             const { state, usage } = computeRuleState(
                 usageByRule.get(rule.uuid),
             );
+            // `'global'` is the org-wide sentinel (not a repo named "global");
+            // normalize it — and empty strings — to null so consumers read
+            // "no repository → global scope".
+            const rawRepoId = rule.repositoryId ?? null;
+            const repositoryId =
+                rawRepoId && rawRepoId !== 'global' ? rawRepoId : null;
             return {
                 ruleId: rule.uuid,
                 title: rule.title,
                 severity: rule.severity ?? null,
-                repositoryId: rule.repositoryId ?? null,
+                repositoryId,
+                repositoryName: repositoryId
+                    ? (repoNames.get(repositoryId) ?? null)
+                    : null,
+                directoryPath: rule.path ? rule.path : null,
                 state,
                 ...usage,
             };

--- a/libs/cockpit/domain/contracts/cockpit-review-analytics.service.contract.ts
+++ b/libs/cockpit/domain/contracts/cockpit-review-analytics.service.contract.ts
@@ -56,6 +56,13 @@ export interface ICockpitReviewAnalyticsService {
         q: CockpitRangeQuery,
     ): Promise<ReviewOperationalMetricsWeeklyRow[]>;
     getKodyRulesUsage(q: CockpitRangeQuery): Promise<KodyRuleUsageRow[]>;
+    /**
+     * Map of `repositoryId` → `repo_full_name` for the org, from the
+     * warehouse. Lets the rule-health table label scope ("which repo")
+     * without a second round-trip — Kody rules only carry the external
+     * `repositoryId`, not the name.
+     */
+    getRepositoryNames(organizationId: string): Promise<Map<string, string>>;
     searchSuggestions(
         q: SuggestionsExplorerQuery,
     ): Promise<SuggestionsExplorerResult>;

--- a/libs/cockpit/domain/types.ts
+++ b/libs/cockpit/domain/types.ts
@@ -266,7 +266,12 @@ export interface ReviewOperationalMetrics {
 export interface KodyRuleHealthRow extends KodyRuleUsageRow {
     title: string;
     severity: string | null;
+    /** External repo id the rule is scoped to; null → org-wide (global). */
     repositoryId: string | null;
+    /** Resolved `repo_full_name` for `repositoryId`, when known. */
+    repositoryName: string | null;
+    /** Folder/path the rule is scoped to; null/'' → not folder-scoped. */
+    directoryPath: string | null;
     /**
      * `noisy` (negative feedback) only becomes computable in phase 3 when
      * `suggestion_feedback` lands in the warehouse.

--- a/libs/cockpit/infrastructure/services/cockpit-review-analytics.service.ts
+++ b/libs/cockpit/infrastructure/services/cockpit-review-analytics.service.ts
@@ -775,6 +775,21 @@ export class CockpitReviewAnalyticsService
         }));
     }
 
+    async getRepositoryNames(
+        organizationId: string,
+    ): Promise<Map<string, string>> {
+        const rows = (await this.ds.query(
+            `SELECT DISTINCT pr."repositoryId" AS id, pr."repo_full_name" AS name
+               FROM "analytics"."pull_requests_opt" pr
+              WHERE pr."organizationId" = $1
+                AND pr."repositoryId" IS NOT NULL
+                AND pr."repo_full_name" IS NOT NULL`,
+            [organizationId],
+        )) as Array<{ id: string; name: string }>;
+
+        return new Map(rows.map((r) => [r.id, r.name]));
+    }
+
     async searchSuggestions(
         q: SuggestionsExplorerQuery,
     ): Promise<SuggestionsExplorerResult> {

--- a/test/unit/cockpit/get-kody-rules-health.use-case.spec.ts
+++ b/test/unit/cockpit/get-kody-rules-health.use-case.spec.ts
@@ -55,9 +55,14 @@ describe('GetKodyRulesHealthUseCase', () => {
         endDate: '2026-06-01',
     };
 
-    const mkUseCase = (usageRows: unknown[], rulesDoc: unknown) => {
+    const mkUseCase = (
+        usageRows: unknown[],
+        rulesDoc: unknown,
+        repoNames: Map<string, string> = new Map(),
+    ) => {
         const reviewAnalytics = {
             getKodyRulesUsage: jest.fn().mockResolvedValue(usageRows),
+            getRepositoryNames: jest.fn().mockResolvedValue(repoNames),
         };
         const kodyRulesService = {
             findByOrganizationId: jest.fn().mockResolvedValue(rulesDoc),
@@ -150,5 +155,56 @@ describe('GetKodyRulesHealthUseCase', () => {
     it('handles orgs without a kodyRules doc', async () => {
         const useCase = mkUseCase([], null);
         await expect(useCase.execute(baseQuery)).resolves.toEqual([]);
+    });
+
+    it('labels scope: global sentinel → null, repo → resolved name, folder → path', async () => {
+        const useCase = mkUseCase(
+            [],
+            {
+                rules: [
+                    {
+                        uuid: 'g',
+                        title: 'Global rule',
+                        repositoryId: 'global',
+                        status: KodyRulesStatus.ACTIVE,
+                    },
+                    {
+                        uuid: 'r',
+                        title: 'Repo rule',
+                        repositoryId: '670345891',
+                        status: KodyRulesStatus.ACTIVE,
+                    },
+                    {
+                        uuid: 'f',
+                        title: 'Folder rule',
+                        repositoryId: '670345891',
+                        path: 'src/auth',
+                        status: KodyRulesStatus.ACTIVE,
+                    },
+                ],
+            },
+            new Map([['670345891', 'kodustech/kodus-ai']]),
+        );
+
+        const rows = await useCase.execute(baseQuery);
+        const byId = Object.fromEntries(rows.map((r) => [r.ruleId, r]));
+
+        // global sentinel collapses to null → frontend reads it as "Global"
+        expect(byId.g).toMatchObject({
+            repositoryId: null,
+            repositoryName: null,
+            directoryPath: null,
+        });
+        // repo-scoped: id kept, name resolved from the warehouse map
+        expect(byId.r).toMatchObject({
+            repositoryId: '670345891',
+            repositoryName: 'kodustech/kodus-ai',
+            directoryPath: null,
+        });
+        // folder-scoped: path surfaced
+        expect(byId.f).toMatchObject({
+            repositoryName: 'kodustech/kodus-ai',
+            directoryPath: 'src/auth',
+        });
     });
 });


### PR DESCRIPTION
## What

The **Kody Rules — health** table (Kodus Review tab) gave no indication of *where* each rule applies — global, a specific repository, or a folder. This adds a single **Scope** column.

| Scope | Rendered as |
|-------|-------------|
| org-wide | `Global` |
| repository | `Repo · kodustech/kodus-ai` |
| folder | `Folder · src/auth` |

## How

**Backend**
- `KodyRuleHealthRow` now carries `repositoryName` + `directoryPath` (`repositoryId` was already present).
- `GetKodyRulesHealthUseCase` resolves the repo name from the warehouse (`pull_requests_opt.repo_full_name`) via a new `getRepositoryNames()` on the review-analytics service — Kody rules only store the external `repositoryId`, not the name.
- Normalizes the legacy `"global"` sentinel `repositoryId` to `null`, so it reads as global scope instead of a repo literally named "global".

**Frontend**
- New `Scope` column in `rules-columns.tsx` deriving the label from `directoryPath` / `repositoryId`.

## Notes
- Repo name resolution falls back to the raw `repositoryId` when the repo has no PRs in the warehouse window (so the name isn't known). Acceptable.
- No data migration / new query cost beyond one `SELECT DISTINCT` per request.

## Testing
- `test/unit/cockpit/get-kody-rules-health.use-case.spec.ts` — added a case covering global-sentinel → null, repo → resolved name, folder → path. Full cockpit + analytics unit suite green locally (75 tests).
- The `.tsx` was not type-checked locally (no `apps/web` install on this machine) — relies on CI build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)