### PR TITLE
feat(cockpit): Scope column for the Kody Rules health table

### DIFF
--- a/apps/web/src/features/ee/cockpit/@kodusReviewTab/_components/rules-columns.tsx
+++ b/apps/web/src/features/ee/cockpit/@kodusReviewTab/_components/rules-columns.tsx
@@ -1,6 +1,11 @@
 "use client";
 
 import { DataTableColumnHeader } from "@components/ui/data-table";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "@components/ui/tooltip";
 import type { ColumnDef } from "@tanstack/react-table";
 import { cn } from "src/core/utils/components";
 
@@ -21,18 +26,33 @@ export const stateMeta: Record<
     low_data: { label: "Low data", className: "bg-info/15 text-info" },
 };
 
-/** Derives the rule's scope label from its repo/folder fields. */
+/**
+ * Derives the rule's scope label from its repo/folder fields. For folder
+ * scope, a directory can group several folders — surface the first as the
+ * primary detail, the count of the rest as `extra`, and the full list as
+ * `title` (tooltip), mirroring the code-review sidebar.
+ */
 function ruleScope(row: KodyRuleHealthRow): {
     kind: "Global" | "Repo" | "Folder";
     detail: string | null;
+    extra: number;
+    items: string[];
 } {
-    if (row.directoryPath) {
-        return { kind: "Folder", detail: row.directoryPath };
+    if (row.directoryId) {
+        const folders = row.directoryFolders ?? [];
+        const detail = folders[0] ?? row.directoryId;
+        return {
+            kind: "Folder",
+            detail,
+            extra: folders.length > 1 ? folders.length - 1 : 0,
+            items: folders.length ? folders : [detail],
+        };
     }
     if (row.repositoryId) {
-        return { kind: "Repo", detail: row.repositoryName ?? row.repositoryId };
+        const detail = row.repositoryName ?? row.repositoryId;
+        return { kind: "Repo", detail, extra: 0, items: [detail] };
     }
-    return { kind: "Global", detail: null };
+    return { kind: "Global", detail: null, extra: 0, items: [] };
 }
 
 const scopeClass: Record<ReturnType<typeof ruleScope>["kind"], string> = {
@@ -60,7 +80,7 @@ export const rulesColumns: ColumnDef<KodyRuleHealthRow>[] = [
             <DataTableColumnHeader column={column} title="Scope" />
         ),
         cell: ({ row }) => {
-            const { kind, detail } = ruleScope(row.original);
+            const { kind, detail, extra, items } = ruleScope(row.original);
             return (
                 <span className="flex items-center gap-1.5 text-xs whitespace-nowrap">
                     <span
@@ -71,11 +91,29 @@ export const rulesColumns: ColumnDef<KodyRuleHealthRow>[] = [
                         {kind}
                     </span>
                     {detail && (
-                        <span
-                            className="text-text-tertiary max-w-[180px] truncate font-mono"
-                            title={detail}>
-                            {detail}
-                        </span>
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <span className="text-text-tertiary flex min-w-0 cursor-default items-center gap-1 font-mono">
+                                    <span className="max-w-[180px] truncate">
+                                        {detail}
+                                    </span>
+                                    {extra > 0 && (
+                                        <span className="text-text-tertiary/70 shrink-0">
+                                            +{extra}
+                                        </span>
+                                    )}
+                                </span>
+                            </TooltipTrigger>
+                            <TooltipContent side="right" className="text-xs">
+                                <ul className="list-none space-y-0.5">
+                                    {items.map((p) => (
+                                        <li key={p} className="font-mono">
+                                            {p}
+                                        </li>
+                                    ))}
+                                </ul>
+                            </TooltipContent>
+                        </Tooltip>
                     )}
                 </span>
             );

--- a/apps/web/src/features/ee/cockpit/_services/analytics/review/fetch.ts
+++ b/apps/web/src/features/ee/cockpit/_services/analytics/review/fetch.ts
@@ -71,7 +71,8 @@ export type KodyRuleHealthRow = {
     severity: string | null;
     repositoryId: string | null;
     repositoryName: string | null;
-    directoryPath: string | null;
+    directoryId: string | null;
+    directoryFolders: string[] | null;
     state: KodyRuleHealthState;
     triggers: number;
     implemented: number;

--- a/libs/cockpit/application/use-cases/get-kody-rules-health.use-case.ts
+++ b/libs/cockpit/application/use-cases/get-kody-rules-health.use-case.ts
@@ -8,6 +8,15 @@ import {
     IKodyRule,
     KodyRulesStatus,
 } from '@libs/kodyRules/domain/interfaces/kodyRules.interface';
+import {
+    ITeamService,
+    TEAM_SERVICE_TOKEN,
+} from '@libs/organization/domain/team/contracts/team.service.contract';
+import {
+    IParametersService,
+    PARAMETERS_SERVICE_TOKEN,
+} from '@libs/organization/domain/parameters/contracts/parameters.service.contract';
+import { ParametersKey } from '@libs/core/domain/enums';
 
 import {
     CockpitRangeQuery,
@@ -83,14 +92,75 @@ export class GetKodyRulesHealthUseCase {
         private readonly reviewAnalytics: ICockpitReviewAnalyticsService,
         @Inject(KODY_RULES_SERVICE_TOKEN)
         private readonly kodyRulesService: IKodyRulesService,
+        @Inject(TEAM_SERVICE_TOKEN)
+        private readonly teamService: ITeamService,
+        @Inject(PARAMETERS_SERVICE_TOKEN)
+        private readonly parametersService: IParametersService,
     ) {}
 
+    /**
+     * Builds a `directoryId → folder path(s)` map for the org by walking the
+     * code-review config of every team (the config is team-scoped, so a single
+     * org can hold several). Directory metadata lives only in this config, not
+     * on the rule itself — the rule carries just `directoryId`. A directory can
+     * group several folders, so we surface the whole list and let the UI render
+     * a primary + "+N" the same way the code-review sidebar does.
+     */
+    private async resolveDirectoryFolders(
+        organizationId: string,
+    ): Promise<Map<string, string[]>> {
+        const map = new Map<string, string[]>();
+        try {
+            const teams = await this.teamService.find({
+                organization: { uuid: organizationId },
+            });
+
+            const configs = await Promise.all(
+                teams.map((team) =>
+                    this.parametersService
+                        .findByKey(ParametersKey.CODE_REVIEW_CONFIG, {
+                            organizationId,
+                            teamId: team.uuid,
+                        })
+                        .catch(() => undefined),
+                ),
+            );
+
+            for (const param of configs) {
+                for (const repo of param?.configValue?.repositories ?? []) {
+                    for (const dir of repo.directories ?? []) {
+                        const paths = (dir?.folders ?? [])
+                            .map((f) => f?.path)
+                            .filter((p): p is string => Boolean(p));
+                        // Fall back to the directory's name when it carries no
+                        // folder paths, so we never surface a raw id when the
+                        // config has a usable label.
+                        const labels = paths.length
+                            ? paths
+                            : dir?.name
+                              ? [dir.name]
+                              : [];
+                        if (dir?.id && labels.length) map.set(dir.id, labels);
+                    }
+                }
+            }
+        } catch {
+            // Config lookup is best-effort metadata enrichment; a failure must
+            // not take down the whole health table. Folder rules fall back to
+            // the raw directoryId.
+        }
+
+        return map;
+    }
+
     async execute(q: CockpitRangeQuery): Promise<KodyRuleHealthRow[]> {
-        const [usageRows, rulesDoc, repoNames] = await Promise.all([
-            this.reviewAnalytics.getKodyRulesUsage(q),
-            this.kodyRulesService.findByOrganizationId(q.organizationId),
-            this.reviewAnalytics.getRepositoryNames(q.organizationId),
-        ]);
+        const [usageRows, rulesDoc, repoNames, directoryFolders] =
+            await Promise.all([
+                this.reviewAnalytics.getKodyRulesUsage(q),
+                this.kodyRulesService.findByOrganizationId(q.organizationId),
+                this.reviewAnalytics.getRepositoryNames(q.organizationId),
+                this.resolveDirectoryFolders(q.organizationId),
+            ]);
 
         const usageByRule = new Map(usageRows.map((u) => [u.ruleId, u]));
         const rules = (rulesDoc?.rules ?? []).filter(
@@ -112,6 +182,10 @@ export class GetKodyRulesHealthUseCase {
             const rawRepoId = rule.repositoryId ?? null;
             const repositoryId =
                 rawRepoId && rawRepoId !== 'global' ? rawRepoId : null;
+            // Folder scope is keyed off `directoryId`, NOT `rule.path`: `path`
+            // is a file glob (`**/*.ts`) every rule carries and says nothing
+            // about where the rule is scoped.
+            const directoryId = rule.directoryId || null;
             return {
                 ruleId: rule.uuid,
                 title: rule.title,
@@ -120,7 +194,10 @@ export class GetKodyRulesHealthUseCase {
                 repositoryName: repositoryId
                     ? (repoNames.get(repositoryId) ?? null)
                     : null,
-                directoryPath: rule.path ? rule.path : null,
+                directoryId,
+                directoryFolders: directoryId
+                    ? (directoryFolders.get(directoryId) ?? null)
+                    : null,
                 state,
                 ...usage,
             };

--- a/libs/cockpit/domain/types.ts
+++ b/libs/cockpit/domain/types.ts
@@ -270,8 +270,17 @@ export interface KodyRuleHealthRow extends KodyRuleUsageRow {
     repositoryId: string | null;
     /** Resolved `repo_full_name` for `repositoryId`, when known. */
     repositoryName: string | null;
-    /** Folder/path the rule is scoped to; null/'' → not folder-scoped. */
-    directoryPath: string | null;
+    /**
+     * Directory id the rule is scoped to; null → not folder-scoped. This —
+     * not `rule.path` (a file glob every rule carries) — is what makes a rule
+     * folder-scoped.
+     */
+    directoryId: string | null;
+    /**
+     * Folder path(s) the directory groups, resolved from the code-review
+     * config. A directory can span multiple folders; null when unresolved.
+     */
+    directoryFolders: string[] | null;
     /**
      * `noisy` (negative feedback) only becomes computable in phase 3 when
      * `suggestion_feedback` lands in the warehouse.

--- a/libs/cockpit/modules/cockpit.module.ts
+++ b/libs/cockpit/modules/cockpit.module.ts
@@ -5,6 +5,8 @@ import { EmailModule } from '@libs/common/email/email.module';
 import { LicenseModule } from '@libs/ee/license/license.module';
 import { UserModule } from '@libs/identity/modules/user.module';
 import { OrganizationModule } from '@libs/organization/modules/organization.module';
+import { TeamModule } from '@libs/organization/modules/team.module';
+import { ParametersModule } from '@libs/organization/modules/parameters.module';
 
 import { COCKPIT_DEVELOPER_PRODUCTIVITY_SERVICE_TOKEN } from '../domain/contracts/cockpit-developer-productivity.service.contract';
 import { COCKPIT_REVIEW_ANALYTICS_SERVICE_TOKEN } from '../domain/contracts/cockpit-review-analytics.service.contract';
@@ -35,6 +37,8 @@ import { NotificationModule } from '@libs/notifications/modules/notification.mod
         forwardRef(() => OrganizationModule),
         forwardRef(() => NotificationModule),
         forwardRef(() => KodyRulesModule),
+        forwardRef(() => TeamModule),
+        forwardRef(() => ParametersModule),
     ],
     providers: [
         CockpitSourceResolver,

--- a/test/unit/cockpit/get-kody-rules-health.use-case.spec.ts
+++ b/test/unit/cockpit/get-kody-rules-health.use-case.spec.ts
@@ -59,6 +59,11 @@ describe('GetKodyRulesHealthUseCase', () => {
         usageRows: unknown[],
         rulesDoc: unknown,
         repoNames: Map<string, string> = new Map(),
+        directories: Array<{
+            id: string;
+            name?: string;
+            folders?: Array<{ path: string }>;
+        }> = [],
     ) => {
         const reviewAnalytics = {
             getKodyRulesUsage: jest.fn().mockResolvedValue(usageRows),
@@ -67,9 +72,21 @@ describe('GetKodyRulesHealthUseCase', () => {
         const kodyRulesService = {
             findByOrganizationId: jest.fn().mockResolvedValue(rulesDoc),
         };
+        const teamService = {
+            find: jest.fn().mockResolvedValue([{ uuid: 'team-1' }]),
+        };
+        const parametersService = {
+            findByKey: jest.fn().mockResolvedValue({
+                configValue: {
+                    repositories: [{ directories }],
+                },
+            }),
+        };
         return new GetKodyRulesHealthUseCase(
             reviewAnalytics as never,
             kodyRulesService as never,
+            teamService as never,
+            parametersService as never,
         );
     };
 
@@ -157,7 +174,7 @@ describe('GetKodyRulesHealthUseCase', () => {
         await expect(useCase.execute(baseQuery)).resolves.toEqual([]);
     });
 
-    it('labels scope: global sentinel → null, repo → resolved name, folder → path', async () => {
+    it('labels scope: global sentinel → null, repo → resolved name, folder → resolved directory name', async () => {
         const useCase = mkUseCase(
             [],
             {
@@ -172,18 +189,35 @@ describe('GetKodyRulesHealthUseCase', () => {
                         uuid: 'r',
                         title: 'Repo rule',
                         repositoryId: '670345891',
+                        // a file glob is NOT folder scope — must read as Repo
+                        path: '**/*.ts',
                         status: KodyRulesStatus.ACTIVE,
                     },
                     {
                         uuid: 'f',
                         title: 'Folder rule',
                         repositoryId: '670345891',
-                        path: 'src/auth',
+                        directoryId: 'dir-1',
+                        path: '**/*.ts',
+                        status: KodyRulesStatus.ACTIVE,
+                    },
+                    {
+                        uuid: 'm',
+                        title: 'Multi-folder rule',
+                        repositoryId: '670345891',
+                        directoryId: 'dir-2',
                         status: KodyRulesStatus.ACTIVE,
                     },
                 ],
             },
             new Map([['670345891', 'kodustech/kodus-ai']]),
+            [
+                { id: 'dir-1', folders: [{ path: '/apps/api' }] },
+                {
+                    id: 'dir-2',
+                    folders: [{ path: '/apps/api' }, { path: '/apps/web' }],
+                },
+            ],
         );
 
         const rows = await useCase.execute(baseQuery);
@@ -193,18 +227,26 @@ describe('GetKodyRulesHealthUseCase', () => {
         expect(byId.g).toMatchObject({
             repositoryId: null,
             repositoryName: null,
-            directoryPath: null,
+            directoryId: null,
+            directoryFolders: null,
         });
-        // repo-scoped: id kept, name resolved from the warehouse map
+        // repo-scoped: id kept, name resolved; a file glob does NOT make it a folder
         expect(byId.r).toMatchObject({
             repositoryId: '670345891',
             repositoryName: 'kodustech/kodus-ai',
-            directoryPath: null,
+            directoryId: null,
+            directoryFolders: null,
         });
-        // folder-scoped: path surfaced
+        // folder-scoped: directoryId drives scope, folder path resolved from config
         expect(byId.f).toMatchObject({
             repositoryName: 'kodustech/kodus-ai',
-            directoryPath: 'src/auth',
+            directoryId: 'dir-1',
+            directoryFolders: ['/apps/api'],
+        });
+        // multi-folder directory: all folder paths surfaced for the UI's +N
+        expect(byId.m).toMatchObject({
+            directoryId: 'dir-2',
+            directoryFolders: ['/apps/api', '/apps/web'],
         });
     });
 });


### PR DESCRIPTION
## What

Adds a **Scope** column to the Cockpit *Kody Rules — health* table so each rule shows where it applies: **Global**, **Repo · `<name>`**, or **Folder · `<path>` (+N)**.

## Why

The table gave no indication of a rule's scope — you couldn't tell a repo-wide rule from a folder-scoped one, which matters when deciding whether to edit, rescope, or disable it.

## How

- **Backend** (`get-kody-rules-health.use-case.ts`): the row now carries `repositoryName`, `directoryId` and `directoryFolders`.
  - Repo name resolved from the warehouse (`pull_requests_opt.repo_full_name`).
  - The legacy `'global'` sentinel normalizes to `null` so it reads as global scope, not a repo literally named "global".
  - Folder scope is keyed off **`directoryId`** — the field that actually marks a rule folder-scoped — **not `rule.path`**, which is a file glob (`**/*.ts`) every rule carries. Using `path` mislabeled nearly every rule as "Folder".
  - The folder path(s) are resolved from the team-scoped code-review config (`org → teams → repositories[].directories[]`). A directory can group several folders, so the whole list is surfaced. Resolution is best-effort: a config-lookup failure falls back to the raw `directoryId` and never takes down the table.
- **Frontend**: Folder scope renders the primary folder path + `+N`, with a tooltip listing every folder — mirroring the code-review sidebar. Repo/Global unchanged.

## Test

- `test/unit/cockpit/get-kody-rules-health.use-case.spec.ts` — 9/9 green (covers global/repo/folder scope, single + multi-folder resolution, and that a file glob does **not** make a rule folder-scoped).
- Manually validated end-to-end on the local stack (folder rule pointing at a multi-folder directory → `Folder · /packages/lib +1` with the tooltip listing both folders).

🤖 Generated with [Claude Code](https://claude.com/claude-code)