### PR TITLE
fix(ast-graph): make kodus-graph available in self-hosted worker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -201,6 +201,10 @@ USER 1000
 # Install kodus-graph for the runtime user so self-hosted worker images can
 # find it through $HOME/.bun/bin after dropping root privileges.
 RUN bun install -g @kodus/kodus-graph@${KODUS_GRAPH_VERSION}
+USER root
+RUN printf '%s\n' '#!/bin/sh' 'exec /home/node/.bun/bin/kodus-graph "$@"' > /usr/local/bin/kodus-graph \
+  && chmod 0755 /usr/local/bin/kodus-graph
+USER 1000
 
 ENTRYPOINT ["/usr/local/bin/prod-entrypoint"]
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -158,12 +158,14 @@ ENV NODE_ENV=production
 # Redeclare ARGs to make them available in this stage
 ARG API_CLOUD_MODE=false
 ARG RELEASE_VERSION=local
+ARG KODUS_GRAPH_VERSION=0.2.19
 
 # Set ENVs for runtime
 ENV API_CLOUD_MODE=${API_CLOUD_MODE}
 ENV API_DEVELOPMENT_MODE=false
 ENV RELEASE_VERSION=${RELEASE_VERSION}
 ENV SENTRY_RELEASE=${RELEASE_VERSION}
+ENV PATH="/home/node/.bun/bin:${PATH}"
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \
@@ -172,9 +174,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
   && apt-get install -y --no-install-recommends \
     ca-certificates procps git ripgrep
 
-# Copy the bun binary from the official image and install kodus-graph with it.
+# Copy the bun binary from the official image.
 COPY --from=bun-source /usr/local/bin/bun /usr/local/bin/bun
-RUN bun install -g @kodus/kodus-graph
 
 COPY --chown=1000:1000 --from=prod-deps /usr/src/app/node_modules ./node_modules
 COPY --chown=1000:1000 --from=build /usr/src/app/dist ./dist
@@ -196,6 +197,10 @@ COPY --chmod=0755 docker/prod-entrypoint-mcp-manager.sh /usr/local/bin/prod-entr
 RUN chown 1000:1000 /usr/src/app
 
 USER 1000
+
+# Install kodus-graph for the runtime user so self-hosted worker images can
+# find it through $HOME/.bun/bin after dropping root privileges.
+RUN bun install -g @kodus/kodus-graph@${KODUS_GRAPH_VERSION}
 
 ENTRYPOINT ["/usr/local/bin/prod-entrypoint"]
 

