### PR TITLE
fix(e2e): widen pipeline-start budget so rate-limit-deferred reviews don't false-fail

### DIFF
--- a/tests/e2e/scenarios/code-review-basic.ts
+++ b/tests/e2e/scenarios/code-review-basic.ts
@@ -75,11 +75,11 @@ export const codeReviewBasic: Scenario = {
         // `trial-managed-review` (real managed-LLM review on a throwaway repo).
         license: ["paid", "license-paid"],
     },
-    // Scenario budget must comfortably exceed the inner pollForReview
-    // budget (1500s) + onboarding + open-PR overhead. 1800s gives a
-    // ~5min cushion so the outer kill never fires before the inner
+    // Scenario budget must comfortably exceed phase A (600s) + the inner
+    // pollForReview budget (1500s) + onboarding + open-PR overhead. 2700s
+    // keeps a ~5min cushion so the outer kill never fires before the inner
     // timeout has a chance to surface a meaningful assertion message.
-    timeoutSec: 1800,
+    timeoutSec: 2700,
     async run(ctx: RunContext) {
         ctx.assert(
             ctx.tenant,
@@ -115,10 +115,17 @@ export const codeReviewBasic: Scenario = {
         });
 
         try {
-            // Two-phase wait. Phase A fails fast (~60s) if the pipeline
-            // never woke up — separates the "worker dequeued the PR
-            // and Kody posted a heartbeat" signal from the "LLM found
-            // the deliberate bugs" signal. The morning of 2026-05-21
+            // Two-phase wait. Phase A waits for the pipeline to wake up —
+            // separates the "worker dequeued the PR and Kody posted a
+            // heartbeat" signal from the "LLM found the deliberate bugs"
+            // signal. Budget is deliberately generous (600s): under matrix
+            // load the GitHub bot's rate-limit gate defers the review job
+            // by minutes (it republishes-with-delay until the API bucket
+            // resets), so a tight ~60s budget false-flagged "never started"
+            // when the review was merely queued behind a rate-limit reset
+            // (matrix run 2026-06-12, PR #96: review ran ~5min late, past
+            // the old 60s budget, so the cell failed both attempts even
+            // though the pipeline was healthy). The morning of 2026-05-21
             // a run sat in silence for 25 min while the test runner
             // assumed nothing happened — in reality the LLM had
             // completed review in 2.6s and decided the clean fixture
@@ -134,7 +141,7 @@ export const codeReviewBasic: Scenario = {
             if (ctx.provider.waitForPipelineStart) {
                 const started = await ctx.provider.waitForPipelineStart(
                     { number: pr.number },
-                    { sinceIso, timeoutSec: 60 },
+                    { sinceIso, timeoutSec: 600 },
                 );
                 pipelineStartedAt = started.startedAt;
             }

--- a/tests/e2e/scenarios/code-review-vertex-byok.ts
+++ b/tests/e2e/scenarios/code-review-vertex-byok.ts
@@ -72,7 +72,8 @@ export const codeReviewVertexByok: Scenario = {
         provider: ["github"],
         license: ["paid", "license-paid"],
     },
-    timeoutSec: 1800,
+    // Phase A (600s) + pollForReview (1500s) + onboarding/PR overhead.
+    timeoutSec: 2700,
     async run(ctx: RunContext) {
         ctx.assert(
             ctx.tenant,
@@ -126,9 +127,11 @@ export const codeReviewVertexByok: Scenario = {
         try {
             let pipelineStartedAt: string | undefined;
             if (ctx.provider.waitForPipelineStart) {
+                // Generous start budget: the GitHub rate-limit gate can defer
+                // the review job by minutes under load (see code-review-basic).
                 const started = await ctx.provider.waitForPipelineStart(
                     { number: pr.number },
-                    { sinceIso, timeoutSec: 60 },
+                    { sinceIso, timeoutSec: 600 },
                 );
                 pipelineStartedAt = started.startedAt;
             }

--- a/tests/e2e/scenarios/trial-managed-review.ts
+++ b/tests/e2e/scenarios/trial-managed-review.ts
@@ -63,8 +63,9 @@ export const trialManagedReview: Scenario = {
         provider: ["github"],
         license: ["trial"],
     },
-    // Onboarding (~3-5 min incl. kody-rules generation) + 900s review poll.
-    timeoutSec: 1800,
+    // Onboarding (~3-5 min incl. kody-rules generation) + 600s pipeline-start
+    // budget + 900s review poll.
+    timeoutSec: 2400,
     async run(ctx: RunContext) {
         const target = ctx.target as TargetContext;
         const baseRepo =
@@ -143,9 +144,12 @@ export const trialManagedReview: Scenario = {
                 // Distinguishes "webhook/org-routing broke" from "pipeline
                 // ran but produced nothing".
                 if (provider.waitForPipelineStart) {
+                    // Generous start budget: the GitHub rate-limit gate can
+                    // defer the review job by minutes under matrix load (see
+                    // code-review-basic).
                     await provider.waitForPipelineStart(
                         { number: pr.number },
-                        { sinceIso, timeoutSec: 120 },
+                        { sinceIso, timeoutSec: 600 },
                     );
                 }
 


### PR DESCRIPTION
## What broke
The cloud matrix gated on `code-review-basic × cloud × github × paid`:
> No kody-codereview status comment on PR #96 within 60s — review pipeline likely never started.

## Root cause (the review was healthy — just late)
Reconstructed from QA Mongo: the `pullRequests` doc for PR #96 was written at **19:17:17**, but the test opened the PR at **19:12:10** and closed it at **19:13:11** (after the 60s budget). So the review ran **~5 min late**, not "never".

Under matrix load the GitHub bot's **rate-limit gate** (`code-review-job-processor` → `rateLimitGate.check`) defers the review job — republishing it with a delay until the API bucket resets — so the pipeline legitimately takes minutes to *start*. The old **60s Phase-A** (`waitForPipelineStart`) budget false-flagged "never started", and the cell failed both attempts even though nothing was broken (`command-review × github × paid` — same tenant/repo — recovered on retry, confirming the path works).

Note: this is **per-installation/bot** rate-limiting, shared across the org's repos — so per-scenario repo isolation would *not* fix it; the right lever is the start budget.

## Change
Widen the Phase-A `waitForPipelineStart` budget across the three pipeline-start scenarios, and bump scenario timeouts to fit phase A + the unchanged review poll:

| scenario | phase A | scenario budget |
|---|---|---|
| code-review-basic | 60s → **600s** | 1800 → **2700** |
| code-review-vertex-byok | 60s → **600s** | 1800 → **2700** |
| trial-managed-review | 120s → **600s** | 1800 → **2400** |

Phase B (the real review-completion poll) is untouched. `per-seat-license-toggle`'s 60s is left alone — it's a `pollForLicenseBlock` confirm of an already-present signal, not a pipeline-start wait.

## Follow-up (not in this PR)
Root cause is GitHub API rate-limit pressure on the shared `kodus-e2e` bot during the matrix burst. Durable fix is infra-side (token pool / fewer concurrent github cells / spacing GitHub ops) — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)