### PR TITLE
fix(code-review): detect Atlassian Rovo and Jira keys in business logic skip

### DIFF
--- a/libs/code-review/pipeline/stages/business-logic-validation.stage.ts
+++ b/libs/code-review/pipeline/stages/business-logic-validation.stage.ts
@@ -44,6 +44,18 @@ export class BusinessLogicValidationStage extends BasePipelineStage<CodeReviewPi
     ];
     private static readonly TIMEOUT_MS = 300_000; // 5 min
 
+    /** Jira-style issue keys, e.g. LKDB-286, PROJ_1-42 (case-insensitive). */
+    private static readonly TICKET_KEY_PATTERN = /[A-Za-z][A-Za-z0-9_]+-\d+/g;
+
+    /** MCPs that can resolve ticket keys (not URL-only sources like Notion). */
+    private static readonly TICKET_KEY_MCPS = [
+        'jira',
+        'linear',
+        'clickup',
+        'githubissues',
+        'atlassianrovo',
+    ] as const;
+
     private static readonly TASK_MANAGEMENT_HINTS = [
         'jira',
         'linear',
@@ -345,14 +357,16 @@ export class BusinessLogicValidationStage extends BasePipelineStage<CodeReviewPi
             return {
                 reason: 'no_task_mcp',
                 message:
-                    'Skipped: no task-management MCP connected (Jira, Linear, Notion, ClickUp, etc.).',
+                    'Skipped: no task-management MCP connected (Jira, Atlassian Rovo, Linear, Notion, ClickUp, etc.).',
             };
         }
 
         const prBody = context.pullRequest?.body ?? '';
         const signalSources = this.buildSignalSources(context);
 
