### PR TITLE
fix(env): declare ANALYTICS_INGESTION_RUN_ON_BOOT in schema

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -611,6 +611,12 @@ ANALYTICS_INGESTION_CRON="*/30 * * * *"
 # (type: boolean)
 ANALYTICS_INGESTION_DISABLED=false
 
+# Run one ingestion pass on worker boot instead of waiting for the first
+# scheduled cron tick (so a fresh install / restart catches up immediately).
+# Opt-out only: set 'false' to skip the boot pass. Default = run on boot.
+# (type: boolean)
+ANALYTICS_INGESTION_RUN_ON_BOOT=true
+
 # Cron — LLM-based PR type classifier (analytics worker role).
 # (type: cron)
 ANALYTICS_CLASSIFIER_CRON="*/15 * * * *"

--- a/.env.schema
+++ b/.env.schema
@@ -876,6 +876,13 @@ ANALYTICS_INGESTION_CRON=*/30 * * * *
 # kodus: audience=cloud
 ANALYTICS_INGESTION_DISABLED=false
 
+# Run one ingestion pass on worker boot instead of waiting for the first
+# scheduled cron tick (so a fresh install / restart catches up immediately).
+# Opt-out only: set 'false' to skip the boot pass. Default = run on boot.
+# @type=boolean
+# kodus: audience=cloud,self-hosted-enterprise
+ANALYTICS_INGESTION_RUN_ON_BOOT=true
+
 # Cron — LLM-based PR type classifier (analytics worker role).
 # @type=cron
 # kodus: audience=cloud,self-hosted-enterprise

--- a/.env.template
+++ b/.env.template
@@ -621,6 +621,12 @@ ANALYTICS_INGESTION_CRON="*/30 * * * *"
 # (type: boolean)
 ANALYTICS_INGESTION_DISABLED=false
 
+# Run one ingestion pass on worker boot instead of waiting for the first
+# scheduled cron tick (so a fresh install / restart catches up immediately).
+# Opt-out only: set 'false' to skip the boot pass. Default = run on boot.
+# (type: boolean)
+ANALYTICS_INGESTION_RUN_ON_BOOT=true
+
 # Cron — LLM-based PR type classifier (analytics worker role).
 # (type: cron)
 ANALYTICS_CLASSIFIER_CRON="*/15 * * * *"

--- a/docs/_snippets/env-vars-generated.mdx
+++ b/docs/_snippets/env-vars-generated.mdx
@@ -237,6 +237,7 @@
 | `ANALYTICS_PG_POOL_MAX` | – | string | 🏢 ☁️ Cloud | Upper bound on the analytics Postgres pool. |
 | `ANALYTICS_INGESTION_CRON` | – | cron | 🏢 ☁️ Cloud | Cron expression — analytics ingestion. Default = every 30 min. |
 | `ANALYTICS_INGESTION_DISABLED` | – | boolean | ☁️ Cloud | Kill switch for the ingestion cron regardless of role. |
+| `ANALYTICS_INGESTION_RUN_ON_BOOT` | – | boolean | 🏢 ☁️ Cloud | Run one ingestion pass on worker boot instead of waiting for the first scheduled cron tick (so a fresh install / restart catches up immediately). Opt-out only: set 'false' to skip the boot pass. Default = run on boot. |
 | `ANALYTICS_CLASSIFIER_CRON` | – | cron | 🏢 ☁️ Cloud | Cron — LLM-based PR type classifier (analytics worker role). |
 | `ANALYTICS_CLASSIFIER_DISABLED` | – | boolean | ☁️ Cloud | Kill switch for the classifier. |
 | `API_PG_ANALYTICS_HOST` | – | string | 🏢 ☁️ Cloud | Alternative naming used by some loaders. Verify if duplicate of ANALYTICS_PG_DB_*. |


### PR DESCRIPTION
## Why
PR #1305 (`feat(cockpit): review operational metrics from analytics warehouse`) added `process.env.ANALYTICS_INGESTION_RUN_ON_BOOT` to `apps/worker/src/cron/analytics-ingestion.cron.ts` but never declared it in `.env.schema`.

The `env-drift-check` → **Check schema covers every env var used in code** step now fails on **every PR** branched off main (e.g. #1315), because the var is referenced in code but missing from the schema.

## What
- Declare `ANALYTICS_INGESTION_RUN_ON_BOOT` in `.env.schema` next to its siblings (`ANALYTICS_INGESTION_CRON` / `ANALYTICS_INGESTION_DISABLED`), `audience=cloud,self-hosted-enterprise`, `@type=boolean`, default `true`.
- Regenerated the derived files via `pnpm run env:apply` (`.env.example`, `.env.template`, `docs/_snippets/env-vars-generated.mdx`).

## Behavior (unchanged)
It's an **opt-out** flag: the cron only skips the boot pass when the value is exactly `'false'`. Unset/empty → it runs one ingestion pass on worker boot (so a fresh install / restart catches up immediately instead of waiting up to 30 min for the first cron tick). Operators never need to set it.

## Validation
`pnpm run env:check:coverage` passes locally after the change (was the failing step). Files regenerated with the real `env:apply`, so the regenerate-and-diff step is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)