### PR TITLE
fix(ci): use feature-gate:changelog script for changelog publish

### DIFF
--- a/.github/workflows/changelog-publish.yml
+++ b/.github/workflows/changelog-publish.yml
@@ -126,8 +126,7 @@ jobs:
                   DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
                   RELEASE_TAG: ${{ needs.validate.outputs.tag }}
               run: |
-                  pnpm run ts-node scripts/feature-gate/publish-changelog.ts \
-                      --tag "$RELEASE_TAG"
+                  pnpm run feature-gate:changelog -- --tag "$RELEASE_TAG"
 
             - name: Commit changelog entry (if any)
               env:


### PR DESCRIPTION
## Problem

The self-hosted release's changelog-publish step failed (run [27503555278](https://github.com/kodustech/kodus-ai/actions/runs/27503555278), job 81298081273, "Draft and publish promotions for this release"):

```
> node -e "...if (!ua.startsWith('pnpm')) { console.error('Este repo migrou para pnpm. Use: pnpm install'); process.exit(1); }"
##[error]Process completed with exit code 1
```

`changelog-publish.yml` invoked `pnpm run ts-node scripts/feature-gate/publish-changelog.ts`, but there is **no `ts-node` package.json script** — `ts-node` is only a devDependency. The malformed `pnpm run ts-node ...` tripped the repo's pnpm-enforcement `preinstall` guard and aborted. A pnpm-migration leftover.

## Fix

Use the existing, documented entrypoint script `feature-gate:changelog` (`package.json` → `ts-node scripts/feature-gate/publish-changelog.ts`), forwarding `--tag` after `--`:

```yaml
run: pnpm run feature-gate:changelog -- --tag "$RELEASE_TAG"
```

## Scope

- The release itself shipped fine (promote retagged images + pushed the git tag). This only fixes the post-promote changelog announcement step so it stops failing on every release.
- Not related to the separate failure in the same run (CLI version-bump push to `main` rejected by the `release-freeze-eligible` ruleset) — that's an infra/ruleset issue, not in this repo.

## Testing

⚠️ Workflow change — can't fully exercise outside a real release run. Verified the target script exists and accepts `--tag` (it's the script's documented invocation). The next release (or a manual `changelog-publish` dispatch on a tag) is the real validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)