### PR TITLE
perf(docker): persist webpack cache + move CI build cache to GHCR registry

### DIFF
--- a/.github/workflows/prod-build-push-and-pr-green.yml
+++ b/.github/workflows/prod-build-push-and-pr-green.yml
@@ -64,6 +64,8 @@ jobs:
             # Required by github/codeql-action/upload-sarif to publish
             # Trivy findings to the repo's Security tab.
             security-events: write
+            # Push the buildx layer cache to GHCR (images still go to ECR).
+            packages: write
 
         steps:
             - name: Validate tag format (x.y.z)
@@ -154,12 +156,25 @@ jobs:
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v4.0.0
 
+            # Cache push/pull target. Images go to ECR; the buildx layer
+            # cache lives in GHCR (durable, no 10GB GHA eviction).
+            - name: Login to GitHub Container Registry (build cache)
+              uses: docker/login-action@v4.1.0
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
             - name: Build, tag, and push (api/webhooks/worker)
               env:
                   # Authenticates @vscode/ripgrep's postinstall download via
                   # the bake-level `github_token` secret (anonymous GitHub
                   # API calls from runner IPs are rate-limited → 403).
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  # Durable registry build cache in GHCR (read by bake's
+                  # CACHE_TYPE/CACHE_REF — see docker-bake.hcl). arm64-only tag.
+                  CACHE_TYPE: registry
+                  CACHE_REF: ghcr.io/${{ github.repository_owner }}/kodus-ai-buildcache:prod-arm64
                   ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
                   API_TAGS: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY_API
                       }}:${{ env.IMAGE_TAG }}
@@ -173,8 +188,6 @@ jobs:
                   docker buildx bake -f docker-bake.hcl \
                     --set base.args.RELEASE_VERSION=${{ env.IMAGE_TAG }} \
                     --set base.args.API_CLOUD_MODE=true \
-                    --set base.cache-from=type=gha,scope=${{ env.BUILDX_CACHE_SCOPE }} \
-                    --set base.cache-to=type=gha,scope=${{ env.BUILDX_CACHE_SCOPE }},mode=max \
                     --set *.platform=${{ env.BUILDX_PLATFORMS }} \
                     --push \
                     api webhooks worker

--- a/.github/workflows/qa-build-push-and-pr-green.yml
+++ b/.github/workflows/qa-build-push-and-pr-green.yml
@@ -63,6 +63,8 @@ jobs:
             # Required by github/codeql-action/upload-sarif to publish
             # Trivy findings to the repo's Security tab.
             security-events: write
+            # Push the buildx layer cache to GHCR (images still go to ECR).
+            packages: write
 
         steps:
             - name: Checkout code
@@ -123,12 +125,25 @@ jobs:
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v4.0.0
 
+            # Cache push/pull target. Images go to ECR; the buildx layer
+            # cache lives in GHCR (durable, no 10GB GHA eviction).
+            - name: Login to GitHub Container Registry (build cache)
+              uses: docker/login-action@v4.1.0
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
             - name: Build, tag, and push (api/webhooks/worker)
               env:
                   # Authenticates @vscode/ripgrep's postinstall download via
                   # the bake-level `github_token` secret (anonymous GitHub
                   # API calls from runner IPs are rate-limited → 403).
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  # Durable registry build cache in GHCR (read by bake's
+                  # CACHE_TYPE/CACHE_REF — see docker-bake.hcl). arm64-only tag.
+                  CACHE_TYPE: registry
+                  CACHE_REF: ghcr.io/${{ github.repository_owner }}/kodus-ai-buildcache:qa-arm64
                   ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
                   API_TAGS: ${{ steps.login-ecr.outputs.registry }}/${{ env.ECR_REPOSITORY_API
                       }}:${{ env.IMAGE_TAG }}
