### PR TITLE
fix(agents): recognize Atlassian Rovo in business-rules-validation MCP preflight

### DIFF
--- a/libs/agents/skills/business-rules-validation/SKILL.md
+++ b/libs/agents/skills/business-rules-validation/SKILL.md
@@ -41,7 +41,7 @@ metadata:
         required-mcps:
             - category: task-management
               label: Task Management
-              examples: Jira, Linear, Notion, ClickUp, Github Issues
+              examples: Jira, Atlassian Rovo, Linear, Notion, ClickUp, Github Issues
 ---
 
 # Business Rules Gap Analysis

--- a/test/unit/agents/skills/generic-skill-runner.service.spec.ts
+++ b/test/unit/agents/skills/generic-skill-runner.service.spec.ts
@@ -247,6 +247,41 @@ describe('GenericSkillRunnerService', () => {
         ).resolves.toBeDefined();
     });
 
+    it('accepts Atlassian Rovo when it is listed in required MCP examples', async () => {
+        skillLoaderService.loadSkillMetaFromFilesystem.mockReturnValue(
+            withSkillMeta({
+                requiredMcps: [
+                    {
+                        category: 'task-management',
+                        label: 'Task Management',
+                        examples:
+                            'Jira, Atlassian Rovo, Linear, Notion, ClickUp, Github Issues',
+                    },
+                ],
+            }),
+        );
+        mcpManagerService.getConnections.mockResolvedValue([
+            {
+                provider: 'kodusmcp',
+                name: 'Kodus MCP',
+                allowedTools: ['KODUS_GET_PULL_REQUEST'],
+            },
+            {
+                provider: 'kodusmcp',
+                name: 'Atlassian Rovo',
+                allowedTools: ['getJiraIssue'],
+            },
+        ] as any);
+
+        await expect(
+            service.createFetcherOrchestration(
+                'business-rules-validation',
+                {} as any,
+                organizationAndTeamData,
+            ),
+        ).resolves.toBeDefined();
+    });
+
     it('filters external MCP providers by required MCP hints while keeping kodusmcp', async () => {
         skillLoaderService.loadSkillMetaFromFilesystem.mockReturnValue(
             withSkillMeta({


### PR DESCRIPTION
## Summary

- Add **Atlassian Rovo** to `required-mcps.examples` in `business-rules-validation/SKILL.md` so MCP preflight accepts Rovo as a task-management provider.
- Add a unit test confirming a connected **Atlassian Rovo** MCP passes preflight when listed in examples.

Fixes `NO_TASK_MCP` / preflight failures for teams that use **Atlassian Rovo** (installed via Kodus MCP catalog) without a separate custom Jira MCP — e.g. `@kody -v business-logic` on Symfa self-hosted (LKDB-286).

## Context

`generic-skill-runner.service.ts` matches connected MCPs against provider hints parsed from `examples`. Rovo normalizes to `atlassianrovo`, which was not listed; the pipeline stage already includes `atlassianrovo` in `TASK_MANAGEMENT_HINTS`, but skill preflight did not.

## Test plan

- [ ] Unit test: `accepts Atlassian Rovo when it is listed in required MCP examples`
- [ ] Self-hosted with **Atlassian Rovo Installed** (no custom Jira): `@kody -v business-logic <jira-url>` completes preflight and fetches ticket context
- [ ] Regression: custom Jira MCP and Linear still pass preflight