### PR TITLE
test(e2e): cockpit-analytics self-hosted scenario + matrices

### DIFF
--- a/.github/workflows/e2e-self-hosted-matrix.yml
+++ b/.github/workflows/e2e-self-hosted-matrix.yml
@@ -206,6 +206,16 @@ jobs:
                   API_LLM_PROVIDER_MODEL: gpt-5.4-mini
 
                   TARGET_FILTER_PROVIDER: ${{ matrix.cell.provider }}
+
+                  # Cockpit analytics: bring up the worker-analytics service
+                  # (COMPOSE_PROFILES=analytics, via vm.sh) and let the
+                  # cockpit-analytics scenario assert the cron-driven ingestion
+                  # (layer 3). Only on github cells — cockpit-analytics is
+                  # github-only (appliesTo), so other providers would just run
+                  # an idle analytics worker. Requires the worker-analytics
+                  # service in the kodus-installer compose (shipped together).
+                  ANALYTICS_WORKER: ${{ matrix.cell.provider == 'github' && '1' || '' }}
+                  ANALYTICS_WORKER_EXPECTED: ${{ matrix.cell.provider == 'github' && '1' || '' }}
               run: |
                   # Build a single-cell matrix YAML that mirrors the SOURCE
                   # matrix (fast.yml / full.yml) instead of hardcoding a