--- a/libs/code-review/infrastructure/adapters/services/graph/kodus-graph-cli.ts
+++ b/libs/code-review/infrastructure/adapters/services/graph/kodus-graph-cli.ts
@@ -26,7 +26,10 @@ export class KodusGraphCli {
 
     async install(sandbox: SandboxInstance): Promise<void> {
         const check = await sandbox.run(
-            'which kodus-graph 2>/dev/null && kodus-graph --version 2>/dev/null || true',
+            [
+                BUN_PATH_PREFIX,
+                'which kodus-graph 2>/dev/null && kodus-graph --version 2>/dev/null || true',
+            ].join(' && '),
             { timeoutMs: 5_000 },
         );
 
@@ -162,7 +165,9 @@ export class KodusGraphCli {
         } = options;
         const outDir = dirname(outPath);
         const filesArg = quoteFiles(files);
-        const graphArg = graphPath ? ` --graph ${shSingleQuote(graphPath)}` : '';
+        const graphArg = graphPath
+            ? ` --graph ${shSingleQuote(graphPath)}`
+            : '';
         const diffArg = diffPath ? ` --diff ${shSingleQuote(diffPath)}` : '';
         const cmd = `kodus-graph context --files ${filesArg}${graphArg}${diffArg} --repo-dir . --format xml --out ${shSingleQuote(outPath)}`;
 

--- a/test/unit/code-review/infrastructure/adapters/services/graph/graph-indexer.service.spec.ts
+++ b/test/unit/code-review/infrastructure/adapters/services/graph/graph-indexer.service.spec.ts
@@ -2,7 +2,10 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { GraphIndexerService } from '@libs/code-review/infrastructure/adapters/services/graph/graph-indexer.service';
 import { KodusGraphCli } from '@libs/code-review/infrastructure/adapters/services/graph/kodus-graph-cli';
 import { AstGraphRepository } from '@libs/code-review/infrastructure/adapters/repositories/astGraph.repository';
-import { IRepositoryService, REPOSITORY_SERVICE_TOKEN } from '@libs/code-review/domain/contracts/RepositoryService.contract';
+import {
+    IRepositoryService,
+    REPOSITORY_SERVICE_TOKEN,
+} from '@libs/code-review/domain/contracts/RepositoryService.contract';
 import { AstGraphStatus } from '@libs/code-review/infrastructure/adapters/repositories/schemas/repository.model';
 import { SandboxInstance } from '@libs/sandbox/domain/contracts/sandbox.provider';
 
@@ -104,7 +107,10 @@ describe('GraphIndexerService', () => {
                 GraphIndexerService,
                 KodusGraphCli,
                 { provide: AstGraphRepository, useValue: mockAstGraphRepo },
-                { provide: REPOSITORY_SERVICE_TOKEN, useValue: mockRepositoryRepo },
+                {
+                    provide: REPOSITORY_SERVICE_TOKEN,
+                    useValue: mockRepositoryRepo,
+                },
             ],
         }).compile();
 
@@ -130,6 +136,36 @@ describe('GraphIndexerService', () => {
             expect(installIdx).toBeGreaterThanOrEqual(0);
             expect(parseIdx).toBeGreaterThan(installIdx);
             expect(runCmd(mockSandbox, installIdx)).toContain('kodus-graph');
+        });
+
+        it('should find preinstalled kodus-graph through the Bun global bin path', async () => {
+            mockSandbox.run
+                .mockResolvedValueOnce({
+                    stdout: '/home/node/.bun/bin/kodus-graph\n0.2.19',
+                    stderr: '',
+                    exitCode: 0,
+                })
+                .mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+
+            await service.fullBuild({
+                repositoryId: REPO_ID,
+                sandbox: mockSandbox,
+                headSha: HEAD_SHA,
+            });
+
+            const checkCmd = runCmd(mockSandbox, 0);
+            expect(checkCmd).toContain('export PATH="$HOME/.bun/bin:$PATH"');
+            expect(checkCmd).toContain('which kodus-graph');
+            expect(
+                mockSandbox.run.mock.calls.some((call) =>
+                    (call[0] as string).includes('bun install'),
+                ),
+            ).toBe(false);
+            expect(
+                findRunIndex(mockSandbox, (cmd) =>
+                    cmd.includes('kodus-graph parse --all'),
+                ),
+            ).toBeGreaterThan(0);
         });
 
         it('should call sandbox.readFile() to read graph JSON', async () => {
@@ -234,9 +270,10 @@ describe('GraphIndexerService', () => {
                 }),
             ).rejects.toThrow('kodus-graph parse --all failed');
 
-            expect(
-                mockRepositoryRepo.updateGraphStatus,
-            ).toHaveBeenCalledWith(REPO_ID, AstGraphStatus.FAILED);
+            expect(mockRepositoryRepo.updateGraphStatus).toHaveBeenCalledWith(
+                REPO_ID,
+                AstGraphStatus.FAILED,
+            );
         });
 
         it('should mark status as FAILED on empty graph (0 nodes)', async () => {
@@ -249,9 +286,10 @@ describe('GraphIndexerService', () => {
                 headSha: HEAD_SHA,
             });
 
-            expect(
-                mockRepositoryRepo.updateGraphStatus,
-            ).toHaveBeenCalledWith(REPO_ID, AstGraphStatus.FAILED);
+            expect(mockRepositoryRepo.updateGraphStatus).toHaveBeenCalledWith(
+                REPO_ID,
+                AstGraphStatus.FAILED,
+            );
 
             expect(mockAstGraphRepo.fullRebuild).not.toHaveBeenCalled();
         });
