### PR TITLE
feat(code-review): route subscription-trial orgs to Kimi K2.6

### DIFF
--- a/libs/code-review/pipeline/context/code-review-pipeline.context.ts
+++ b/libs/code-review/pipeline/context/code-review-pipeline.context.ts
@@ -104,6 +104,10 @@ export interface CodeReviewPipelineContext extends PipelineContext {
         notificationHandled?: boolean;
         showStatusFeedback?: boolean;
         forceFullRerun?: boolean;
+        /** Org subscription status (e.g. 'trial', 'active'), captured by
+         *  ValidatePrerequisitesStage from the license validation so later
+         *  stages can pick a trial-specific model. */
+        subscriptionStatus?: string;
         /** Set by the pipeline provider before execution. When true, the
          *  agent (v4) engine will run, which has its own token-budget chunking
          *  and tolerates much larger PRs than the legacy engine. */

--- a/libs/code-review/pipeline/stages/agent-review.stage.ts
+++ b/libs/code-review/pipeline/stages/agent-review.stage.ts
@@ -509,24 +509,32 @@ export class AgentReviewStage extends BasePipelineStage<CodeReviewPipelineContex
                 callGraph,
                 callGraphJson: context.callGraphJson,
                 reviewMode: context.codeReviewConfig?.reviewMode || 'normal',
-                // Trial mode has no BYOK config (organizationId='trial'
-                // isn't a UUID, so getBYOKConfig returns null). Without
-                // this override the agent falls back to gemini-3.1-pro,
-                // which makes anonymous public-demo reviews take 4–5
-                // minutes. Force Kimi K2.6 (Moonshot) for the trial flow —
-                // a coding-tuned model that showcases review quality while
-                // staying fast enough for demo latency. The `kimi-` prefix
-                // routes through Moonshot's OpenAI-compatible endpoint in
-                // byokToVercelModel, which reads API_MOONSHOT_API_KEY —
-                // that env MUST be set in the cloud/trial deployment.
-                // `isTrialMode` lives on the CLI pipeline context — we
-                // can't import that type here without inverting the
-                // dep graph (cli-review depends on code-review), so
-                // the cast is intentional.
-                defaultModelOverride: (context as { isTrialMode?: boolean })
-                    .isTrialMode
-                    ? 'kimi-k2.6'
-                    : undefined,
+                // Route trial reviews to Kimi K2.6 (Moonshot) instead of the
+                // production default (gemini-3.1-pro). Two distinct "trial"
+                // surfaces both qualify, and neither carries a BYOK config:
+                //   1. Anonymous public demo — `isTrialMode` on the CLI
+                //      pipeline context (organizationId='trial', not a UUID).
+                //   2. Signed-up orgs in their subscription trial —
+                //      `subscriptionStatus === 'trial'`, captured by
+                //      ValidatePrerequisitesStage from the license check.
+                //      These run the managed pipeline with no BYOK, so without
+                //      this they'd burn the expensive 3.1-pro default on
+                //      Kodus's dime for the whole trial window.
+                // The `kimi-` prefix routes through Moonshot's
+                // OpenAI-compatible endpoint in byokToVercelModel, which reads
+                // API_MOONSHOT_API_KEY — that env MUST be set in the cloud
+                // deployment. The override is ignored whenever a BYOK config
+                // is present (byokToVercelModel prefers BYOK), so a trial org
+                // that configured its own key keeps using it.
+                // `isTrialMode` lives on the CLI pipeline context — we can't
+                // import that type here without inverting the dep graph
+                // (cli-review depends on code-review), so the cast is
+                // intentional.
+                defaultModelOverride:
+                    (context as { isTrialMode?: boolean }).isTrialMode ||
+                    context.pipelineMetadata?.subscriptionStatus === 'trial'
+                        ? 'kimi-k2.6'
+                        : undefined,
                 // Per-repo/directory model override resolved by ValidateConfigStage.
                 byokModel: context.codeReviewConfig?.byokModel,
                 // Adaptive-fit profile: agents read this to decide whether

--- a/libs/code-review/pipeline/stages/agent-review.stage.ts
+++ b/libs/code-review/pipeline/stages/agent-review.stage.ts
@@ -513,16 +513,19 @@ export class AgentReviewStage extends BasePipelineStage<CodeReviewPipelineContex
                 // isn't a UUID, so getBYOKConfig returns null). Without
                 // this override the agent falls back to gemini-3.1-pro,
                 // which makes anonymous public-demo reviews take 4–5
-                // minutes. Force Gemini 3 Flash for the trial flow —
-                // newer than 2.5 Flash, fast enough for demo latency
-                // (~30s), and the agent loop stays under control.
+                // minutes. Force Kimi K2.6 (Moonshot) for the trial flow —
+                // a coding-tuned model that showcases review quality while
+                // staying fast enough for demo latency. The `kimi-` prefix
+                // routes through Moonshot's OpenAI-compatible endpoint in
+                // byokToVercelModel, which reads API_MOONSHOT_API_KEY —
+                // that env MUST be set in the cloud/trial deployment.
                 // `isTrialMode` lives on the CLI pipeline context — we
                 // can't import that type here without inverting the
                 // dep graph (cli-review depends on code-review), so
                 // the cast is intentional.
                 defaultModelOverride: (context as { isTrialMode?: boolean })
                     .isTrialMode
-                    ? 'gemini-3-flash-preview'
+                    ? 'kimi-k2.6'
                     : undefined,
                 // Per-repo/directory model override resolved by ValidateConfigStage.
                 byokModel: context.codeReviewConfig?.byokModel,

--- a/libs/code-review/pipeline/stages/agent-review.stage.ts
+++ b/libs/code-review/pipeline/stages/agent-review.stage.ts
@@ -509,32 +509,36 @@ export class AgentReviewStage extends BasePipelineStage<CodeReviewPipelineContex
                 callGraph,
                 callGraphJson: context.callGraphJson,
                 reviewMode: context.codeReviewConfig?.reviewMode || 'normal',
-                // Route trial reviews to Kimi K2.6 (Moonshot) instead of the
-                // production default (gemini-3.1-pro). Two distinct "trial"
-                // surfaces both qualify, and neither carries a BYOK config:
-                //   1. Anonymous public demo — `isTrialMode` on the CLI
-                //      pipeline context (organizationId='trial', not a UUID).
-                //   2. Signed-up orgs in their subscription trial —
-                //      `subscriptionStatus === 'trial'`, captured by
-                //      ValidatePrerequisitesStage from the license check.
-                //      These run the managed pipeline with no BYOK, so without
-                //      this they'd burn the expensive 3.1-pro default on
-                //      Kodus's dime for the whole trial window.
-                // The `kimi-` prefix routes through Moonshot's
-                // OpenAI-compatible endpoint in byokToVercelModel, which reads
-                // API_MOONSHOT_API_KEY — that env MUST be set in the cloud
-                // deployment. The override is ignored whenever a BYOK config
-                // is present (byokToVercelModel prefers BYOK), so a trial org
-                // that configured its own key keeps using it.
+                // Trial reviews get a forced default model (only consulted
+                // when there's no BYOK config). Two distinct "trial" surfaces,
+                // each with its OWN model:
+                //   1. Subscription trial — signed-up orgs in their 14-day
+                //      trial (`subscriptionStatus === 'trial'`, captured by
+                //      ValidatePrerequisitesStage). Routed to Kimi K2.6: they
+                //      run the managed pipeline with no BYOK, so without this
+                //      they'd burn the expensive 3.1-pro default on Kodus's
+                //      dime for the whole trial window. The `kimi-` prefix
+                //      routes through Moonshot's OpenAI-compatible endpoint in
+                //      byokToVercelModel (reads API_MOONSHOT_API_KEY — that env
+                //      MUST be set in the cloud deployment).
+                //   2. Anonymous public demo (`isTrialMode`, try.kodus.io) —
+                //      kept on Gemini 3 Flash: it's a latency-sensitive public
+                //      demo and the try UI advertises "Gemini 3 Flash". Without
+                //      this it would fall back to the slow 3.1-pro default
+                //      (~4-5 min).
+                // Either override is ignored when a BYOK config is present
+                // (byokToVercelModel prefers BYOK), so a trial org that
+                // configured its own key keeps using it.
                 // `isTrialMode` lives on the CLI pipeline context — we can't
                 // import that type here without inverting the dep graph
                 // (cli-review depends on code-review), so the cast is
                 // intentional.
                 defaultModelOverride:
-                    (context as { isTrialMode?: boolean }).isTrialMode ||
                     context.pipelineMetadata?.subscriptionStatus === 'trial'
                         ? 'kimi-k2.6'
-                        : undefined,
+                        : (context as { isTrialMode?: boolean }).isTrialMode
+                          ? 'gemini-3-flash-preview'
+                          : undefined,
                 // Per-repo/directory model override resolved by ValidateConfigStage.
                 byokModel: context.codeReviewConfig?.byokModel,
                 // Adaptive-fit profile: agents read this to decide whether

--- a/libs/code-review/pipeline/stages/validate-prerequisites.stage.ts
+++ b/libs/code-review/pipeline/stages/validate-prerequisites.stage.ts
@@ -219,6 +219,13 @@ export class ValidatePrerequisitesStage extends BasePipelineStage<CodeReviewPipe
                     draft.codeReviewConfig.byokConfig =
                         validationResult.byokConfig;
                 }