@@ -142,8 +157,6 @@ jobs:
                   docker buildx bake -f docker-bake.hcl \
                     --set base.args.RELEASE_VERSION=${{ env.IMAGE_TAG }} \
                     --set base.args.API_CLOUD_MODE=true \
-                    --set base.cache-from=type=gha,scope=${{ env.BUILDX_CACHE_SCOPE }} \
-                    --set base.cache-to=type=gha,scope=${{ env.BUILDX_CACHE_SCOPE }},mode=max \
                     --set *.platform=${{ env.BUILDX_PLATFORMS }} \
                     --push \
                     api webhooks worker

--- a/.github/workflows/selfhosted-build-push.yml
+++ b/.github/workflows/selfhosted-build-push.yml
@@ -322,6 +322,11 @@ jobs:
                   RC_VERSION: ${{ needs.plan-release.outputs.rc_version }}
                   RELEASE_VERSION_FINAL: ${{ needs.plan-release.outputs.release_version }}
                   OWNER: ${{ github.repository_owner }}
+                  # Durable build cache in GHCR (no 10GB GHA eviction). Read
+                  # by bake's CACHE_TYPE/CACHE_REF variables (see docker-bake.hcl).
+                  # Multi-arch tag — this job builds amd64+arm64.
+                  CACHE_TYPE: registry
+                  CACHE_REF: ghcr.io/${{ github.repository_owner }}/kodus-ai-buildcache:selfhosted
                   API_TAGS: ghcr.io/${{ github.repository_owner }}/kodus-ai-api:${{ needs.plan-release.outputs.rc_version }}
                   WEBHOOKS_TAGS: ghcr.io/${{ github.repository_owner }}/kodus-ai-webhook:${{ needs.plan-release.outputs.rc_version }}
                   WORKER_TAGS: ghcr.io/${{ github.repository_owner }}/kodus-ai-worker:${{ needs.plan-release.outputs.rc_version }}
@@ -332,8 +337,6 @@ jobs:
                   docker buildx bake -f docker-bake.hcl \
                     --set base.args.RELEASE_VERSION=${RELEASE_VERSION_FINAL} \
                     --set base.args.API_CLOUD_MODE=false \
-                    --set base.cache-from=type=gha \
-                    --set base.cache-to=type=gha,mode=max \
                     --set *.platform=linux/amd64,linux/arm64 \
                     --push
 

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -14,6 +14,21 @@ variable "CACHE_SCOPE" {
   default = "kodus-ai-arm64"
 }
 
+# Build-cache backend. Defaults to GitHub Actions cache (`type=gha`) so
+# local builds, `docker compose build`, and the web workflow are
+# unchanged. CI jobs that want a durable cache set CACHE_TYPE=registry +
+# CACHE_REF=<registry>/<repo>:<tag> to push/pull the cache to a registry
+# image instead — registry cache has no 10GB GHA eviction ceiling, so
+# cold runners and fresh droplets pull warm layers instead of rebuilding
+# the deps/prod-deps stages from scratch.
+variable "CACHE_TYPE" {
+  default = "gha"
+}
+
+variable "CACHE_REF" {
+  default = ""
+}
+
 variable "API_TAGS" {
   default = "kodus-ai-api:local"
 }