--- a/tests/e2e/lib/__tests__/scenarios.test.ts
+++ b/tests/e2e/lib/__tests__/scenarios.test.ts
@@ -6,6 +6,7 @@ test("allScenarios: includes the registered release-gate scenarios", () => {
     const ids = Object.keys(allScenarios).sort();
     assert.deepEqual(ids, [
         "centralized-config-sync",
+        "cockpit-analytics",
         "code-review-basic",
         "code-review-vertex-byok",
         "command-review",

--- a/tests/e2e/matrix/cockpit-only.yml
+++ b/tests/e2e/matrix/cockpit-only.yml
@@ -1,0 +1,17 @@
+id: cockpit-only
+description: |
+    Focused single-cell matrix for the cockpit-analytics red→green of the
+    vestigial WEB_ANALYTICS_SECRET gate. Self-hosted × github × license-paid
+    (the customer case; the SH e2e license is Enterprise → cockpit-eligible).
+    Used with provisioning/self-hosted/vm.sh TEST_KEEP_RUNNING=1 so the same
+    droplet serves the RED baseline (published image, empty secret → "Analytics
+    Not Available") and the GREEN run (web image rebuilt with the gate removed).
+    cockpit-analytics opens no PRs, so no webhook delivery is required.
+
+scenarios:
+    - cockpit-analytics
+
+cells:
+    - target: self-hosted
+      provider: github
+      license: license-paid

--- a/tests/e2e/matrix/full.yml
+++ b/tests/e2e/matrix/full.yml
@@ -67,6 +67,11 @@ scenarios:
     # Chromium per role and asserts the Token Usage menu item + /token-usage
     # screen actually RENDER, and denied roles get a rendered /forbidden page.
     - rbac-ui-render
+    # Cockpit analytics availability (real browser): warehouse-up API probe +
+    # /cockpit page not gated behind the vestigial WEB_ANALYTICS_SECRET. Runs
+    # on cloud (paid/trial) and self-hosted (license-paid) github cells via
+    # appliesTo; browser layer self-skips on non-cockpit tiers.
+    - cockpit-analytics
     # Public PR-review demo API (also in fast.yml). Anonymous, cloud-only;
     # appliesTo pins it to one cell (cloud × github × paid).
     - public-pr-demo

--- a/tests/e2e/matrix/sh-all.yml
+++ b/tests/e2e/matrix/sh-all.yml
@@ -16,6 +16,13 @@ scenarios:
     - command-review
     - kody-rules-create-and-apply
     - license-attribution
+    # Cockpit analytics availability (github × license-paid cell only via
+    # appliesTo): proves the analytics warehouse is up (API) AND the /cockpit
+    # page isn't gated behind the vestigial WEB_ANALYTICS_SECRET (browser).
+    # Guards the self-hosted "Analytics Not Available despite valid license"
+    # regression. Skips the browser layer (not fails) if the SH e2e license
+    # isn't Enterprise-tier.
+    - cockpit-analytics
     # per-seat gate (license-paid only); exercises pollForLicenseBlock on all
     # four providers — the cross-provider validation this run is for.
     - per-seat-license-toggle

--- a/tests/e2e/matrix/sh-analytics.yml
+++ b/tests/e2e/matrix/sh-analytics.yml
@@ -1,0 +1,27 @@
+id: sh-analytics
+description: |
+    Self-hosted Cockpit/analytics topology — the Enterprise analytics worker
+    end-to-end. Brings up the optional `worker-analytics` service (role=analytics)
+    that the default installer omits, and verifies the whole pipeline:
+      1. /cockpit/validate 200 (warehouse migrated + tier eligible)
+      2. /cockpit page renders (not gated behind the vestigial WEB_ANALYTICS_SECRET)
+      3. the ingestion CRON runs on its own (a successful analytics.ingestion_runs
+         row appears) — proving the service keeps the warehouse fresh without a
+         manual backfill.
+
+    REQUIRES, when provisioning via provisioning/self-hosted/vm.sh:
+      ANALYTICS_WORKER=1            → vm.sh enables COMPOSE_PROFILES=analytics +
+                                      a fast ANALYTICS_INGESTION_CRON (*/2).
+      ANALYTICS_WORKER_EXPECTED=1   → cockpit-analytics runs its layer-3 cron
+                                      assertion (otherwise layer 3 is skipped).
+    The api+worker images under test MUST include the tsconfig.migrations fix
+    (analytics warehouse migrations shipped to dist) or the warehouse never
+    migrates on boot and validate 500s. License must be Enterprise-tier.
+
+scenarios:
+    - cockpit-analytics
+
+cells:
+    - target: self-hosted
+      provider: github
+      license: license-paid

--- a/tests/e2e/playwright/cockpit-analytics.mjs
+++ b/tests/e2e/playwright/cockpit-analytics.mjs
@@ -1,0 +1,154 @@
+// Cockpit analytics RENDER guard (Playwright, real browser).
+//
+// Proves the /cockpit page is actually AVAILABLE for an onboarded org on a
+// cockpit-allowed tier — i.e. it neither (a) redirects to /settings/git (tier
+// gate) nor (b) renders the "Analytics Not Available" card. (b) is the exact
+// regression a self-hosted Enterprise customer hit: the layout used to gate on
+// `WEB_ANALYTICS_SECRET` (the x-api-key of the retired kodus-service-analytics
+// microservice), which self-hosted ships empty — so a valid license + a healthy
+// Postgres warehouse still showed "Analytics Not Available". A pure API check on
+// /cockpit/validate would NOT catch this (the secret only gated the web layout),
+// which is why this assertion runs in a real browser.
+//
+// Auth: mint a next-auth session over HTTP (validated credentials flow) and
+// inject the cookies into the browser context — same approach as
+// rbac-ui-render.mjs, no brittle sign-in form.
+//
+// Env:
+//   WEB_URL   e.g. http://127.0.0.1:3000  (or https://qa.web.kodus.io)
+//   EMAIL     onboarded org owner email
+//   PASSWORD  that user's password
+//   OUT_DIR   directory for screenshots/video (default: ./cockpit-analytics-evidence)
+
+import { chromium } from "playwright";
+import { mkdirSync } from "node:fs";
+
+import { applyWafBypass } from "./waf-bypass.mjs";
+
+const WEB = (process.env.WEB_URL || "http://127.0.0.1:3000").replace(/\/$/, "");
+const EMAIL = process.env.EMAIL || "";
+const PASSWORD = process.env.PASSWORD || "";
+const OUT_DIR = process.env.OUT_DIR || "./cockpit-analytics-evidence";
+mkdirSync(OUT_DIR, { recursive: true });
+
+const log = (m) => console.log(`[cockpit-analytics] ${m}`);
+
+if (!EMAIL || !PASSWORD) {
+    console.error("[cockpit-analytics] EMAIL and PASSWORD are required");
+    process.exit(1);
+}
+
+function jarToCookies(setCookies) {
+    const out = [];
+    for (const c of setCookies) {
+        const [pair] = c.split(";");
+        const eq = pair.indexOf("=");
+        if (eq > 0)
+            out.push({
+                name: pair.slice(0, eq).trim(),
+                value: pair.slice(eq + 1).trim(),
+                url: WEB,
+            });
+    }
+    return out;
+}
+
+async function nextAuthCookies(email) {
+    const jar = new Map();
+    const absorb = (res) => {
+        for (const c of res.headers.getSetCookie()) {
+            const [pair] = c.split(";");
+            const eq = pair.indexOf("=");
+            if (eq > 0) jar.set(pair.slice(0, eq).trim(), c);
+        }
+    };
+    const csrfRes = await fetch(`${WEB}/api/auth/csrf`, { redirect: "manual" });
+    absorb(csrfRes);
+    const { csrfToken } = await csrfRes.json();
+    const cookieHeader = [...jar.values()]
+        .map((c) => c.split(";")[0])
+        .join("; ");
+    const cbRes = await fetch(`${WEB}/api/auth/callback/credentials`, {
+        method: "POST",
+        headers: {
+            "Content-Type": "application/x-www-form-urlencoded",
+            Cookie: cookieHeader,
+        },
+        body: new URLSearchParams({
+            csrfToken,
+            email,
+            password: PASSWORD,
+            redirect: "false",
+            json: "true",
+        }).toString(),
+        redirect: "manual",
+    });
+    absorb(cbRes);
+    const setCookies = [...jar.values()];
+    if (
+        !setCookies.some((c) =>
+            /authjs\.session-token|__Secure-authjs\.session-token/.test(c),
+        )
+    ) {
+        throw new Error(`no session cookie for ${email} (HTTP ${cbRes.status})`);
+    }
+    return jarToCookies(setCookies);
+}
+
+const browser = await chromium.launch({ headless: true });
+const ctx = await browser.newContext({
+    recordVideo: { dir: OUT_DIR, size: { width: 1280, height: 800 } },
+    viewport: { width: 1280, height: 800 },
+});
+await applyWafBypass(ctx);
+
+let failure = null;
+try {
+    const cookies = await nextAuthCookies(EMAIL);
+    await ctx.addCookies(cookies);
+    const page = await ctx.newPage();
+
+    await page.goto(`${WEB}/cockpit`, {
+        waitUntil: "domcontentloaded",
+        timeout: 30_000,
+    });
+    // The app polls (issues count, notifications) so "networkidle" never
+    // fires; a fixed settle is enough for the server-rendered shell + the
+    // tier redirect / not-available card to have resolved.
+    await page.waitForTimeout(2500);
+
+    const url = page.url();
+    const bodyText = (
+        await page.locator("body").innerText().catch(() => "")
+    ).toLowerCase();
+    await page.screenshot({ path: `${OUT_DIR}/cockpit.png`, fullPage: true });
+
+    // (a) Tier gate: a cockpit-allowed org must NOT be bounced to settings.
+    if (/\/settings\/git\b/.test(url)) {
+        failure =
+            `/cockpit redirected to ${url} — tier gate blocked an org the ` +
+            `scenario asserted is cockpit-allowed (check license planType/` +
+            `subscriptionStatus).`;
+    }
+    // (b) The regression: the vestigial WEB_ANALYTICS_SECRET gate rendered
+    // this card despite a valid license. Its copy: "Analytics Not Available".
+    else if (bodyText.includes("analytics not available")) {
+        failure =
+            `/cockpit rendered the "Analytics Not Available" card for a ` +
+            `licensed org — the WEB_ANALYTICS_SECRET gate regressed ` +
+            `(url=${url}).`;
+    } else {
+        log(`OK  /cockpit available (url=${url})`);
+    }
+} catch (e) {
+    failure = e.message;
+} finally {
+    await ctx.close(); // flushes the video
+    await browser.close();
+}
+
+if (failure) {
+    console.error(`[cockpit-analytics] FAIL: ${failure}`);
+    process.exit(1);
+}
+console.log(`[cockpit-analytics] PASS — /cockpit available. Evidence in ${OUT_DIR}`);

--- a/tests/e2e/playwright/rbac-ui-render.mjs
+++ b/tests/e2e/playwright/rbac-ui-render.mjs
@@ -157,7 +157,7 @@ for (const { role, email } of ROLES) {
 
         // ---- 2) Route render: open each route, assert render vs /forbidden ----
         for (const entry of ROUTE_CHECKS) {
-            const { path, marker } = entry;
+            const { path, marker, notMarker } = entry;
             const want = isAllowed(entry, role);
             await page.goto(`${WEB}${path}`, { waitUntil: "domcontentloaded", timeout: 30_000 });
             await page.waitForTimeout(1500);
@@ -169,9 +169,15 @@ for (const { role, email } of ROLES) {
             if (want) {
                 const onForbidden = /\/forbidden\b/.test(url);
                 const renderedTitle = marker ? bodyText.includes(marker) : true;
-                if (onForbidden || !renderedTitle) {
+                // notMarker asserts a substring is ABSENT (e.g. /cockpit must
+                // not render the "Analytics Not Available" card for an allowed
+                // role — that's a 200 page, so onForbidden/marker miss it).
+                const badMarker = notMarker ? bodyText.includes(notMarker) : false;
+                if (onForbidden || !renderedTitle || badMarker) {
                     failures.push(
-                        `${role}: ${path} should RENDER (got url=${url}, hasMarker=${renderedTitle})`,
+                        `${role}: ${path} should RENDER (got url=${url}, hasMarker=${renderedTitle}` +
+                            (notMarker ? `, sawNotMarker="${notMarker}"=${badMarker}` : "") +
+                            `)`,
                     );
                 } else {
                     log(`OK  ${role} ${path} rendered${marker ? " (marker visible)" : ""}`);

--- a/tests/e2e/provisioning/self-hosted/vm.sh
+++ b/tests/e2e/provisioning/self-hosted/vm.sh
@@ -371,6 +371,20 @@ env_set API_MG_DB_PASSWORD "\$(openssl rand -hex 16)"
 env_set API_DATABASE_DISABLE_SSL "true"
 env_set API_PG_DB_SSL "false"
 env_set WORKER_ROLE "code-review"
+# Analytics worker (Cockpit). When ANALYTICS_WORKER=1 is passed to vm.sh,
+# enable the \`analytics\` compose profile so the installer's worker-analytics
+# service (role=analytics) comes up alongside the code-review worker, and point
+# the ingestion cron at a fast schedule so the cockpit-analytics scenario can
+# observe an automatic ingestion run within its poll window. The \`:+\` guard is
+# expanded LOCALLY (unquoted REMOTE heredoc), so COMPOSE_PROFILES is empty when
+# the flag is off → community topology unchanged. We deliberately do NOT set
+# ANALYTICS_PG_DB_HOST (leave it unset → loader cascades to API_PG_DB_*; an
+# empty value would be a footgun pre-loader-fix). Classifier disabled: the test
+# droplet has no LLM key for PR-type classification.
+env_set COMPOSE_PROFILES "${ANALYTICS_WORKER:+analytics}"
+env_set ANALYTICS_PG_DB_SCHEMA "analytics"
+env_set ANALYTICS_INGESTION_CRON "${ANALYTICS_INGESTION_CRON:-*/2 * * * *}"
+env_set ANALYTICS_CLASSIFIER_DISABLED "true"
 # The notifications module hard-requires this (ConfigService.getOrThrow).
 # Set a dummy so the app boots — emails won't actually send.
 env_set RESEND_API_KEY "${RESEND_API_KEY:-disabled-for-dev}"

--- a/tests/e2e/scenarios/cockpit-analytics.ts
+++ b/tests/e2e/scenarios/cockpit-analytics.ts
@@ -1,0 +1,183 @@
+import { spawn } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { http } from "../lib/http.js";
+import { ensureLicenseSeat } from "../lib/onboarding.js";
+import type { RunContext, Scenario } from "../lib/types.js";
+
+// ---------------------------------------------------------------------------
+// Cockpit analytics availability guard.
+//
+// Catches the self-hosted regression where the cockpit page showed "Analytics
+// Not Available" despite a valid Enterprise license and a healthy Postgres
+// warehouse: the web layout gated on `WEB_ANALYTICS_SECRET` (the x-api-key of
+// the retired `kodus-service-analytics` microservice, shipped EMPTY on
+// self-hosted) instead of the license tier. The legacy path is dead
+// server-side (CockpitSourceResolver hard-returns INTERNAL) so the secret is
+// vestigial — yet it blocked the whole page. The matrix never exercised
+// analytics, so it slipped through for months.
+//
+// Two layers:
+//   1. API probe — GET /cockpit/validate (the cockpit endpoint is itself the
+//      authority on eligibility):
+//        • 200 + numeric PR count → tier-eligible AND the analytics warehouse
+//          (2nd TypeORM datasource + its migrations) is reachable.
+//        • 403 "not on a supported tier" → the org isn't cockpit-eligible
+//          (e.g. unlicensed self-hosted, or a managed cloud plan that's neither
+//          teams_* nor enterprise_*) → SKIP, not fail.
+//        • anything else → fail (warehouse down / app error).
+//      We deliberately do NOT use the billing `validate-org-license` endpoint
+//      to gate tier: it's cloud-only and 500s on self-hosted (no billing
+//      service in the SH compose).
+//   2. Browser render — /cockpit must NOT redirect to /settings/git (tier gate)
+//      and must NOT render the "Analytics Not Available" card. This is the only
+//      layer that exercises the web LAYOUT gate, i.e. the actual customer bug
+//      (the vestigial WEB_ANALYTICS_SECRET block); the API probe passes right
+//      through it. Reached only when layer 1 returned 200 (eligible).
+// ---------------------------------------------------------------------------
+
+const PLAYWRIGHT_DIR = resolve(import.meta.dirname, "..", "playwright");
+const SPEC = resolve(PLAYWRIGHT_DIR, "cockpit-analytics.mjs");
+
+export const cockpitAnalytics: Scenario = {
+    id: "cockpit-analytics",
+    title:
+        "Cockpit analytics is available for a licensed org (warehouse up + page not gated)",
+    priority: "P0",
+    appliesTo: {
+        target: ["cloud", "self-hosted"],
+        provider: ["github"],
+        // license-paid = the self-hosted Enterprise customer case (the
+        // regression). paid/trial cover cloud. Tiers that legitimately can't
+        // reach cockpit (free, community-byok, license-free) are excluded —
+        // their "not available" is correct behavior, not a regression. Cells
+        // whose tenant resolves to an ineligible tier at runtime self-skip via
+        // the 403 branch below.
+        license: ["paid", "trial", "license-paid"],
+    },
+    // Full onboarding (finishOnboarding polls up to 300s) + a browser render.
+    timeoutSec: 900,
+    async run(ctx: RunContext) {
+        ctx.assert(ctx.tenant, "scenario requires a tenant");
+        ctx.assert(existsSync(SPEC), `Playwright spec not found at ${SPEC}`);
+
+        const session = await ctx.kodus.login(ctx.tenant!);
+        await ctx.kodus.registerIntegration(session);
+        const repo = await ctx.kodus.registerRepo(session);
+        // The (app) layout redirects every page to /setup until the team is
+        // ACTIVE and finishOnboard is true — the browser render needs a fully
+        // onboarded org, not just a signed-up one.
+        await ctx.kodus.finishOnboarding(session, repo);
+        await ensureLicenseSeat(ctx.target, session, ctx.provider);
+
+        // ---- Layer 1: cockpit eligibility + warehouse reachability ----
+        // Routed through the web's generic API proxy (/api/proxy/api/* →
+        // apps/api). The cockpit endpoint's own tier guard tells us whether the
+        // org is eligible — no separate (cloud-only) billing call.
+        const validateUrl =
+            `${ctx.target.webBaseUrl}/api/proxy/api/cockpit/validate` +
+            `?organizationId=${encodeURIComponent(session.organizationId)}`;
+        // apps/api wraps controller returns in the global TransformInterceptor
+        // envelope `{ data, statusCode, type }`, so the cockpit payload lives
+        // under `.data` (see cockpit.controller.ts header comment).
+        const validateResp = await http<{
+            data?: { hasData?: boolean; pullRequestsCount?: number };
+        }>(validateUrl, {
+            method: "GET",
+            headers: { Authorization: `Bearer ${session.accessToken}` },
+            timeoutMs: 30_000,
+        });
+
+        if (validateResp.status === 403) {
+            // Not cockpit-eligible (unlicensed SH, or a non-teams/enterprise
+            // cloud plan). The availability regression isn't provable here —
+            // record why rather than emit a false red.
+            ctx.skip(
+                `cockpit not provable: /cockpit/validate 403 — ` +
+                    `${validateResp.raw.slice(0, 200)}`,
+            );
+        }
+        ctx.assert(
+            validateResp.status === 200,
+            `GET /cockpit/validate returned HTTP ${validateResp.status} ` +
+                `(expected 200 — analytics warehouse datasource/migrations may ` +
+                `be down): ${validateResp.raw.slice(0, 300)}`,
+        );
+        const payload = validateResp.body?.data;
+        const count = payload?.pullRequestsCount;
+        ctx.assert(
+            typeof count === "number",
+            `GET /cockpit/validate body missing numeric data.pullRequestsCount ` +
+                `(warehouse query failed?): ${validateResp.raw.slice(0, 300)}`,
+        );
+
+        // ---- Layer 2: web page availability (the actual customer bug) ----
+        const code = await new Promise<number>((done) => {
+            const child = spawn("node", ["cockpit-analytics.mjs"], {
+                cwd: PLAYWRIGHT_DIR,
+                env: {
+                    ...process.env,
+                    WEB_URL: ctx.target.webBaseUrl,
+                    EMAIL: ctx.tenant!.email,
+                    PASSWORD: ctx.tenant!.password,
+                    OUT_DIR: ctx.artifactDir,
+                },
+                stdio: ["ignore", "inherit", "inherit"],
+            });
+            child.on("close", (c) => done(c ?? -1));
+        });
+        ctx.assert(
+            code === 0,
+            `cockpit-analytics Playwright render failed (exit ${code}) — the ` +
+                `/cockpit page was unavailable for a licensed org. See ` +
+                `${ctx.artifactDir}.`,
+        );
+
+        // ---- Layer 3 (analytics-worker matrix only): the ingestion SERVICE runs --
+        // Gated by ANALYTICS_WORKER_EXPECTED (set when vm.sh provisioned the
+        // worker-analytics service via COMPOSE_PROFILES=analytics). Layers 1-2
+        // only prove the page/warehouse are reachable — they'd pass even if the
+        // ingestion cron never ran (the bug that left SH cockpits empty: the
+        // analytics worker isn't deployed). Here we prove the SERVICE keeps the
+        // warehouse fresh on its own: poll the PUBLIC health/runs endpoint until
+        // a successful ingestion run appears. The cron writes an
+        // analytics.ingestion_runs row every tick even when it scans 0 PRs, so
+        // this needs no seeded data — only a live role=analytics worker.
+        let ingestionRunObserved: boolean | undefined;
+        if (process.env.ANALYTICS_WORKER_EXPECTED === "1") {
+            const runsUrl = `${ctx.target.apiBaseUrl}/cockpit/health/runs`;
+            const deadlineMs = Date.now() + 240_000; // ~2 ticks of a */2 cron
+            let lastBody = "";
+            ingestionRunObserved = false;
+            while (Date.now() < deadlineMs) {
+                const r = await http<{ data?: { lastOk?: unknown } }>(runsUrl, {
+                    method: "GET",
+                    timeoutMs: 20_000,
+                });
+                lastBody = r.raw.slice(0, 300);
+                if (r.body?.data?.lastOk) {
+                    ingestionRunObserved = true;
+                    break;
+                }
+                await new Promise((res) => setTimeout(res, 15_000));
+            }
+            ctx.assert(
+                ingestionRunObserved,
+                `no successful analytics ingestion run within 4min — the ` +
+                    `worker-analytics service (role=analytics) is likely absent ` +
+                    `or crash-looping, so the cockpit warehouse never refreshes. ` +
+                    `/cockpit/health/runs=${lastBody}`,
+            );
+        }
+
+        return {
+            pullRequestsCount: count,
+            hasData: payload?.hasData ?? false,
+            ingestionRunObserved,
+            evidenceDir: ctx.artifactDir,
+        };
+    },
+};
+
+export default cockpitAnalytics;

--- a/tests/e2e/scenarios/index.ts
+++ b/tests/e2e/scenarios/index.ts
@@ -1,5 +1,6 @@
 import type { Scenario } from '../lib/types.js';
 import centralizedConfigSync from './centralized-config-sync.js';
+import cockpitAnalytics from './cockpit-analytics.js';
 import codeReviewBasic from './code-review-basic.js';
 import codeReviewVertexByok from './code-review-vertex-byok.js';
 import conversationVertexByok from './conversation-vertex-byok.js';
@@ -26,6 +27,7 @@ export const allScenarios: Record<string, Scenario> = {
     [conversationVertexByok.id]: conversationVertexByok,
     [centralizedConfigSync.id]: centralizedConfigSync,
     [commandReview.id]: commandReview,
+    [cockpitAnalytics.id]: cockpitAnalytics,
     [kodyRulesCreateAndApply.id]: kodyRulesCreateAndApply,
     [licenseAttribution.id]: licenseAttribution,
     [perSeatLicenseToggle.id]: perSeatLicenseToggle,
@@ -55,6 +57,7 @@ export function resolveScenarios(ids: string[]): Scenario[] {
 
 export {
     centralizedConfigSync,
+    cockpitAnalytics,
     codeReviewBasic,
     codeReviewVertexByok,
     conversationVertexByok,

--- a/tests/e2e/scenarios/rbac-ui-render.ts
+++ b/tests/e2e/scenarios/rbac-ui-render.ts
@@ -28,7 +28,10 @@ const SPEC = resolve(PLAYWRIGHT_DIR, "rbac-ui-render.mjs");
 
 // Routes whose RENDER we prove in the browser, with a DOM marker that the
 // screen actually painted (`null` = only assert allow-side is not /forbidden —
-// cockpit's body is data-dependent charts with no stable heading).
+// cockpit's body is data-dependent charts with no stable heading). `notMarker`
+// asserts a substring is ABSENT on the allow side — for /cockpit it catches the
+// "Analytics Not Available" card the vestigial WEB_ANALYTICS_SECRET gate used to
+// render (a 200 page, so the not-/forbidden check alone passed right through it).
 //
 // The allow/deny verdict per role is NOT defined here: it comes from the
 // committed route manifest (permissions.route-manifest.json), itself derived
@@ -37,11 +40,15 @@ const SPEC = resolve(PLAYWRIGHT_DIR, "rbac-ui-render.mjs");
 // /user-logs is deliberately absent: the page is feature-gated (EE
 // activity-logs) and redirects to /settings when off, so its render is
 // environment-dependent, not role-dependent.
-const RENDER_ROUTES: Array<{ path: string; marker: string | null }> = [
+const RENDER_ROUTES: Array<{
+    path: string;
+    marker: string | null;
+    notMarker?: string;
+}> = [
     { path: "/token-usage", marker: "token usage" },
     { path: "/pull-requests", marker: "pull requests" },
     { path: "/settings/git", marker: "git settings" },
-    { path: "/cockpit", marker: null },
+    { path: "/cockpit", marker: null, notMarker: "analytics not available" },
 ];
 
 const MANIFEST_PATH = join(
@@ -69,14 +76,14 @@ function buildRouteChecks() {
         readFileSync(MANIFEST_PATH, "utf8"),
     ) as ManifestEntry[];
     const byRoute = new Map(manifest.map((m) => [m.route, m]));
-    return RENDER_ROUTES.map(({ path, marker }) => {
+    return RENDER_ROUTES.map(({ path, marker, notMarker }) => {
         const entry = byRoute.get(path);
         if (!entry) {
             throw new Error(
                 `route ${path} not found in permissions.route-manifest.json — regenerate with UPDATE_ROUTE_MANIFEST=1`,
             );
         }
-        return { path, marker, expected: entry.expected };
+        return { path, marker, notMarker, expected: entry.expected };
     });
 }
 


### PR DESCRIPTION
Salvages the still-unmerged **e2e coverage** from #1293 (`feat/selfhosted-matrix-analytics`) onto current `main`.

#1293 went stale (CONFLICTING, CHANGES_REQUESTED) and is now ~90% redundant: its three production fixes already landed via #1297 (forward-port of selfhosted-2.1.17), the analytics-worker deploy docs are already on `main`, and its notifications/kodyRules churn merged separately (#1296 + routing-rule). The only thing never merged was the **test coverage** — this PR brings just that, rebased clean on `main`, with none of the conflicting product code.

## What's here
- **`cockpit-analytics` scenario** — 3 layers: `/cockpit/validate` 200 + cockpit page render not tier-gated + cron-driven ingestion via `/cockpit/health/runs`.
- **Matrices** — new `sh-analytics` + `cockpit-only`; wired into `sh-all` and `full`.
- **`vm.sh`** — provisions the analytics worker (`COMPOSE_PROFILES=analytics`) under `ANALYTICS_WORKER=1`.
- **`rbac-ui-render`** — now asserts the "Analytics Not Available" card is absent on `/cockpit`.
- **`e2e-self-hosted-matrix.yml`** — `sh-analytics` job.

## Validation
- `tsc --noEmit` on `tests/e2e` clean.
- No product code touched — test/CI/provisioning only.

## Follow-up
Once this lands, **#1293 can be closed** (superseded). This PR does not touch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)