+                if (validationResult.subscriptionStatus) {
+                    if (!draft.pipelineMetadata) {
+                        draft.pipelineMetadata = {};
+                    }
+                    draft.pipelineMetadata.subscriptionStatus =
+                        validationResult.subscriptionStatus;
+                }
             });
         }
 

--- a/libs/ee/shared/services/permissionValidation.service.ts
+++ b/libs/ee/shared/services/permissionValidation.service.ts
@@ -46,6 +46,10 @@ export interface ValidationResult {
     byokConfig?: BYOKConfig | null;
     errorType?: ValidationErrorType;
     metadata?: Record<string, any>;
+    // Subscription status of the org (e.g. 'trial', 'active'). Exposed so
+    // downstream consumers (the review pipeline) can pick a trial-specific
+    // model without re-validating the license.
+    subscriptionStatus?: string;
 }
 
 @Injectable()
@@ -166,7 +170,10 @@ export class PermissionValidationService {
 
             // 2. Trial always allows (no BYOK required and no user validation)
             if (validation.subscriptionStatus === 'trial') {
-                return { allowed: true };
+                return {
+                    allowed: true,
+                    subscriptionStatus: validation.subscriptionStatus,
+                };
             }
 
             // 3. Identify plan type
@@ -255,6 +262,7 @@ export class PermissionValidationService {
             return {
                 allowed: true,
                 byokConfig,
+                subscriptionStatus: validation.subscriptionStatus,
                 metadata: { planType: validation.planType, identifiedPlanType },
             };
         } catch (error) {


### PR DESCRIPTION
## What

Code reviews for orgs in their **14-day subscription trial** (`subscriptionStatus === 'trial'`) now run on **`kimi-k2.6`** instead of the production default (`gemini-3.1-pro-preview-customtools`).

These orgs run the normal managed pipeline with **no BYOK**, so they fall through to the expensive `gemini-3.1-pro` default — billed to Kodus for the entire trial window. Routing them to Kimi cuts that cost.

**The public demo (`try.kodus.io`) is unchanged** — it stays on `gemini-3-flash-preview` (latency-sensitive, and the try UI advertises "Gemini 3 Flash"). Net diff vs main leaves the `isTrialMode` branch exactly as-is.

## How

- `permissionValidation.service.ts` — expose `subscriptionStatus` on `ValidationResult` (it was already computed, just not surfaced).
- `validate-prerequisites.stage.ts` — stash `subscriptionStatus` onto `pipelineMetadata` (same `updateContext` that stores `byokConfig`).
- `code-review-pipeline.context.ts` — declare `pipelineMetadata.subscriptionStatus`.
- `agent-review.stage.ts` — `defaultModelOverride = 'kimi-k2.6'` when `subscriptionStatus === 'trial'`; `isTrialMode` (demo) still → `gemini-3-flash-preview`.

The `kimi-` prefix routes through Moonshot's OpenAI-compatible endpoint in `byokToVercelModel` (reads `API_MOONSHOT_API_KEY`).

## Scope / safety

- **BYOK wins:** `ValidateConfigStage` populates `byokConfig` from the org's saved parameters regardless of subscription status, and `byokToVercelModel` prefers BYOK — so a trial org that configured its own key keeps using it. The override only fires when no BYOK.
- **Paid/active orgs:** unchanged (BYOK or `gemini-3.1-pro`).
- **Self-hosted:** unaffected — status is `self-hosted`/`licensed-self-hosted`, never `trial` (and SH already defaults to Kimi via the env path).
- **Hybrid, by design:** only the main review agents move to Kimi. Post-processing helpers (dedup, severity, formatting) stay on `gemini-3-flash-preview` (hardcoded; out of scope — Flash is fine there).

## ⚠️ Deploy prerequisite — BOTH keys required in the cloud env

- `API_MOONSHOT_API_KEY` **must be ADDED** — drives the Kimi trial review. Without it trial reviews fail with 401.
- `API_GOOGLE_AI_API_KEY` (or `GOOGLE_GENERATIVE_AI_API_KEY`) **must STAY set** — the public demo (Flash) and the post-processing helpers still use it.

Infra/secrets change (INFRA_REPO / QA+prod), not in this repo. Must land before/with merge.

## Testing

⚠️ **Not yet validated.** Local build not run (nest/tsc not installed in checkout); CI build is the authoritative typecheck. E2E plan: trigger a managed review on a cloud org in `trial` subscription status (no BYOK) on QA and confirm the agent log line `[AGENT] ... using model: kimi-k2.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)