@@ -52,8 +67,12 @@ target "base" {
   # bake time; absent env → empty secret → install runs unauthenticated
   # exactly as before (local builds unaffected).
   secret = ["id=github_token,env=GITHUB_TOKEN"]
-  cache-from = ["type=gha,scope=${CACHE_SCOPE}"]
-  cache-to = ["type=gha,scope=${CACHE_SCOPE},mode=max"]
+  # `image-manifest=true,oci-mediatypes=true` keeps the registry cache a
+  # single OCI image (required by ECR, harmless on GHCR). `ignore-error=true`
+  # makes a cache-export failure non-fatal — a release must never fail just
+  # because the cache push hiccuped.
+  cache-from = CACHE_TYPE == "registry" ? ["type=registry,ref=${CACHE_REF}"] : ["type=gha,scope=${CACHE_SCOPE}"]
+  cache-to = CACHE_TYPE == "registry" ? ["type=registry,ref=${CACHE_REF},mode=max,image-manifest=true,oci-mediatypes=true,ignore-error=true"] : ["type=gha,scope=${CACHE_SCOPE},mode=max"]
 }
 
 target "api" {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -92,7 +92,15 @@ RUN sed -e "s/__CLOUD_MODE__/${API_CLOUD_MODE}/g" \
         -e "/declare const/d" \
         libs/ee/configs/environment/environment.template.ts > libs/ee/configs/environment/environment.ts
 
-RUN pnpm run build:apps && pnpm run build:migrations
+# Persist webpack's incremental filesystem cache (node_modules/.cache/webpack,
+# the default when cache.type='filesystem' with no cacheDirectory — see
+# webpack.config.js) across builds via a BuildKit cache mount. Without this the
+# `COPY . .` above invalidates the layer on every source change and webpack
+# recompiles all 6 apps from scratch (~3min). With it, only the changed modules
+# rebuild → seconds. sharing=locked because build:apps runs the 6 nest builds in
+# parallel against one shared cache dir.
+RUN --mount=type=cache,target=/usr/src/app/node_modules/.cache,sharing=locked \
+    pnpm run build:apps && pnpm run build:migrations
 
 # Install production dependencies only
 FROM base AS prod-deps


### PR DESCRIPTION
## What & why

Two independent build-speed wins for the kodus-ai Docker images (slow incremental ~3min, cold build ~12min).

### 1. Persist webpack's incremental cache (works on merge, zero config)
`pnpm run build:apps` writes a webpack filesystem cache to `node_modules/.cache/webpack`, but that dir wasn't mounted as a BuildKit cache — so every `COPY . .` invalidation recompiled all 6 apps from scratch. Now mounted via `--mount=type=cache`, so only changed modules rebuild.

**Validated locally** (two builds, small source change in between):
- Bottleneck app (decides wall-clock, apps build in parallel): **9.5s → 6.0s** (~37%). Proportionally larger on slower CI/droplet hardware.
- Output correctness: identical 254-file `dist/` tree; unchanged apps (`worker`/`webhooks`/`analytics-cli`) **byte-identical** (sha256) cold vs warm — only the touched `api` differs. No stale/corrupt output.

### 2. Move CI layer cache from GHA cache → GHCR registry
`type=gha` has a 10GB eviction ceiling that keeps getting exhausted → cold runners/droplets rebuild `deps`/`prod-deps` from scratch (the bulk of the ~12min fresh build). Registry cache has no such ceiling.

- **Images still publish to ECR.** Only the *build cache* moves to `ghcr.io/<owner>/kodus-ai-buildcache`.
- `docker-bake.hcl` gains `CACHE_TYPE`/`CACHE_REF` vars **defaulting to `type=gha`** → local builds, `docker compose build`, and the web workflow are unchanged.
- prod/qa/selfhosted opt in to registry cache. prod/qa also get a `ghcr.io` login + `packages: write`.
- `cache-to` uses `ignore-error=true` (a cache push failure can never fail a release) + `image-manifest=true,oci-mediatypes=true` (registry compat).

## Activation / what to check
- Task 1: works on merge, nothing to configure.
- Task 2: the **first** run per workflow only *writes* the cache (creates the `kodus-ai-buildcache` GHCR package automatically) — speedup kicks in from the **2nd** run. On the first run, confirm the cache push to `ghcr.io` doesn't fail on permissions; if the org restricts `GITHUB_TOKEN` packages writes, swap in a PAT with `write:packages`. No ECR repo / secrets to create.

## Notes
- `BUILDX_CACHE_SCOPE` env in prod/qa is now unused (left in place for an easy rollback to `gha`).
- `web`/`rabbitmq` bake targets intentionally stay on `type=gha` (separate workflows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)