-        if (!this.hasRelevantBusinessSignals(signalSources, connectedMcps)) {
+        if (
+            !this.hasRelevantBusinessSignals(signalSources, connectedMcps)
+        ) {
             return {
                 reason: 'no_signals',
                 message:
@@ -406,45 +420,54 @@ export class BusinessLogicValidationStage extends BasePipelineStage<CodeReviewPi
 
     /**
      * Returns the normalized names of connected task-management MCPs
-     * (e.g. ['jira', 'linear']). Empty array = none connected.
+     * (e.g. ['jira', 'atlassianrovo']). Considers both installed connections
+     * (`mcp_connections`) and OAuth-authenticated managed plugins
+     * (`mcp_integration_oauth`, surfaced as `active` on integrations).
      */
     private async getConnectedTaskManagementMcps(
         context: CodeReviewPipelineContext,
     ): Promise<string[]> {
         try {
+            const orgId = context.organizationAndTeamData?.organizationId;
+            const matched: string[] = [];
+
             const allConnections = await this.mcpManagerService.getConnections(
                 context.organizationAndTeamData,
                 false,
             );
 
-            const orgId = context.organizationAndTeamData?.organizationId;
-            const connections = (allConnections ?? []).filter(
+            for (const conn of (allConnections ?? []).filter(
                 (c) => c.organizationId === orgId,
+            )) {
+                this.appendTaskManagementHints(matched, [
+                    conn.appName,
+                    conn.provider,
+                    conn.integrationId,
+                ]);
+            }
+
+            const integrations = await this.mcpManagerService.getIntegrations(
+                context.organizationAndTeamData,
             );
 
-            const matched: string[] = [];
-
-            for (const conn of connections) {
-                const aliases = [conn.appName, conn.provider]
-                    .map((v) =>
-                        typeof v === 'string'
-                            ? v
-                                  .trim()
-                                  .toLowerCase()
-                                  .replace(/[^a-z0-9]+/g, '')
-                            : '',
-                    )
-                    .filter(Boolean);
-
-                for (const alias of aliases) {
-                    const hint =
-                        BusinessLogicValidationStage.TASK_MANAGEMENT_HINTS.find(
-                            (h) => alias.includes(h) || h.includes(alias),
-                        );
-                    if (hint && !matched.includes(hint)) {
-                        matched.push(hint);
-                    }
+            for (const integration of integrations ?? []) {
+                if (integration.isDefault) {
+                    continue;
                 }
+
+                const isUsable =
+                    integration.isConnected === true ||
+                    integration.active === true;
+                if (!isUsable) {
+                    continue;
+                }
+
+                this.appendTaskManagementHints(matched, [
+                    integration.id,
+                    integration.appName,
+                    integration.name,
+                    integration.provider,
+                ]);
             }
 
             return matched;
@@ -458,6 +481,47 @@ export class BusinessLogicValidationStage extends BasePipelineStage<CodeReviewPi
         }
     }
 
+    private appendTaskManagementHints(
+        matched: string[],
+        aliases: Array<string | undefined>,
+    ): void {
+        for (const hint of this.matchTaskManagementHints(aliases)) {
+            if (!matched.includes(hint)) {
+                matched.push(hint);
+            }
+        }
+    }
+
+    private normalizeMcpAlias(value: string | undefined): string {
+        if (typeof value !== 'string') {
+            return '';
+        }
+        return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, '');
+    }
+
+    private matchTaskManagementHints(
+        aliases: Array<string | undefined>,
+    ): string[] {
+        const matched: string[] = [];
+
+        for (const raw of aliases) {
+            const alias = this.normalizeMcpAlias(raw);
+            if (!alias) {
+                continue;
+            }
+
+            const hint =
+                BusinessLogicValidationStage.TASK_MANAGEMENT_HINTS.find(
+                    (h) => alias.includes(h) || h.includes(alias),
+                );
+            if (hint && !matched.includes(hint)) {
+                matched.push(hint);
+            }
+        }
+
+        return matched;
+    }
+
     /**
      * Returns true when the PR description contains business signals
      * (ticket keys or URLs) that match a connected task-management MCP.
@@ -467,13 +531,14 @@ export class BusinessLogicValidationStage extends BasePipelineStage<CodeReviewPi
         body: string,
         connectedMcps: string[],
     ): boolean {
-        // Ticket keys (e.g. KAN-1) are valid if any MCP that handles
-        // tickets is connected (jira, linear, clickup, githubissues).
         const ticketKeys = this.detectTicketKeys(body);
-        const ticketMcps = ['jira', 'linear', 'clickup', 'githubissues'];
         if (
             ticketKeys.length > 0 &&
-            connectedMcps.some((mcp) => ticketMcps.includes(mcp))
+            connectedMcps.some((mcp) =>
+                (
+                    BusinessLogicValidationStage.TICKET_KEY_MCPS as readonly string[]
+                ).includes(mcp),
+            )
         ) {
             return true;
         }
@@ -495,8 +560,9 @@ export class BusinessLogicValidationStage extends BasePipelineStage<CodeReviewPi
         return false;
     }
 
-    private detectTicketKeys(body: string): string[] {
-        const matches = body.match(/[A-Za-z]{2,}-\d+/g) ?? [];
+    private detectTicketKeys(text: string): string[] {
+        const matches =
+            text.match(BusinessLogicValidationStage.TICKET_KEY_PATTERN) ?? [];
         return Array.from(new Set(matches.map((m) => m.toUpperCase())));
     }
 

--- a/libs/mcp-server/services/mcp-manager.service.ts
+++ b/libs/mcp-server/services/mcp-manager.service.ts
@@ -39,6 +39,18 @@ type MCPData = {
     items: MCPItem[];
 };
 
+export type MCPIntegrationItem = {
+    id: string;
+    name: string;
+    appName: string;
+    provider: string;
+    isConnected?: boolean;
+    active?: boolean;
+    isDefault?: boolean;
+    baseUrl?: string;
+    allowedTools?: string[];
+};
+
 enum MCPIntegrationAuthType {
     NONE = 'none',
     API_KEY = 'api_key',
@@ -231,6 +243,30 @@ export class MCPManagerService {
         } catch (error) {
             this.logger.error({
                 message: 'Error fetching MCP connections',
+                context: MCPManagerService.name,
+                error: error,
+                metadata: { organizationAndTeamData },
+            });
+            return [];
+        }
+    }
+
+    public async getIntegrations(
+        organizationAndTeamData: OrganizationAndTeamData,
+    ): Promise<MCPIntegrationItem[]> {
+        try {
+            const data = await this.axiosMCPManagerService.get(
+                'mcp/integrations',
+                {
+                    headers: this.getAuthHeaders(organizationAndTeamData),
+                    params: { page: 1, pageSize: 100 },
+                },
+            );
+
+            return Array.isArray(data) ? data : [];
+        } catch (error) {
+            this.logger.error({
+                message: 'Error fetching MCP integrations',
                 context: MCPManagerService.name,
                 error: error,
                 metadata: { organizationAndTeamData },

--- a/test/unit/code-review/pipeline/stages/business-logic-validation.stage.spec.ts
+++ b/test/unit/code-review/pipeline/stages/business-logic-validation.stage.spec.ts
@@ -27,7 +27,10 @@ const jiraConnection = (organizationId: string): JiraConnection => ({
 describe('BusinessLogicValidationStage', () => {
     let stage: BusinessLogicValidationStage;
     let agentProvider: { execute: jest.Mock };
-    let mcpManagerService: { getConnections: jest.Mock };
+    let mcpManagerService: {
+        getConnections: jest.Mock;
+        getIntegrations: jest.Mock;
+    };
 
     const buildContext = (overrides: Record<string, unknown> = {}) => ({
         organizationAndTeamData: {
@@ -55,6 +58,7 @@ describe('BusinessLogicValidationStage', () => {
         agentProvider = { execute: jest.fn() };
         mcpManagerService = {
             getConnections: jest.fn().mockResolvedValue([jiraConnection('org-1')]),
+            getIntegrations: jest.fn().mockResolvedValue([]),
         };
         stage = new BusinessLogicValidationStage(
             agentProvider as any,
@@ -69,7 +73,7 @@ describe('BusinessLogicValidationStage', () => {
                 pullRequest: {
                     number: 42,
                     body: 'Some prose without identifiers',
-                    title: '[DL-2773] Add print working mode',
+                    title: 'LKDB-286 Add print working mode',
                     head: { ref: 'feature/print-mode' },
                     base: { ref: 'main' },
                 },
@@ -246,6 +250,11 @@ describe('BusinessLogicValidationStage', () => {
     });
 
     describe('detectTicketKeys', () => {
+        it('matches Jira-style keys with underscores', () => {
+            const keys = (stage as any).detectTicketKeys('Implements PROJ_1-42');
+            expect(keys).toEqual(['PROJ_1-42']);
+        });
+
         it('matches uppercase keys', () => {
             const keys = (stage as any).detectTicketKeys('Implements ACME-123');
             expect(keys).toEqual(['ACME-123']);
@@ -274,6 +283,14 @@ describe('BusinessLogicValidationStage', () => {
             );
             expect(result).toBe(true);
         });
+
+        it('matches Jira keys when Atlassian Rovo is the connected MCP', () => {
+            const result = (stage as any).hasRelevantBusinessSignals(
+                'LKDB-286 refactor logging',
+                ['atlassianrovo'],
+            );
+            expect(result).toBe(true);
+        });
     });
 
     describe('skip when no task MCP connected', () => {
@@ -281,6 +298,7 @@ describe('BusinessLogicValidationStage', () => {
             mcpManagerService.getConnections.mockResolvedValue([
                 { appName: 'Slack', provider: 'slack', organizationId: 'org-1' },
             ]);
+            mcpManagerService.getIntegrations.mockResolvedValue([]);
 
             const context = buildContext({
                 pullRequest: {
@@ -297,6 +315,62 @@ describe('BusinessLogicValidationStage', () => {
             expect(decision).toEqual(
                 expect.objectContaining({ reason: 'no_task_mcp' }),
             );
+        });
+
+        it('does not skip when Atlassian Rovo OAuth is active without a connection row', async () => {
+            mcpManagerService.getConnections.mockResolvedValue([]);
+            mcpManagerService.getIntegrations.mockResolvedValue([
+                {
+                    id: 'atlassian-rovo-default',
+                    name: 'Atlassian Rovo',
+                    appName: 'Atlassian Rovo',
+                    provider: 'kodusmcp',
+                    active: true,
+                    isConnected: false,
+                },
+            ]);
+
+            const context = buildContext({
+                pullRequest: {
+                    number: 42,
+                    body: 'Implements LKDB-286',
+                    title: '',
+                    head: { ref: '' },
+                    base: { ref: 'main' },
+                },
+            });
+
+            const decision = await (stage as any).evaluateSkip(context);
+
+            expect(decision).toBeNull();
+        });
+
+        it('does not skip for a custom MCP named Jira with only OAuth active', async () => {
+            mcpManagerService.getConnections.mockResolvedValue([]);
+            mcpManagerService.getIntegrations.mockResolvedValue([
+                {
+                    id: 'custom-jira-1',
+                    name: 'Company Jira',
+                    appName: 'Company Jira',
+                    provider: 'custom',
+                    active: true,
+                    isConnected: false,
+                },
+            ]);
+
+            const context = buildContext({
+                pullRequest: {
+                    number: 42,
+                    body: '',
+                    title: 'LKDB-286 Fix checkout',
+                    head: { ref: '' },
+                    base: { ref: 'main' },
+                },
+            });
+
+            const decision = await (stage as any).evaluateSkip(context);
+
+            expect(decision).toBeNull();
         });
     });
 


### PR DESCRIPTION
## Summary

- Recognize task-management MCP from both `mcp_connections` and OAuth-active integrations (`active` on `/mcp/integrations`), so Atlassian Rovo and custom Jira plugins are detected even when only OAuth completed before Install
- Treat **Atlassian Rovo** as a ticket-key provider alongside Jira/Linear (fixes false `no_signals` skip when PR title/branch contains keys like `LKDB-286`)
- Tighten Jira issue key regex to `[A-Za-z][A-Za-z0-9_]+-\d+` (supports underscores in project keys)
- Add `MCPManagerService.getIntegrations()` for pipeline-stage MCP discovery

## Context

Business logic validation was skipping with `Skipped: no task-management MCP connected` even when Atlassian Rovo OAuth was active in `mcp_integration_oauth`, because `evaluateSkip` only inspected `mcp_connections`.

## Test plan

- [ ] Unit tests: `pnpm run test -- test/unit/code-review/pipeline/stages/business-logic-validation.stage.spec.ts`
- [ ] Org with Atlassian Rovo OAuth + ACTIVE connection; PR with `LKDB-286` in title → `BusinessLogicValidationStage` runs (not `no_task_mcp` / `no_signals`)
- [ ] Org with only OAuth-active Rovo (no connection row) → stage no longer skips on `no_task_mcp`
- [ ] PR without ticket key still skips with `no_signals`