### PR TITLE
fix(web): allow MCP OAuth callback after onboarding completes

### DIFF
--- a/apps/web/src/app/(setup)/layout.tsx
+++ b/apps/web/src/app/(setup)/layout.tsx
@@ -15,12 +15,16 @@ import { AllTeamsProvider } from "src/core/providers/all-teams-context";
 import { AuthProvider } from "src/core/providers/auth.provider";
 import { SelectedTeamProvider } from "src/core/providers/selected-team-context";
 import { TEAM_STATUS } from "src/core/types";
+import { getCurrentPathnameOnServerComponents } from "src/core/utils/headers";
 import { OrganizationProvider } from "src/features/organization/_providers/organization-context";
 
 import { SetupGithubStars } from "./_components/setup-github-stars";
 import { SetupUserNav } from "./_components/setup-user-nav";
 import { SetupProgressSaver } from "./setup/_components/setup-step-tracker";
 import { Team } from "@services/teams/types";
+
+/** OAuth providers redirect here after authorization; must run even when onboarding is finished. */
+const MCP_OAUTH_CALLBACK_PATH = "/setup/mcp/oauth";
 
 export default async function Layout(props: React.PropsWithChildren) {
     const [teams, organizationId, organizationName, session] =
@@ -49,7 +53,14 @@ export default async function Layout(props: React.PropsWithChildren) {
             teamId: candidateTeamId,
         }).catch(() => null);
         if (platformConfigs?.configValue?.finishOnboard) {
-            redirect("/");
+            const currentPath = await getCurrentPathnameOnServerComponents();
+            const isMcpOauthCallback =
+                currentPath === MCP_OAUTH_CALLBACK_PATH ||
+                currentPath?.startsWith(`${MCP_OAUTH_CALLBACK_PATH}/`);
+
+            if (!isMcpOauthCallback) {
+                redirect("/");
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

On self-hosted deployments where onboarding is already complete (`finishOnboard=true`), the setup layout redirected every `/setup/*` route to `/` — including the MCP OAuth callback at `/setup/mcp/oauth`. OAuth finalize never ran, so managed MCP plugins (Atlassian Rovo, Linear, Sentry, etc.) could not be connected after onboarding.

This change skips the `finishOnboard` redirect only for the MCP OAuth callback path (using the existing `x-current-path` header from middleware).

Fixes #1327

## Changelog routing (driven by the PR title prefix)

`fix:` → **Bug fixes** section

## Test plan

- [ ] Self-hosted org with `finishOnboard=true`: open **Settings → Plugins → Atlassian Rovo (or other managed OAuth MCP) → Authorize**, complete provider OAuth → land on `/setup/mcp/oauth?code=...&state=...` and see success (not redirected to `/settings/code-review/global/general`)
- [ ] After OAuth completes, plugin appears connected in **Settings → Plugins**
- [ ] Org with `finishOnboard=true` visiting other `/setup/*` routes (e.g. `/setup/choosing-a-pull-request`) still redirects to `/` as before
- [ ] Org with `finishOnboard=false` onboarding flow unchanged

## Notes for the reviewer

Minimal Option A from #1327 — uses `getCurrentPathnameOnServerComponents()` already wired by `apps/web/src/middleware.ts`. Option B (move callback out of `(setup)` group) can be a follow-up if preferred.

Related self-hosted MCP config items from #1327 (internal `API_KODUS_MCP_SERVER_URL`, default Kodus MCP connection) are separate ops/docs concerns and not included in this PR.