### PR TITLE
fix(cockpit): resolve Kody Rule repo name from integration config

### DIFF
--- a/libs/cockpit/application/use-cases/get-kody-rules-health.use-case.ts
+++ b/libs/cockpit/application/use-cases/get-kody-rules-health.use-case.ts
@@ -16,7 +16,12 @@ import {
     IParametersService,
     PARAMETERS_SERVICE_TOKEN,
 } from '@libs/organization/domain/parameters/contracts/parameters.service.contract';
-import { ParametersKey } from '@libs/core/domain/enums';
+import {
+    IIntegrationConfigService,
+    INTEGRATION_CONFIG_SERVICE_TOKEN,
+} from '@libs/integrations/domain/integrationConfigs/contracts/integration-config.service.contracts';
+import { IntegrationConfigKey, ParametersKey } from '@libs/core/domain/enums';
+import { Repositories } from '@libs/platform/domain/platformIntegrations/types/codeManagement/repositories.type';
 
 import {
     CockpitRangeQuery,
@@ -96,71 +101,94 @@ export class GetKodyRulesHealthUseCase {
         private readonly teamService: ITeamService,
         @Inject(PARAMETERS_SERVICE_TOKEN)
         private readonly parametersService: IParametersService,
+        @Inject(INTEGRATION_CONFIG_SERVICE_TOKEN)
+        private readonly integrationConfigService: IIntegrationConfigService,
     ) {}
 
     /**
-     * Builds a `directoryId → folder path(s)` map for the org by walking the
-     * code-review config of every team (the config is team-scoped, so a single
-     * org can hold several). Directory metadata lives only in this config, not
-     * on the rule itself — the rule carries just `directoryId`. A directory can
-     * group several folders, so we surface the whole list and let the UI render
-     * a primary + "+N" the same way the code-review sidebar does.
+     * Builds the scope-label lookups for the org by walking each team's config
+     * (both are team-scoped, so a single org can hold several):
+     *  - `directoryId → folder path(s)` from the code-review config. A
+     *    directory can group several folders, so the whole list is surfaced.
+     *  - `repositoryId → full name` from the code-management integration's
+     *    repository list. This is the authoritative source for EVERY selected
+     *    repo, unlike the warehouse (`getRepositoryNames`) which only knows
+     *    repos that have had a PR analyzed — so a repo-scoped rule on a repo
+     *    with no reviewed PRs no longer falls back to a raw numeric id.
+     *
+     * Both are best-effort: a config-lookup failure must not take down the
+     * health table; callers fall back to the raw id.
      */
-    private async resolveDirectoryFolders(
-        organizationId: string,
-    ): Promise<Map<string, string[]>> {
-        const map = new Map<string, string[]>();
+    private async resolveScopeMaps(organizationId: string): Promise<{
+        dirFolders: Map<string, string[]>;
+        repoNames: Map<string, string>;
+    }> {
+        const dirFolders = new Map<string, string[]>();
+        const repoNames = new Map<string, string>();
         try {
             const teams = await this.teamService.find({
                 organization: { uuid: organizationId },
             });
 
-            const configs = await Promise.all(
-                teams.map((team) =>
-                    this.parametersService
-                        .findByKey(ParametersKey.CODE_REVIEW_CONFIG, {
-                            organizationId,
-                            teamId: team.uuid,
-                        })
-                        .catch(() => undefined),
-                ),
-            );
+            await Promise.all(
+                teams.map(async (team) => {
+                    const orgTeam = { organizationId, teamId: team.uuid };
+                    const [reviewConfig, repos] = await Promise.all([
+                        this.parametersService
+                            .findByKey(
+                                ParametersKey.CODE_REVIEW_CONFIG,
+                                orgTeam,
+                            )
+                            .catch(() => undefined),
+                        this.integrationConfigService
+                            .findIntegrationConfigFormatted<Repositories[]>(
+                                IntegrationConfigKey.REPOSITORIES,
+                                orgTeam,
+                            )
+                            .catch(() => undefined),
+                    ]);
 
-            for (const param of configs) {
-                for (const repo of param?.configValue?.repositories ?? []) {
-                    for (const dir of repo.directories ?? []) {
-                        const paths = (dir?.folders ?? [])
-                            .map((f) => f?.path)
-                            .filter((p): p is string => Boolean(p));
-                        // Fall back to the directory's name when it carries no
-                        // folder paths, so we never surface a raw id when the
-                        // config has a usable label.
-                        const labels = paths.length
-                            ? paths
-                            : dir?.name
-                              ? [dir.name]
-                              : [];
-                        if (dir?.id && labels.length) map.set(dir.id, labels);
+                    for (const repo of reviewConfig?.configValue
+                        ?.repositories ?? []) {
+                        for (const dir of repo.directories ?? []) {
+                            const paths = (dir?.folders ?? [])
+                                .map((f) => f?.path)
+                                .filter((p): p is string => Boolean(p));
+                            // Fall back to the directory's name when it carries
+                            // no folder paths, so we never surface a raw id when
+                            // the config has a usable label.
+                            const labels = paths.length
+                                ? paths
+                                : dir?.name
+                                  ? [dir.name]
+                                  : [];
+                            if (dir?.id && labels.length)
+                                dirFolders.set(dir.id, labels);
+                        }
                     }
-                }
-            }
+
+                    for (const repo of repos ?? []) {
+                        const name = repo?.full_name || repo?.name;
+                        if (repo?.id && name) repoNames.set(repo.id, name);
+                    }
+                }),
+            );
         } catch {
-            // Config lookup is best-effort metadata enrichment; a failure must
-            // not take down the whole health table. Folder rules fall back to
-            // the raw directoryId.
+            // Best-effort metadata enrichment; never break the table.
         }
 
-        return map;
+        return { dirFolders, repoNames };
     }
 
     async execute(q: CockpitRangeQuery): Promise<KodyRuleHealthRow[]> {
-        const [usageRows, rulesDoc, repoNames, directoryFolders] =
+        const [usageRows, rulesDoc, warehouseRepoNames, scopeMaps] =
             await Promise.all([
                 this.reviewAnalytics.getKodyRulesUsage(q),
                 this.kodyRulesService.findByOrganizationId(q.organizationId),
                 this.reviewAnalytics.getRepositoryNames(q.organizationId),
-                this.resolveDirectoryFolders(q.organizationId),
+                this.resolveScopeMaps(q.organizationId),
             ]);
+        const { dirFolders, repoNames: configRepoNames } = scopeMaps;
 
         const usageByRule = new Map(usageRows.map((u) => [u.ruleId, u]));
         const rules = (rulesDoc?.rules ?? []).filter(
@@ -191,12 +219,17 @@ export class GetKodyRulesHealthUseCase {
                 title: rule.title,
                 severity: rule.severity ?? null,
                 repositoryId,
+                // Prefer the warehouse name (full_name with activity context),
+                // fall back to the integration config so repos with no reviewed
+                // PR still resolve instead of showing a raw numeric id.
                 repositoryName: repositoryId
-                    ? (repoNames.get(repositoryId) ?? null)
+                    ? (warehouseRepoNames.get(repositoryId) ??
+                      configRepoNames.get(repositoryId) ??
+                      null)
                     : null,
                 directoryId,
                 directoryFolders: directoryId
-                    ? (directoryFolders.get(directoryId) ?? null)
+                    ? (dirFolders.get(directoryId) ?? null)
                     : null,
                 state,
                 ...usage,

--- a/libs/cockpit/modules/cockpit.module.ts
+++ b/libs/cockpit/modules/cockpit.module.ts
@@ -7,6 +7,7 @@ import { UserModule } from '@libs/identity/modules/user.module';
 import { OrganizationModule } from '@libs/organization/modules/organization.module';
 import { TeamModule } from '@libs/organization/modules/team.module';
 import { ParametersModule } from '@libs/organization/modules/parameters.module';
+import { IntegrationConfigModule } from '@libs/integrations/modules/config.module';
 
 import { COCKPIT_DEVELOPER_PRODUCTIVITY_SERVICE_TOKEN } from '../domain/contracts/cockpit-developer-productivity.service.contract';
 import { COCKPIT_REVIEW_ANALYTICS_SERVICE_TOKEN } from '../domain/contracts/cockpit-review-analytics.service.contract';
@@ -39,6 +40,7 @@ import { NotificationModule } from '@libs/notifications/modules/notification.mod
         forwardRef(() => KodyRulesModule),
         forwardRef(() => TeamModule),
         forwardRef(() => ParametersModule),
+        forwardRef(() => IntegrationConfigModule),
     ],
     providers: [
         CockpitSourceResolver,

--- a/test/unit/cockpit/get-kody-rules-health.use-case.spec.ts
+++ b/test/unit/cockpit/get-kody-rules-health.use-case.spec.ts
@@ -64,6 +64,11 @@ describe('GetKodyRulesHealthUseCase', () => {
             name?: string;
             folders?: Array<{ path: string }>;
         }> = [],
+        configRepos: Array<{
+            id: string;
+            name?: string;
+            full_name?: string;
+        }> = [],
     ) => {
         const reviewAnalytics = {
             getKodyRulesUsage: jest.fn().mockResolvedValue(usageRows),
@@ -82,11 +87,17 @@ describe('GetKodyRulesHealthUseCase', () => {
                 },
             }),
         };
+        const integrationConfigService = {
+            findIntegrationConfigFormatted: jest
+                .fn()
+                .mockResolvedValue(configRepos),
+        };
         return new GetKodyRulesHealthUseCase(
             reviewAnalytics as never,
             kodyRulesService as never,
             teamService as never,
             parametersService as never,
+            integrationConfigService as never,
         );
     };
 
@@ -247,6 +258,34 @@ describe('GetKodyRulesHealthUseCase', () => {
         expect(byId.m).toMatchObject({
             directoryId: 'dir-2',
             directoryFolders: ['/apps/api', '/apps/web'],
+        });
+    });
+
+    it('resolves repo name from the integration config when the warehouse has no PRs for it', async () => {
+        const useCase = mkUseCase(
+            [],
+            {
+                rules: [
+                    {
+                        uuid: 'noPr',
+                        title: 'Repo rule on a repo with no reviewed PRs',
+                        repositoryId: '670345891',
+                        status: KodyRulesStatus.ACTIVE,
+                    },
+                ],
+            },
+            // warehouse knows nothing about this repo (0 triggers → no row)
+            new Map(),
+            [],
+            // ...but the code-management integration does
+            [{ id: '670345891', full_name: 'kodustech/kodus-ai' }],
+        );
+
+        const rows = await useCase.execute(baseQuery);
+
+        expect(rows[0]).toMatchObject({
+            repositoryId: '670345891',
+            repositoryName: 'kodustech/kodus-ai',
         });
     });
 });


### PR DESCRIPTION
## What

Repo-scoped Kody Rules pointing at a repository with **no reviewed PRs** rendered as a raw numeric id in the Scope column — `Repo · 670345891` instead of `Repo · kodustech/kodus-ai`.

## Why

Repo names were resolved **only** from the warehouse (`pull_requests_opt.repo_full_name`), which only knows repos that have had a PR analyzed. A rule scoped to a repo with 0 triggers had no warehouse row → no name → fell back to the raw id.

## How

Resolve `repositoryId → full name` from the code-management integration's repository list (`IntegrationConfigKey.REPOSITORIES`) — the authoritative source for **every** selected repo — and use it as a fallback after the warehouse name.

- Folded into the existing per-team config walk (same `teamService.find` already used for directory resolution), so it's one extra `findIntegrationConfigFormatted` per team, in parallel.
- Best-effort: a lookup failure still falls back to the raw id and never breaks the health table.
- Backend-only — the frontend already renders `repositoryName ?? repositoryId`.

## Test

- `test/unit/cockpit/get-kody-rules-health.use-case.spec.ts` — 10/10 green; adds a case proving a repo-scoped rule resolves its name from the integration config when the warehouse has no PRs for it.
- Verified the endpoint returns 200 with the new dependency injected (DI resolves cleanly) on the local stack.

> Builds on #1318 (now merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)