@@ -274,15 +312,14 @@ describe('GraphIndexerService', () => {
                 }),
             ).rejects.toThrow('kodus-graph install failed');
 
-            expect(
-                mockRepositoryRepo.updateGraphStatus,
-            ).toHaveBeenCalledWith(REPO_ID, AstGraphStatus.FAILED);
+            expect(mockRepositoryRepo.updateGraphStatus).toHaveBeenCalledWith(
+                REPO_ID,
+                AstGraphStatus.FAILED,
+            );
         });
 
         it('should mark status as FAILED on readFile error', async () => {
-            mockSandbox.readFile.mockRejectedValue(
-                new Error('File not found'),
-            );
+            mockSandbox.readFile.mockRejectedValue(new Error('File not found'));
 
             await expect(
                 service.fullBuild({
@@ -292,9 +329,10 @@ describe('GraphIndexerService', () => {
                 }),
             ).rejects.toThrow('Failed to read graph file from sandbox');
 
-            expect(
-                mockRepositoryRepo.updateGraphStatus,
-            ).toHaveBeenCalledWith(REPO_ID, AstGraphStatus.FAILED);
+            expect(mockRepositoryRepo.updateGraphStatus).toHaveBeenCalledWith(
+                REPO_ID,
+                AstGraphStatus.FAILED,
+            );
         });
     });
 
@@ -344,9 +382,7 @@ describe('GraphIndexerService', () => {
                 newSha,
             });
 
-            expect(
-                mockRepositoryRepo.updateGraphStatus,
-            ).toHaveBeenCalledWith(
+            expect(mockRepositoryRepo.updateGraphStatus).toHaveBeenCalledWith(
                 REPO_ID,
                 AstGraphStatus.READY,
                 expect.objectContaining({


### PR DESCRIPTION
## Summary

Fixes #1343

The self-hosted worker image installed `@kodus/kodus-graph` before dropping privileges to `USER 1000`, but the worker process runs with `HOME=/home/node` and did not have `kodus-graph` available in its runtime PATH.

This PR makes the self-hosted worker image expose `kodus-graph` to the runtime user and aligns `KodusGraphCli.install()` with the existing parse/context commands by checking for the binary through `BUN_PATH_PREFIX`.

## What changed

- Add `KODUS_GRAPH_VERSION=0.2.19` to the production Dockerfile runtime stage.
- Add `/home/node/.bun/bin` to the runtime `PATH`.
- Install `@kodus/kodus-graph@${KODUS_GRAPH_VERSION}` after `USER 1000`, so Bun installs it under the runtime user's home.
- Update `KodusGraphCli.install()` to run the existing-binary check with `BUN_PATH_PREFIX`.
- Add regression coverage for detecting a preinstalled `/home/node/.bun/bin/kodus-graph` and skipping a redundant install.

## Changelog routing

`fix:` routes this change to the public **Bug fixes** changelog section.

## Test plan

- [x] `corepack pnpm exec prettier --write libs/code-review/infrastructure/adapters/services/graph/kodus-graph-cli.ts test/unit/code-review/infrastructure/adapters/services/graph/graph-indexer.service.spec.ts`
- [x] `corepack pnpm exec jest test/unit/code-review/infrastructure/adapters/services/graph/graph-indexer.service.spec.ts --runInBand --config jest.config.ts`
- [x] `git diff --check`

## Notes for reviewers

This is a self-hosted AST graph reliability fix. The Dockerfile already attempted to install `kodus-graph`, but the published worker image did not expose it to the non-root runtime user. The code path also had a small inconsistency: parse/context commands used `BUN_PATH_PREFIX`, while the install check did not.

The fix keeps the graph CLI version pinned to the same version expected by `KodusGraphCli`.
