### PR TITLE
feat(trial): backward-compatible trial review credits + UX/copy

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -422,6 +422,12 @@ CODE_MANAGEMENT_SECRET=
 # (secret)
 CODE_MANAGEMENT_WEBHOOK_TOKEN=
 
+# Discord channel webhook used to deliver "Request more trial reviews" form
+# submissions to our team. Optional — when unset the request fails honestly
+# and the UI tells the user the channel is not configured.
+# (secret)
+API_DISCORD_TRIAL_REQUEST_WEBHOOK_URL=
+
 # ============================================================
 # Observability
 # ============================================================

--- a/.env.schema
+++ b/.env.schema
@@ -584,6 +584,13 @@ CODE_MANAGEMENT_SECRET=
 # kodus: audience=both autogen=base64url-32
 CODE_MANAGEMENT_WEBHOOK_TOKEN=
 
+# Discord channel webhook used to deliver "Request more trial reviews" form
+# submissions to our team. Optional — when unset the request fails honestly
+# and the UI tells the user the channel is not configured.
+# @optional @sensitive
+# kodus: audience=cloud
+API_DISCORD_TRIAL_REQUEST_WEBHOOK_URL=
+
 # ============================================================
 # Observability
 # kodus: category=observability

--- a/.env.template
+++ b/.env.template
@@ -432,6 +432,12 @@ CODE_MANAGEMENT_SECRET=op://Kodus-Dev/CODE_MANAGEMENT_SECRET/password
 # (secret)
 CODE_MANAGEMENT_WEBHOOK_TOKEN=op://Kodus-Dev/CODE_MANAGEMENT_WEBHOOK_TOKEN/password
 
+# Discord channel webhook used to deliver "Request more trial reviews" form
+# submissions to our team. Optional — when unset the request fails honestly
+# and the UI tells the user the channel is not configured.
+# (secret)
+API_DISCORD_TRIAL_REQUEST_WEBHOOK_URL=op://Kodus-Dev/API_DISCORD_TRIAL_REQUEST_WEBHOOK_URL/password
+
 # ============================================================
 # Observability
 # ============================================================

--- a/apps/api/src/api.module.ts
+++ b/apps/api/src/api.module.ts
@@ -68,6 +68,7 @@ import { IssuesController } from './controllers/issues.controller';
 import { KodyRulesController } from './controllers/kodyRules.controller';
 import { LicenseController } from './controllers/license.controller';
 import { OrganizationController } from './controllers/organization.controller';
+import { TrialExtensionNotifierService } from './services/trial-extension-notifier.service';
 import { OrganizationParametersController } from './controllers/organizationParameters.controller';
 import { ParametersController } from './controllers/parameters.controller';
 import { PermissionsController } from './controllers/permissions.controller';
@@ -193,6 +194,6 @@ import { NotificationController } from './controllers/notification.controller';
         CockpitWeeklyRecapController,
         NotificationController,
     ],
-    providers: [LangfuseShutdownProvider],
+    providers: [LangfuseShutdownProvider, TrialExtensionNotifierService],
 })
 export class ApiModule {}

--- a/apps/api/src/controllers/__tests__/endpoint-authorization.spec.ts
+++ b/apps/api/src/controllers/__tests__/endpoint-authorization.spec.ts
@@ -65,6 +65,7 @@ const INTENTIONALLY_UNGATED = new Set<string>([
     'organization.controller.ts#getReleaseTrack', // release-track flag for caller's org
     'kodyRules.controller.ts#findLibraryKodyRulesWithFeedback', // kody-rules library is all-roles
     'license.controller.ts#orgStatus', // org license status; sibling /status is owner-gated
+    'license.controller.ts#requestTrialExtension', // any trial org member can ask for more trial reviews (low-stakes; forwards to Discord)
     'team.controller.ts#list', // list of org teams (read)
     'team.controller.ts#listWithIntegrations', // list of org teams with integrations (read)
 

--- a/apps/api/src/controllers/license.controller.ts
+++ b/apps/api/src/controllers/license.controller.ts
@@ -24,6 +24,7 @@ import { checkPermissions } from '@libs/identity/infrastructure/adapters/service
 import { CreateOrUpdateOrganizationParametersUseCase } from '@libs/organization/application/use-cases/organizationParameters/create-or-update.use-case';
 import { SelfHostedLicenseService } from '@libs/ee/license/self-hosted-license.service';
 import { ApiStandardResponses } from '../docs/api-standard-responses.decorator';
+import { TrialExtensionNotifierService } from '../services/trial-extension-notifier.service';
 
 @ApiTags('License')
 @ApiBearerAuth('jwt')
@@ -33,6 +34,7 @@ export class LicenseController {
     constructor(
         private readonly selfHostedLicenseService: SelfHostedLicenseService,
         private readonly createOrUpdateOrganizationParametersUseCase: CreateOrUpdateOrganizationParametersUseCase,
+        private readonly trialExtensionNotifierService: TrialExtensionNotifierService,
 
         @Inject(REQUEST)
         private readonly request: UserRequest,
@@ -254,5 +256,33 @@ export class LicenseController {
         }
 
         return { successful, failed };
+    }
+
+    @Post('/trial-extension-request')
+    @UseGuards(PolicyGuard)
+    @ApiOperation({
+        summary: 'Request more trial PR reviews',
+        description:
+            'Forwards a trial extension request (team size + message) to our team channel. Available to any authenticated org member.',
+    })
+    public async requestTrialExtension(
+        @Body() body: { teamId?: string; teamSize?: number; message?: string },
+    ) {
+        const organization = this.request?.user?.organization;
+
+        if (!organization?.uuid) {
+            throw new BadRequestException(
+                'Organization ID is missing from request',
+            );
+        }
+
+        return this.trialExtensionNotifierService.notify({
+            organizationId: organization.uuid,
+            organizationName: organization.name,
+            teamId: body.teamId,
+            requestedByEmail: this.request?.user?.email,
+            teamSize: body.teamSize,
+            message: body.message,
+        });
     }
 }

--- a/apps/api/src/services/trial-extension-notifier.service.spec.ts
+++ b/apps/api/src/services/trial-extension-notifier.service.spec.ts
@@ -1,0 +1,71 @@
+import { TrialExtensionNotifierService } from './trial-extension-notifier.service';
+
+/**
+ * The notifier owns the Discord webhook secret and must FAIL HONESTLY: when
+ * the channel is unconfigured or delivery fails it returns success:false so
+ * the UI never pretends the request was sent.
+ */
+describe('TrialExtensionNotifierService', () => {
+    const ENV_KEY = 'API_DISCORD_TRIAL_REQUEST_WEBHOOK_URL';
+    let savedEnv: string | undefined;
+    let fetchMock: jest.Mock;
+
+    const payload = {
+        organizationId: 'org-1',
+        organizationName: 'Acme',
+        teamId: 'team-1',
+        requestedByEmail: 'founder@acme.dev',
+        teamSize: 12,
+        message: 'Evaluating for the platform team',
+    };
+
+    beforeEach(() => {
+        savedEnv = process.env[ENV_KEY];
+        delete process.env[ENV_KEY];
+        fetchMock = jest.fn();
+        global.fetch = fetchMock as unknown as typeof fetch;
+    });
+
+    afterEach(() => {
+        if (savedEnv === undefined) delete process.env[ENV_KEY];
+        else process.env[ENV_KEY] = savedEnv;
+    });
+
+    it('fails honestly (no webhook call) when the channel is not configured', async () => {
+        const result = await new TrialExtensionNotifierService().notify(
+            payload,
+        );
+
+        expect(result.success).toBe(false);
+        expect(result.message).toMatch(/not configured/i);
+        expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('posts the request to the Discord webhook when configured', async () => {
+        process.env[ENV_KEY] = 'https://discord.com/api/webhooks/abc';
+        fetchMock.mockResolvedValue({ ok: true });
+
+        const result = await new TrialExtensionNotifierService().notify(
+            payload,
+        );
+
+        expect(result).toEqual({ success: true });
+        const [url, config] = fetchMock.mock.calls[0];
+        expect(url).toBe('https://discord.com/api/webhooks/abc');
+        const content = JSON.parse(config.body).content as string;
+        expect(content).toContain('Acme');
+        expect(content).toContain('founder@acme.dev');
+        expect(content).toContain('12');
+    });
+
+    it('fails honestly when the webhook responds non-2xx', async () => {
+        process.env[ENV_KEY] = 'https://discord.com/api/webhooks/abc';
+        fetchMock.mockResolvedValue({ ok: false, status: 500 });
+
+        const result = await new TrialExtensionNotifierService().notify(
+            payload,
+        );
+
+        expect(result.success).toBe(false);
+    });
+});

--- a/apps/api/src/services/trial-extension-notifier.service.ts
+++ b/apps/api/src/services/trial-extension-notifier.service.ts
@@ -1,0 +1,88 @@
+import { Injectable } from '@nestjs/common';
+
+import { createLogger } from '@kodus/flow';
+
+export type TrialExtensionRequestPayload = {
+    organizationId?: string;
+    organizationName?: string;
+    teamId?: string;
+    requestedByEmail?: string;
+    teamSize?: number;
+    message?: string;
+};
+
+export type TrialExtensionNotifyResult = {
+    success: boolean;
+    message?: string;
+};
+
+/**
+ * Posts "Request more trial reviews" submissions to our Discord via an
+ * incoming webhook. The webhook URL is a secret and lives only in the API
+ * env (API_DISCORD_TRIAL_REQUEST_WEBHOOK_URL) — it never reaches the browser.
+ *
+ * When the webhook is not configured we fail honestly (success:false) so the
+ * UI can tell the user instead of pretending the request was delivered.
+ */
+@Injectable()
+export class TrialExtensionNotifierService {
+    private readonly logger = createLogger(TrialExtensionNotifierService.name);
+
+    async notify(
+        payload: TrialExtensionRequestPayload,
+    ): Promise<TrialExtensionNotifyResult> {
+        const webhookUrl = process.env.API_DISCORD_TRIAL_REQUEST_WEBHOOK_URL;
+
+        if (!webhookUrl) {
+            this.logger.warn({
+                message:
+                    'Trial extension request received but Discord webhook is not configured',
+                context: TrialExtensionNotifierService.name,
+                metadata: { organizationId: payload.organizationId },
+            });
+
+            return {
+                success: false,
+                message: 'Trial request channel is not configured yet.',
+            };
+        }
+
+        const note = (payload.message ?? '').trim().slice(0, 1500);
+        const lines = [
+            '**New trial extension request**',
+            `**Org:** ${payload.organizationName ?? '—'} (${payload.organizationId ?? '—'})`,
+            `**Team:** ${payload.teamId ?? '—'}`,
+            `**Requested by:** ${payload.requestedByEmail ?? '—'}`,
+            typeof payload.teamSize === 'number'
+                ? `**Team size:** ${payload.teamSize}`
+                : null,
+            note ? `**Message:** ${note}` : null,
+        ].filter(Boolean);
+
+        try {
+            const res = await fetch(webhookUrl, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ content: lines.join('\n') }),
+            });
+
+            if (!res.ok) {
+                throw new Error(`Discord webhook responded ${res.status}`);
+            }
+
+            return { success: true };
+        } catch (error) {
+            this.logger.error({
+                message: 'Failed to deliver trial extension request to Discord',
+                context: TrialExtensionNotifierService.name,
+                error,
+                metadata: { organizationId: payload.organizationId },
+            });
+
+            return {
+                success: false,
+                message: 'Could not deliver the request.',
+            };
+        }
+    }
+}

--- a/apps/web/src/app/(app)/layout.tsx
+++ b/apps/web/src/app/(app)/layout.tsx
@@ -88,6 +88,11 @@ export default async function Layout({ children }: React.PropsWithChildren) {
     const isBYOK = organizationLicense
         ? isBYOKSubscriptionPlan(organizationLicense)
         : false;
+    // A configured BYOK key lives in the API, not in billing — so the trial
+    // license's `byok` flag stays false even after the user connects a key.
+    // Surface it from the LLM config so the trial UI (badge/banner/card)
+    // reflects "unlimited with your key".
+    const hasByokKey = Boolean(llmConfigStatus?.byok?.configured);
     const isTrial = organizationLicense?.subscriptionStatus === "trial";
     const isEnterprise = organizationLicense
         ? isEnterprisePlan(organizationLicense)
@@ -119,11 +124,19 @@ export default async function Layout({ children }: React.PropsWithChildren) {
             featureFlags={featureFlags}>
             <SubscriptionProvider
                 license={
-                    organizationLicense ?? {
-                        valid: false,
-                        subscriptionStatus: "inactive",
-                        numberOfLicenses: 0,
-                    }
+                    organizationLicense
+                        ? ({
+                              ...organizationLicense,
+                              byok:
+                                  hasByokKey ||
+                                  (organizationLicense as { byok?: boolean })
+                                      .byok,
+                          } as typeof organizationLicense)
+                        : {
+                              valid: false,
+                              subscriptionStatus: "inactive",
+                              numberOfLicenses: 0,
+                          }
                 }
                 usersWithAssignedLicense={usersWithAssignedLicense}>
                 <NavMenu />

--- a/apps/web/src/app/(setup)/layout.tsx
+++ b/apps/web/src/app/(setup)/layout.tsx
@@ -9,6 +9,7 @@ import {
 import { getTeamParametersNoCache } from "@services/parameters/fetch";
 import { ParametersConfigKey } from "@services/parameters/types";
 import { getTeams } from "@services/teams/fetch";
+import { Team } from "@services/teams/types";
 import { auth } from "src/core/config/auth";
 import { SupportDropdown } from "src/core/layout/navbar/_components/support";
 import { AllTeamsProvider } from "src/core/providers/all-teams-context";
@@ -20,7 +21,6 @@ import { OrganizationProvider } from "src/features/organization/_providers/organ
 import { SetupGithubStars } from "./_components/setup-github-stars";
 import { SetupUserNav } from "./_components/setup-user-nav";
 import { SetupProgressSaver } from "./setup/_components/setup-step-tracker";
-import { Team } from "@services/teams/types";
 
 export default async function Layout(props: React.PropsWithChildren) {
     const [teams, organizationId, organizationName, session] =
@@ -39,8 +39,9 @@ export default async function Layout(props: React.PropsWithChildren) {
         redirect("/confirm-email");
     }
 
-    const candidateTeamId =
-        teams?.find((t: Team) => t.status === TEAM_STATUS.ACTIVE)?.uuid;
+    const candidateTeamId = teams?.find(
+        (t: Team) => t.status === TEAM_STATUS.ACTIVE,
+    )?.uuid;
     if (candidateTeamId) {
         const platformConfigs = await getTeamParametersNoCache<{
             configValue: { finishOnboard?: boolean };
@@ -75,7 +76,13 @@ export default async function Layout(props: React.PropsWithChildren) {
                                     <SetupUserNav />
                                 </div>
                             </div>
-                            <div className="pt-16">{props.children}</div>
+                            {/* Single scroll container for every setup page:
+                                exactly the viewport area below the fixed 4rem
+                                topbar, so any page taller than the screen gets
+                                a scrollbar instead of clipping its CTA. */}
+                            <div className="mt-16 h-[calc(100dvh-4rem)] overflow-y-auto">
+                                {props.children}
+                            </div>
                         </div>
                         <MagicModalPortal />
                     </SelectedTeamProvider>

--- a/apps/web/src/app/(setup)/setup/choose-workspace/page.tsx
+++ b/apps/web/src/app/(setup)/setup/choose-workspace/page.tsx
@@ -11,10 +11,10 @@ import { Label } from "@components/ui/label";
 import { Link } from "@components/ui/link";
 import { Page } from "@components/ui/page";
 import { Spinner } from "@components/ui/spinner";
+import { useConfig } from "@providers/ConfigProvider";
 import { joinOrganization } from "@services/users/fetch";
 import { ArrowRight } from "lucide-react";
 import { useAuth } from "src/core/providers/auth.provider";
-import { useConfig } from "@providers/ConfigProvider";
 import type { AwaitedReturnType } from "src/core/types";
 import { getOrganizationsByDomain } from "src/lib/auth/fetchers";
 
@@ -177,7 +177,7 @@ export default function ChooseWorkspacePage() {
     );
 
     return (
-        <Page.Root className="mx-auto flex max-h-screen flex-row overflow-hidden p-6">
+        <Page.Root className="mx-auto flex min-h-full w-full flex-row p-6">
             <div className="bg-card-lv1 flex flex-10 flex-col justify-center gap-10 rounded-3xl p-12">
                 <div className="flex-1 overflow-hidden rounded-3xl">
                     <video

--- a/apps/web/src/app/(setup)/setup/choosing-a-pull-request/page.tsx
+++ b/apps/web/src/app/(setup)/setup/choosing-a-pull-request/page.tsx
@@ -139,24 +139,22 @@ export default function App() {
                                         <AlertTitle>
                                             {hasBYOK
                                                 ? "This review uses your AI key"
-                                                : "Your trial includes managed reviews"}
+                                                : `Your trial includes ${TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED} PR reviews with Kodus credits`}
                                         </AlertTitle>
                                         <AlertDescription>
                                             {hasBYOK ? (
                                                 <p>
                                                     BYOK is configured, so this
                                                     PR uses your provider key
-                                                    and does not consume Kodus
-                                                    managed trial reviews.
+                                                    and does not spend your
+                                                    Kodus trial review credits.
                                                 </p>
                                             ) : (
                                                 <p>
-                                                    Reviewing now uses 1 of the{" "}
-                                                    {
-                                                        TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED
-                                                    }{" "}
-                                                    managed AI PR reviews
-                                                    included in your{" "}
+                                                    Kodus covers the AI cost for
+                                                    these first reviews.
+                                                    Reviewing this PR spends 1
+                                                    credit from your{" "}
                                                     {TRIAL_DAYS}-day Team trial.
                                                 </p>
                                             )}

--- a/apps/web/src/app/(setup)/setup/choosing-a-pull-request/page.tsx
+++ b/apps/web/src/app/(setup)/setup/choosing-a-pull-request/page.tsx
@@ -87,7 +87,7 @@ export default function App() {
     if (shouldSkipPullRequestSelection) return null;
 
     return (
-        <Page.Root className="flex h-full w-full flex-col items-center overflow-auto py-20">
+        <Page.Root className="flex min-h-full w-full flex-col items-center py-20">
             <MagicModalContext.Provider value={{ closeable: false }}>
                 <Dialog open>
                     <DialogContent className="gap-0 p-10">
@@ -139,29 +139,28 @@ export default function App() {
                                         <AlertTitle>
                                             {hasBYOK
                                                 ? "This review uses your AI key"
-                                                : `Your first ${TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED} PR reviews are on Kodus`}
+                                                : `Your first ${TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED} PR reviews are on us`}
                                         </AlertTitle>
                                         <AlertDescription>
                                             {hasBYOK ? (
                                                 <p>
-                                                    BYOK is configured, so this
-                                                    PR uses your provider key
-                                                    and does not count against
-                                                    the PR reviews paid by
-                                                    Kodus.
+                                                    Your AI key is connected, so
+                                                    this review runs on your key
+                                                    — unlimited, and it doesn't
+                                                    use your trial reviews.
                                                 </p>
                                             ) : (
                                                 <p>
                                                     During your {TRIAL_DAYS}-day
-                                                    Team trial, this review uses
-                                                    1 of the{" "}
+                                                    trial, this review uses 1 of
+                                                    the{" "}
                                                     {
                                                         TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED
                                                     }{" "}
-                                                    PR reviews paid by Kodus.
-                                                    After that, connect BYOK or
-                                                    upgrade to keep reviewing
-                                                    PRs.
+                                                    we cover for you. After
+                                                    that, connect your AI key
+                                                    for unlimited reviews (free,
+                                                    on any plan).
                                                 </p>
                                             )}
                                         </AlertDescription>

--- a/apps/web/src/app/(setup)/setup/choosing-a-pull-request/page.tsx
+++ b/apps/web/src/app/(setup)/setup/choosing-a-pull-request/page.tsx
@@ -139,7 +139,7 @@ export default function App() {
                                         <AlertTitle>
                                             {hasBYOK
                                                 ? "This review uses your AI key"
-                                                : `Your trial includes ${TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED} PR reviews`}
+                                                : `Your first ${TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED} PR reviews are on Kodus`}
                                         </AlertTitle>
                                         <AlertDescription>
                                             {hasBYOK ? (
@@ -147,16 +147,21 @@ export default function App() {
                                                     BYOK is configured, so this
                                                     PR uses your provider key
                                                     and does not count against
-                                                    your included trial PR
-                                                    reviews.
+                                                    the PR reviews paid by
+                                                    Kodus.
                                                 </p>
                                             ) : (
                                                 <p>
-                                                    Kodus covers the AI cost for
-                                                    these first reviews.
-                                                    Reviewing this PR uses 1
-                                                    included review from your{" "}
-                                                    {TRIAL_DAYS}-day Team trial.
+                                                    During your {TRIAL_DAYS}-day
+                                                    Team trial, this review uses
+                                                    1 of the{" "}
+                                                    {
+                                                        TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED
+                                                    }{" "}
+                                                    PR reviews paid by Kodus.
+                                                    After that, connect BYOK or
+                                                    upgrade to keep reviewing
+                                                    PRs.
                                                 </p>
                                             )}
                                         </AlertDescription>

--- a/apps/web/src/app/(setup)/setup/choosing-a-pull-request/page.tsx
+++ b/apps/web/src/app/(setup)/setup/choosing-a-pull-request/page.tsx
@@ -94,7 +94,7 @@ export default function App() {
                         <DialogHeader>
                             <DialogTitle className="flex items-center gap-2">
                                 <PartyPopperIcon className="text-primary-light size-6" />
-                                Congrats! Your automation is live!
+                                Kody is ready for your first PR review
                             </DialogTitle>
 
                             <DialogDescription className="mt-4">

--- a/apps/web/src/app/(setup)/setup/choosing-a-pull-request/page.tsx
+++ b/apps/web/src/app/(setup)/setup/choosing-a-pull-request/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, type ComponentProps } from "react";
 import { redirect } from "next/navigation";
 import { SelectPullRequest } from "@components/system/select-pull-requests";
 import { Alert, AlertDescription, AlertTitle } from "@components/ui/alert";
@@ -17,13 +17,20 @@ import { Link } from "@components/ui/link";
 import { MagicModalContext } from "@components/ui/magic-modal";
 import { Page } from "@components/ui/page";
 import { useSuspenseGetOnboardingPullRequests } from "@services/codeManagement/hooks";
+import { useSuspenseGetBYOK } from "@services/organizationParameters/hooks";
 import { useSuspenseGetParameterPlatformConfigs } from "@services/parameters/hooks";
 import { useSuspenseGetOrganizationId } from "@services/setup/hooks";
-import { PartyPopperIcon } from "lucide-react";
+import { InfoIcon, PartyPopperIcon } from "lucide-react";
 import { useAuth } from "src/core/providers/auth.provider";
 import { useSelectedTeamId } from "src/core/providers/selected-team-context";
 import { useFinishOnboardingReviewingPR } from "src/features/ee/onboarding/_hooks/use-finish-onboarding-reviewing-pr";
 import { useFinishOnboardingWithoutSelectingPR } from "src/features/ee/onboarding/_hooks/use-finish-onboarding-without-selecting-pr";
+import {
+    TRIAL_DAYS,
+    TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED,
+} from "src/features/ee/subscription/_constants/trial";
+
+type PullRequestOption = ComponentProps<typeof SelectPullRequest>["value"];
 
 export default function App() {
     const { userId } = useAuth();
@@ -35,11 +42,13 @@ export default function App() {
 
     const pullRequests = useSuspenseGetOnboardingPullRequests(teamId);
     const organizationId = useSuspenseGetOrganizationId();
+    const byokConfig = useSuspenseGetBYOK();
+    const hasBYOK = !!byokConfig?.configValue?.main;
 
     const [open, setOpen] = useState(false);
-    const [selectedPR, setSelectedPR] = useState<
-        (typeof pullRequests)[number] | undefined
-    >(pullRequests.length === 1 ? pullRequests[0] : undefined);
+    const [selectedPR, setSelectedPR] = useState<PullRequestOption>(
+        pullRequests.length === 1 ? pullRequests[0] : undefined,
+    );
 
     const [requestedPullRequestReview, setRequestedPullRequestReview] =
         useState(false);
@@ -125,6 +134,35 @@ export default function App() {
                                 </>
                             ) : (
                                 <>
+                                    <Alert variant="info" className="mb-1">
+                                        <InfoIcon />
+                                        <AlertTitle>
+                                            {hasBYOK
+                                                ? "This review uses your AI key"
+                                                : "Your trial includes managed reviews"}
+                                        </AlertTitle>
+                                        <AlertDescription>
+                                            {hasBYOK ? (
+                                                <p>
+                                                    BYOK is configured, so this
+                                                    PR uses your provider key
+                                                    and does not consume Kodus
+                                                    managed trial reviews.
+                                                </p>
+                                            ) : (
+                                                <p>
+                                                    Reviewing now uses 1 of the{" "}
+                                                    {
+                                                        TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED
+                                                    }{" "}
+                                                    managed AI PR reviews
+                                                    included in your{" "}
+                                                    {TRIAL_DAYS}-day Team trial.
+                                                </p>
+                                            )}
+                                        </AlertDescription>
+                                    </Alert>
+
                                     <FormControl.Root>
                                         <FormControl.Label htmlFor="select-pull-request">
                                             Select a PR to review

--- a/apps/web/src/app/(setup)/setup/choosing-a-pull-request/page.tsx
+++ b/apps/web/src/app/(setup)/setup/choosing-a-pull-request/page.tsx
@@ -139,22 +139,23 @@ export default function App() {
                                         <AlertTitle>
                                             {hasBYOK
                                                 ? "This review uses your AI key"
-                                                : `Your trial includes ${TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED} PR reviews with Kodus credits`}
+                                                : `Your trial includes ${TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED} PR reviews`}
                                         </AlertTitle>
                                         <AlertDescription>
                                             {hasBYOK ? (
                                                 <p>
                                                     BYOK is configured, so this
                                                     PR uses your provider key
-                                                    and does not spend your
-                                                    Kodus trial review credits.
+                                                    and does not count against
+                                                    your included trial PR
+                                                    reviews.
                                                 </p>
                                             ) : (
                                                 <p>
                                                     Kodus covers the AI cost for
                                                     these first reviews.
-                                                    Reviewing this PR spends 1
-                                                    credit from your{" "}
+                                                    Reviewing this PR uses 1
+                                                    included review from your{" "}
                                                     {TRIAL_DAYS}-day Team trial.
                                                 </p>
                                             )}

--- a/apps/web/src/app/(setup)/setup/choosing-repositories/page.tsx
+++ b/apps/web/src/app/(setup)/setup/choosing-repositories/page.tsx
@@ -240,7 +240,7 @@ export default function App() {
     });
 
     return (
-        <Page.Root className="mx-auto flex h-full min-h-[calc(100vh-4rem)] w-full flex-row overflow-hidden p-6">
+        <Page.Root className="mx-auto flex min-h-full w-full flex-row p-6">
             <div className="bg-card-lv1 flex flex-10 flex-col justify-center gap-10 rounded-3xl p-12">
                 <div className="text-text-secondary flex flex-1 flex-col justify-center gap-8 text-[15px]">
                     <div className="flex flex-col gap-4">
@@ -347,17 +347,19 @@ export default function App() {
                                     <AlertTitle>
                                         Your first{" "}
                                         {TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED}{" "}
-                                        PR reviews are on Kodus
+                                        PR reviews are on us
                                     </AlertTitle>
                                     <AlertDescription>
                                         <p>
-                                            During your {TRIAL_DAYS}-day Team
-                                            trial, Kodus pays for up to{" "}
+                                            During your {TRIAL_DAYS}-day trial
+                                            we cover your first{" "}
                                             {
                                                 TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED
                                             }{" "}
-                                            PR reviews. After that, connect BYOK
-                                            or upgrade to keep reviewing PRs.
+                                            PR reviews — no AI key needed. After
+                                            that, connect your AI key for
+                                            unlimited reviews (free, on any
+                                            plan).
                                         </p>
                                     </AlertDescription>
                                 </Alert>

--- a/apps/web/src/app/(setup)/setup/choosing-repositories/page.tsx
+++ b/apps/web/src/app/(setup)/setup/choosing-repositories/page.tsx
@@ -345,18 +345,19 @@ export default function App() {
                                 <Alert variant="info">
                                     <InfoIcon />
                                     <AlertTitle>
-                                        Your trial includes{" "}
+                                        Your first{" "}
                                         {TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED}{" "}
-                                        PR reviews
+                                        PR reviews are on Kodus
                                     </AlertTitle>
                                     <AlertDescription>
                                         <p>
-                                            Kodus covers the AI cost for these
-                                            first reviews during your{" "}
-                                            {TRIAL_DAYS}-day Team trial. If you
-                                            connect BYOK, reviews use your AI
-                                            key instead and do not count against
-                                            those included PR reviews.
+                                            During your {TRIAL_DAYS}-day Team
+                                            trial, Kodus pays for up to{" "}
+                                            {
+                                                TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED
+                                            }{" "}
+                                            PR reviews. After that, connect BYOK
+                                            or upgrade to keep reviewing PRs.
                                         </p>
                                     </AlertDescription>
                                 </Alert>

--- a/apps/web/src/app/(setup)/setup/choosing-repositories/page.tsx
+++ b/apps/web/src/app/(setup)/setup/choosing-repositories/page.tsx
@@ -345,18 +345,18 @@ export default function App() {
                                 <Alert variant="info">
                                     <InfoIcon />
                                     <AlertTitle>
-                                        Team trial includes managed PR reviews
+                                        Your trial includes{" "}
+                                        {TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED}{" "}
+                                        PR reviews with Kodus credits
                                     </AlertTitle>
                                     <AlertDescription>
                                         <p>
-                                            Your {TRIAL_DAYS}-day Team trial
-                                            includes{" "}
-                                            {
-                                                TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED
-                                            }{" "}
-                                            managed AI PR reviews. BYOK reviews
-                                            use your AI key and do not consume
-                                            Kodus credits.
+                                            Kodus covers the AI cost for these
+                                            first reviews during your{" "}
+                                            {TRIAL_DAYS}-day Team trial. If you
+                                            connect BYOK, reviews use your AI
+                                            key instead and do not spend those
+                                            credits.
                                         </p>
                                     </AlertDescription>
                                 </Alert>

--- a/apps/web/src/app/(setup)/setup/choosing-repositories/page.tsx
+++ b/apps/web/src/app/(setup)/setup/choosing-repositories/page.tsx
@@ -347,7 +347,7 @@ export default function App() {
                                     <AlertTitle>
                                         Your trial includes{" "}
                                         {TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED}{" "}
-                                        PR reviews with Kodus credits
+                                        PR reviews
                                     </AlertTitle>
                                     <AlertDescription>
                                         <p>
@@ -355,8 +355,8 @@ export default function App() {
                                             first reviews during your{" "}
                                             {TRIAL_DAYS}-day Team trial. If you
                                             connect BYOK, reviews use your AI
-                                            key instead and do not spend those
-                                            credits.
+                                            key instead and do not count against
+                                            those included PR reviews.
                                         </p>
                                     </AlertDescription>
                                 </Alert>

--- a/apps/web/src/app/(setup)/setup/choosing-repositories/page.tsx
+++ b/apps/web/src/app/(setup)/setup/choosing-repositories/page.tsx
@@ -38,6 +38,7 @@ import {
     AlertTriangle,
     FolderX,
     HatGlasses,
+    InfoIcon,
     KeyRound,
     PowerIcon,
     Sparkles,
@@ -48,6 +49,10 @@ import { IntegrationCategory } from "src/core/types";
 import { generateQueryKey } from "src/core/utils/reactQuery";
 import { safeArray } from "src/core/utils/safe-array";
 import { pluralize } from "src/core/utils/string";
+import {
+    TRIAL_DAYS,
+    TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED,
+} from "src/features/ee/subscription/_constants/trial";
 
 import { StepIndicators } from "../_components/step-indicators";
 
@@ -194,7 +199,9 @@ export default function App() {
                         ),
                     }),
                     queryClient.invalidateQueries({
-                        queryKey: [CODE_MANAGEMENT_API_PATHS.GET_REPOSITORIES_ORG],
+                        queryKey: [
+                            CODE_MANAGEMENT_API_PATHS.GET_REPOSITORIES_ORG,
+                        ],
                     }),
                 ]);
 
@@ -335,6 +342,25 @@ export default function App() {
                             </div>
 
                             <div className="flex flex-col gap-4">
+                                <Alert variant="info">
+                                    <InfoIcon />
+                                    <AlertTitle>
+                                        Team trial includes managed PR reviews
+                                    </AlertTitle>
+                                    <AlertDescription>
+                                        <p>
+                                            Your {TRIAL_DAYS}-day Team trial
+                                            includes{" "}
+                                            {
+                                                TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED
+                                            }{" "}
+                                            managed AI PR reviews. BYOK reviews
+                                            use your AI key and do not consume
+                                            Kodus credits.
+                                        </p>
+                                    </AlertDescription>
+                                </Alert>
+
                                 <FormControl.Root>
                                     <FormControl.Label htmlFor="select-repositories">
                                         Select repositories

--- a/apps/web/src/app/(setup)/setup/creating-workspace/page.tsx
+++ b/apps/web/src/app/(setup)/setup/creating-workspace/page.tsx
@@ -154,7 +154,7 @@ export default function App() {
     const autoJoinEnabled = form.watch("autoJoin");
 
     return (
-        <Page.Root className="mx-auto flex max-h-screen flex-row overflow-hidden p-6">
+        <Page.Root className="mx-auto flex min-h-full w-full flex-row p-6">
             <div className="bg-card-lv1 flex flex-10 flex-col justify-center gap-10 rounded-3xl p-12">
                 <div className="flex-1 overflow-hidden rounded-3xl">
                     <video

--- a/apps/web/src/app/(setup)/setup/customize-team/page.tsx
+++ b/apps/web/src/app/(setup)/setup/customize-team/page.tsx
@@ -285,7 +285,7 @@ export default function CustomizeTeamPage() {
     };
 
     return (
-        <Page.Root className="mx-auto flex min-h-screen flex-col gap-6 overflow-x-hidden p-6 lg:flex-row lg:gap-6">
+        <Page.Root className="mx-auto flex min-h-full w-full flex-col gap-6 p-6 lg:flex-row lg:gap-6">
             <div className="bg-card-lv1 flex w-full flex-col justify-center gap-10 rounded-3xl p-8 lg:max-w-none lg:flex-10 lg:p-12">
                 <div className="flex-1 overflow-hidden">
                     <h1 className="text-2xl font-bold">

--- a/apps/web/src/app/(setup)/setup/marketing-survey/page.tsx
+++ b/apps/web/src/app/(setup)/setup/marketing-survey/page.tsx
@@ -183,7 +183,7 @@ export default function MarketingSurveyPage() {
     const canContinue = selectedSource && selectedGoal;
 
     return (
-        <Page.Root className="mx-auto flex max-h-screen min-h-screen flex-col gap-6 overflow-hidden p-6 lg:flex-row lg:gap-6">
+        <Page.Root className="mx-auto flex min-h-full w-full flex-col gap-6 p-6 lg:flex-row lg:gap-6">
             <div className="bg-card-lv1 flex w-full flex-col justify-center gap-10 rounded-3xl p-8 lg:max-w-none lg:flex-10 lg:p-12">
                 <div className="flex-1 space-y-6 overflow-hidden">
                     <h1 className="text-2xl font-bold">

--- a/apps/web/src/app/(setup)/setup/no-repositories/page.tsx
+++ b/apps/web/src/app/(setup)/setup/no-repositories/page.tsx
@@ -22,7 +22,7 @@ export default function App() {
     }
 
     return (
-        <Page.Root className="mx-auto flex max-h-screen flex-row overflow-hidden p-6">
+        <Page.Root className="mx-auto flex min-h-full w-full flex-row p-6">
             <div className="bg-card-lv1 flex flex-10 flex-col justify-center gap-10 rounded-3xl p-12">
                 <div className="text-text-secondary flex flex-1 flex-col justify-center gap-8 text-[15px]">
                     <div className="flex flex-col gap-4">

--- a/apps/web/src/app/(setup)/setup/organization-account-required/page.tsx
+++ b/apps/web/src/app/(setup)/setup/organization-account-required/page.tsx
@@ -23,7 +23,7 @@ export default function App() {
     }
 
     return (
-        <Page.Root className="mx-auto flex max-h-screen flex-row overflow-hidden p-6">
+        <Page.Root className="mx-auto flex min-h-full w-full flex-row p-6">
             <div className="bg-card-lv1 flex flex-10 flex-col justify-center gap-10 rounded-3xl p-12">
                 <div className="text-text-secondary flex flex-1 flex-col justify-center gap-8 text-[15px]">
                     <div className="flex flex-col gap-4">

--- a/apps/web/src/app/(setup)/setup/review-mode/page.tsx
+++ b/apps/web/src/app/(setup)/setup/review-mode/page.tsx
@@ -315,7 +315,7 @@ export default function ReviewModePage() {
     };
 
     return (
-        <Page.Root className="mx-auto flex min-h-screen flex-col gap-6 overflow-x-hidden p-6 lg:flex-row lg:gap-6">
+        <Page.Root className="mx-auto flex min-h-full w-full flex-col gap-6 p-6 lg:flex-row lg:gap-6">
             <div className="bg-card-lv1 flex w-full flex-col justify-center gap-10 rounded-3xl p-8 lg:max-w-none lg:flex-10 lg:p-12">
                 <div className="flex-1 space-y-4 overflow-hidden">
                     <h1 className="text-2xl font-bold">

--- a/apps/web/src/core/layout/navbar/index.tsx
+++ b/apps/web/src/core/layout/navbar/index.tsx
@@ -192,7 +192,7 @@ export const NavMenu = () => {
                                             href={href}
                                             active={isActive(href, matcher)}
                                             className={cn(
-                                                "text-text-tertiary relative flex h-full flex-row items-center gap-2 border-b-2 border-transparent px-4 text-sm transition",
+                                                "text-text-tertiary relative flex h-full flex-row items-center gap-2 border-b-2 border-transparent px-3 text-xs whitespace-nowrap transition",
                                                 "hover:text-white focus-visible:text-white",
                                                 "data-active:font-semibold data-active:text-white",
                                                 "data-active:border-primary-light",

--- a/apps/web/src/features/ee/subscription/@status/_components/index.tsx
+++ b/apps/web/src/features/ee/subscription/@status/_components/index.tsx
@@ -2,6 +2,11 @@
 
 import type { TeamMembersResponse } from "@services/setup/types";
 import { useSubscriptionStatus } from "src/features/ee/subscription/_hooks/use-subscription-status";
+import {
+    SubscriptionProvider,
+    useSubscriptionContext,
+} from "src/features/ee/subscription/_providers/subscription-context";
+import type { OrganizationLicenseTrial } from "src/features/ee/subscription/_services/billing/types";
 
 import { Active } from "./active";
 import { Canceled } from "./canceled";
@@ -26,6 +31,40 @@ const components: Partial<
 };
 
 export const Redirect = ({
+    members,
+    codeHostMembersCount,
+    trialLicense,
+}: {
+    members: TeamMembersResponse["members"];
+    codeHostMembersCount?: number;
+    trialLicense?: OrganizationLicenseTrial;
+}) => {
+    const subscriptionContext = useSubscriptionContext();
+
+    if (trialLicense) {
+        return (
+            <SubscriptionProvider
+                license={trialLicense}
+                usersWithAssignedLicense={
+                    subscriptionContext.usersWithAssignedLicense
+                }>
+                <RedirectContent
+                    members={members}
+                    codeHostMembersCount={codeHostMembersCount}
+                />
+            </SubscriptionProvider>
+        );
+    }
+
+    return (
+        <RedirectContent
+            members={members}
+            codeHostMembersCount={codeHostMembersCount}
+        />
+    );
+};
+
+const RedirectContent = ({
     members,
     codeHostMembersCount,
 }: {

--- a/apps/web/src/features/ee/subscription/@status/_components/index.tsx
+++ b/apps/web/src/features/ee/subscription/@status/_components/index.tsx
@@ -19,6 +19,7 @@ const components: Partial<
     "active": Active,
     "trial-active": Trial,
     "trial-expiring": Trial,
+    "trial-exhausted": Trial,
     "free": FreeByok,
     "canceled": Canceled,
     "payment-failed": PaymentFailed,
@@ -26,8 +27,10 @@ const components: Partial<
 
 export const Redirect = ({
     members,
+    codeHostMembersCount,
 }: {
     members: TeamMembersResponse["members"];
+    codeHostMembersCount?: number;
 }) => {
     const subscriptionStatus = useSubscriptionStatus();
     const { status } = subscriptionStatus;
@@ -47,5 +50,10 @@ export const Redirect = ({
     const Component = components[status];
 
     if (!Component) return null;
-    return <Component members={members} />;
+    return (
+        <Component
+            members={members}
+            codeHostMembersCount={codeHostMembersCount}
+        />
+    );
 };

--- a/apps/web/src/features/ee/subscription/@status/_components/trial.tsx
+++ b/apps/web/src/features/ee/subscription/@status/_components/trial.tsx
@@ -7,15 +7,17 @@ import { usePermission } from "@services/permissions/hooks";
 import { Action, ResourceType } from "@services/permissions/types";
 import type { TeamMembersResponse } from "@services/setup/types";
 import { ArrowUpCircle } from "lucide-react";
-import { pluralize } from "src/core/utils/string";
 
+import { TrialCreditsSummary } from "../../_components/trial-credits-summary";
 import { useSubscriptionStatus } from "../../_hooks/use-subscription-status";
 
 export const Trial = ({
     members,
+    codeHostMembersCount,
     forceShow = false,
 }: {
     members: TeamMembersResponse["members"];
+    codeHostMembersCount?: number;
     forceShow?: boolean;
 }) => {
     const organizationAdminsCount = members.length;
@@ -27,7 +29,8 @@ export const Trial = ({
     if (!forceShow) {
         if (
             subscriptionStatus.status !== "trial-active" &&
-            subscriptionStatus.status !== "trial-expiring"
+            subscriptionStatus.status !== "trial-expiring" &&
+            subscriptionStatus.status !== "trial-exhausted"
         ) {
             return null;
         }
@@ -35,46 +38,53 @@ export const Trial = ({
 
     const isTrial =
         subscriptionStatus.status === "trial-active" ||
-        subscriptionStatus.status === "trial-expiring";
+        subscriptionStatus.status === "trial-expiring" ||
+        subscriptionStatus.status === "trial-exhausted";
 
     return (
         <Card className="w-full">
-            <CardHeader className="flex flex-row justify-between gap-2">
-                <div className="flex flex-col gap-2">
-                    {isTrial &&
-                        subscriptionStatus.trialDaysLeft !== undefined && (
-                            <p className="text-text-secondary text-sm">
-                                {subscriptionStatus.trialDaysLeft} days free
-                                trial
-                            </p>
-                        )}
-                    <CardTitle className="text-2xl">PRO plan</CardTitle>
-
-                    <div className="mt-4 flex gap-6">
-                        {/* <p className="text-sm text-text-secondary">
-                            <strong>5</strong> of <strong>7</strong> licenses
-                            assigned
-                        </p> */}
-
-                        <p className="text-text-secondary text-sm">
-                            <strong>{organizationAdminsCount}</strong> workspace{" "}
-                            {pluralize(organizationAdminsCount, {
-                                singular: "member",
-                                plural: "members",
-                            })}
-                        </p>
+            <CardHeader className="flex flex-col gap-6">
+                <div className="flex flex-row justify-between gap-4">
+                    <div className="flex flex-col gap-2">
+                        {isTrial &&
+                            subscriptionStatus.trialDaysLeft !== undefined && (
+                                <p className="text-text-secondary text-sm">
+                                    {subscriptionStatus.trialDaysLeft} days left
+                                    in Team trial
+                                </p>
+                            )}
+                        <CardTitle className="text-2xl">Team trial</CardTitle>
                     </div>
+
+                    <Button
+                        size="lg"
+                        variant="primary"
+                        className="h-fit"
+                        disabled={!canEdit}
+                        leftIcon={<ArrowUpCircle />}
+                        onClick={() => router.push("/choose-plan")}>
+                        Upgrade
+                    </Button>
                 </div>
 
-                <Button
-                    size="lg"
-                    variant="primary"
-                    className="h-fit"
-                    disabled={!canEdit}
-                    leftIcon={<ArrowUpCircle />}
-                    onClick={() => router.push("/choose-plan")}>
-                    Upgrade
-                </Button>
+                {isTrial && (
+                    <TrialCreditsSummary
+                        credits={subscriptionStatus.trialReviewCredits}
+                        trialCreditTier={subscriptionStatus.trialCreditTier}
+                        trialUnlocks={subscriptionStatus.trialUnlocks}
+                        byok={subscriptionStatus.byok}
+                        daysLeft={subscriptionStatus.trialDaysLeft}
+                        workspaceMembersCount={organizationAdminsCount}
+                        codeHostMembersCount={codeHostMembersCount}
+                    />
+                )}
+
+                {!isTrial && (
+                    <p className="text-text-secondary text-sm">
+                        Your Team trial has ended. Upgrade to keep managed PR
+                        reviews running.
+                    </p>
+                )}
             </CardHeader>
         </Card>
     );

--- a/apps/web/src/features/ee/subscription/@status/_components/trial.tsx
+++ b/apps/web/src/features/ee/subscription/@status/_components/trial.tsx
@@ -81,8 +81,8 @@ export const Trial = ({
 
                 {!isTrial && (
                     <p className="text-text-secondary text-sm">
-                        Your Team trial has ended. Upgrade to keep managed PR
-                        reviews running.
+                        Your Team trial has ended. Upgrade to keep PR reviews
+                        running.
                     </p>
                 )}
             </CardHeader>

--- a/apps/web/src/features/ee/subscription/@status/page.tsx
+++ b/apps/web/src/features/ee/subscription/@status/page.tsx
@@ -3,14 +3,26 @@ import { SETUP_PATHS } from "@services/setup";
 import type { TeamMembersResponse } from "@services/setup/types";
 import { getGlobalSelectedTeamId } from "src/core/utils/get-global-selected-team-id";
 
+import { getOrganizationMembers } from "../_services/billing/fetch";
 import { Redirect } from "./_components";
 
 export default async function SubscriptionStatus() {
     const teamId = await getGlobalSelectedTeamId();
-    const { members } = await authorizedFetch<TeamMembersResponse>(
-        SETUP_PATHS.TEAM_MEMBERS,
-        { params: { teamId } },
-    );
+    const [{ members }, organizationMembers] = await Promise.all([
+        authorizedFetch<TeamMembersResponse>(SETUP_PATHS.TEAM_MEMBERS, {
+            params: { teamId },
+        }),
+        getOrganizationMembers({ teamId }).catch(() => []),
+    ]);
 
-    return <Redirect members={members} />;
+    return (
+        <Redirect
+            members={members}
+            codeHostMembersCount={
+                Array.isArray(organizationMembers)
+                    ? organizationMembers.length
+                    : undefined
+            }
+        />
+    );
 }

--- a/apps/web/src/features/ee/subscription/@status/page.tsx
+++ b/apps/web/src/features/ee/subscription/@status/page.tsx
@@ -1,4 +1,5 @@
 import { authorizedFetch } from "@services/fetch";
+import { getBYOK } from "@services/organizationParameters/fetch";
 import { SETUP_PATHS } from "@services/setup";
 import type { TeamMembersResponse } from "@services/setup/types";
 import { auth } from "src/core/config/auth";
@@ -19,13 +20,20 @@ const hasCompanyEmail = (email?: string | null) => {
 
 export default async function SubscriptionStatus() {
     const teamId = await getGlobalSelectedTeamId();
-    const [session, { members }, organizationMembers] = await Promise.all([
-        auth(),
-        authorizedFetch<TeamMembersResponse>(SETUP_PATHS.TEAM_MEMBERS, {
-            params: { teamId },
-        }),
-        getOrganizationMembers({ teamId }).catch(() => []),
-    ]);
+    const [session, { members }, organizationMembers, byokConfig] =
+        await Promise.all([
+            auth(),
+            authorizedFetch<TeamMembersResponse>(SETUP_PATHS.TEAM_MEMBERS, {
+                params: { teamId },
+            }),
+            getOrganizationMembers({ teamId }).catch(() => []),
+            getBYOK().catch(() => undefined),
+        ]);
+
+    // BYOK config lives in the API (org parameters), not in billing — so the
+    // billing license never knows a key was connected. Detect it here and use
+    // it both as a recalc signal and as the source of truth for `byok`.
+    const hasByok = Boolean(byokConfig?.main);
 
     const codeHostMembersCount = Array.isArray(organizationMembers)
         ? organizationMembers.length
@@ -36,12 +44,16 @@ export default async function SubscriptionStatus() {
             companyEmailVerified: hasCompanyEmail(session?.user?.email),
             workspaceMembersCount: members.length,
             codeHostMembersCount,
+            byok: hasByok,
         },
     }).catch(() => undefined);
     const trialLicense =
         recalculatedLicense?.valid &&
         recalculatedLicense.subscriptionStatus === "trial"
-            ? recalculatedLicense
+            ? {
+                  ...recalculatedLicense,
+                  byok: hasByok || recalculatedLicense.byok,
+              }
             : undefined;
 
     return (

--- a/apps/web/src/features/ee/subscription/@status/page.tsx
+++ b/apps/web/src/features/ee/subscription/@status/page.tsx
@@ -1,28 +1,54 @@
 import { authorizedFetch } from "@services/fetch";
 import { SETUP_PATHS } from "@services/setup";
 import type { TeamMembersResponse } from "@services/setup/types";
+import { auth } from "src/core/config/auth";
+import { publicDomainsSet } from "src/core/utils/email";
 import { getGlobalSelectedTeamId } from "src/core/utils/get-global-selected-team-id";
 
-import { getOrganizationMembers } from "../_services/billing/fetch";
+import {
+    getOrganizationMembers,
+    recalculateTrialUnlocks,
+} from "../_services/billing/fetch";
 import { Redirect } from "./_components";
+
+const hasCompanyEmail = (email?: string | null) => {
+    const domain = email?.split("@")[1]?.toLowerCase();
+
+    return Boolean(domain && !publicDomainsSet.has(domain));
+};
 
 export default async function SubscriptionStatus() {
     const teamId = await getGlobalSelectedTeamId();
-    const [{ members }, organizationMembers] = await Promise.all([
+    const [session, { members }, organizationMembers] = await Promise.all([
+        auth(),
         authorizedFetch<TeamMembersResponse>(SETUP_PATHS.TEAM_MEMBERS, {
             params: { teamId },
         }),
         getOrganizationMembers({ teamId }).catch(() => []),
     ]);
 
+    const codeHostMembersCount = Array.isArray(organizationMembers)
+        ? organizationMembers.length
+        : undefined;
+    const recalculatedLicense = await recalculateTrialUnlocks({
+        teamId,
+        signals: {
+            companyEmailVerified: hasCompanyEmail(session?.user?.email),
+            workspaceMembersCount: members.length,
+            codeHostMembersCount,
+        },
+    }).catch(() => undefined);
+    const trialLicense =
+        recalculatedLicense?.valid &&
+        recalculatedLicense.subscriptionStatus === "trial"
+            ? recalculatedLicense
+            : undefined;
+
     return (
         <Redirect
             members={members}
-            codeHostMembersCount={
-                Array.isArray(organizationMembers)
-                    ? organizationMembers.length
-                    : undefined
-            }
+            codeHostMembersCount={codeHostMembersCount}
+            trialLicense={trialLicense}
         />
     );
 }

--- a/apps/web/src/features/ee/subscription/_components/request-extension-popover.tsx
+++ b/apps/web/src/features/ee/subscription/_components/request-extension-popover.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@components/ui/button";
+import { Input } from "@components/ui/input";
+import { Label } from "@components/ui/label";
+import {
+    Popover,
+    PopoverContent,
+    PopoverTrigger,
+} from "@components/ui/popover";
+import { Textarea } from "@components/ui/textarea";
+import { toast } from "@components/ui/toaster/use-toast";
+import { useSelectedTeamId } from "src/core/providers/selected-team-context";
+
+import { requestTrialExtension } from "../_services/billing/fetch";
+
+export const RequestExtensionPopover = ({
+    triggerLabel = "Request review",
+}: {
+    triggerLabel?: string;
+}) => {
+    const { teamId } = useSelectedTeamId();
+    const [open, setOpen] = useState(false);
+    const [teamSize, setTeamSize] = useState("");
+    const [message, setMessage] = useState("");
+    const [submitting, setSubmitting] = useState(false);
+
+    const handleSubmit = async () => {
+        setSubmitting(true);
+        try {
+            const result = await requestTrialExtension({
+                teamId,
+                request: {
+                    teamSize: teamSize ? Number(teamSize) : undefined,
+                    message: message.trim() || undefined,
+                },
+            });
+
+            if (!result?.success) {
+                throw new Error(result?.message || "Request failed");
+            }
+
+            toast({
+                variant: "success",
+                title: "Request sent",
+                description:
+                    "We'll review your trial signals and follow up shortly.",
+            });
+            setOpen(false);
+            setTeamSize("");
+            setMessage("");
+        } catch (error) {
+            toast({
+                variant: "warning",
+                title: "Could not send request",
+                description:
+                    error instanceof Error
+                        ? error.message
+                        : "Please try again in a moment.",
+            });
+        } finally {
+            setSubmitting(false);
+        }
+    };
+
+    return (
+        <Popover open={open} onOpenChange={setOpen}>
+            <PopoverTrigger asChild>
+                <Button size="xs" variant="helper">
+                    {triggerLabel}
+                </Button>
+            </PopoverTrigger>
+            <PopoverContent
+                align="end"
+                className="w-80"
+                onOpenAutoFocus={(event) => event.preventDefault()}>
+                <div className="flex flex-col gap-4">
+                    <div>
+                        <p className="text-text-primary text-sm font-semibold">
+                            Request more trial reviews
+                        </p>
+                        <p className="text-text-secondary mt-1 text-xs">
+                            Tell us about your team and we'll review your trial
+                            signals.
+                        </p>
+                    </div>
+
+                    <div className="flex flex-col gap-1.5">
+                        <Label
+                            htmlFor="trial-ext-team-size"
+                            className="text-xs">
+                            Team size
+                        </Label>
+                        <Input
+                            id="trial-ext-team-size"
+                            type="number"
+                            min={1}
+                            inputMode="numeric"
+                            placeholder="e.g. 12"
+                            value={teamSize}
+                            onChange={(event) =>
+                                setTeamSize(event.target.value)
+                            }
+                        />
+                    </div>
+
+                    <div className="flex flex-col gap-1.5">
+                        <Label htmlFor="trial-ext-message" className="text-xs">
+                            Anything we should know?
+                        </Label>
+                        <Textarea
+                            id="trial-ext-message"
+                            rows={3}
+                            placeholder="What are you evaluating Kodus for?"
+                            value={message}
+                            onChange={(event) => setMessage(event.target.value)}
+                        />
+                    </div>
+
+                    <Button
+                        size="sm"
+                        variant="primary"
+                        loading={submitting}
+                        onClick={handleSubmit}>
+                        Send request
+                    </Button>
+                </div>
+            </PopoverContent>
+        </Popover>
+    );
+};

--- a/apps/web/src/features/ee/subscription/_components/subscription-badge.tsx
+++ b/apps/web/src/features/ee/subscription/_components/subscription-badge.tsx
@@ -18,7 +18,7 @@ const SubscriptionTrial = () => {
     if (subscriptionStatus.status === "trial-exhausted") {
         return (
             <Button decorative size="sm" variant="tertiary">
-                No Kodus credits left
+                No trial PR reviews left
             </Button>
         );
     }
@@ -28,7 +28,7 @@ const SubscriptionTrial = () => {
     return (
         <Button decorative size="sm" variant="tertiary">
             {typeof remaining === "number"
-                ? `${remaining} review credits left`
+                ? `${remaining} trial PR reviews left`
                 : `${subscriptionStatus.trialDaysLeft} days Team trial`}
         </Button>
     );

--- a/apps/web/src/features/ee/subscription/_components/subscription-badge.tsx
+++ b/apps/web/src/features/ee/subscription/_components/subscription-badge.tsx
@@ -18,7 +18,7 @@ const SubscriptionTrial = () => {
     if (subscriptionStatus.status === "trial-exhausted") {
         return (
             <Button decorative size="sm" variant="tertiary">
-                No trial reviews left
+                No Kodus credits left
             </Button>
         );
     }
@@ -28,7 +28,7 @@ const SubscriptionTrial = () => {
     return (
         <Button decorative size="sm" variant="tertiary">
             {typeof remaining === "number"
-                ? `${remaining} PR reviews left`
+                ? `${remaining} review credits left`
                 : `${subscriptionStatus.trialDaysLeft} days Team trial`}
         </Button>
     );

--- a/apps/web/src/features/ee/subscription/_components/subscription-badge.tsx
+++ b/apps/web/src/features/ee/subscription/_components/subscription-badge.tsx
@@ -9,14 +9,27 @@ const SubscriptionTrial = () => {
     const subscriptionStatus = useSubscriptionStatus();
     if (
         subscriptionStatus.status !== "trial-active" &&
-        subscriptionStatus.status !== "trial-expiring"
+        subscriptionStatus.status !== "trial-expiring" &&
+        subscriptionStatus.status !== "trial-exhausted"
     ) {
         return null;
     }
 
+    if (subscriptionStatus.status === "trial-exhausted") {
+        return (
+            <Button decorative size="sm" variant="tertiary">
+                No trial reviews left
+            </Button>
+        );
+    }
+
+    const remaining = subscriptionStatus.trialReviewCredits?.remaining;
+
     return (
         <Button decorative size="sm" variant="tertiary">
-            {subscriptionStatus.trialDaysLeft} days free trial
+            {typeof remaining === "number"
+                ? `${remaining} PR reviews left`
+                : `${subscriptionStatus.trialDaysLeft} days Team trial`}
         </Button>
     );
 };
@@ -74,6 +87,7 @@ const components: Partial<
     "active": SubscriptionActive,
     "trial-active": SubscriptionTrial,
     "trial-expiring": SubscriptionTrial,
+    "trial-exhausted": SubscriptionTrial,
     "free": SubscriptionUpgrade,
     "canceled": SubscriptionUpgrade,
     "payment-failed": SubscriptionPaymentFailed,

--- a/apps/web/src/features/ee/subscription/_components/subscription-badge.tsx
+++ b/apps/web/src/features/ee/subscription/_components/subscription-badge.tsx
@@ -2,9 +2,72 @@
 
 import { Button } from "@components/ui/button";
 import { Link } from "@components/ui/link";
-import { AlertTriangle } from "lucide-react";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "@components/ui/tooltip";
+import {
+    AlertTriangle,
+    CalendarClockIcon,
+    GiftIcon,
+    SparklesIcon,
+} from "lucide-react";
 import { useSubscriptionStatus } from "src/features/ee/subscription/_hooks/use-subscription-status";
 
+// Keep the pill label short; the full "what is this?" context lives in the
+// tooltip so the navbar stays uncluttered but the meaning is one hover away.
+const TrialBadge = ({
+    children,
+    variant,
+    icon,
+    tooltip,
+}: {
+    children: React.ReactNode;
+    variant: React.ComponentProps<typeof Button>["variant"];
+    icon?: React.ReactNode;
+    tooltip: React.ReactNode;
+}) => (
+    <Tooltip>
+        <TooltipTrigger asChild>
+            <Button decorative size="sm" variant={variant} leftIcon={icon}>
+                {children}
+            </Button>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" className="max-w-64 text-xs">
+            {tooltip}
+        </TooltipContent>
+    </Tooltip>
+);
+
+const TooltipRow = ({
+    icon: Icon,
+    label,
+    value,
+    iconTone,
+    valueTone,
+}: {
+    icon: React.ElementType;
+    label: string;
+    value: string;
+    iconTone?: string;
+    valueTone?: string;
+}) => (
+    <div className="flex items-center gap-2">
+        <Icon
+            className={`size-3.5 shrink-0 ${iconTone ?? "text-text-tertiary"}`}
+        />
+        <span className="text-text-secondary">{label}</span>
+        <span
+            className={`ml-auto font-medium ${valueTone ?? "text-text-primary"}`}>
+            {value}
+        </span>
+    </div>
+);
+
+// Plan-identity badge only ("which subscription am I on" — becomes the plan
+// name after the trial). The trial detail (days left + review allowance) lives
+// in the hover tooltip so the navbar stays a single, uncluttered pill.
 const SubscriptionTrial = () => {
     const subscriptionStatus = useSubscriptionStatus();
     if (
@@ -15,22 +78,66 @@ const SubscriptionTrial = () => {
         return null;
     }
 
-    if (subscriptionStatus.status === "trial-exhausted") {
-        return (
-            <Button decorative size="sm" variant="tertiary">
-                No trial PR reviews left
-            </Button>
-        );
-    }
+    const { trialDaysLeft, byok, trialReviewCredits } = subscriptionStatus;
+    const remaining = trialReviewCredits?.remaining;
+    const total = trialReviewCredits?.total;
 
-    const remaining = subscriptionStatus.trialReviewCredits?.remaining;
+    // With BYOK the reviews are unlimited because the user pays their own AI
+    // key — NOT because Kodus covers them. So drop the "free / on us" framing
+    // and just call it "Reviews".
+    const reviews = byok
+        ? {
+              icon: SparklesIcon,
+              label: "Reviews",
+              value: "BYOK · Unlimited",
+              tone: "text-success",
+          }
+        : typeof remaining === "number"
+          ? remaining === 0
+              ? {
+                    icon: AlertTriangle,
+                    label: "Free reviews",
+                    value: "Used up",
+                    tone: "text-alert",
+                }
+              : {
+                    icon: GiftIcon,
+                    label: "Free reviews",
+                    value: `${remaining}${
+                        typeof total === "number" ? ` of ${total}` : ""
+                    }`,
+                    tone: "text-text-primary",
+                }
+          : null;
 
     return (
-        <Button decorative size="sm" variant="tertiary">
-            {typeof remaining === "number"
-                ? `${remaining} trial PR reviews left`
-                : `${subscriptionStatus.trialDaysLeft} days Team trial`}
-        </Button>
+        <TrialBadge
+            variant="secondary"
+            tooltip={
+                <div className="flex w-44 flex-col gap-2">
+                    <TooltipRow
+                        icon={CalendarClockIcon}
+                        label="Trial"
+                        value={`${trialDaysLeft}d left`}
+                    />
+                    {reviews && (
+                        <TooltipRow
+                            icon={reviews.icon}
+                            iconTone={reviews.tone}
+                            label={reviews.label}
+                            value={reviews.value}
+                            valueTone={reviews.tone}
+                        />
+                    )}
+                    {!byok && (
+                        <p className="border-card-lv3 text-text-tertiary border-t pt-2 leading-snug">
+                            Connect your AI key for unlimited reviews.
+                        </p>
+                    )}
+                </div>
+            }>
+            Team trial
+        </TrialBadge>
     );
 };
 

--- a/apps/web/src/features/ee/subscription/_components/subscription-status-topbar.tsx
+++ b/apps/web/src/features/ee/subscription/_components/subscription-status-topbar.tsx
@@ -24,15 +24,11 @@ const TrialExpiring = () => {
 const TrialExhausted = () => {
     return (
         <div className="bg-danger/30 py-2 text-center text-sm">
-            You used all PR reviews paid by Kodus for this trial.{" "}
+            You've used all the free PR reviews included in your trial.{" "}
             <Link href="/organization/byok" className="font-bold">
-                Connect BYOK
+                Connect your own AI key
             </Link>{" "}
-            or{" "}
-            <Link href="/settings/subscription" className="font-bold">
-                upgrade
-            </Link>{" "}
-            to keep reviewing PRs.
+            to keep Kody reviewing — unlimited, on any plan.
         </div>
     );
 };

--- a/apps/web/src/features/ee/subscription/_components/subscription-status-topbar.tsx
+++ b/apps/web/src/features/ee/subscription/_components/subscription-status-topbar.tsx
@@ -24,7 +24,7 @@ const TrialExpiring = () => {
 const TrialExhausted = () => {
     return (
         <div className="bg-danger/30 py-2 text-center text-sm">
-            Your Kodus trial review credits are used.{" "}
+            You used all included trial PR reviews.{" "}
             <Link href="/organization/byok" className="font-bold">
                 Connect BYOK
             </Link>{" "}

--- a/apps/web/src/features/ee/subscription/_components/subscription-status-topbar.tsx
+++ b/apps/web/src/features/ee/subscription/_components/subscription-status-topbar.tsx
@@ -4,13 +4,35 @@ import { Link } from "@components/ui/link";
 import { useSubscriptionStatus } from "src/features/ee/subscription/_hooks/use-subscription-status";
 
 const TrialExpiring = () => {
+    const subscriptionStatus = useSubscriptionStatus();
+    const daysLeft =
+        subscriptionStatus.status === "trial-expiring"
+            ? subscriptionStatus.trialDaysLeft
+            : 0;
+
     return (
         <div className="bg-danger/30 py-2 text-center text-sm">
-            Your free trial is expiring soon...{" "}
+            Your Team trial expires in {daysLeft} days.{" "}
             <Link href="/settings/subscription" className="font-bold">
                 Upgrade
             </Link>{" "}
-            the subscription to keep all features.
+            to keep all features.
+        </div>
+    );
+};
+
+const TrialExhausted = () => {
+    return (
+        <div className="bg-danger/30 py-2 text-center text-sm">
+            Your managed trial reviews are used.{" "}
+            <Link href="/organization/byok" className="font-bold">
+                Connect BYOK
+            </Link>{" "}
+            or{" "}
+            <Link href="/settings/subscription" className="font-bold">
+                upgrade
+            </Link>{" "}
+            to keep reviewing PRs.
         </div>
     );
 };
@@ -34,6 +56,7 @@ const components: Partial<
     >
 > = {
     "trial-expiring": TrialExpiring,
+    "trial-exhausted": TrialExhausted,
     "expired": SubscriptionInvalid,
     "canceled": SubscriptionInvalid,
     "payment-failed": SubscriptionInvalid,

--- a/apps/web/src/features/ee/subscription/_components/subscription-status-topbar.tsx
+++ b/apps/web/src/features/ee/subscription/_components/subscription-status-topbar.tsx
@@ -24,7 +24,7 @@ const TrialExpiring = () => {
 const TrialExhausted = () => {
     return (
         <div className="bg-danger/30 py-2 text-center text-sm">
-            You used all included trial PR reviews.{" "}
+            You used all PR reviews paid by Kodus for this trial.{" "}
             <Link href="/organization/byok" className="font-bold">
                 Connect BYOK
             </Link>{" "}

--- a/apps/web/src/features/ee/subscription/_components/subscription-status-topbar.tsx
+++ b/apps/web/src/features/ee/subscription/_components/subscription-status-topbar.tsx
@@ -24,7 +24,7 @@ const TrialExpiring = () => {
 const TrialExhausted = () => {
     return (
         <div className="bg-danger/30 py-2 text-center text-sm">
-            Your managed trial reviews are used.{" "}
+            Your Kodus trial review credits are used.{" "}
             <Link href="/organization/byok" className="font-bold">
                 Connect BYOK
             </Link>{" "}

--- a/apps/web/src/features/ee/subscription/_components/trial-credits-summary.tsx
+++ b/apps/web/src/features/ee/subscription/_components/trial-credits-summary.tsx
@@ -53,20 +53,12 @@ const TrialTierItem = ({ unlock }: { unlock: TrialUnlockViewModel }) => {
     const statusVariant = statusVariantByStatus[unlock.status] ?? "helper";
 
     return (
-        <div className="flex items-start gap-3">
+        <div className="grid grid-cols-[auto_1fr] gap-3 md:grid-cols-[auto_1fr_auto]">
             <Icon className="text-primary-light mt-0.5 size-4 shrink-0" />
             <div className="min-w-0 flex-1">
-                <div className="flex flex-wrap items-center gap-2">
-                    <p className="text-text-primary text-sm font-semibold">
-                        {unlock.title}
-                    </p>
-                    <Badge size="xs" variant={statusVariant}>
-                        {statusLabel}
-                    </Badge>
-                    <span className="text-primary-light text-xs font-semibold">
-                        {unlock.rewardLabel}
-                    </span>
-                </div>
+                <p className="text-text-primary text-sm font-semibold">
+                    {unlock.title}
+                </p>
                 <p className="text-text-secondary mt-1 text-xs">
                     {unlock.description}
                 </p>
@@ -85,6 +77,14 @@ const TrialTierItem = ({ unlock }: { unlock: TrialUnlockViewModel }) => {
                         </Button>
                     </Link>
                 )}
+            </div>
+            <div className="col-start-2 flex flex-wrap items-center gap-2 md:col-start-auto md:justify-end">
+                <Badge size="xs" variant={statusVariant}>
+                    {statusLabel}
+                </Badge>
+                <span className="text-primary-light text-xs font-semibold">
+                    {unlock.rewardLabel}
+                </span>
             </div>
         </div>
     );
@@ -116,36 +116,51 @@ export const TrialCreditsSummary = ({
         workspaceMembersCount,
         codeHostMembersCount,
     });
-    const remainingLabel = `${balance.remaining} of ${balance.total}`;
-    const daysLeftLabel =
-        typeof daysLeft === "number"
-            ? `${daysLeft} days left in your Team trial`
-            : `${TRIAL_DAYS}-day Team trial`;
+    const daysLeftValue = typeof daysLeft === "number" ? daysLeft : TRIAL_DAYS;
+    const trialReviewCopy = byok
+        ? "BYOK active. Reviews use your AI key."
+        : `${balance.remaining} of ${balance.total} Kodus-paid PR reviews left.`;
 
     return (
         <section className="flex flex-col gap-5">
             <div className="flex flex-col gap-3">
-                <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+                <div>
+                    <p className="text-text-primary text-base font-semibold">
+                        Team trial status
+                    </p>
+                    <p className="text-text-secondary mt-1 text-sm">
+                        Your Team plan trial and Kodus-paid PR reviews are
+                        separate limits.
+                    </p>
+                </div>
+
+                <div className="border-card-lv3 grid grid-cols-1 gap-4 border-y py-3 md:grid-cols-2">
                     <div>
-                        <p className="text-text-primary text-base font-semibold">
-                            Kodus pays for your first {balance.total} PR reviews
+                        <p className="text-text-tertiary text-xs font-semibold uppercase">
+                            Team plan access
                         </p>
-                        <p className="text-text-secondary mt-1 text-sm">
-                            {daysLeftLabel}. After the {balance.total} reviews,
-                            connect BYOK or upgrade to keep reviewing PRs.
+                        <p className="text-text-primary mt-1 text-xl font-semibold">
+                            {daysLeftValue} days
+                        </p>
+                        <p className="text-text-secondary mt-1 text-xs">
+                            Full Team features during the {TRIAL_DAYS}-day
+                            trial.
                         </p>
                     </div>
 
-                    {!byok && (
-                        <div className="text-left md:text-right">
-                            <p className="text-text-primary text-xl font-semibold">
-                                {remainingLabel}
-                            </p>
-                            <p className="text-text-tertiary text-xs">
-                                Kodus-paid reviews left
-                            </p>
-                        </div>
-                    )}
+                    <div>
+                        <p className="text-text-tertiary text-xs font-semibold uppercase">
+                            PR reviews paid by Kodus
+                        </p>
+                        <p className="text-text-primary mt-1 text-xl font-semibold">
+                            {byok
+                                ? "BYOK"
+                                : `${balance.remaining} of ${balance.total}`}
+                        </p>
+                        <p className="text-text-secondary mt-1 text-xs">
+                            {trialReviewCopy}
+                        </p>
+                    </div>
                 </div>
 
                 {!byok ? (
@@ -171,8 +186,9 @@ export const TrialCreditsSummary = ({
                     <div className="bg-success/10 text-success flex items-start gap-2 rounded-lg p-3 text-sm">
                         <SparklesIcon className="mt-0.5 size-4 shrink-0" />
                         <p>
-                            BYOK is active. Reviews use your AI key and do not
-                            count against the PR reviews paid by Kodus.
+                            BYOK is active, so the 14-day Team trial controls
+                            feature access. PR review volume depends on your AI
+                            provider key.
                         </p>
                     </div>
                 )}
@@ -183,20 +199,20 @@ export const TrialCreditsSummary = ({
                     <div className="flex flex-col gap-1">
                         <div className="flex flex-wrap items-center gap-2">
                             <p className="text-text-primary text-sm font-semibold">
-                                Ways to extend this evaluation
+                                Trial extension tiers
                             </p>
                             <Badge size="xs" variant="helper">
-                                {getTrialTierLabel(trialCreditTier)}
+                                Current: {getTrialTierLabel(trialCreditTier)}
                             </Badge>
                         </div>
                         <p className="text-text-secondary text-xs">
-                            These steps can add more Kodus-paid PR reviews for
-                            qualified trials. BYOK is always available and uses
-                            your own AI key.
+                            These steps can unlock more Kodus-paid PR reviews
+                            for qualified trials. BYOK stays available even when
+                            the Kodus-paid reviews run out.
                         </p>
                     </div>
 
-                    <div className="grid grid-cols-1 gap-x-6 gap-y-4 lg:grid-cols-2">
+                    <div className="grid grid-cols-1 gap-x-6 gap-y-4">
                         {unlocks.map((unlock) => (
                             <TrialTierItem key={unlock.key} unlock={unlock} />
                         ))}

--- a/apps/web/src/features/ee/subscription/_components/trial-credits-summary.tsx
+++ b/apps/web/src/features/ee/subscription/_components/trial-credits-summary.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import type { ComponentProps, ElementType } from "react";
+import { Badge } from "@components/ui/badge";
 import { Button } from "@components/ui/button";
 import { Link } from "@components/ui/link";
 import { Progress } from "@components/ui/progress";
@@ -11,12 +13,91 @@ import type {
     TrialReviewCredits,
     TrialUnlock,
 } from "../_services/billing/types";
-import { getTrialCreditBalance } from "../_utils/trial";
+import {
+    getTrialCreditBalance,
+    getTrialTierLabel,
+    getTrialUnlocks,
+    type TrialUnlockViewModel,
+} from "../_utils/trial";
+
+const unlockIconByKey: Record<string, ElementType> = {
+    team_setup: SparklesIcon,
+    multi_author_review: GitPullRequestIcon,
+    byok: KeyRoundIcon,
+    referral: SparklesIcon,
+    manual: SparklesIcon,
+};
+
+const statusLabelByStatus: Record<string, string> = {
+    locked: "Locked",
+    available: "Available",
+    completed: "Done",
+    claimed: "Done",
+};
+
+const statusVariantByStatus: Record<
+    string,
+    ComponentProps<typeof Badge>["variant"]
+> = {
+    locked: "helper",
+    available: "tertiary",
+    completed: "success",
+    claimed: "success",
+};
+
+const TrialTierItem = ({ unlock }: { unlock: TrialUnlockViewModel }) => {
+    const Icon = unlockIconByKey[unlock.key] ?? SparklesIcon;
+    const isAvailable = unlock.status === "available";
+    const isDone = unlock.status === "completed" || unlock.status === "claimed";
+    const statusLabel = statusLabelByStatus[unlock.status] ?? "Available";
+    const statusVariant = statusVariantByStatus[unlock.status] ?? "helper";
+
+    return (
+        <div className="flex items-start gap-3">
+            <Icon className="text-primary-light mt-0.5 size-4 shrink-0" />
+            <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                    <p className="text-text-primary text-sm font-semibold">
+                        {unlock.title}
+                    </p>
+                    <Badge size="xs" variant={statusVariant}>
+                        {statusLabel}
+                    </Badge>
+                    <span className="text-primary-light text-xs font-semibold">
+                        {unlock.rewardLabel}
+                    </span>
+                </div>
+                <p className="text-text-secondary mt-1 text-xs">
+                    {unlock.description}
+                </p>
+
+                {unlock.href && isAvailable && !isDone && (
+                    <Link
+                        href={unlock.href}
+                        className="mt-2 inline-flex"
+                        noHoverUnderline>
+                        <Button decorative size="xs" variant="tertiary">
+                            {unlock.key === "byok"
+                                ? "Configure BYOK"
+                                : unlock.key === "referral"
+                                  ? "Refer a team"
+                                  : "Open setup"}
+                        </Button>
+                    </Link>
+                )}
+            </div>
+        </div>
+    );
+};
 
 export const TrialCreditsSummary = ({
     credits,
+    trialCreditTier,
+    trialUnlocks,
     byok,
     daysLeft,
+    workspaceMembersCount,
+    codeHostMembersCount,
     compact = false,
 }: {
     credits?: TrialReviewCredits;
@@ -29,6 +110,12 @@ export const TrialCreditsSummary = ({
     compact?: boolean;
 }) => {
     const balance = getTrialCreditBalance(credits);
+    const unlocks = getTrialUnlocks({
+        billingUnlocks: trialUnlocks,
+        byok,
+        workspaceMembersCount,
+        codeHostMembersCount,
+    });
     const remainingLabel = `${balance.remaining} of ${balance.total}`;
     const daysLeftLabel =
         typeof daysLeft === "number"
@@ -93,59 +180,26 @@ export const TrialCreditsSummary = ({
 
             {!compact && (
                 <div className="border-card-lv3 flex flex-col gap-3 border-t pt-4">
-                    <p className="text-text-primary text-sm font-semibold">
-                        Need more reviews?
-                    </p>
-
-                    <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
-                        <div className="flex items-start gap-3">
-                            <KeyRoundIcon className="text-primary-light mt-0.5 size-4 shrink-0" />
-                            <div className="min-w-0">
-                                <p className="text-text-primary text-sm font-semibold">
-                                    Connect BYOK
-                                </p>
-                                <p className="text-text-secondary mt-1 text-xs">
-                                    Reviews use your own AI key, so they do not
-                                    use the {balance.total} PR reviews paid by
-                                    Kodus.
-                                </p>
-                                <Link
-                                    href="/organization/byok"
-                                    className="mt-2 inline-flex"
-                                    noHoverUnderline>
-                                    <Button
-                                        decorative
-                                        size="xs"
-                                        variant="tertiary">
-                                        Configure BYOK
-                                    </Button>
-                                </Link>
-                            </div>
+                    <div className="flex flex-col gap-1">
+                        <div className="flex flex-wrap items-center gap-2">
+                            <p className="text-text-primary text-sm font-semibold">
+                                Ways to extend this evaluation
+                            </p>
+                            <Badge size="xs" variant="helper">
+                                {getTrialTierLabel(trialCreditTier)}
+                            </Badge>
                         </div>
+                        <p className="text-text-secondary text-xs">
+                            These steps can add more Kodus-paid PR reviews for
+                            qualified trials. BYOK is always available and uses
+                            your own AI key.
+                        </p>
+                    </div>
 
-                        <div className="flex items-start gap-3">
-                            <GitPullRequestIcon className="text-primary-light mt-0.5 size-4 shrink-0" />
-                            <div className="min-w-0">
-                                <p className="text-text-primary text-sm font-semibold">
-                                    Upgrade
-                                </p>
-                                <p className="text-text-secondary mt-1 text-xs">
-                                    Keep Kodus-managed PR reviews running after
-                                    the trial allowance ends.
-                                </p>
-                                <Link
-                                    href="/choose-plan"
-                                    className="mt-2 inline-flex"
-                                    noHoverUnderline>
-                                    <Button
-                                        decorative
-                                        size="xs"
-                                        variant="helper">
-                                        View plans
-                                    </Button>
-                                </Link>
-                            </div>
-                        </div>
+                    <div className="grid grid-cols-1 gap-x-6 gap-y-4 lg:grid-cols-2">
+                        {unlocks.map((unlock) => (
+                            <TrialTierItem key={unlock.key} unlock={unlock} />
+                        ))}
                     </div>
                 </div>
             )}

--- a/apps/web/src/features/ee/subscription/_components/trial-credits-summary.tsx
+++ b/apps/web/src/features/ee/subscription/_components/trial-credits-summary.tsx
@@ -146,8 +146,8 @@ export const TrialCreditsSummary = ({
         codeHostMembersCount,
     });
     const liveBalanceLabel = balance.hasLiveData
-        ? `${balance.remaining} of ${balance.total} included PR reviews left`
-        : `${balance.total} PR reviews included in your trial`;
+        ? `${balance.remaining} of ${balance.total} PR reviews paid by Kodus left`
+        : `First ${balance.total} PR reviews are on Kodus`;
 
     return (
         <section className="flex flex-col gap-4">
@@ -197,9 +197,9 @@ export const TrialCreditsSummary = ({
 
                     <p className="text-text-tertiary mt-2 text-xs">
                         {byok
-                            ? "BYOK reviews use your AI key and do not count against your included PR reviews."
+                            ? "BYOK reviews use your AI key and do not count against the PR reviews paid by Kodus."
                             : balance.hasLiveData
-                              ? "Kodus covers the AI cost for each included PR review until the included reviews run out."
+                              ? "After these PR reviews run out, connect BYOK or upgrade to keep reviewing PRs."
                               : "Live PR review usage appears here once billing data is available."}
                     </p>
                 </div>

--- a/apps/web/src/features/ee/subscription/_components/trial-credits-summary.tsx
+++ b/apps/web/src/features/ee/subscription/_components/trial-credits-summary.tsx
@@ -27,6 +27,7 @@ import type {
     TrialUnlock,
 } from "../_services/billing/types";
 import {
+    getTrialCardState,
     getTrialCreditBalance,
     getTrialUnlocks,
     type TrialUnlockViewModel,
@@ -134,7 +135,9 @@ export const TrialCreditsSummary = ({
     // Legacy trials (started before the credit model shipped) have no live
     // credit data — they keep the old "unlimited during the trial" behavior.
     // The credit UI only shows for trials that actually carry credits.
-    const showCredits = !byok && balance.hasLiveData;
+    const showCredits =
+        getTrialCardState({ byok, hasCredits: balance.hasLiveData }) ===
+        "credits";
     const trialReviewCopy = byok
         ? "Unlimited reviews — they run on your key."
         : showCredits
@@ -219,7 +222,13 @@ export const TrialCreditsSummary = ({
                             best quality.
                         </p>
                     </div>
-                ) : null}
+                ) : (
+                    <p className="text-text-tertiary text-xs">
+                        Trial reviews run on a model we pick for you. Connect
+                        your own key to run frontier models for the best
+                        quality.
+                    </p>
+                )}
             </div>
 
             {!compact && showCredits && sortedUnlocks.length > 0 && (

--- a/apps/web/src/features/ee/subscription/_components/trial-credits-summary.tsx
+++ b/apps/web/src/features/ee/subscription/_components/trial-credits-summary.tsx
@@ -146,8 +146,8 @@ export const TrialCreditsSummary = ({
         codeHostMembersCount,
     });
     const liveBalanceLabel = balance.hasLiveData
-        ? `${balance.remaining} of ${balance.total} managed AI PR reviews remaining`
-        : `${balance.total} managed AI PR reviews included`;
+        ? `${balance.remaining} of ${balance.total} Kodus review credits left`
+        : `${balance.total} PR reviews included with Kodus credits`;
 
     return (
         <section className="flex flex-col gap-4">
@@ -197,10 +197,10 @@ export const TrialCreditsSummary = ({
 
                     <p className="text-text-tertiary mt-2 text-xs">
                         {byok
-                            ? "BYOK reviews do not consume Kodus managed trial credits."
+                            ? "BYOK reviews use your AI key and do not spend Kodus trial credits."
                             : balance.hasLiveData
-                              ? "Billing tracks credit usage before managed AI review execution."
-                              : "Live credit balance appears here once billing returns trial credit data."}
+                              ? "Kodus credits cover the AI cost for each review until they run out."
+                              : "Live credit balance appears here once trial credit data is available."}
                     </p>
                 </div>
             </div>
@@ -212,7 +212,7 @@ export const TrialCreditsSummary = ({
                             Unlock more evaluation capacity
                         </p>
                         <span className="text-text-tertiary text-xs">
-                            Billing confirms and grants credits
+                            Credits unlock automatically
                         </span>
                     </div>
 

--- a/apps/web/src/features/ee/subscription/_components/trial-credits-summary.tsx
+++ b/apps/web/src/features/ee/subscription/_components/trial-credits-summary.tsx
@@ -5,7 +5,14 @@ import { Badge } from "@components/ui/badge";
 import { Button } from "@components/ui/button";
 import { Link } from "@components/ui/link";
 import { Progress } from "@components/ui/progress";
-import { GitPullRequestIcon, KeyRoundIcon, SparklesIcon } from "lucide-react";
+import {
+    Building2Icon,
+    GitPullRequestIcon,
+    KeyRoundIcon,
+    MailCheckIcon,
+    SparklesIcon,
+    UsersIcon,
+} from "lucide-react";
 
 import { TRIAL_DAYS } from "../_constants/trial";
 import type {
@@ -21,11 +28,11 @@ import {
 } from "../_utils/trial";
 
 const unlockIconByKey: Record<string, ElementType> = {
-    team_setup: SparklesIcon,
-    multi_author_review: GitPullRequestIcon,
+    company_email: MailCheckIcon,
+    team_setup: UsersIcon,
+    code_org_10_plus: Building2Icon,
     byok: KeyRoundIcon,
-    referral: SparklesIcon,
-    manual: SparklesIcon,
+    manual_extension: GitPullRequestIcon,
 };
 
 const statusLabelByStatus: Record<string, string> = {
@@ -71,8 +78,8 @@ const TrialTierItem = ({ unlock }: { unlock: TrialUnlockViewModel }) => {
                         <Button decorative size="xs" variant="tertiary">
                             {unlock.key === "byok"
                                 ? "Configure BYOK"
-                                : unlock.key === "referral"
-                                  ? "Refer a team"
+                                : unlock.key === "manual_extension"
+                                  ? "Request review"
                                   : "Open setup"}
                         </Button>
                     </Link>
@@ -206,9 +213,9 @@ export const TrialCreditsSummary = ({
                             </Badge>
                         </div>
                         <p className="text-text-secondary text-xs">
-                            These steps can unlock more Kodus-paid PR reviews
-                            for qualified trials. BYOK stays available even when
-                            the Kodus-paid reviews run out.
+                            Automatic signals add more Kodus-paid PR reviews
+                            once. BYOK stays available and does not use these PR
+                            reviews.
                         </p>
                     </div>
 

--- a/apps/web/src/features/ee/subscription/_components/trial-credits-summary.tsx
+++ b/apps/web/src/features/ee/subscription/_components/trial-credits-summary.tsx
@@ -1,21 +1,9 @@
 "use client";
 
-import type { ComponentProps, ElementType } from "react";
-import { Badge } from "@components/ui/badge";
 import { Button } from "@components/ui/button";
 import { Link } from "@components/ui/link";
 import { Progress } from "@components/ui/progress";
-import {
-    Building2Icon,
-    CheckCircle2Icon,
-    CircleIcon,
-    GitPullRequestIcon,
-    KeyRoundIcon,
-    LockIcon,
-    MailPlusIcon,
-    UsersIcon,
-} from "lucide-react";
-import { cn } from "src/core/utils/components";
+import { GitPullRequestIcon, KeyRoundIcon, SparklesIcon } from "lucide-react";
 
 import { TRIAL_DAYS } from "../_constants/trial";
 import type {
@@ -23,110 +11,12 @@ import type {
     TrialReviewCredits,
     TrialUnlock,
 } from "../_services/billing/types";
-import {
-    getTrialCreditBalance,
-    getTrialTierLabel,
-    getTrialUnlocks,
-    type TrialUnlockViewModel,
-} from "../_utils/trial";
-
-const unlockIconByKey: Record<string, ElementType> = {
-    team_setup: UsersIcon,
-    multi_author_review: GitPullRequestIcon,
-    byok: KeyRoundIcon,
-    referral: Building2Icon,
-    manual: MailPlusIcon,
-};
-
-const statusLabelByStatus: Record<string, string> = {
-    locked: "Locked",
-    available: "Available",
-    completed: "Done",
-    claimed: "Done",
-};
-
-const statusVariantByStatus: Record<
-    string,
-    ComponentProps<typeof Badge>["variant"]
-> = {
-    locked: "helper",
-    available: "tertiary",
-    completed: "success",
-    claimed: "success",
-};
-
-const TrialUnlockItem = ({ unlock }: { unlock: TrialUnlockViewModel }) => {
-    const Icon = unlockIconByKey[unlock.key] ?? CircleIcon;
-    const isDone = unlock.status === "completed" || unlock.status === "claimed";
-    const isLocked = unlock.status === "locked";
-    const statusLabel = statusLabelByStatus[unlock.status] ?? "Available";
-    const statusVariant = statusVariantByStatus[unlock.status] ?? "helper";
-
-    return (
-        <div className="border-card-lv3/70 flex items-start gap-3 rounded-lg border p-3">
-            <div
-                className={cn(
-                    "mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg",
-                    isDone
-                        ? "bg-success/15 text-success"
-                        : "bg-card-lv2 text-text-secondary",
-                )}>
-                {isDone ? (
-                    <CheckCircle2Icon className="size-4" />
-                ) : isLocked ? (
-                    <LockIcon className="size-4" />
-                ) : (
-                    <Icon className="size-4" />
-                )}
-            </div>
-
-            <div className="min-w-0 flex-1">
-                <div className="flex flex-wrap items-center gap-2">
-                    <p className="text-text-primary text-sm font-semibold">
-                        {unlock.title}
-                    </p>
-                    <Badge size="xs" variant={statusVariant}>
-                        {statusLabel}
-                    </Badge>
-                    <span className="text-primary-light text-xs font-semibold">
-                        {unlock.rewardLabel}
-                    </span>
-                </div>
-
-                <p className="text-text-secondary mt-1 text-xs">
-                    {unlock.description}
-                </p>
-
-                {unlock.href && !isDone && (
-                    <Link
-                        href={unlock.href}
-                        className="mt-2 inline-flex"
-                        noHoverUnderline>
-                        <Button
-                            decorative
-                            size="xs"
-                            variant={isLocked ? "helper" : "tertiary"}>
-                            {unlock.key === "referral"
-                                ? "Refer a team"
-                                : unlock.key === "byok"
-                                  ? "Configure BYOK"
-                                  : "Open setup"}
-                        </Button>
-                    </Link>
-                )}
-            </div>
-        </div>
-    );
-};
+import { getTrialCreditBalance } from "../_utils/trial";
 
 export const TrialCreditsSummary = ({
     credits,
-    trialCreditTier,
-    trialUnlocks,
     byok,
     daysLeft,
-    workspaceMembersCount,
-    codeHostMembersCount,
     compact = false,
 }: {
     credits?: TrialReviewCredits;
@@ -139,53 +29,49 @@ export const TrialCreditsSummary = ({
     compact?: boolean;
 }) => {
     const balance = getTrialCreditBalance(credits);
-    const unlocks = getTrialUnlocks({
-        billingUnlocks: trialUnlocks,
-        byok,
-        workspaceMembersCount,
-        codeHostMembersCount,
-    });
-    const liveBalanceLabel = balance.hasLiveData
-        ? `${balance.remaining} of ${balance.total} PR reviews paid by Kodus left`
-        : `First ${balance.total} PR reviews are on Kodus`;
+    const remainingLabel = `${balance.remaining} of ${balance.total}`;
+    const daysLeftLabel =
+        typeof daysLeft === "number"
+            ? `${daysLeft} days left in your Team trial`
+            : `${TRIAL_DAYS}-day Team trial`;
 
     return (
-        <section className="flex flex-col gap-4">
+        <section className="flex flex-col gap-5">
             <div className="flex flex-col gap-3">
-                <div className="flex flex-wrap items-center gap-2">
-                    <Badge size="xs" variant="primary-dark">
-                        {getTrialTierLabel(trialCreditTier)}
-                    </Badge>
-                    <Badge size="xs" variant="helper">
-                        {TRIAL_DAYS}-day Team trial
-                    </Badge>
-                    {typeof daysLeft === "number" && (
-                        <Badge size="xs" variant="helper">
-                            {daysLeft} days left
-                        </Badge>
-                    )}
-                    {byok && (
-                        <Badge size="xs" variant="success">
-                            BYOK active
-                        </Badge>
-                    )}
-                </div>
-
-                <div>
-                    <div className="mb-2 flex items-center justify-between gap-4 text-sm">
-                        <p className="text-text-primary font-semibold">
-                            {byok
-                                ? "Reviews use your AI key"
-                                : liveBalanceLabel}
+                <div className="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
+                    <div>
+                        <p className="text-text-primary text-base font-semibold">
+                            Kodus pays for your first {balance.total} PR reviews
                         </p>
-                        {!byok && balance.hasLiveData && (
-                            <p className="text-text-tertiary text-xs">
-                                {balance.used} used
-                            </p>
-                        )}
+                        <p className="text-text-secondary mt-1 text-sm">
+                            {daysLeftLabel}. After the {balance.total} reviews,
+                            connect BYOK or upgrade to keep reviewing PRs.
+                        </p>
                     </div>
 
                     {!byok && (
+                        <div className="text-left md:text-right">
+                            <p className="text-text-primary text-xl font-semibold">
+                                {remainingLabel}
+                            </p>
+                            <p className="text-text-tertiary text-xs">
+                                Kodus-paid reviews left
+                            </p>
+                        </div>
+                    )}
+                </div>
+
+                {!byok ? (
+                    <div>
+                        <div className="mb-2 flex items-center justify-between gap-4 text-sm">
+                            <p className="text-text-secondary text-xs">
+                                {balance.used} used
+                            </p>
+                            <p className="text-text-secondary text-xs">
+                                {balance.total} total
+                            </p>
+                        </div>
+
                         <Progress
                             value={balance.used}
                             max={balance.total}
@@ -193,33 +79,73 @@ export const TrialCreditsSummary = ({
                                 balance.remaining === 0 ? "tertiary" : "primary"
                             }
                         />
-                    )}
-
-                    <p className="text-text-tertiary mt-2 text-xs">
-                        {byok
-                            ? "BYOK reviews use your AI key and do not count against the PR reviews paid by Kodus."
-                            : balance.hasLiveData
-                              ? "After these PR reviews run out, connect BYOK or upgrade to keep reviewing PRs."
-                              : "Live PR review usage appears here once billing data is available."}
-                    </p>
-                </div>
+                    </div>
+                ) : (
+                    <div className="bg-success/10 text-success flex items-start gap-2 rounded-lg p-3 text-sm">
+                        <SparklesIcon className="mt-0.5 size-4 shrink-0" />
+                        <p>
+                            BYOK is active. Reviews use your AI key and do not
+                            count against the PR reviews paid by Kodus.
+                        </p>
+                    </div>
+                )}
             </div>
 
             {!compact && (
-                <div className="flex flex-col gap-2">
-                    <div className="flex items-center justify-between gap-4">
-                        <p className="text-text-primary text-sm font-semibold">
-                            Unlock more trial PR reviews
-                        </p>
-                        <span className="text-text-tertiary text-xs">
-                            Adds apply automatically
-                        </span>
-                    </div>
+                <div className="border-card-lv3 flex flex-col gap-3 border-t pt-4">
+                    <p className="text-text-primary text-sm font-semibold">
+                        Need more reviews?
+                    </p>
 
-                    <div className="grid grid-cols-1 gap-2 xl:grid-cols-2">
-                        {unlocks.map((unlock) => (
-                            <TrialUnlockItem key={unlock.key} unlock={unlock} />
-                        ))}
+                    <div className="grid grid-cols-1 gap-3 lg:grid-cols-2">
+                        <div className="flex items-start gap-3">
+                            <KeyRoundIcon className="text-primary-light mt-0.5 size-4 shrink-0" />
+                            <div className="min-w-0">
+                                <p className="text-text-primary text-sm font-semibold">
+                                    Connect BYOK
+                                </p>
+                                <p className="text-text-secondary mt-1 text-xs">
+                                    Reviews use your own AI key, so they do not
+                                    use the {balance.total} PR reviews paid by
+                                    Kodus.
+                                </p>
+                                <Link
+                                    href="/organization/byok"
+                                    className="mt-2 inline-flex"
+                                    noHoverUnderline>
+                                    <Button
+                                        decorative
+                                        size="xs"
+                                        variant="tertiary">
+                                        Configure BYOK
+                                    </Button>
+                                </Link>
+                            </div>
+                        </div>
+
+                        <div className="flex items-start gap-3">
+                            <GitPullRequestIcon className="text-primary-light mt-0.5 size-4 shrink-0" />
+                            <div className="min-w-0">
+                                <p className="text-text-primary text-sm font-semibold">
+                                    Upgrade
+                                </p>
+                                <p className="text-text-secondary mt-1 text-xs">
+                                    Keep Kodus-managed PR reviews running after
+                                    the trial allowance ends.
+                                </p>
+                                <Link
+                                    href="/choose-plan"
+                                    className="mt-2 inline-flex"
+                                    noHoverUnderline>
+                                    <Button
+                                        decorative
+                                        size="xs"
+                                        variant="helper">
+                                        View plans
+                                    </Button>
+                                </Link>
+                            </div>
+                        </div>
                     </div>
                 </div>
             )}

--- a/apps/web/src/features/ee/subscription/_components/trial-credits-summary.tsx
+++ b/apps/web/src/features/ee/subscription/_components/trial-credits-summary.tsx
@@ -1,0 +1,228 @@
+"use client";
+
+import type { ComponentProps, ElementType } from "react";
+import { Badge } from "@components/ui/badge";
+import { Button } from "@components/ui/button";
+import { Link } from "@components/ui/link";
+import { Progress } from "@components/ui/progress";
+import {
+    Building2Icon,
+    CheckCircle2Icon,
+    CircleIcon,
+    GitPullRequestIcon,
+    KeyRoundIcon,
+    LockIcon,
+    MailPlusIcon,
+    UsersIcon,
+} from "lucide-react";
+import { cn } from "src/core/utils/components";
+
+import { TRIAL_DAYS } from "../_constants/trial";
+import type {
+    TrialCreditTier,
+    TrialReviewCredits,
+    TrialUnlock,
+} from "../_services/billing/types";
+import {
+    getTrialCreditBalance,
+    getTrialTierLabel,
+    getTrialUnlocks,
+    type TrialUnlockViewModel,
+} from "../_utils/trial";
+
+const unlockIconByKey: Record<string, ElementType> = {
+    team_setup: UsersIcon,
+    multi_author_review: GitPullRequestIcon,
+    byok: KeyRoundIcon,
+    referral: Building2Icon,
+    manual: MailPlusIcon,
+};
+
+const statusLabelByStatus: Record<string, string> = {
+    locked: "Locked",
+    available: "Available",
+    completed: "Done",
+    claimed: "Done",
+};
+
+const statusVariantByStatus: Record<
+    string,
+    ComponentProps<typeof Badge>["variant"]
+> = {
+    locked: "helper",
+    available: "tertiary",
+    completed: "success",
+    claimed: "success",
+};
+
+const TrialUnlockItem = ({ unlock }: { unlock: TrialUnlockViewModel }) => {
+    const Icon = unlockIconByKey[unlock.key] ?? CircleIcon;
+    const isDone = unlock.status === "completed" || unlock.status === "claimed";
+    const isLocked = unlock.status === "locked";
+    const statusLabel = statusLabelByStatus[unlock.status] ?? "Available";
+    const statusVariant = statusVariantByStatus[unlock.status] ?? "helper";
+
+    return (
+        <div className="border-card-lv3/70 flex items-start gap-3 rounded-lg border p-3">
+            <div
+                className={cn(
+                    "mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-lg",
+                    isDone
+                        ? "bg-success/15 text-success"
+                        : "bg-card-lv2 text-text-secondary",
+                )}>
+                {isDone ? (
+                    <CheckCircle2Icon className="size-4" />
+                ) : isLocked ? (
+                    <LockIcon className="size-4" />
+                ) : (
+                    <Icon className="size-4" />
+                )}
+            </div>
+
+            <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center gap-2">
+                    <p className="text-text-primary text-sm font-semibold">
+                        {unlock.title}
+                    </p>
+                    <Badge size="xs" variant={statusVariant}>
+                        {statusLabel}
+                    </Badge>
+                    <span className="text-primary-light text-xs font-semibold">
+                        {unlock.rewardLabel}
+                    </span>
+                </div>
+
+                <p className="text-text-secondary mt-1 text-xs">
+                    {unlock.description}
+                </p>
+
+                {unlock.href && !isDone && (
+                    <Link
+                        href={unlock.href}
+                        className="mt-2 inline-flex"
+                        noHoverUnderline>
+                        <Button
+                            decorative
+                            size="xs"
+                            variant={isLocked ? "helper" : "tertiary"}>
+                            {unlock.key === "referral"
+                                ? "Refer a team"
+                                : unlock.key === "byok"
+                                  ? "Configure BYOK"
+                                  : "Open setup"}
+                        </Button>
+                    </Link>
+                )}
+            </div>
+        </div>
+    );
+};
+
+export const TrialCreditsSummary = ({
+    credits,
+    trialCreditTier,
+    trialUnlocks,
+    byok,
+    daysLeft,
+    workspaceMembersCount,
+    codeHostMembersCount,
+    compact = false,
+}: {
+    credits?: TrialReviewCredits;
+    trialCreditTier?: TrialCreditTier;
+    trialUnlocks?: TrialUnlock[];
+    byok?: boolean;
+    daysLeft?: number;
+    workspaceMembersCount?: number;
+    codeHostMembersCount?: number;
+    compact?: boolean;
+}) => {
+    const balance = getTrialCreditBalance(credits);
+    const unlocks = getTrialUnlocks({
+        billingUnlocks: trialUnlocks,
+        byok,
+        workspaceMembersCount,
+        codeHostMembersCount,
+    });
+    const liveBalanceLabel = balance.hasLiveData
+        ? `${balance.remaining} of ${balance.total} managed AI PR reviews remaining`
+        : `${balance.total} managed AI PR reviews included`;
+
+    return (
+        <section className="flex flex-col gap-4">
+            <div className="flex flex-col gap-3">
+                <div className="flex flex-wrap items-center gap-2">
+                    <Badge size="xs" variant="primary-dark">
+                        {getTrialTierLabel(trialCreditTier)}
+                    </Badge>
+                    <Badge size="xs" variant="helper">
+                        {TRIAL_DAYS}-day Team trial
+                    </Badge>
+                    {typeof daysLeft === "number" && (
+                        <Badge size="xs" variant="helper">
+                            {daysLeft} days left
+                        </Badge>
+                    )}
+                    {byok && (
+                        <Badge size="xs" variant="success">
+                            BYOK active
+                        </Badge>
+                    )}
+                </div>
+
+                <div>
+                    <div className="mb-2 flex items-center justify-between gap-4 text-sm">
+                        <p className="text-text-primary font-semibold">
+                            {byok
+                                ? "Reviews use your AI key"
+                                : liveBalanceLabel}
+                        </p>
+                        {!byok && balance.hasLiveData && (
+                            <p className="text-text-tertiary text-xs">
+                                {balance.used} used
+                            </p>
+                        )}
+                    </div>
+
+                    {!byok && (
+                        <Progress
+                            value={balance.used}
+                            max={balance.total}
+                            variant={
+                                balance.remaining === 0 ? "tertiary" : "primary"
+                            }
+                        />
+                    )}
+
+                    <p className="text-text-tertiary mt-2 text-xs">
+                        {byok
+                            ? "BYOK reviews do not consume Kodus managed trial credits."
+                            : balance.hasLiveData
+                              ? "Billing tracks credit usage before managed AI review execution."
+                              : "Live credit balance appears here once billing returns trial credit data."}
+                    </p>
+                </div>
+            </div>
+
+            {!compact && (
+                <div className="flex flex-col gap-2">
+                    <div className="flex items-center justify-between gap-4">
+                        <p className="text-text-primary text-sm font-semibold">
+                            Unlock more evaluation capacity
+                        </p>
+                        <span className="text-text-tertiary text-xs">
+                            Billing confirms and grants credits
+                        </span>
+                    </div>
+
+                    <div className="grid grid-cols-1 gap-2 xl:grid-cols-2">
+                        {unlocks.map((unlock) => (
+                            <TrialUnlockItem key={unlock.key} unlock={unlock} />
+                        ))}
+                    </div>
+                </div>
+            )}
+        </section>
+    );
+};

--- a/apps/web/src/features/ee/subscription/_components/trial-credits-summary.tsx
+++ b/apps/web/src/features/ee/subscription/_components/trial-credits-summary.tsx
@@ -146,8 +146,8 @@ export const TrialCreditsSummary = ({
         codeHostMembersCount,
     });
     const liveBalanceLabel = balance.hasLiveData
-        ? `${balance.remaining} of ${balance.total} Kodus review credits left`
-        : `${balance.total} PR reviews included with Kodus credits`;
+        ? `${balance.remaining} of ${balance.total} included PR reviews left`
+        : `${balance.total} PR reviews included in your trial`;
 
     return (
         <section className="flex flex-col gap-4">
@@ -197,10 +197,10 @@ export const TrialCreditsSummary = ({
 
                     <p className="text-text-tertiary mt-2 text-xs">
                         {byok
-                            ? "BYOK reviews use your AI key and do not spend Kodus trial credits."
+                            ? "BYOK reviews use your AI key and do not count against your included PR reviews."
                             : balance.hasLiveData
-                              ? "Kodus credits cover the AI cost for each review until they run out."
-                              : "Live credit balance appears here once trial credit data is available."}
+                              ? "Kodus covers the AI cost for each included PR review until the included reviews run out."
+                              : "Live PR review usage appears here once billing data is available."}
                     </p>
                 </div>
             </div>
@@ -209,10 +209,10 @@ export const TrialCreditsSummary = ({
                 <div className="flex flex-col gap-2">
                     <div className="flex items-center justify-between gap-4">
                         <p className="text-text-primary text-sm font-semibold">
-                            Unlock more evaluation capacity
+                            Unlock more trial PR reviews
                         </p>
                         <span className="text-text-tertiary text-xs">
-                            Credits unlock automatically
+                            Adds apply automatically
                         </span>
                     </div>
 

--- a/apps/web/src/features/ee/subscription/_components/trial-credits-summary.tsx
+++ b/apps/web/src/features/ee/subscription/_components/trial-credits-summary.tsx
@@ -1,12 +1,18 @@
 "use client";
 
-import type { ComponentProps, ElementType } from "react";
-import { Badge } from "@components/ui/badge";
+import type { ElementType } from "react";
 import { Button } from "@components/ui/button";
 import { Link } from "@components/ui/link";
 import { Progress } from "@components/ui/progress";
 import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from "@components/ui/tooltip";
+import {
     Building2Icon,
+    CheckIcon,
     GitPullRequestIcon,
     KeyRoundIcon,
     MailCheckIcon,
@@ -22,10 +28,10 @@ import type {
 } from "../_services/billing/types";
 import {
     getTrialCreditBalance,
-    getTrialTierLabel,
     getTrialUnlocks,
     type TrialUnlockViewModel,
 } from "../_utils/trial";
+import { RequestExtensionPopover } from "./request-extension-popover";
 
 const unlockIconByKey: Record<string, ElementType> = {
     company_email: MailCheckIcon,
@@ -35,74 +41,66 @@ const unlockIconByKey: Record<string, ElementType> = {
     manual_extension: GitPullRequestIcon,
 };
 
-const statusLabelByStatus: Record<string, string> = {
-    locked: "Locked",
-    available: "Available",
-    completed: "Done",
-    claimed: "Done",
-};
+const isDoneStatus = (status: TrialUnlockViewModel["status"]) =>
+    status === "completed" || status === "claimed";
 
-const statusVariantByStatus: Record<
-    string,
-    ComponentProps<typeof Badge>["variant"]
-> = {
-    locked: "helper",
-    available: "tertiary",
-    completed: "success",
-    claimed: "success",
-};
-
-const TrialTierItem = ({ unlock }: { unlock: TrialUnlockViewModel }) => {
+const UnlockRow = ({ unlock }: { unlock: TrialUnlockViewModel }) => {
     const Icon = unlockIconByKey[unlock.key] ?? SparklesIcon;
-    const isAvailable = unlock.status === "available";
-    const isDone = unlock.status === "completed" || unlock.status === "claimed";
-    const statusLabel = statusLabelByStatus[unlock.status] ?? "Available";
-    const statusVariant = statusVariantByStatus[unlock.status] ?? "helper";
+    const done = isDoneStatus(unlock.status);
+
+    const cta = done ? (
+        <span className="text-success flex items-center gap-1 text-xs font-medium">
+            <CheckIcon className="size-3.5" />
+            Done
+        </span>
+    ) : unlock.kind === "signal" ? (
+        <span className="text-text-tertiary text-xs">
+            {unlock.pendingLabel ?? "Pending"}
+        </span>
+    ) : unlock.actionType === "request_extension" ? (
+        <RequestExtensionPopover triggerLabel={unlock.actionLabel} />
+    ) : unlock.href ? (
+        <Link href={unlock.href} noHoverUnderline>
+            <Button decorative size="xs" variant="helper">
+                {unlock.actionLabel ?? "Open"}
+            </Button>
+        </Link>
+    ) : null;
 
     return (
-        <div className="grid grid-cols-[auto_1fr] gap-3 md:grid-cols-[auto_1fr_auto]">
-            <Icon className="text-primary-light mt-0.5 size-4 shrink-0" />
+        <div className="flex items-center gap-3">
+            <Icon
+                className={`size-4 shrink-0 ${done ? "text-success" : "text-text-tertiary"}`}
+            />
             <div className="min-w-0 flex-1">
-                <p className="text-text-primary text-sm font-semibold">
-                    {unlock.title}
-                </p>
-                <p className="text-text-secondary mt-1 text-xs">
-                    {unlock.description}
-                </p>
-
-                {unlock.href && isAvailable && !isDone && (
-                    <Link
-                        href={unlock.href}
-                        className="mt-2 inline-flex"
-                        noHoverUnderline>
-                        <Button decorative size="xs" variant="tertiary">
-                            {unlock.key === "byok"
-                                ? "Configure BYOK"
-                                : unlock.key === "manual_extension"
-                                  ? "Request review"
-                                  : "Open setup"}
-                        </Button>
-                    </Link>
-                )}
+                <Tooltip>
+                    <TooltipTrigger asChild>
+                        <p className="text-text-primary w-fit cursor-help text-sm decoration-dotted underline-offset-4 hover:underline">
+                            {unlock.title}
+                            <span className="text-text-tertiary ml-2 text-xs">
+                                {unlock.rewardLabel}
+                            </span>
+                        </p>
+                    </TooltipTrigger>
+                    <TooltipContent
+                        side="top"
+                        align="start"
+                        className="max-w-xs text-xs">
+                        {unlock.description}
+                    </TooltipContent>
+                </Tooltip>
             </div>
-            <div className="col-start-2 flex flex-wrap items-center gap-2 md:col-start-auto md:justify-end">
-                <Badge size="xs" variant={statusVariant}>
-                    {statusLabel}
-                </Badge>
-                <span className="text-primary-light text-xs font-semibold">
-                    {unlock.rewardLabel}
-                </span>
-            </div>
+            <div className="flex shrink-0 items-center">{cta}</div>
         </div>
     );
 };
 
 export const TrialCreditsSummary = ({
     credits,
-    trialCreditTier,
     trialUnlocks,
     byok,
     daysLeft,
+    companyEmailVerified,
     workspaceMembersCount,
     codeHostMembersCount,
     compact = false,
@@ -112,6 +110,7 @@ export const TrialCreditsSummary = ({
     trialUnlocks?: TrialUnlock[];
     byok?: boolean;
     daysLeft?: number;
+    companyEmailVerified?: boolean;
     workspaceMembersCount?: number;
     codeHostMembersCount?: number;
     compact?: boolean;
@@ -120,49 +119,76 @@ export const TrialCreditsSummary = ({
     const unlocks = getTrialUnlocks({
         billingUnlocks: trialUnlocks,
         byok,
+        companyEmailVerified,
         workspaceMembersCount,
         codeHostMembersCount,
     });
+    // Actionable items first, automatic signals last; done items sink within
+    // their group so the next thing to do is always on top.
+    const sortedUnlocks = [...unlocks].sort((a, b) => {
+        const rank = (u: TrialUnlockViewModel) =>
+            (u.kind === "action" ? 0 : 2) + (isDoneStatus(u.status) ? 1 : 0);
+        return rank(a) - rank(b);
+    });
     const daysLeftValue = typeof daysLeft === "number" ? daysLeft : TRIAL_DAYS;
+    // Legacy trials (started before the credit model shipped) have no live
+    // credit data — they keep the old "unlimited during the trial" behavior.
+    // The credit UI only shows for trials that actually carry credits.
+    const showCredits = !byok && balance.hasLiveData;
     const trialReviewCopy = byok
-        ? "BYOK active. Reviews use your AI key."
-        : `${balance.remaining} of ${balance.total} Kodus-paid PR reviews left.`;
+        ? "Unlimited reviews — they run on your key."
+        : showCredits
+          ? `${balance.remaining} of ${balance.total} free reviews left while you try.`
+          : "Unlimited reviews during your trial.";
 
     return (
         <section className="flex flex-col gap-5">
             <div className="flex flex-col gap-3">
                 <div>
                     <p className="text-text-primary text-base font-semibold">
-                        Team trial status
+                        {byok
+                            ? "You're all set — reviews are unlimited"
+                            : showCredits
+                              ? "You're trying Kody for free"
+                              : "You're on a Team trial"}
                     </p>
                     <p className="text-text-secondary mt-1 text-sm">
-                        Your Team plan trial and Kodus-paid PR reviews are
-                        separate limits.
+                        {byok
+                            ? `Reviews run on your AI key, so there's no review limit. Your ${TRIAL_DAYS}-day trial just unlocks the full Team features.`
+                            : showCredits
+                              ? `Reviews run on your AI key — free and unlimited, on any plan. To let you start with zero setup, we cover your first ${balance.total} reviews. Add your key anytime to keep going.`
+                              : `Reviews are unlimited during your ${TRIAL_DAYS}-day trial. Connect your AI key anytime to keep them unlimited after it ends.`}
                     </p>
                 </div>
 
                 <div className="border-card-lv3 grid grid-cols-1 gap-4 border-y py-3 md:grid-cols-2">
                     <div>
                         <p className="text-text-tertiary text-xs font-semibold uppercase">
-                            Team plan access
+                            Team trial
                         </p>
                         <p className="text-text-primary mt-1 text-xl font-semibold">
                             {daysLeftValue} days
                         </p>
                         <p className="text-text-secondary mt-1 text-xs">
-                            Full Team features during the {TRIAL_DAYS}-day
-                            trial.
+                            Full Team features for {daysLeftValue} more days.
                         </p>
                     </div>
 
                     <div>
                         <p className="text-text-tertiary text-xs font-semibold uppercase">
-                            PR reviews paid by Kodus
-                        </p>
-                        <p className="text-text-primary mt-1 text-xl font-semibold">
                             {byok
-                                ? "BYOK"
-                                : `${balance.remaining} of ${balance.total}`}
+                                ? "Your AI key"
+                                : showCredits
+                                  ? "Reviews on us"
+                                  : "Reviews"}
+                        </p>
+                        <p
+                            className={`mt-1 text-xl font-semibold ${showCredits ? "text-text-primary" : "text-success"}`}>
+                            {byok
+                                ? "Connected"
+                                : showCredits
+                                  ? `${balance.remaining} of ${balance.total}`
+                                  : "Unlimited"}
                         </p>
                         <p className="text-text-secondary mt-1 text-xs">
                             {trialReviewCopy}
@@ -170,17 +196,16 @@ export const TrialCreditsSummary = ({
                     </div>
                 </div>
 
-                {!byok ? (
-                    <div>
-                        <div className="mb-2 flex items-center justify-between gap-4 text-sm">
-                            <p className="text-text-secondary text-xs">
-                                {balance.used} used
-                            </p>
-                            <p className="text-text-secondary text-xs">
-                                {balance.total} total
-                            </p>
-                        </div>
-
+                {byok ? (
+                    <div className="bg-success/10 text-success flex items-start gap-2 rounded-lg p-3 text-sm">
+                        <SparklesIcon className="mt-0.5 size-4 shrink-0" />
+                        <p>
+                            Your AI key is connected, so reviews are unlimited —
+                            on any plan, even after the trial ends.
+                        </p>
+                    </div>
+                ) : showCredits ? (
+                    <div className="flex flex-col gap-2">
                         <Progress
                             value={balance.used}
                             max={balance.total}
@@ -188,42 +213,34 @@ export const TrialCreditsSummary = ({
                                 balance.remaining === 0 ? "tertiary" : "primary"
                             }
                         />
-                    </div>
-                ) : (
-                    <div className="bg-success/10 text-success flex items-start gap-2 rounded-lg p-3 text-sm">
-                        <SparklesIcon className="mt-0.5 size-4 shrink-0" />
-                        <p>
-                            BYOK is active, so the 14-day Team trial controls
-                            feature access. PR review volume depends on your AI
-                            provider key.
+                        <p className="text-text-tertiary text-xs">
+                            Trial reviews run on a model we pick for you.
+                            Connect your own key to run frontier models for the
+                            best quality.
                         </p>
                     </div>
-                )}
+                ) : null}
             </div>
 
-            {!compact && (
+            {!compact && showCredits && sortedUnlocks.length > 0 && (
                 <div className="border-card-lv3 flex flex-col gap-3 border-t pt-4">
-                    <div className="flex flex-col gap-1">
-                        <div className="flex flex-wrap items-center gap-2">
-                            <p className="text-text-primary text-sm font-semibold">
-                                Trial extension tiers
-                            </p>
-                            <Badge size="xs" variant="helper">
-                                Current: {getTrialTierLabel(trialCreditTier)}
-                            </Badge>
-                        </div>
-                        <p className="text-text-secondary text-xs">
-                            Automatic signals add more Kodus-paid PR reviews
-                            once. BYOK stays available and does not use these PR
-                            reviews.
+                    <div>
+                        <p className="text-text-primary text-sm font-semibold">
+                            Keep reviews running
+                        </p>
+                        <p className="text-text-secondary mt-1 text-xs">
+                            Connect your AI key for unlimited reviews (free, any
+                            plan), or earn a few more trial reviews on us.
                         </p>
                     </div>
 
-                    <div className="grid grid-cols-1 gap-x-6 gap-y-4">
-                        {unlocks.map((unlock) => (
-                            <TrialTierItem key={unlock.key} unlock={unlock} />
-                        ))}
-                    </div>
+                    <TooltipProvider delayDuration={150}>
+                        <div className="flex flex-col gap-3.5">
+                            {sortedUnlocks.map((unlock) => (
+                                <UnlockRow key={unlock.key} unlock={unlock} />
+                            ))}
+                        </div>
+                    </TooltipProvider>
                 </div>
             )}
         </section>

--- a/apps/web/src/features/ee/subscription/_constants/trial.ts
+++ b/apps/web/src/features/ee/subscription/_constants/trial.ts
@@ -1,0 +1,6 @@
+export const TRIAL_DAYS = 14;
+export const TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED = 5;
+export const TRIAL_UNLOCK_TEAM_REWARD = 5;
+export const TRIAL_UNLOCK_MULTI_AUTHOR_REWARD = 5;
+export const TRIAL_UNLOCK_REFERRAL_REWARD = 5;
+export const TRIAL_UNLOCK_BYOK_REWARD_LABEL = "Unlimited with your key";

--- a/apps/web/src/features/ee/subscription/_constants/trial.ts
+++ b/apps/web/src/features/ee/subscription/_constants/trial.ts
@@ -1,6 +1,6 @@
 export const TRIAL_DAYS = 14;
 export const TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED = 5;
+export const TRIAL_UNLOCK_COMPANY_EMAIL_REWARD = 5;
 export const TRIAL_UNLOCK_TEAM_REWARD = 5;
-export const TRIAL_UNLOCK_MULTI_AUTHOR_REWARD = 5;
-export const TRIAL_UNLOCK_REFERRAL_REWARD = 5;
+export const TRIAL_UNLOCK_CODE_ORG_REWARD = 20;
 export const TRIAL_UNLOCK_BYOK_REWARD_LABEL = "Unlimited with your key";

--- a/apps/web/src/features/ee/subscription/_hooks/use-subscription-status.ts
+++ b/apps/web/src/features/ee/subscription/_hooks/use-subscription-status.ts
@@ -3,40 +3,32 @@
 import { differenceInDays } from "date-fns";
 
 import { useSubscriptionContext } from "../_providers/subscription-context";
-import type { PlanType } from "../_services/billing/types";
+import type {
+    OrganizationLicense,
+    OrganizationLicenseTrial,
+    PlanType,
+    TrialReviewCredits,
+    TrialUnlock,
+} from "../_services/billing/types";
 
-type SubscriptionContextLicense =
-    | {
-          valid: false;
-          subscriptionStatus: "payment_failed" | "canceled" | "expired";
-          numberOfLicenses: number;
-          planType?: PlanType;
-          stripeCustomerId?: string | null;
-      }
-    | {
-          valid: true;
-          subscriptionStatus: "trial";
-          trialEnd: string;
-      }
-    | {
-          valid: true;
-          subscriptionStatus: "active";
-          numberOfLicenses: number;
-          planType: PlanType;
-      };
+type SubscriptionContextLicense = OrganizationLicense;
 
 type TrialSubscriptionStatus = {
-    status: "trial-active" | "trial-expiring";
+    status: "trial-active" | "trial-expiring" | "trial-exhausted";
     valid: true;
     trialEnd: string;
     trialDaysLeft: number;
+    byok?: boolean;
+    trialReviewCredits?: TrialReviewCredits;
+    trialCreditTier?: OrganizationLicenseTrial["trialCreditTier"];
+    trialUnlocks?: TrialUnlock[];
 };
 
 type InvalidSubscriptionStatus = {
     valid: false;
     numberOfLicenses: number;
     usersWithAssignedLicense: { git_id: string }[];
-    status: "payment-failed" | "canceled" | "expired";
+    status: "payment-failed" | "canceled" | "expired" | "inactive";
     planType?: PlanType;
     stripeCustomerId?: string | null;
 };
@@ -79,6 +71,27 @@ type SubscriptionStatus =
     | SelfHostedSubscriptionStatus
     | LicensedSelfHostedSubscriptionStatus
     | FreeSubscriptionStatus;
+
+const getTrialReviewCredits = (
+    license: OrganizationLicenseTrial,
+): TrialReviewCredits | undefined => {
+    const hasCreditData =
+        typeof license.trialReviewCreditsTotal === "number" ||
+        typeof license.trialReviewCreditsUsed === "number" ||
+        typeof license.trialReviewCreditsRemaining === "number" ||
+        Boolean(license.trialCreditTier);
+
+    if (!hasCreditData) {
+        return undefined;
+    }
+
+    return {
+        total: license.trialReviewCreditsTotal,
+        used: license.trialReviewCreditsUsed,
+        remaining: license.trialReviewCreditsRemaining,
+        tier: license.trialCreditTier,
+    };
+};
 
 export const useSubscriptionStatus = (): SubscriptionStatus => {
     const subscription = useSubscriptionContext();
@@ -141,38 +154,59 @@ export const useSubscriptionStatus = (): SubscriptionStatus => {
         // Trial
         if (license.subscriptionStatus === "trial") {
             const daysLeft = differenceInDays(license.trialEnd, new Date());
+            const trialReviewCredits = getTrialReviewCredits(license);
+            const trialBase = {
+                valid: true as const,
+                trialEnd: license.trialEnd,
+                trialDaysLeft: daysLeft,
+                byok: license.byok,
+                trialReviewCredits,
+                trialCreditTier: license.trialCreditTier,
+                trialUnlocks: license.trialUnlocks,
+            };
+
+            if (license.byok !== true && trialReviewCredits?.remaining === 0) {
+                return {
+                    ...trialBase,
+                    status: "trial-exhausted",
+                };
+            }
 
             if (
                 // If the trial is not expired, but expiring in 3 days or less
                 differenceInDays(new Date(), license.trialEnd) >= -3
             ) {
                 return {
-                    valid: true,
-                    trialEnd: license.trialEnd,
-                    trialDaysLeft: daysLeft,
+                    ...trialBase,
                     status: "trial-expiring",
                 };
             }
 
             return {
-                valid: true,
-                trialEnd: license.trialEnd,
-                trialDaysLeft: daysLeft,
+                ...trialBase,
                 status: "trial-active",
             };
         }
     }
 
-    // Caso inválido
+    if (!license.valid) {
+        return {
+            valid: false,
+            numberOfLicenses: license.numberOfLicenses || 0,
+            status:
+                license.subscriptionStatus === "payment_failed"
+                    ? "payment-failed"
+                    : license.subscriptionStatus,
+            usersWithAssignedLicense: subscription.usersWithAssignedLicense,
+            planType: license.planType,
+            stripeCustomerId: license.stripeCustomerId,
+        };
+    }
+
     return {
         valid: false,
-        numberOfLicenses: (license as any).numberOfLicenses || 0,
-        status:
-            license.subscriptionStatus === "payment_failed"
-                ? "payment-failed"
-                : license.subscriptionStatus,
+        numberOfLicenses: 0,
+        status: "inactive",
         usersWithAssignedLicense: subscription.usersWithAssignedLicense,
-        planType: (license as any).planType,
-        stripeCustomerId: (license as any).stripeCustomerId,
     };
 };

--- a/apps/web/src/features/ee/subscription/_services/billing/fetch.spec.ts
+++ b/apps/web/src/features/ee/subscription/_services/billing/fetch.spec.ts
@@ -1,0 +1,79 @@
+/**
+ * requestTrialExtension goes through the API (/license/trial-extension-request),
+ * which owns the Discord webhook secret and resolves org/user from the JWT.
+ * The client only sends teamId + the form fields, and failures must surface
+ * honestly (no fake success when the channel is down or unconfigured).
+ */
+
+const authorizedFetchMock = jest.fn();
+jest.mock("@services/fetch", () => ({
+    authorizedFetch: (...args: unknown[]) => authorizedFetchMock(...args),
+}));
+jest.mock("src/core/utils/helpers", () => ({
+    pathToApiUrl: (p: string) => `API${p}`,
+}));
+
+// fetch.ts pulls these in at module scope for sibling functions; stub them
+// so importing the module under test stays isolated.
+jest.mock("./utils", () => ({ billingFetch: jest.fn() }));
+jest.mock("@services/organizations/fetch", () => ({
+    getOrganizationId: jest.fn().mockResolvedValue("org-1"),
+}));
+jest.mock("src/core/utils/self-hosted", () => ({ isSelfHosted: false }));
+
+describe("requestTrialExtension", () => {
+    beforeEach(() => {
+        authorizedFetchMock.mockReset();
+    });
+
+    it("posts teamId + form fields to the API trial-extension endpoint", async () => {
+        authorizedFetchMock.mockResolvedValue({ success: true });
+        const { requestTrialExtension } = await import("./fetch");
+
+        const result = await requestTrialExtension({
+            teamId: "team-1",
+            request: { teamSize: 12, message: "Evaluating for the platform team" },
+        });
+
+        expect(result).toEqual({ success: true });
+
+        const [url, config] = authorizedFetchMock.mock.calls[0];
+        expect(url).toBe("API/license/trial-extension-request");
+        expect(config.method).toBe("POST");
+        expect(JSON.parse(config.body)).toEqual({
+            teamId: "team-1",
+            teamSize: 12,
+            message: "Evaluating for the platform team",
+        });
+        // The secret-bearing org/user context is resolved server-side.
+        expect(config.body).not.toContain("organizationId");
+    });
+
+    it("fails honestly when the API reports the channel is unconfigured", async () => {
+        authorizedFetchMock.mockResolvedValue({
+            success: false,
+            message: "Trial request channel is not configured yet.",
+        });
+        const { requestTrialExtension } = await import("./fetch");
+
+        const result = await requestTrialExtension({
+            teamId: "team-1",
+            request: {},
+        });
+
+        expect(result.success).toBe(false);
+        expect(result.message).toMatch(/not configured/i);
+    });
+
+    it("does not fake success when the request throws", async () => {
+        authorizedFetchMock.mockRejectedValue(new Error("network down"));
+        const { requestTrialExtension } = await import("./fetch");
+
+        const result = await requestTrialExtension({
+            teamId: "team-1",
+            request: {},
+        });
+
+        expect(result.success).toBe(false);
+    });
+});

--- a/apps/web/src/features/ee/subscription/_services/billing/fetch.ts
+++ b/apps/web/src/features/ee/subscription/_services/billing/fetch.ts
@@ -7,6 +7,8 @@ import type {
     OrganizationLicense,
     Plan,
     PlanType,
+    TrialExtensionRequest,
+    TrialExtensionRequestResult,
     TrialUnlock,
     TrialUnlockSignals,
 } from "./types";
@@ -227,6 +229,38 @@ export const recalculateTrialUnlocks = async (params: {
             signals: params.signals,
         }),
     });
+};
+
+export const requestTrialExtension = async (params: {
+    teamId: string;
+    request: TrialExtensionRequest;
+}): Promise<TrialExtensionRequestResult> => {
+    // Goes through the API, which owns the Discord webhook secret and resolves
+    // the org + requesting user server-side from the JWT.
+    try {
+        const data = await authorizedFetch<TrialExtensionRequestResult>(
+            pathToApiUrl("/license/trial-extension-request"),
+            {
+                method: "POST",
+                body: JSON.stringify({
+                    teamId: params.teamId,
+                    teamSize: params.request.teamSize,
+                    message: params.request.message,
+                }),
+            },
+        );
+
+        if (!data?.success) {
+            return {
+                success: false,
+                message: data?.message ?? "Request failed",
+            };
+        }
+
+        return data;
+    } catch {
+        return { success: false, message: "Request failed" };
+    }
 };
 
 export const migrateToFree = async (params: {

--- a/apps/web/src/features/ee/subscription/_services/billing/fetch.ts
+++ b/apps/web/src/features/ee/subscription/_services/billing/fetch.ts
@@ -3,7 +3,13 @@ import { getOrganizationId } from "@services/organizations/fetch";
 import { pathToApiUrl } from "src/core/utils/helpers";
 import { isSelfHosted } from "src/core/utils/self-hosted";
 
-import type { OrganizationLicense, Plan, PlanType, TrialUnlock } from "./types";
+import type {
+    OrganizationLicense,
+    Plan,
+    PlanType,
+    TrialUnlock,
+    TrialUnlockSignals,
+} from "./types";
 import { billingFetch } from "./utils";
 
 type OrganizationMember = {
@@ -201,6 +207,25 @@ export const validateOrganizationLicense = async (params: {
     return billingFetch<OrganizationLicense>(`validate-org-license`, {
         method: "GET",
         params: { organizationId, teamId: params.teamId },
+    });
+};
+
+export const recalculateTrialUnlocks = async (params: {
+    teamId: string;
+    signals: TrialUnlockSignals;
+}): Promise<OrganizationLicense | undefined> => {
+    if (isSelfHosted) {
+        return undefined;
+    }
+
+    const organizationId = await getOrganizationId();
+    return billingFetch<OrganizationLicense>(`trial-unlocks/recalculate`, {
+        method: "POST",
+        body: JSON.stringify({
+            organizationId,
+            teamId: params.teamId,
+            signals: params.signals,
+        }),
     });
 };
 

--- a/apps/web/src/features/ee/subscription/_services/billing/fetch.ts
+++ b/apps/web/src/features/ee/subscription/_services/billing/fetch.ts
@@ -3,7 +3,7 @@ import { getOrganizationId } from "@services/organizations/fetch";
 import { pathToApiUrl } from "src/core/utils/helpers";
 import { isSelfHosted } from "src/core/utils/self-hosted";
 
-import type { OrganizationLicense, Plan, PlanType } from "./types";
+import type { OrganizationLicense, Plan, PlanType, TrialUnlock } from "./types";
 import { billingFetch } from "./utils";
 
 type OrganizationMember = {
@@ -51,6 +51,12 @@ export const startTeamTrial = async (params: {
         stripeSubscriptionId: null;
         totalLicenses: number;
         assignedLicenses: number;
+        byok?: boolean;
+        trialReviewCreditsTotal?: number;
+        trialReviewCreditsUsed?: number;
+        trialReviewCreditsRemaining?: number;
+        trialCreditTier?: string;
+        trialUnlocks?: Array<TrialUnlock>;
         createdAt: Date;
         updatedAt: Date;
     }>(`trial`, {

--- a/apps/web/src/features/ee/subscription/_services/billing/types.ts
+++ b/apps/web/src/features/ee/subscription/_services/billing/types.ts
@@ -55,6 +55,17 @@ export type TrialReviewCredits = {
     tier?: TrialCreditTier;
 };
 
+export type TrialExtensionRequest = {
+    teamSize?: number;
+    message?: string;
+    contactEmail?: string;
+};
+
+export type TrialExtensionRequestResult = {
+    success: boolean;
+    message?: string;
+};
+
 export type TrialUnlockSignals = {
     companyEmailVerified?: boolean;
     workspaceMembersCount?: number;

--- a/apps/web/src/features/ee/subscription/_services/billing/types.ts
+++ b/apps/web/src/features/ee/subscription/_services/billing/types.ts
@@ -23,15 +23,14 @@ export type TrialCreditTier =
     | "team_signal"
     | "qualified"
     | "manual"
-    | "referral"
     | (string & {});
 
 export type TrialUnlockKey =
+    | "company_email"
     | "team_setup"
-    | "multi_author_review"
+    | "code_org_10_plus"
     | "byok"
-    | "referral"
-    | "manual"
+    | "manual_extension"
     | (string & {});
 
 export type TrialUnlockStatus =
@@ -54,6 +53,13 @@ export type TrialReviewCredits = {
     used?: number;
     remaining?: number;
     tier?: TrialCreditTier;
+};
+
+export type TrialUnlockSignals = {
+    companyEmailVerified?: boolean;
+    workspaceMembersCount?: number;
+    codeHostMembersCount?: number;
+    byok?: boolean;
 };
 
 export type PlanType =

--- a/apps/web/src/features/ee/subscription/_services/billing/types.ts
+++ b/apps/web/src/features/ee/subscription/_services/billing/types.ts
@@ -10,6 +10,50 @@ export type OrganizationLicenseTrial = {
     valid: true;
     subscriptionStatus: "trial";
     trialEnd: string;
+    byok?: boolean;
+    trialReviewCreditsTotal?: number;
+    trialReviewCreditsUsed?: number;
+    trialReviewCreditsRemaining?: number;
+    trialCreditTier?: TrialCreditTier;
+    trialUnlocks?: Array<TrialUnlock>;
+};
+
+export type TrialCreditTier =
+    | "base"
+    | "team_signal"
+    | "qualified"
+    | "manual"
+    | "referral"
+    | (string & {});
+
+export type TrialUnlockKey =
+    | "team_setup"
+    | "multi_author_review"
+    | "byok"
+    | "referral"
+    | "manual"
+    | (string & {});
+
+export type TrialUnlockStatus =
+    | "locked"
+    | "available"
+    | "completed"
+    | "claimed";
+
+export type TrialUnlock = {
+    key: TrialUnlockKey;
+    status: TrialUnlockStatus;
+    rewardCredits?: number;
+    title?: string;
+    description?: string;
+    completedAt?: string;
+};
+
+export type TrialReviewCredits = {
+    total?: number;
+    used?: number;
+    remaining?: number;
+    tier?: TrialCreditTier;
 };
 
 export type PlanType =

--- a/apps/web/src/features/ee/subscription/_utils/trial.spec.ts
+++ b/apps/web/src/features/ee/subscription/_utils/trial.spec.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "@jest/globals";
+
+import {
+    getTrialCreditBalance,
+    getTrialTierLabel,
+    getTrialUnlocks,
+} from "./trial";
+
+describe("trial subscription helpers", () => {
+    it("uses the base managed review allowance when billing has not returned live credits", () => {
+        expect(getTrialCreditBalance()).toEqual({
+            total: 5,
+            used: 0,
+            remaining: 5,
+            hasLiveData: false,
+            percentUsed: 0,
+        });
+    });
+
+    it("uses live billing credit data when available", () => {
+        expect(
+            getTrialCreditBalance({
+                total: 8,
+                used: 6,
+                remaining: 2,
+            }),
+        ).toMatchObject({
+            total: 8,
+            used: 6,
+            remaining: 2,
+            hasLiveData: true,
+            percentUsed: 75,
+        });
+    });
+
+    it("maps internal trial tiers to customer-facing labels", () => {
+        expect(getTrialTierLabel("base")).toBe("Base evaluation");
+        expect(getTrialTierLabel("team_signal")).toBe("Team evaluation");
+        expect(getTrialTierLabel("qualified")).toBe("Qualified evaluation");
+        expect(getTrialTierLabel("unknown")).toBe("Base evaluation");
+    });
+
+    it("marks BYOK unlock as completed when BYOK is active", () => {
+        const byokUnlock = getTrialUnlocks({ byok: true }).find(
+            (unlock) => unlock.key === "byok",
+        );
+
+        expect(byokUnlock).toMatchObject({
+            status: "completed",
+            rewardLabel: "Unlimited with your key",
+        });
+    });
+
+    it("overrides fallback unlock status with billing unlock data", () => {
+        const unlocks = getTrialUnlocks({
+            billingUnlocks: [
+                {
+                    key: "multi_author_review",
+                    status: "completed",
+                    rewardCredits: 10,
+                },
+            ],
+        });
+
+        expect(
+            unlocks.find((unlock) => unlock.key === "multi_author_review"),
+        ).toMatchObject({
+            status: "completed",
+            rewardLabel: "+10 reviews",
+        });
+    });
+
+    it("keeps billing-only unlocks so new trial experiments can render without frontend changes", () => {
+        const unlocks = getTrialUnlocks({
+            billingUnlocks: [
+                {
+                    key: "manual",
+                    title: "Sales extension",
+                    description: "Manual extension approved by sales.",
+                    status: "claimed",
+                    rewardCredits: 20,
+                },
+            ],
+        });
+
+        expect(unlocks.find((unlock) => unlock.key === "manual")).toMatchObject(
+            {
+                title: "Sales extension",
+                status: "claimed",
+                rewardLabel: "+20 reviews",
+            },
+        );
+    });
+});

--- a/apps/web/src/features/ee/subscription/_utils/trial.spec.ts
+++ b/apps/web/src/features/ee/subscription/_utils/trial.spec.ts
@@ -55,18 +55,18 @@ describe("trial subscription helpers", () => {
         const unlocks = getTrialUnlocks({
             billingUnlocks: [
                 {
-                    key: "multi_author_review",
+                    key: "code_org_10_plus",
                     status: "completed",
-                    rewardCredits: 10,
+                    rewardCredits: 20,
                 },
             ],
         });
 
         expect(
-            unlocks.find((unlock) => unlock.key === "multi_author_review"),
+            unlocks.find((unlock) => unlock.key === "code_org_10_plus"),
         ).toMatchObject({
             status: "completed",
-            rewardLabel: "+10 reviews",
+            rewardLabel: "+20 reviews",
         });
     });
 
@@ -74,21 +74,20 @@ describe("trial subscription helpers", () => {
         const unlocks = getTrialUnlocks({
             billingUnlocks: [
                 {
-                    key: "manual",
+                    key: "manual_extension",
                     title: "Sales extension",
                     description: "Manual extension approved by sales.",
                     status: "claimed",
-                    rewardCredits: 20,
                 },
             ],
         });
 
-        expect(unlocks.find((unlock) => unlock.key === "manual")).toMatchObject(
-            {
-                title: "Sales extension",
-                status: "claimed",
-                rewardLabel: "+20 reviews",
-            },
-        );
+        expect(
+            unlocks.find((unlock) => unlock.key === "manual_extension"),
+        ).toMatchObject({
+            title: "Sales extension",
+            status: "claimed",
+            rewardLabel: "Manual review",
+        });
     });
 });

--- a/apps/web/src/features/ee/subscription/_utils/trial.spec.ts
+++ b/apps/web/src/features/ee/subscription/_utils/trial.spec.ts
@@ -1,10 +1,35 @@
 import { describe, expect, it } from "@jest/globals";
 
 import {
+    getTrialCardState,
     getTrialCreditBalance,
     getTrialTierLabel,
     getTrialUnlocks,
 } from "./trial";
+
+describe("getTrialCardState", () => {
+    it("byok wins regardless of credit data", () => {
+        expect(getTrialCardState({ byok: true, hasCredits: true })).toBe(
+            "byok",
+        );
+        expect(getTrialCardState({ byok: true, hasCredits: false })).toBe(
+            "byok",
+        );
+    });
+
+    it("credits when no byok and live credit data", () => {
+        expect(getTrialCardState({ byok: false, hasCredits: true })).toBe(
+            "credits",
+        );
+    });
+
+    it("legacy when no byok and no credit data", () => {
+        expect(getTrialCardState({ byok: false, hasCredits: false })).toBe(
+            "legacy",
+        );
+        expect(getTrialCardState({ hasCredits: false })).toBe("legacy");
+    });
+});
 
 describe("trial subscription helpers", () => {
     it("uses the base managed review allowance when billing has not returned live credits", () => {

--- a/apps/web/src/features/ee/subscription/_utils/trial.spec.ts
+++ b/apps/web/src/features/ee/subscription/_utils/trial.spec.ts
@@ -34,10 +34,10 @@ describe("trial subscription helpers", () => {
     });
 
     it("maps internal trial tiers to customer-facing labels", () => {
-        expect(getTrialTierLabel("base")).toBe("Base evaluation");
-        expect(getTrialTierLabel("team_signal")).toBe("Team evaluation");
-        expect(getTrialTierLabel("qualified")).toBe("Qualified evaluation");
-        expect(getTrialTierLabel("unknown")).toBe("Base evaluation");
+        expect(getTrialTierLabel("base")).toBe("Base");
+        expect(getTrialTierLabel("team_signal")).toBe("Team signal");
+        expect(getTrialTierLabel("qualified")).toBe("Qualified");
+        expect(getTrialTierLabel("unknown")).toBe("Base");
     });
 
     it("marks BYOK unlock as completed when BYOK is active", () => {

--- a/apps/web/src/features/ee/subscription/_utils/trial.ts
+++ b/apps/web/src/features/ee/subscription/_utils/trial.ts
@@ -44,6 +44,24 @@ export type TrialUnlockViewModel = {
     pendingLabel?: string;
 };
 
+/**
+ * Which trial view to render:
+ * - `byok`    → AI key connected, reviews unlimited.
+ * - `credits` → new trial on the credit model (show "X of N", progress, unlocks).
+ * - `legacy`  → trial started before the credit model (no live credit data) —
+ *               unlimited like the old trial, no credit UI.
+ */
+export type TrialCardState = "byok" | "credits" | "legacy";
+
+export const getTrialCardState = (params: {
+    byok?: boolean;
+    hasCredits: boolean;
+}): TrialCardState => {
+    if (params.byok) return "byok";
+    if (params.hasCredits) return "credits";
+    return "legacy";
+};
+
 export const getTrialCreditBalance = (
     credits?: TrialReviewCredits,
 ): TrialCreditBalance => {

--- a/apps/web/src/features/ee/subscription/_utils/trial.ts
+++ b/apps/web/src/features/ee/subscription/_utils/trial.ts
@@ -1,8 +1,8 @@
 import {
     TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED,
     TRIAL_UNLOCK_BYOK_REWARD_LABEL,
-    TRIAL_UNLOCK_MULTI_AUTHOR_REWARD,
-    TRIAL_UNLOCK_REFERRAL_REWARD,
+    TRIAL_UNLOCK_CODE_ORG_REWARD,
+    TRIAL_UNLOCK_COMPANY_EMAIL_REWARD,
     TRIAL_UNLOCK_TEAM_REWARD,
 } from "../_constants/trial";
 import type {
@@ -66,8 +66,6 @@ export const getTrialTierLabel = (tier?: TrialCreditTier): string => {
             return "Qualified";
         case "manual":
             return "Manual";
-        case "referral":
-            return "Referral";
         default:
             return "Base";
     }
@@ -79,28 +77,39 @@ const fallbackUnlocks = (params: {
     codeHostMembersCount?: number;
 }): TrialUnlockViewModel[] => [
     {
-        key: "team_setup",
-        title: "Add your team",
+        key: "company_email",
+        title: "Use a company email",
         description:
-            params.workspaceMembersCount && params.workspaceMembersCount > 1
-                ? "Team member detected. We can confirm this extension."
-                : params.codeHostMembersCount &&
-                    params.codeHostMembersCount >= 3
-                  ? "Invite teammates so the evaluation reflects real team usage."
-                  : "Invite another developer to evaluate Kodus as a team.",
+            "A confirmed work email helps us qualify the trial automatically.",
+        rewardLabel: `+${TRIAL_UNLOCK_COMPANY_EMAIL_REWARD} reviews`,
+        status: "locked",
+    },
+    {
+        key: "team_setup",
+        title: "Invite 3 teammates",
+        description:
+            params.workspaceMembersCount && params.workspaceMembersCount >= 3
+                ? "Workspace has enough teammates for a real team evaluation."
+                : "Add teammates so the trial reflects a real review workflow.",
         rewardLabel: `+${TRIAL_UNLOCK_TEAM_REWARD} reviews`,
         status:
-            params.workspaceMembersCount && params.workspaceMembersCount > 1
-                ? "available"
+            params.workspaceMembersCount && params.workspaceMembersCount >= 3
+                ? "completed"
                 : "locked",
         href: "/settings/subscription?tab=admins",
     },
     {
-        key: "multi_author_review",
-        title: "Review PRs from 2 developers",
-        description: "Run reviews on real PRs from more than one author.",
-        rewardLabel: `+${TRIAL_UNLOCK_MULTI_AUTHOR_REWARD} reviews`,
-        status: "locked",
+        key: "code_org_10_plus",
+        title: "Connect a 10+ developer code org",
+        description:
+            params.codeHostMembersCount && params.codeHostMembersCount >= 10
+                ? "Connected code org has at least 10 members."
+                : "Connect the organization, not only a personal account, so we can evaluate team fit.",
+        rewardLabel: `+${TRIAL_UNLOCK_CODE_ORG_REWARD} reviews`,
+        status:
+            params.codeHostMembersCount && params.codeHostMembersCount >= 10
+                ? "completed"
+                : "locked",
     },
     {
         key: "byok",
@@ -112,12 +121,13 @@ const fallbackUnlocks = (params: {
         href: "/organization/byok",
     },
     {
-        key: "referral",
-        title: "Refer another engineering team",
-        description: "Both teams can get extra evaluation reviews after setup.",
-        rewardLabel: `+${TRIAL_UNLOCK_REFERRAL_REWARD} reviews`,
-        status: "locked",
-        href: "mailto:?subject=Try%20Kodus%20for%20AI%20PR%20reviews&body=Hey%2C%20we%27re%20trying%20Kodus%20for%20AI%20pull%20request%20reviews.%20Might%20be%20useful%20for%20your%20engineering%20team%3A%20https%3A%2F%2Fkodus.io",
+        key: "manual_extension",
+        title: "Request more trial PR reviews",
+        description:
+            "Ask Kodus to review your trial signals and extend the evaluation manually.",
+        rewardLabel: "Manual review",
+        status: "available",
+        href: "mailto:sales@kodus.io?subject=Trial%20PR%20review%20extension",
     },
 ];
 
@@ -129,7 +139,7 @@ const getBillingUnlockRewardLabel = (
         return `+${unlock.rewardCredits} reviews`;
     }
 
-    return fallbackRewardLabel ?? "Extra PR reviews";
+    return fallbackRewardLabel ?? "Manual review";
 };
 
 export const getTrialUnlocks = (params: {

--- a/apps/web/src/features/ee/subscription/_utils/trial.ts
+++ b/apps/web/src/features/ee/subscription/_utils/trial.ts
@@ -1,0 +1,179 @@
+import {
+    TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED,
+    TRIAL_UNLOCK_BYOK_REWARD_LABEL,
+    TRIAL_UNLOCK_MULTI_AUTHOR_REWARD,
+    TRIAL_UNLOCK_REFERRAL_REWARD,
+    TRIAL_UNLOCK_TEAM_REWARD,
+} from "../_constants/trial";
+import type {
+    TrialCreditTier,
+    TrialReviewCredits,
+    TrialUnlock,
+    TrialUnlockKey,
+    TrialUnlockStatus,
+} from "../_services/billing/types";
+
+export type TrialCreditBalance = {
+    total: number;
+    used: number;
+    remaining: number;
+    hasLiveData: boolean;
+    percentUsed: number;
+};
+
+export type TrialUnlockViewModel = {
+    key: TrialUnlockKey;
+    title: string;
+    description: string;
+    rewardLabel: string;
+    status: TrialUnlockStatus;
+    href?: string;
+};
+
+export const getTrialCreditBalance = (
+    credits?: TrialReviewCredits,
+): TrialCreditBalance => {
+    const hasLiveData =
+        typeof credits?.total === "number" ||
+        typeof credits?.used === "number" ||
+        typeof credits?.remaining === "number";
+
+    const fallbackTotal = TRIAL_MANAGED_REVIEW_CREDITS_INCLUDED;
+    const total = Math.max(0, credits?.total ?? fallbackTotal);
+    const used = Math.max(0, credits?.used ?? 0);
+    const remaining = Math.max(
+        0,
+        credits?.remaining ?? Math.max(0, total - used),
+    );
+    const percentUsed = total > 0 ? Math.min(100, (used / total) * 100) : 100;
+
+    return {
+        total,
+        used,
+        remaining,
+        hasLiveData,
+        percentUsed,
+    };
+};
+
+export const getTrialTierLabel = (tier?: TrialCreditTier): string => {
+    switch (tier) {
+        case "base":
+            return "Base evaluation";
+        case "team_signal":
+            return "Team evaluation";
+        case "qualified":
+            return "Qualified evaluation";
+        case "manual":
+            return "Manual extension";
+        case "referral":
+            return "Referral bonus";
+        default:
+            return "Base evaluation";
+    }
+};
+
+const fallbackUnlocks = (params: {
+    byok?: boolean;
+    workspaceMembersCount?: number;
+    codeHostMembersCount?: number;
+}): TrialUnlockViewModel[] => [
+    {
+        key: "team_setup",
+        title: "Add your team",
+        description:
+            params.workspaceMembersCount && params.workspaceMembersCount > 1
+                ? "Team member detected. Extra review credits are granted when billing confirms the unlock."
+                : params.codeHostMembersCount &&
+                    params.codeHostMembersCount >= 3
+                  ? "Code organization size detected. Invite teammates to evaluate on real PRs."
+                  : "Invite another developer so the trial reflects a real team workflow.",
+        rewardLabel: `+${TRIAL_UNLOCK_TEAM_REWARD} reviews`,
+        status:
+            params.workspaceMembersCount && params.workspaceMembersCount > 1
+                ? "available"
+                : "locked",
+        href: "/settings/subscription?tab=admins",
+    },
+    {
+        key: "multi_author_review",
+        title: "Review PRs from 2 developers",
+        description:
+            "Run Kodus on real PRs from more than one author to unlock a stronger evaluation.",
+        rewardLabel: `+${TRIAL_UNLOCK_MULTI_AUTHOR_REWARD} reviews`,
+        status: "locked",
+    },
+    {
+        key: "byok",
+        title: "Connect BYOK",
+        description:
+            "Use your AI key for trial reviews without consuming Kodus managed credits.",
+        rewardLabel: TRIAL_UNLOCK_BYOK_REWARD_LABEL,
+        status: params.byok ? "completed" : "available",
+        href: "/organization/byok",
+    },
+    {
+        key: "referral",
+        title: "Refer another engineering team",
+        description:
+            "Both teams get extra evaluation reviews after the referred company connects an org and runs its first review.",
+        rewardLabel: `+${TRIAL_UNLOCK_REFERRAL_REWARD} reviews`,
+        status: "locked",
+        href: "mailto:?subject=Try%20Kodus%20for%20AI%20PR%20reviews&body=Hey%2C%20we%27re%20trying%20Kodus%20for%20AI%20pull%20request%20reviews.%20Might%20be%20useful%20for%20your%20engineering%20team%3A%20https%3A%2F%2Fkodus.io",
+    },
+];
+
+const getBillingUnlockRewardLabel = (
+    unlock: TrialUnlock,
+    fallbackRewardLabel?: string,
+) => {
+    if (typeof unlock.rewardCredits === "number") {
+        return `+${unlock.rewardCredits} reviews`;
+    }
+
+    return fallbackRewardLabel ?? "Configured by billing";
+};
+
+export const getTrialUnlocks = (params: {
+    billingUnlocks?: TrialUnlock[];
+    byok?: boolean;
+    workspaceMembersCount?: number;
+    codeHostMembersCount?: number;
+}): TrialUnlockViewModel[] => {
+    const fallback = fallbackUnlocks(params);
+    const billingUnlocksByKey = new Map(
+        params.billingUnlocks?.map((unlock) => [unlock.key, unlock]) ?? [],
+    );
+    const fallbackKeys = new Set(fallback.map((unlock) => unlock.key));
+
+    const mergedFallbackUnlocks = fallback.map((unlock) => {
+        const billingUnlock = billingUnlocksByKey.get(unlock.key);
+        if (!billingUnlock) return unlock;
+
+        return {
+            ...unlock,
+            title: billingUnlock.title || unlock.title,
+            description: billingUnlock.description || unlock.description,
+            rewardLabel: getBillingUnlockRewardLabel(
+                billingUnlock,
+                unlock.rewardLabel,
+            ),
+            status: billingUnlock.status,
+        };
+    });
+
+    const billingOnlyUnlocks =
+        params.billingUnlocks
+            ?.filter((unlock) => !fallbackKeys.has(unlock.key))
+            .map((unlock) => ({
+                key: unlock.key,
+                title: unlock.title || "Trial unlock",
+                description:
+                    unlock.description ||
+                    "This unlock is managed by billing for this trial.",
+                rewardLabel: getBillingUnlockRewardLabel(unlock),
+                status: unlock.status,
+            })) ?? [];
+
+    return [...mergedFallbackUnlocks, ...billingOnlyUnlocks];
+};

--- a/apps/web/src/features/ee/subscription/_utils/trial.ts
+++ b/apps/web/src/features/ee/subscription/_utils/trial.ts
@@ -83,7 +83,7 @@ const fallbackUnlocks = (params: {
         title: "Add your team",
         description:
             params.workspaceMembersCount && params.workspaceMembersCount > 1
-                ? "Team member detected. Extra review credits are granted when billing confirms the unlock."
+                ? "Team member detected. Extra review credits unlock after this step is confirmed."
                 : params.codeHostMembersCount &&
                     params.codeHostMembersCount >= 3
                   ? "Code organization size detected. Invite teammates to evaluate on real PRs."
@@ -107,7 +107,7 @@ const fallbackUnlocks = (params: {
         key: "byok",
         title: "Connect BYOK",
         description:
-            "Use your AI key for trial reviews without consuming Kodus managed credits.",
+            "Use your AI key for trial reviews without spending Kodus credits.",
         rewardLabel: TRIAL_UNLOCK_BYOK_REWARD_LABEL,
         status: params.byok ? "completed" : "available",
         href: "/organization/byok",
@@ -131,7 +131,7 @@ const getBillingUnlockRewardLabel = (
         return `+${unlock.rewardCredits} reviews`;
     }
 
-    return fallbackRewardLabel ?? "Configured by billing";
+    return fallbackRewardLabel ?? "Extra credits";
 };
 
 export const getTrialUnlocks = (params: {
@@ -170,7 +170,7 @@ export const getTrialUnlocks = (params: {
                 title: unlock.title || "Trial unlock",
                 description:
                     unlock.description ||
-                    "This unlock is managed by billing for this trial.",
+                    "This unlock can add more review credits to this trial.",
                 rewardLabel: getBillingUnlockRewardLabel(unlock),
                 status: unlock.status,
             })) ?? [];

--- a/apps/web/src/features/ee/subscription/_utils/trial.ts
+++ b/apps/web/src/features/ee/subscription/_utils/trial.ts
@@ -107,7 +107,7 @@ const fallbackUnlocks = (params: {
         key: "byok",
         title: "Connect BYOK",
         description:
-            "Use your AI key for trial reviews without using included PR reviews.",
+            "Use your AI key for trial reviews without using PR reviews paid by Kodus.",
         rewardLabel: TRIAL_UNLOCK_BYOK_REWARD_LABEL,
         status: params.byok ? "completed" : "available",
         href: "/organization/byok",

--- a/apps/web/src/features/ee/subscription/_utils/trial.ts
+++ b/apps/web/src/features/ee/subscription/_utils/trial.ts
@@ -83,7 +83,7 @@ const fallbackUnlocks = (params: {
         title: "Add your team",
         description:
             params.workspaceMembersCount && params.workspaceMembersCount > 1
-                ? "Team member detected. Extra review credits unlock after this step is confirmed."
+                ? "Team member detected. Extra PR reviews unlock after this step is confirmed."
                 : params.codeHostMembersCount &&
                     params.codeHostMembersCount >= 3
                   ? "Code organization size detected. Invite teammates to evaluate on real PRs."
@@ -107,7 +107,7 @@ const fallbackUnlocks = (params: {
         key: "byok",
         title: "Connect BYOK",
         description:
-            "Use your AI key for trial reviews without spending Kodus credits.",
+            "Use your AI key for trial reviews without using included PR reviews.",
         rewardLabel: TRIAL_UNLOCK_BYOK_REWARD_LABEL,
         status: params.byok ? "completed" : "available",
         href: "/organization/byok",
@@ -131,7 +131,7 @@ const getBillingUnlockRewardLabel = (
         return `+${unlock.rewardCredits} reviews`;
     }
 
-    return fallbackRewardLabel ?? "Extra credits";
+    return fallbackRewardLabel ?? "Extra PR reviews";
 };
 
 export const getTrialUnlocks = (params: {
@@ -170,7 +170,7 @@ export const getTrialUnlocks = (params: {
                 title: unlock.title || "Trial unlock",
                 description:
                     unlock.description ||
-                    "This unlock can add more review credits to this trial.",
+                    "This unlock can add more PR reviews to this trial.",
                 rewardLabel: getBillingUnlockRewardLabel(unlock),
                 status: unlock.status,
             })) ?? [];

--- a/apps/web/src/features/ee/subscription/_utils/trial.ts
+++ b/apps/web/src/features/ee/subscription/_utils/trial.ts
@@ -59,17 +59,17 @@ export const getTrialCreditBalance = (
 export const getTrialTierLabel = (tier?: TrialCreditTier): string => {
     switch (tier) {
         case "base":
-            return "Base evaluation";
+            return "Base";
         case "team_signal":
-            return "Team evaluation";
+            return "Team signal";
         case "qualified":
-            return "Qualified evaluation";
+            return "Qualified";
         case "manual":
-            return "Manual extension";
+            return "Manual";
         case "referral":
-            return "Referral bonus";
+            return "Referral";
         default:
-            return "Base evaluation";
+            return "Base";
     }
 };
 
@@ -83,11 +83,11 @@ const fallbackUnlocks = (params: {
         title: "Add your team",
         description:
             params.workspaceMembersCount && params.workspaceMembersCount > 1
-                ? "Team member detected. Extra PR reviews unlock after this step is confirmed."
+                ? "Team member detected. We can confirm this extension."
                 : params.codeHostMembersCount &&
                     params.codeHostMembersCount >= 3
-                  ? "Code organization size detected. Invite teammates to evaluate on real PRs."
-                  : "Invite another developer so the trial reflects a real team workflow.",
+                  ? "Invite teammates so the evaluation reflects real team usage."
+                  : "Invite another developer to evaluate Kodus as a team.",
         rewardLabel: `+${TRIAL_UNLOCK_TEAM_REWARD} reviews`,
         status:
             params.workspaceMembersCount && params.workspaceMembersCount > 1
@@ -98,8 +98,7 @@ const fallbackUnlocks = (params: {
     {
         key: "multi_author_review",
         title: "Review PRs from 2 developers",
-        description:
-            "Run Kodus on real PRs from more than one author to unlock a stronger evaluation.",
+        description: "Run reviews on real PRs from more than one author.",
         rewardLabel: `+${TRIAL_UNLOCK_MULTI_AUTHOR_REWARD} reviews`,
         status: "locked",
     },
@@ -107,7 +106,7 @@ const fallbackUnlocks = (params: {
         key: "byok",
         title: "Connect BYOK",
         description:
-            "Use your AI key for trial reviews without using PR reviews paid by Kodus.",
+            "Use your own AI key. Reviews no longer use Kodus-paid PRs.",
         rewardLabel: TRIAL_UNLOCK_BYOK_REWARD_LABEL,
         status: params.byok ? "completed" : "available",
         href: "/organization/byok",
@@ -115,8 +114,7 @@ const fallbackUnlocks = (params: {
     {
         key: "referral",
         title: "Refer another engineering team",
-        description:
-            "Both teams get extra evaluation reviews after the referred company connects an org and runs its first review.",
+        description: "Both teams can get extra evaluation reviews after setup.",
         rewardLabel: `+${TRIAL_UNLOCK_REFERRAL_REWARD} reviews`,
         status: "locked",
         href: "mailto:?subject=Try%20Kodus%20for%20AI%20PR%20reviews&body=Hey%2C%20we%27re%20trying%20Kodus%20for%20AI%20pull%20request%20reviews.%20Might%20be%20useful%20for%20your%20engineering%20team%3A%20https%3A%2F%2Fkodus.io",

--- a/apps/web/src/features/ee/subscription/_utils/trial.ts
+++ b/apps/web/src/features/ee/subscription/_utils/trial.ts
@@ -27,7 +27,21 @@ export type TrialUnlockViewModel = {
     description: string;
     rewardLabel: string;
     status: TrialUnlockStatus;
+    /**
+     * `signal` unlocks are evaluated automatically by Kodus and the user
+     * cannot trigger them directly (e.g. company email comes from the
+     * signup address). `action` unlocks expose something the user can do
+     * right now (invite teammates, manage the git connection, configure
+     * BYOK, request a manual extension).
+     */
+    kind: "signal" | "action";
     href?: string;
+    /** Label for the call-to-action button (action unlocks only). */
+    actionLabel?: string;
+    /** Special client-handled actions that don't navigate via href. */
+    actionType?: "request_extension";
+    /** Status label shown for a `signal` that has not qualified yet. */
+    pendingLabel?: string;
 };
 
 export const getTrialCreditBalance = (
@@ -73,43 +87,52 @@ export const getTrialTierLabel = (tier?: TrialCreditTier): string => {
 
 const fallbackUnlocks = (params: {
     byok?: boolean;
+    companyEmailVerified?: boolean;
     workspaceMembersCount?: number;
     codeHostMembersCount?: number;
 }): TrialUnlockViewModel[] => [
     {
         key: "company_email",
-        title: "Use a company email",
-        description:
-            "A confirmed work email helps us qualify the trial automatically.",
+        title: "Company email",
+        description: params.companyEmailVerified
+            ? "We detected a work email, so this signal is qualified."
+            : "Detected automatically from the email you signed up with. A work email (not a personal one) qualifies the trial — this only changes if you sign up again with a company address.",
         rewardLabel: `+${TRIAL_UNLOCK_COMPANY_EMAIL_REWARD} reviews`,
-        status: "locked",
+        status: params.companyEmailVerified ? "completed" : "locked",
+        kind: "signal",
+        pendingLabel: "Personal email",
+    },
+    {
+        key: "code_org_10_plus",
+        title: "10+ developer code org",
+        description:
+            params.codeHostMembersCount && params.codeHostMembersCount >= 10
+                ? "Your connected code org has at least 10 members."
+                : "Counts the members of the Git organization Kodus is connected to. Connect your org (not a personal account) — it qualifies automatically once it reaches 10 developers. Switching orgs requires reconnecting the integration.",
+        rewardLabel: `+${TRIAL_UNLOCK_CODE_ORG_REWARD} reviews`,
+        status:
+            params.codeHostMembersCount && params.codeHostMembersCount >= 10
+                ? "completed"
+                : "available",
+        kind: "action",
+        href: "/settings/git",
+        actionLabel: "Manage connection",
     },
     {
         key: "team_setup",
         title: "Invite 3 teammates",
         description:
             params.workspaceMembersCount && params.workspaceMembersCount >= 3
-                ? "Workspace has enough teammates for a real team evaluation."
+                ? "Your workspace already has enough teammates."
                 : "Add teammates so the trial reflects a real review workflow.",
         rewardLabel: `+${TRIAL_UNLOCK_TEAM_REWARD} reviews`,
         status:
             params.workspaceMembersCount && params.workspaceMembersCount >= 3
                 ? "completed"
-                : "locked",
+                : "available",
+        kind: "action",
         href: "/settings/subscription?tab=admins",
-    },
-    {
-        key: "code_org_10_plus",
-        title: "Connect a 10+ developer code org",
-        description:
-            params.codeHostMembersCount && params.codeHostMembersCount >= 10
-                ? "Connected code org has at least 10 members."
-                : "Connect the organization, not only a personal account, so we can evaluate team fit.",
-        rewardLabel: `+${TRIAL_UNLOCK_CODE_ORG_REWARD} reviews`,
-        status:
-            params.codeHostMembersCount && params.codeHostMembersCount >= 10
-                ? "completed"
-                : "locked",
+        actionLabel: "Invite teammates",
     },
     {
         key: "byok",
@@ -118,16 +141,20 @@ const fallbackUnlocks = (params: {
             "Use your own AI key. Reviews no longer use Kodus-paid PRs.",
         rewardLabel: TRIAL_UNLOCK_BYOK_REWARD_LABEL,
         status: params.byok ? "completed" : "available",
+        kind: "action",
         href: "/organization/byok",
+        actionLabel: "Configure BYOK",
     },
     {
         key: "manual_extension",
         title: "Request more trial PR reviews",
         description:
-            "Ask Kodus to review your trial signals and extend the evaluation manually.",
+            "Tell us about your team and we'll review your trial signals to extend the evaluation.",
         rewardLabel: "Manual review",
         status: "available",
-        href: "mailto:sales@kodus.io?subject=Trial%20PR%20review%20extension",
+        kind: "action",
+        actionLabel: "Request review",
+        actionType: "request_extension",
     },
 ];
 
@@ -145,6 +172,7 @@ const getBillingUnlockRewardLabel = (
 export const getTrialUnlocks = (params: {
     billingUnlocks?: TrialUnlock[];
     byok?: boolean;
+    companyEmailVerified?: boolean;
     workspaceMembersCount?: number;
     codeHostMembersCount?: number;
 }): TrialUnlockViewModel[] => {
@@ -173,15 +201,18 @@ export const getTrialUnlocks = (params: {
     const billingOnlyUnlocks =
         params.billingUnlocks
             ?.filter((unlock) => !fallbackKeys.has(unlock.key))
-            .map((unlock) => ({
-                key: unlock.key,
-                title: unlock.title || "Trial unlock",
-                description:
-                    unlock.description ||
-                    "This unlock can add more PR reviews to this trial.",
-                rewardLabel: getBillingUnlockRewardLabel(unlock),
-                status: unlock.status,
-            })) ?? [];
+            .map(
+                (unlock): TrialUnlockViewModel => ({
+                    key: unlock.key,
+                    title: unlock.title || "Trial unlock",
+                    description:
+                        unlock.description ||
+                        "This unlock can add more PR reviews to this trial.",
+                    rewardLabel: getBillingUnlockRewardLabel(unlock),
+                    status: unlock.status,
+                    kind: "action",
+                }),
+            ) ?? [];
 
     return [...mergedFallbackUnlocks, ...billingOnlyUnlocks];
 };

--- a/apps/web/src/features/ee/subscription/choose-plan/page.client.tsx
+++ b/apps/web/src/features/ee/subscription/choose-plan/page.client.tsx
@@ -18,6 +18,7 @@ import { NumberInput } from "@components/ui/number-input";
 import { Switch } from "@components/ui/switch";
 import { toast } from "@components/ui/toaster/use-toast";
 import { useAsyncAction } from "@hooks/use-async-action";
+import { useConfig } from "@providers/ConfigProvider";
 import {
     BadgeDollarSignIcon,
     BookOpenIcon,
@@ -38,7 +39,6 @@ import {
     type LucideIcon,
 } from "lucide-react";
 import { useAuth } from "src/core/providers/auth.provider";
-import { useConfig } from "@providers/ConfigProvider";
 import { useSelectedTeamId } from "src/core/providers/selected-team-context";
 import { CurrencyHelpers } from "src/core/utils/currency";
 import { addSearchParamsToUrl } from "src/core/utils/url";
@@ -66,14 +66,16 @@ export function ChoosePlanPageClient({
         <div className="flex flex-col gap-6">
             {tokenProjectionSlot}
 
+            {/* Anchor message: the #1 thing people get wrong about pricing —
+                reviews are unlimited on every plan because they run on the
+                user's own key. Plans only change features. */}
+            <AllPlansInclude />
+
             <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
                 {plans.free && <FreePlan plan={plans.free} />}
                 {plans.teams_byok && <TeamsPlan plan={plans.teams_byok} />}
                 {plans.enterprise && <EnterprisePlan plan={plans.enterprise} />}
             </div>
-
-            {/* All plans include */}
-            <AllPlansInclude />
         </div>
     );
 }
@@ -114,36 +116,33 @@ function getFeatureIcon(feature: string): LucideIcon {
 }
 
 function AllPlansInclude() {
+    const items = [
+        { icon: GitPullRequestIcon, label: "Unlimited PR reviews" },
+        { icon: UsersIcon, label: "Unlimited users" },
+        { icon: KeyIcon, label: "Runs on your own AI key" },
+    ];
+
     return (
-        <div className="bg-card-lv1 flex items-center gap-6 rounded-lg px-5 py-4">
-            <p className="text-text-secondary text-sm font-medium">
-                All plans include
+        <div className="bg-card-lv1 border-card-lv3 flex flex-col gap-3 rounded-lg border px-5 py-4 md:flex-row md:items-center md:justify-between md:gap-6">
+            <p className="text-text-primary text-sm font-semibold text-balance">
+                Reviews are unlimited on every plan — they run on your own AI
+                key.{" "}
+                <span className="text-text-secondary font-normal">
+                    Plans differ by features, not by how many PRs Kody can
+                    review.
+                </span>
             </p>
-            <div className="flex items-center gap-6">
-                <div className="flex items-center gap-2">
-                    <div className="bg-success/20 flex size-6 items-center justify-center rounded-full">
-                        <GitPullRequestIcon className="text-success size-3.5" />
+            <div className="flex flex-wrap items-center gap-x-6 gap-y-2">
+                {items.map(({ icon: Icon, label }) => (
+                    <div key={label} className="flex items-center gap-2">
+                        <div className="bg-success/20 flex size-6 items-center justify-center rounded-full">
+                            <Icon className="text-success size-3.5" />
+                        </div>
+                        <span className="text-text-primary text-sm whitespace-nowrap">
+                            {label}
+                        </span>
                     </div>
-                    <span className="text-text-primary text-sm">
-                        Unlimited PRs
-                    </span>
-                </div>
-                <div className="flex items-center gap-2">
-                    <div className="bg-success/20 flex size-6 items-center justify-center rounded-full">
-                        <UsersIcon className="text-success size-3.5" />
-                    </div>
-                    <span className="text-text-primary text-sm">
-                        Unlimited users
-                    </span>
-                </div>
-                <div className="flex items-center gap-2">
-                    <div className="bg-success/20 flex size-6 items-center justify-center rounded-full">
-                        <KeyIcon className="text-success size-3.5" />
-                    </div>
-                    <span className="text-text-primary text-sm">
-                        Your own API key
-                    </span>
-                </div>
+                ))}
             </div>
         </div>
     );
@@ -357,7 +356,7 @@ function TeamsPlan({ plan }: { plan: Plan }) {
             <CardContent className="flex flex-none flex-col gap-4 pt-0 pb-5">
                 <FormControl.Root>
                     <FormControl.Label htmlFor="teams-quantity">
-                        Quantity of licenses
+                        Developer licenses
                     </FormControl.Label>
 
                     <FormControl.Input>
@@ -371,6 +370,12 @@ function TeamsPlan({ plan }: { plan: Plan }) {
                             <NumberInput.Increment />
                         </NumberInput.Root>
                     </FormControl.Input>
+
+                    <p className="text-text-tertiary text-xs">
+                        One license per developer whose PRs Kody reviews.
+                        Workspace members (reviewers, viewers, admins) are
+                        unlimited and free.
+                    </p>
                 </FormControl.Root>
 
                 <Button

--- a/docs/_snippets/env-vars-generated.mdx
+++ b/docs/_snippets/env-vars-generated.mdx
@@ -148,6 +148,7 @@
 | `API_FORGEJO_CODE_MANAGEMENT_WEBHOOK` | – | url | ⚙️ Both |  |
 | `CODE_MANAGEMENT_SECRET` | ✅ | secret | ⚙️ Both | Shared secret used to sign internal webhook calls. |
 | `CODE_MANAGEMENT_WEBHOOK_TOKEN` | – | secret | ⚙️ Both |  |
+| `API_DISCORD_TRIAL_REQUEST_WEBHOOK_URL` | – | secret | ☁️ Cloud | Discord channel webhook used to deliver "Request more trial reviews" form submissions to our team. Optional — when unset the request fails honestly and the UI tells the user the channel is not configured. |
 
 ## Observability
 

--- a/docs/how_to_use/en/pricing.mdx
+++ b/docs/how_to_use/en/pricing.mdx
@@ -2,148 +2,161 @@
 title: "Pricing Deep Dive"
 ---
 
-Here's everything you need to know about our pricing to help you make the best decision for your organization. For the latest plan details and live pricing, see [kodus.io/pricing](https://kodus.io/pricing).
+Everything you need to choose the right plan. For live pricing, see [kodus.io/pricing](https://kodus.io/pricing).
+
+<Note>
+  **Reviews are unlimited on every plan** — they run on your own AI key (BYOK).
+  Plans differ by **features**, not by how many PRs Kody can review. Every plan
+  includes unlimited users and unlimited pull requests, with no per-seat minimum.
+</Note>
 
 ## Plans at a glance
 
-- **Community** — free. BYOK. Self-hosted or cloud.
-- **Teams** — $10/dev/month + token costs (BYOK). Cloud only. **14-day free trial, no credit card.** 20% off when billed annually.
-- **Enterprise** — custom pricing. Self-hosted or cloud. Choose **BYOK** or **Kodus AI Tokens API key**.
+<CardGroup cols={3}>
+  <Card title="Community" icon="github">
+    **Free, forever.** BYOK. Self-hosted or cloud.
 
-All plans include unlimited users, unlimited pull requests, and no per-seat minimum.
+    For indie devs, students, OSS maintainers, and small teams.
+  </Card>
+  <Card title="Teams" icon="users">
+    **$10/dev/month** + token costs (BYOK). Cloud only.
 
-## Community vs. Teams vs. Enterprise
+    14-day free trial, no credit card. 20% off annually.
+  </Card>
+  <Card title="Enterprise" icon="building">
+    **Custom pricing.** Self-hosted or cloud.
 
-Kodus is available in three versions:
+    Hardened security, governance, and hands-on onboarding.
+  </Card>
+</CardGroup>
 
-- **Community:** Free to use and modify. Available for both self-hosted and cloud deployments.
+## The free trial (Teams)
 
-  - Bring your own API keys (BYOK)
-  - Unlimited code reviews and unlimited users
-  - Unlimited issues on Quality Radar
-  - Kody Learnings and Memory
-  - Kodus MCP
-  - Up to 10 Kody Rules
-  - Up to 3 plugins / MCPs (includes the default Kodus MCP)
-  - ❌ No Cockpit (Teams and Enterprise only)
-  - Community support via Discord
+A Teams trial runs on **two separate, independent clocks** — the 14 days govern Team **features**, never your ability to review PRs:
 
-- **Teams:** Cloud-only paid version. $10/dev/month + token costs (BYOK).
+<CardGroup cols={2}>
+  <Card title="14 days of Team features" icon="calendar">
+    Cockpit, unlimited Kody Rules and plugins, priority queue, and more.
+  </Card>
+  <Card title="Your first 5 PR reviews on us" icon="gift">
+    We cover the AI tokens, so you can try Kody with **zero setup — no API key
+    needed.** (Earn a few more by completing onboarding steps.)
+  </Card>
+</CardGroup>
 
-  - Everything in Community, plus:
-  - Unlimited Kody Rules (no 10-rule limit)
-  - Unlimited plugins / MCPs (no 3-plugin limit)
-  - **Priority queue for Kody Agents**
-  - **Kodus Cockpit** (engineering metrics)
-  - Email + Discord support
-  - Automatic updates and maintenance
-  - **14-day free trial** — no credit card required
-  - **20% discount** when billed annually
+**To keep reviewing past the 5 trial reviews — or to go unlimited right away — [connect your AI key](/how_to_use/en/byok).** Reviews then run on your key: unlimited, on any plan, even after the 14 days end. Trial reviews run on a model Kodus picks for you; with your own key you can run frontier models for the best quality.
 
-- **Enterprise:** Customized version for enterprise use. Available self-hosted or cloud.
+If trial reviews run out before you connect a key, Kody pauses reviews and posts a comment with a one-click link to add your key.
 
-  - Everything in Teams, plus:
-  - SSO / SAML
-  - **RBAC, audit logs, and analytics**
-  - **SOC 2 compliance in progress**
-  - Choice of token model: **BYOK** or **Kodus AI Tokens API key** (managed tokens billed by Kodus)
-  - Dedicated instance
-  - Custom SLAs
-  - Up to **5 hours/month** of dedicated support
-  - Private Discord channel
-  - Advanced security features
-  - Training and onboarding assistance
-  - Customization options
+## What's included
 
-## How Pricing Works
+| Feature | Community | Teams | Enterprise |
+| --- | --- | --- | --- |
+| **Price** | Free | $10/dev/mo | Custom |
+| **Deployment** | Self-hosted or cloud | Cloud | Self-hosted or cloud |
+| **Code reviews** | Unlimited | Unlimited | Unlimited |
+| **Users** | Unlimited | Unlimited | Unlimited |
+| **Kody Rules** | Up to 10 | Unlimited | Unlimited |
+| **Plugins / MCPs** | Up to 3 | Unlimited | Unlimited |
+| **Quality Radar issues** | Unlimited | Unlimited | Unlimited |
+| **Kody Learnings & Memory** | ✓ | ✓ | ✓ |
+| **Priority queue** | — | ✓ | ✓ |
+| **Kodus Cockpit (metrics)** | — | ✓ | ✓ |
+| **SSO / SAML** | — | — | ✓ |
+| **RBAC + audit logs** | — | — | ✓ |
+| **SOC 2 compliant** | — | — | ✓ |
+| **Dedicated instance & SLAs** | — | — | ✓ |
+| **Support** | Discord | Email + Discord | Private Discord + up to 5h/mo dedicated |
 
-Our pricing is per developer who actively creates pull requests in your team. This keeps billing aligned with value as your team evolves:
+## How pricing works
 
-- **Pay per active developer:** only developers who contribute PRs count toward your seat.
-- **Adjustable at any time:** change the number of active developers through your account settings. No minimums, no annual lock-in on seat count.
+<CardGroup cols={2}>
+  <Card title="Pay per active developer" icon="user-check">
+    Only developers who open PRs count toward a seat. No minimums, no seat
+    lock-in.
+  </Card>
+  <Card title="Adjust anytime" icon="sliders">
+    Change your active-developer count in account settings whenever your team
+    changes.
+  </Card>
+</CardGroup>
 
-## BYOK is the default across all plans
+## BYOK: the default across all plans
 
-Kodus does **not** sell LLM tokens by default. Community, Teams, and Enterprise all run on **Bring Your Own Key** (BYOK): you connect your own provider account — OpenAI, Anthropic, Gemini, or any OpenAI-compatible provider — and tokens are billed directly by that provider on their dashboard. Kodus never marks up tokens.
+Kodus does **not** sell LLM tokens by default. Community, Teams, and Enterprise all run on **Bring Your Own Key** — you connect your own provider (OpenAI, Anthropic, Gemini, or any OpenAI-compatible), and tokens are billed directly by that provider. Kodus never marks up tokens.
 
-The price difference between plans is **what Kodus charges on top of your token spend**, not the token model itself:
+| Plan | What you pay Kodus | Tokens |
+| --- | --- | --- |
+| **Community** | $0 | You pay your provider (BYOK) |
+| **Teams** | $10/active dev/mo | You pay your provider (BYOK) |
+| **Enterprise** | Custom | You pay your provider (BYOK) |
 
-| Plan | What you pay Kodus | How tokens are billed |
-| ---- | ------------------ | --------------------- |
-| **Community** | $0 | You pay your LLM provider directly (BYOK) |
-| **Teams** | $10/active dev/month | You pay your LLM provider directly (BYOK) |
-| **Enterprise** | Custom (contract) | BYOK, **or** let Kodus manage tokens via **Kodus AI Tokens API key** and receive a single invoice |
+See the [BYOK overview](/how_to_use/en/byok) for supported providers and setup.
 
-See the [BYOK overview](/how_to_use/en/byok) for the supported providers and setup flow. Everything below is about the **Kodus-side fee**.
+## Teams pricing — $10/active dev/month
 
-## Teams Pricing
+In addition to your provider's token cost (no Kodus markup).
 
-### $10 per active developer per month
+<CardGroup cols={2}>
+  <Card title="What the $10/dev covers" icon="box">
+    - Managed cloud hosting + automatic updates
+    - Priority queue for Kody Agents
+    - Kodus Cockpit (engineering metrics)
+    - Unlimited Kody Rules & plugins/MCPs
+    - Email + Discord support
+  </Card>
+  <Card title="What tokens cover" icon="coins">
+    - Every LLM call Kody makes during a review
+    - Billed by your provider; switch anytime
+    - You pick the model — cost-effective (Gemini Flash, GPT-5-mini) or frontier (Claude 4.5 Sonnet, GPT-5)
+  </Card>
+</CardGroup>
 
-The Teams subscription is **$10 per active developer per month**, in addition to whatever you pay your LLM provider for tokens. No Kodus markup on tokens.
+**Billing:** monthly, or **20% off** annually · 14-day free trial, no card · cancel anytime (effective end of cycle).
 
-What the $10/dev/month covers:
+## Enterprise pricing
 
-- **Cloud hosting** — fully managed by Kodus, with automatic updates and maintenance.
-- **Priority queue for Kody Agents** — Teams traffic is reviewed before free-tier traffic.
-- **Kodus Cockpit** — engineering metrics and reporting.
-- **Unlimited Kody Rules and plugins/MCPs** (no 10-rule / 3-plugin caps).
-- **Email + Discord support**.
+Custom-priced via contract. Like every plan, Enterprise is **BYOK** — Kodus bills only the per-seat fee and you pay your LLM provider directly.
 
-What the token cost covers:
-
-- Every API call Kodus makes to your chosen LLM provider during a review.
-- Billed directly by the provider; you can switch providers at any time.
-- You choose the model — cost-effective (e.g. Gemini Flash, GPT-5-mini) or frontier (Claude 4.5 Sonnet, GPT-5).
-
-### Billing cadence
-
-- **Monthly:** $10/dev/month, billed month-to-month.
-- **Annually:** 20% off when billed once a year.
-- **Free trial:** 14 days on Teams, no credit card required.
-- **Cancel anytime:** changes take effect at the end of the current billing cycle.
-
-## Enterprise Pricing
-
-Enterprise is custom-priced and signed via contract. You pick the token model that fits your ops:
-
-- **BYOK** — same as Community and Teams, you bring your own LLM keys. Kodus bills only the per-seat fee.
-- **Kodus AI Tokens API key** — Kodus supplies a managed API key and bills tokens along with the seat fee. Good for teams that want a single vendor, a single invoice, and no direct relationship with the LLM provider.
-
-Enterprise-only features include SSO / SAML, RBAC with audit logs and analytics, dedicated instance option, custom SLAs, up to **5 hours/month** of dedicated support, and a private Discord channel. SOC 2 compliance is in progress.
+Enterprise adds SSO / SAML, RBAC with audit logs and analytics, a dedicated instance, custom SLAs, up to **5 hours/month** of dedicated support, and a private Discord channel. Kodus is **SOC 2 compliant**.
 
 [Contact sales](https://kodus.io/pricing) for a quote tailored to your organization.
 
-## Unlimited Pull Requests
+## Unlimited pull requests
 
-Your team can submit as many pull requests as they want — there's no PR limit on any plan. The only hard limit is on **very large pull requests**: we do not review PRs with more than **200 changed files**. Git-provider-side rate limits may also apply.
+No PR limit on any plan. The only hard limit: we don't review PRs with more than **200 changed files**. Git-provider-side rate limits may also apply.
 
 ## Kody Pilot Program
 
-We subsidize Kodus for teams that move the industry forward and for teams that couldn't otherwise afford it. The **Kody Pilot Program** offers **30–100% discounts** for:
+We subsidize Kodus with **30–100% discounts** for teams that move the industry forward or couldn't otherwise afford it:
 
-- **Early-stage startups**
-- **Open-source projects** with active development
-- **Teams in economically disadvantaged regions**
-- **Non-profit organizations**
+- Early-stage startups
+- Open-source projects with active development
+- Teams in economically disadvantaged regions
+- Non-profit organizations
 
-### How to apply
+<Steps>
+  <Step title="Join our Discord">
+    Hop into the [community](https://discord.gg/TFZBRk9fT6).
+  </Step>
+  <Step title="Tell us about you">
+    Share your org name, website, and a brief description of your work.
+  </Step>
+  <Step title="Show eligibility">
+    Startup stage/funding, OSS repo links, region context, or proof of
+    non-profit status.
+  </Step>
+  <Step title="Hear back in 3 business days">
+    We review your application and follow up.
+  </Step>
+</Steps>
 
-1. Join our Discord community at [discord.gg/TFZBRk9fT6](https://discord.gg/TFZBRk9fT6).
-2. Share your organization name, website, and a brief description of your work.
-3. Provide proof of eligibility:
-   - Startups: stage and funding round (if any).
-   - Open source: links to public repositories.
-   - Disadvantaged regions: country and context.
-   - Non-profits: proof of non-profit status.
-4. We'll review your application within 3 business days.
+## Payments & billing
 
-## Payments and Billing
-
-- **Powered by Stripe:** payments are processed securely using Stripe, a globally trusted platform.
-- **Cancel anytime:** you can cancel your plan at any point; changes take effect at the end of your billing cycle (monthly or annual).
-- **Invoices and Brazilian Nota Fiscal:** for Brazilian customers 🇧🇷, we provide invoices and issue a Nota Fiscal (tax receipt) for every transaction.
+- **Powered by Stripe** — secure, globally trusted payment processing.
+- **Cancel anytime** — changes take effect at the end of your billing cycle.
+- **Invoices & Nota Fiscal** — for Brazilian customers 🇧🇷, we provide invoices and issue a Nota Fiscal for every transaction.
 
 ---
 
-Questions? Join our [Discord community](https://discord.gg/TFZBRk9fT6), or check the latest plan details at [kodus.io/pricing](https://kodus.io/pricing).
+Questions? Join our [Discord community](https://discord.gg/TFZBRk9fT6), or see the latest plan details at [kodus.io/pricing](https://kodus.io/pricing).

--- a/libs/code-review/pipeline/stages/validate-prerequisites.stage.spec.ts
+++ b/libs/code-review/pipeline/stages/validate-prerequisites.stage.spec.ts
@@ -403,7 +403,66 @@ describe('ValidatePrerequisitesStage', () => {
             const result = await stage.execute(context);
 
             // statusInfo not changed from in_progress
-            expect(result.statusInfo?.status).not.toBe(AutomationStatus.SKIPPED);
+            expect(result.statusInfo?.status).not.toBe(
+                AutomationStatus.SKIPPED,
+            );
+        });
+    });
+
+    describe('trial review credit consumption', () => {
+        it('asks to consume a managed trial credit keyed by repo:pr', async () => {
+            const context = makeContext();
+
+            mockPermissionValidationService.validateExecutionPermissions.mockResolvedValue(
+                { allowed: true },
+            );
+            mockParametersService.findByKey.mockResolvedValue({
+                configValue: {
+                    configs: { showStatusFeedback: true },
+                    repositories: [],
+                },
+            });
+
+            await stage.execute(context);
+
+            expect(
+                mockPermissionValidationService.validateExecutionPermissions,
+            ).toHaveBeenCalledWith(
+                context.organizationAndTeamData,
+                'user-1',
+                ValidatePrerequisitesStage.name,
+                {
+                    consumeTrialReviewCredit: true,
+                    trialReviewCreditUsageKey: 'repo-1:42',
+                },
+            );
+        });
+
+        it('posts a BYOK-focused comment (not "trial ended") when trial credits run out', async () => {
+            const context = makeContext();
+
+            mockPermissionValidationService.validateExecutionPermissions.mockResolvedValue(
+                {
+                    allowed: false,
+                    errorType: ValidationErrorType.PLAN_LIMIT_EXCEEDED,
+                    subscriptionStatus: 'trial',
+                },
+            );
+            mockParametersService.findByKey.mockResolvedValue({
+                configValue: {
+                    configs: { showStatusFeedback: true },
+                    repositories: [],
+                },
+            });
+
+            await stage.execute(context);
+
+            const body =
+                mockCodeManagementService.createIssueComment.mock.calls[0][0]
+                    .body;
+            expect(body).toContain('Kodus-paid PR reviews');
+            expect(body).toContain('/organization/byok');
+            expect(body).not.toContain('trial has ended');
         });
     });
 });

--- a/libs/code-review/pipeline/stages/validate-prerequisites.stage.ts
+++ b/libs/code-review/pipeline/stages/validate-prerequisites.stage.ts
@@ -56,9 +56,16 @@ import { CodeReviewPipelineContext } from '../context/code-review-pipeline.conte
 
 const SKIPPED_NO_LICENSE_RATE_LIMIT_TTL_SECONDS = 24 * 60 * 60; // 24h
 
+type NoActiveSubscriptionType =
+    | 'user'
+    | 'general'
+    | 'byok_required'
+    | 'trial_credits_exhausted'
+    | 'no_error';
+
 const ERROR_TO_MESSAGE_TYPE: Record<
     ValidationErrorType,
-    'user' | 'general' | 'byok_required' | 'no_error'
+    NoActiveSubscriptionType
 > = {
     [ValidationErrorType.INVALID_LICENSE]: 'general',
     [ValidationErrorType.USER_NOT_LICENSED]: 'user',
@@ -410,9 +417,21 @@ export class ValidatePrerequisitesStage extends BasePipelineStage<CodeReviewPipe
                 });
             }
         } else {
-            const noActiveSubscriptionType = validationResult.errorType
-                ? ERROR_TO_MESSAGE_TYPE[validationResult.errorType]
-                : 'general';
+            let noActiveSubscriptionType: NoActiveSubscriptionType =
+                validationResult.errorType
+                    ? ERROR_TO_MESSAGE_TYPE[validationResult.errorType]
+                    : 'general';
+
+            // Running out of Kodus-paid trial reviews is a plan limit, but the
+            // trial itself (features/time) is still active — and BYOK keeps
+            // reviews running for free. Steer there instead of "trial ended".
+            if (
+                validationResult.errorType ===
+                    ValidationErrorType.PLAN_LIMIT_EXCEEDED &&
+                validationResult.subscriptionStatus === 'trial'
+            ) {
+                noActiveSubscriptionType = 'trial_credits_exhausted';
+            }
 
             if (showStatusFeedback) {
                 await this.createNoActiveSubscriptionComment({
@@ -657,11 +676,7 @@ export class ValidatePrerequisitesStage extends BasePipelineStage<CodeReviewPipe
         organizationAndTeamData: OrganizationAndTeamData;
         repository: { id: string; name: string };
         prNumber: number;
-        noActiveSubscriptionType:
-            | 'user'
-            | 'general'
-            | 'byok_required'
-            | 'no_error';
+        noActiveSubscriptionType: NoActiveSubscriptionType;
     }) {
         if (params.noActiveSubscriptionType === 'no_error') {
             return;
@@ -673,6 +688,10 @@ export class ValidatePrerequisitesStage extends BasePipelineStage<CodeReviewPipe
             message = await this.noActiveSubscriptionForUser();
         } else if (params.noActiveSubscriptionType === 'byok_required') {
             message = await this.noBYOKConfiguredMessage();
+        } else if (
+            params.noActiveSubscriptionType === 'trial_credits_exhausted'
+        ) {
+            message = await this.trialCreditsExhaustedMessage();
         }
 
         await this.codeManagementService.createIssueComment({
@@ -698,6 +717,19 @@ export class ValidatePrerequisitesStage extends BasePipelineStage<CodeReviewPipe
             '## Your trial has ended! 😢\n\n' +
             'To keep getting reviews, activate your plan [here](https://app.kodus.io/settings/subscription).\n\n' +
             'Got questions about plans or want to see if we can extend your trial? Talk to our founders [here](https://cal.com/gabrielmalinosqui/30min).😎\n\n' +
+            '<!-- kody-codereview -->'
+        );
+    }
+
+    private async trialCreditsExhaustedMessage(): Promise<string> {
+        return (
+            "## You've used all your free Kodus-paid PR reviews 🎁\n\n" +
+            'Your trial is still active — this just means the PR reviews we ' +
+            'cover during the trial are used up.\n\n' +
+            '**[Connect your own AI key](https://app.kodus.io/organization/byok)** ' +
+            'to keep Kody reviewing — unlimited reviews, on any plan (Free included).\n\n' +
+            'Want more trial reviews to finish evaluating before adding a key? ' +
+            '[Talk to our founders](https://cal.com/gabrielmalinosqui/30min). 😎\n\n' +
             '<!-- kody-codereview -->'
         );
     }

--- a/libs/code-review/pipeline/stages/validate-prerequisites.stage.ts
+++ b/libs/code-review/pipeline/stages/validate-prerequisites.stage.ts
@@ -203,6 +203,13 @@ export class ValidatePrerequisitesStage extends BasePipelineStage<CodeReviewPipe
                 organizationAndTeamData,
                 userGitId,
                 ValidatePrerequisitesStage.name,
+                {
+                    consumeTrialReviewCredit: true,
+                    trialReviewCreditUsageKey:
+                        context.repository?.id && pullRequest?.number
+                            ? `${context.repository.id}:${pullRequest.number}`
+                            : undefined,
+                },
             );
 
         if (
@@ -231,7 +238,9 @@ export class ValidatePrerequisitesStage extends BasePipelineStage<CodeReviewPipe
 
         // If validation failed due to USER_NOT_LICENSED, try auto-assign FIRST
         // (before checking autoReviewEnabled, because auto-assign should work regardless)
-        if (validationResult.errorType === ValidationErrorType.USER_NOT_LICENSED) {
+        if (
+            validationResult.errorType === ValidationErrorType.USER_NOT_LICENSED
+        ) {
             const failureHandled = await this.handleValidationFailure(
                 context,
                 validationResult,
@@ -887,7 +896,8 @@ export class ValidatePrerequisitesStage extends BasePipelineStage<CodeReviewPipe
             this.logger.error({
                 message:
                     'Failed to emit review.skipped_no_license notification',
-                error: error instanceof Error ? error : new Error(String(error)),
+                error:
+                    error instanceof Error ? error : new Error(String(error)),
                 context: this.stageName,
             });
         }

--- a/libs/ee/license/interfaces/license.interface.ts
+++ b/libs/ee/license/interfaces/license.interface.ts
@@ -32,10 +32,25 @@ export type OrganizationLicenseValidationResult = {
     numberOfLicenses?: number;
     planType?: string;
     expiresAt?: string;
+    byok?: boolean;
+    trialReviewCreditsTotal?: number;
+    trialReviewCreditsUsed?: number;
+    trialReviewCreditsRemaining?: number;
+    trialCreditTier?: string;
+    trialUnlocks?: TrialUnlock[];
 };
 
 export type UserWithLicense = {
     git_id: string;
+};
+
+export type TrialUnlock = {
+    key: string;
+    status: 'locked' | 'available' | 'completed' | 'claimed' | string;
+    rewardCredits?: number;
+    title?: string;
+    description?: string;
+    completedAt?: string;
 };
 
 export const LICENSE_SERVICE_TOKEN = Symbol.for('LicenseService');

--- a/libs/ee/license/interfaces/license.interface.ts
+++ b/libs/ee/license/interfaces/license.interface.ts
@@ -53,6 +53,17 @@ export type TrialUnlock = {
     completedAt?: string;
 };
 
+export type ConsumeTrialReviewCreditResult = {
+    allowed: boolean;
+    reason?: string;
+    alreadyConsumed?: boolean;
+    trialReviewCreditsTotal?: number;
+    trialReviewCreditsUsed?: number;
+    trialReviewCreditsRemaining?: number;
+    trialCreditTier?: string;
+    trialUnlocks?: TrialUnlock[];
+};
+
 export const LICENSE_SERVICE_TOKEN = Symbol.for('LicenseService');
 
 export interface ILicenseService {
@@ -89,4 +100,15 @@ export interface ILicenseService {
         userGitId: string,
         provider: string,
     ): Promise<boolean>;
+
+    /**
+     * Atomically consume one Kodus-funded trial review credit.
+     *
+     * @param organizationAndTeamData Organization ID and team ID.
+     * @param usageKey Optional idempotency key for the reviewed PR.
+     */
+    consumeTrialReviewCredit(
+        organizationAndTeamData: OrganizationAndTeamData,
+        usageKey?: string,
+    ): Promise<ConsumeTrialReviewCreditResult>;
 }

--- a/libs/ee/license/license.service.spec.ts
+++ b/libs/ee/license/license.service.spec.ts
@@ -1,0 +1,68 @@
+import { LicenseService } from './license.service';
+
+/**
+ * Cloud LicenseService.consumeTrialReviewCredit talks to the billing
+ * microservice. These tests pin the error contract that the review pipeline
+ * relies on:
+ *   - a billing "allowed:false" body (e.g. credits exhausted) is PROPAGATED
+ *     so the caller can surface the real reason, and
+ *   - any other failure FAILS CLOSED (allowed:false) so a flaky billing call
+ *     can never silently grant a free managed review.
+ */
+describe('LicenseService.consumeTrialReviewCredit', () => {
+    const orgTeam = { organizationId: 'org-1', teamId: 'team-1' } as any;
+
+    const makeService = (post: jest.Mock) => {
+        const service = new LicenseService();
+        (service as any).licenseRequest = { post };
+        return service;
+    };
+
+    it('returns the billing result and forwards org/team/usageKey on success', async () => {
+        const billingResult = {
+            allowed: true,
+            trialReviewCreditsRemaining: 4,
+            trialReviewCreditsUsed: 1,
+        };
+        const post = jest.fn().mockResolvedValue(billingResult);
+        const service = makeService(post);
+
+        const result = await service.consumeTrialReviewCredit(
+            orgTeam,
+            'repo-9:42',
+        );
+
+        expect(result).toEqual(billingResult);
+        expect(post).toHaveBeenCalledWith('trial-review-credit/consume', {
+            organizationId: 'org-1',
+            teamId: 'team-1',
+            usageKey: 'repo-9:42',
+        });
+    });
+
+    it('propagates a billing allowed:false response (e.g. exhausted credits)', async () => {
+        const denied = {
+            allowed: false,
+            reason: 'TRIAL_REVIEW_CREDITS_EXHAUSTED',
+            trialReviewCreditsRemaining: 0,
+        };
+        const post = jest.fn().mockRejectedValue({ response: { data: denied } });
+        const service = makeService(post);
+
+        const result = await service.consumeTrialReviewCredit(orgTeam);
+
+        expect(result).toEqual(denied);
+    });
+
+    it('fails closed when billing errors without an allowed:false body', async () => {
+        const post = jest.fn().mockRejectedValue(new Error('network down'));
+        const service = makeService(post);
+
+        const result = await service.consumeTrialReviewCredit(orgTeam);
+
+        expect(result).toEqual({
+            allowed: false,
+            reason: 'CONSUME_TRIAL_REVIEW_CREDIT_FAILED',
+        });
+    });
+});

--- a/libs/ee/license/license.service.ts
+++ b/libs/ee/license/license.service.ts
@@ -1,9 +1,12 @@
 import { createLogger } from '@kodus/flow';
 
+import { AxiosError } from 'axios';
+
 import { AxiosLicenseService } from '@libs/core/infrastructure/config/axios/microservices/license.axios';
 import { OrganizationAndTeamData } from '@libs/core/infrastructure/config/types/general/organizationAndTeamData';
 
 import {
+    ConsumeTrialReviewCreditResult,
     ILicenseService,
     OrganizationLicenseValidationResult,
     UserWithLicense,
@@ -51,6 +54,45 @@ export class LicenseService implements ILicenseService {
                 },
             });
             return { valid: false };
+        }
+    }
+
+    async consumeTrialReviewCredit(
+        organizationAndTeamData: OrganizationAndTeamData,
+        usageKey?: string,
+    ): Promise<ConsumeTrialReviewCreditResult> {
+        try {
+            return await this.licenseRequest.post(
+                'trial-review-credit/consume',
+                {
+                    organizationId: organizationAndTeamData.organizationId,
+                    teamId: organizationAndTeamData.teamId,
+                    usageKey,
+                },
+            );
+        } catch (error) {
+            const responseData = (error as AxiosError)?.response
+                ?.data as ConsumeTrialReviewCreditResult;
+
+            if (responseData?.allowed === false) {
+                return responseData;
+            }
+
+            this.logger.error({
+                message: 'ConsumeTrialReviewCredit not working',
+                context: LicenseService.name,
+                error,
+                serviceName: 'LicenseService consumeTrialReviewCredit',
+                metadata: {
+                    ...organizationAndTeamData,
+                    usageKey,
+                },
+            });
+
+            return {
+                allowed: false,
+                reason: 'CONSUME_TRIAL_REVIEW_CREDIT_FAILED',
+            };
         }
     }
 

--- a/libs/ee/license/self-hosted-license.service.spec.ts
+++ b/libs/ee/license/self-hosted-license.service.spec.ts
@@ -46,3 +46,27 @@ describe('SelfHostedLicenseService.getLicenseKey', () => {
         expect(await getKey(makeService())).toBeNull();
     });
 });
+
+/**
+ * Self-hosted has no Kodus-funded managed trial credits, so credit
+ * consumption must always allow — the licensed seat model gates reviews
+ * instead. Returning allowed:false here would block self-hosted reviews.
+ */
+describe('SelfHostedLicenseService.consumeTrialReviewCredit', () => {
+    const orgTeam = { organizationId: 'org-1', teamId: 'team-1' } as any;
+    const makeService = () =>
+        new SelfHostedLicenseService({ findByKey: jest.fn() } as any);
+
+    it('always allows on self-hosted', async () => {
+        const result = await makeService().consumeTrialReviewCredit(orgTeam);
+        expect(result).toEqual({ allowed: true, reason: 'SELF_HOSTED' });
+    });
+
+    it('allows regardless of the usageKey', async () => {
+        const result = await makeService().consumeTrialReviewCredit(
+            orgTeam,
+            'repo-1:7',
+        );
+        expect(result.allowed).toBe(true);
+    });
+});

--- a/libs/ee/license/self-hosted-license.service.ts
+++ b/libs/ee/license/self-hosted-license.service.ts
@@ -10,6 +10,7 @@ import {
 } from '@libs/organization/domain/organizationParameters/contracts/organizationParameters.service.contract';
 
 import {
+    ConsumeTrialReviewCreditResult,
     ILicenseService,
     OrganizationLicenseValidationResult,
     SelfHostedLicensePayload,
@@ -199,6 +200,16 @@ export class SelfHostedLicenseService implements ILicenseService {
             });
             return false;
         }
+    }
+
+    async consumeTrialReviewCredit(
+        _organizationAndTeamData: OrganizationAndTeamData,
+        _usageKey?: string,
+    ): Promise<ConsumeTrialReviewCreditResult> {
+        return {
+            allowed: true,
+            reason: 'SELF_HOSTED',
+        };
     }
 
     private async getAssignedUsers(

--- a/libs/ee/shared/services/permissionValidation.service.ts
+++ b/libs/ee/shared/services/permissionValidation.service.ts
@@ -168,11 +168,68 @@ export class PermissionValidationService {
                 };
             }
 
-            // 2. Trial always allows (no BYOK required and no user validation)
+            // 2. Trial skips user validation, but still honors BYOK and
+            // billing-managed review credits when those fields are present.
             if (validation.subscriptionStatus === 'trial') {
+                let trialByokConfig: BYOKConfig | null = null;
+
+                try {
+                    trialByokConfig = await this.getBYOKConfig(
+                        organizationAndTeamData,
+                    );
+                } catch (error) {
+                    this.logger.warn({
+                        message:
+                            'Could not resolve BYOK config for trial; continuing with managed trial validation',
+                        context:
+                            contextName || PermissionValidationService.name,
+                        metadata: { organizationAndTeamData },
+                        error,
+                    });
+                }
+
+                if (
+                    !trialByokConfig &&
+                    validation.trialReviewCreditsRemaining === 0
+                ) {
+                    this.logger.warn({
+                        message: 'Trial managed review credits exhausted',
+                        context:
+                            contextName || PermissionValidationService.name,
+                        metadata: {
+                            organizationAndTeamData,
+                            trialReviewCreditsTotal:
+                                validation.trialReviewCreditsTotal,
+                            trialReviewCreditsUsed:
+                                validation.trialReviewCreditsUsed,
+                            trialCreditTier: validation.trialCreditTier,
+                            trialUnlocks: validation.trialUnlocks,
+                        },
+                    });
+
+                    return {
+                        allowed: false,
+                        errorType: ValidationErrorType.PLAN_LIMIT_EXCEEDED,
+                        metadata: { validation },
+                        subscriptionStatus: validation.subscriptionStatus,
+                    };
+                }
+
                 return {
                     allowed: true,
+                    byokConfig: trialByokConfig,
                     subscriptionStatus: validation.subscriptionStatus,
+                    metadata: {
+                        byok: Boolean(trialByokConfig),
+                        trialReviewCreditsTotal:
+                            validation.trialReviewCreditsTotal,
+                        trialReviewCreditsUsed:
+                            validation.trialReviewCreditsUsed,
+                        trialReviewCreditsRemaining:
+                            validation.trialReviewCreditsRemaining,
+                        trialCreditTier: validation.trialCreditTier,
+                        trialUnlocks: validation.trialUnlocks,
+                    },
                 };
             }
 

--- a/libs/ee/shared/services/permissionValidation.service.ts
+++ b/libs/ee/shared/services/permissionValidation.service.ts
@@ -194,7 +194,16 @@ export class PermissionValidationService {
                     });
                 }
 
+                // Only trials created under the managed-credit model carry
+                // these fields. Legacy trials (started before this shipped)
+                // have no credit data — they must keep the old behaviour:
+                // unlimited reviews for the full trial, no consumption, no gate.
+                const usesTrialCredits =
+                    typeof validation.trialReviewCreditsTotal === 'number' ||
+                    typeof validation.trialReviewCreditsRemaining === 'number';
+
                 if (
+                    usesTrialCredits &&
                     !trialByokConfig &&
                     validation.trialReviewCreditsRemaining === 0
                 ) {
@@ -221,7 +230,11 @@ export class PermissionValidationService {
                     };
                 }
 
-                if (!trialByokConfig && options.consumeTrialReviewCredit) {
+                if (
+                    usesTrialCredits &&
+                    !trialByokConfig &&
+                    options.consumeTrialReviewCredit
+                ) {
                     const consumeResult =
                         await this.licenseService.consumeTrialReviewCredit(
                             organizationAndTeamData,

--- a/libs/ee/shared/services/permissionValidation.service.ts
+++ b/libs/ee/shared/services/permissionValidation.service.ts
@@ -52,6 +52,11 @@ export interface ValidationResult {
     subscriptionStatus?: string;
 }
 
+export type ExecutionPermissionValidationOptions = {
+    consumeTrialReviewCredit?: boolean;
+    trialReviewCreditUsageKey?: string;
+};
+
 @Injectable()
 export class PermissionValidationService {
     private readonly isCloud: boolean;
@@ -118,6 +123,7 @@ export class PermissionValidationService {
         organizationAndTeamData: OrganizationAndTeamData,
         userGitId?: string,
         contextName?: string,
+        options: ExecutionPermissionValidationOptions = {},
     ): Promise<ValidationResult> {
         try {
             // Development mode always allows
@@ -213,6 +219,51 @@ export class PermissionValidationService {
                         metadata: { validation },
                         subscriptionStatus: validation.subscriptionStatus,
                     };
+                }
+
+                if (!trialByokConfig && options.consumeTrialReviewCredit) {
+                    const consumeResult =
+                        await this.licenseService.consumeTrialReviewCredit(
+                            organizationAndTeamData,
+                            options.trialReviewCreditUsageKey,
+                        );
+
+                    if (!consumeResult.allowed) {
+                        this.logger.warn({
+                            message: 'Trial review credit consumption denied',
+                            context:
+                                contextName || PermissionValidationService.name,
+                            metadata: {
+                                organizationAndTeamData,
+                                reason: consumeResult.reason,
+                                trialReviewCreditUsageKey:
+                                    options.trialReviewCreditUsageKey,
+                                consumeResult,
+                            },
+                        });
+
+                        return {
+                            allowed: false,
+                            errorType: ValidationErrorType.PLAN_LIMIT_EXCEEDED,
+                            metadata: { validation, consumeResult },
+                            subscriptionStatus: validation.subscriptionStatus,
+                        };
+                    }
+
+                    validation.trialReviewCreditsTotal =
+                        consumeResult.trialReviewCreditsTotal ??
+                        validation.trialReviewCreditsTotal;
+                    validation.trialReviewCreditsUsed =
+                        consumeResult.trialReviewCreditsUsed ??
+                        validation.trialReviewCreditsUsed;
+                    validation.trialReviewCreditsRemaining =
+                        consumeResult.trialReviewCreditsRemaining ??
+                        validation.trialReviewCreditsRemaining;
+                    validation.trialCreditTier =
+                        consumeResult.trialCreditTier ??
+                        validation.trialCreditTier;
+                    validation.trialUnlocks =
+                        consumeResult.trialUnlocks ?? validation.trialUnlocks;
                 }
 
                 return {

--- a/libs/ee/shared/services/permissionValidation.service.ts
+++ b/libs/ee/shared/services/permissionValidation.service.ts
@@ -178,12 +178,14 @@ export class PermissionValidationService {
             // billing-managed review credits when those fields are present.
             if (validation.subscriptionStatus === 'trial') {
                 let trialByokConfig: BYOKConfig | null = null;
+                let byokLookupFailed = false;
 
                 try {
                     trialByokConfig = await this.getBYOKConfig(
                         organizationAndTeamData,
                     );
                 } catch (error) {
+                    byokLookupFailed = true;
                     this.logger.warn({
                         message:
                             'Could not resolve BYOK config for trial; continuing with managed trial validation',
@@ -193,6 +195,12 @@ export class PermissionValidationService {
                         error,
                     });
                 }
+
+                // Only enforce the credit gate when we're CONFIDENT there's no
+                // BYOK. If the lookup threw we can't rule out a connected key,
+                // so a user who burned their credits and then connected BYOK
+                // must not be blocked by a flaky read — fail open on BYOK.
+                const noByok = !trialByokConfig && !byokLookupFailed;
 
                 // Only trials created under the managed-credit model carry
                 // these fields. Legacy trials (started before this shipped)
@@ -204,7 +212,7 @@ export class PermissionValidationService {
 
                 if (
                     usesTrialCredits &&
-                    !trialByokConfig &&
+                    noByok &&
                     validation.trialReviewCreditsRemaining === 0
                 ) {
                     this.logger.warn({
@@ -232,7 +240,7 @@ export class PermissionValidationService {
 
                 if (
                     usesTrialCredits &&
-                    !trialByokConfig &&
+                    noByok &&
                     options.consumeTrialReviewCredit
                 ) {
                     const consumeResult =

--- a/test/unit/ee/license/permission-validation-execution.spec.ts
+++ b/test/unit/ee/license/permission-validation-execution.spec.ts
@@ -41,6 +41,14 @@ function createMockLicenseService(overrides: any = {}) {
         }),
         getAllUsersWithLicense: jest.fn().mockResolvedValue([]),
         assignLicense: jest.fn().mockResolvedValue(true),
+        consumeTrialReviewCredit: jest.fn().mockResolvedValue({
+            allowed: true,
+            trialReviewCreditsTotal: 5,
+            trialReviewCreditsUsed: 1,
+            trialReviewCreditsRemaining: 4,
+            trialCreditTier: 'base',
+            trialUnlocks: [],
+        }),
     };
 }
 
@@ -104,6 +112,71 @@ describe('PermissionValidationService.validateExecutionPermissions', () => {
 
         const result = await service.validateExecutionPermissions(orgData);
         expect(result.allowed).toBe(true);
+    });
+
+    it('should consume one managed trial credit when requested by review execution', async () => {
+        const licenseService = createMockLicenseService({
+            subscriptionStatus: 'trial',
+            planType: 'trial',
+            trialReviewCreditsTotal: 5,
+            trialReviewCreditsUsed: 0,
+            trialReviewCreditsRemaining: 5,
+        });
+        const service = createService(
+            licenseService,
+            createMockOrgParamsService(),
+        );
+
+        const result = await service.validateExecutionPermissions(
+            orgData,
+            undefined,
+            'ValidatePrerequisitesStage',
+            {
+                consumeTrialReviewCredit: true,
+                trialReviewCreditUsageKey: 'repo-1:123',
+            },
+        );
+
+        expect(result.allowed).toBe(true);
+        expect(licenseService.consumeTrialReviewCredit).toHaveBeenCalledWith(
+            orgData,
+            'repo-1:123',
+        );
+        expect(result.metadata?.trialReviewCreditsRemaining).toBe(4);
+    });
+
+    it('should deny trial review when billing cannot consume a trial credit', async () => {
+        const licenseService = createMockLicenseService({
+            subscriptionStatus: 'trial',
+            planType: 'trial',
+            trialReviewCreditsTotal: 5,
+            trialReviewCreditsUsed: 5,
+            trialReviewCreditsRemaining: 1,
+        });
+        licenseService.consumeTrialReviewCredit.mockResolvedValue({
+            allowed: false,
+            reason: 'TRIAL_REVIEW_CREDITS_EXHAUSTED',
+            trialReviewCreditsTotal: 5,
+            trialReviewCreditsUsed: 5,
+            trialReviewCreditsRemaining: 0,
+        });
+        const service = createService(
+            licenseService,
+            createMockOrgParamsService(),
+        );
+
+        const result = await service.validateExecutionPermissions(
+            orgData,
+            undefined,
+            'ValidatePrerequisitesStage',
+            {
+                consumeTrialReviewCredit: true,
+                trialReviewCreditUsageKey: 'repo-1:123',
+            },
+        );
+
+        expect(result.allowed).toBe(false);
+        expect(result.errorType).toBe(ValidationErrorType.PLAN_LIMIT_EXCEEDED);
     });
 
     it('should deny managed trial when review credits are exhausted', async () => {

--- a/test/unit/ee/license/permission-validation-execution.spec.ts
+++ b/test/unit/ee/license/permission-validation-execution.spec.ts
@@ -240,6 +240,33 @@ describe('PermissionValidationService.validateExecutionPermissions', () => {
         expect(result.byokConfig).toEqual(byokConfig);
     });
 
+    it('should NOT consume a trial credit when BYOK is configured (key, not credits)', async () => {
+        const licenseService = createMockLicenseService({
+            subscriptionStatus: 'trial',
+            planType: 'trial',
+            trialReviewCreditsTotal: 5,
+            trialReviewCreditsUsed: 0,
+            trialReviewCreditsRemaining: 5,
+        });
+        const service = createService(
+            licenseService,
+            createMockOrgParamsService(byokConfig),
+        );
+
+        const result = await service.validateExecutionPermissions(
+            orgData,
+            undefined,
+            'ValidatePrerequisitesStage',
+            { consumeTrialReviewCredit: true, trialReviewCreditUsageKey: 'r:1' },
+        );
+
+        expect(result.allowed).toBe(true);
+        expect(result.byokConfig).toEqual(byokConfig);
+        expect(
+            licenseService.consumeTrialReviewCredit,
+        ).not.toHaveBeenCalled();
+    });
+
     // ─── free_byok ──────────────────────────────────────────────────
 
     describe('free_byok plan', () => {

--- a/test/unit/ee/license/permission-validation-execution.spec.ts
+++ b/test/unit/ee/license/permission-validation-execution.spec.ts
@@ -46,9 +46,9 @@ function createMockLicenseService(overrides: any = {}) {
 
 function createMockOrgParamsService(byok: any = null) {
     return {
-        findByKey: jest.fn().mockResolvedValue(
-            byok ? { configValue: byok } : null,
-        ),
+        findByKey: jest
+            .fn()
+            .mockResolvedValue(byok ? { configValue: byok } : null),
     };
 }
 
@@ -95,12 +95,49 @@ describe('PermissionValidationService.validateExecutionPermissions', () => {
 
     it('should allow trial without BYOK and without user check', async () => {
         const service = createService(
-            createMockLicenseService({ subscriptionStatus: 'trial', planType: 'trial' }),
+            createMockLicenseService({
+                subscriptionStatus: 'trial',
+                planType: 'trial',
+            }),
             createMockOrgParamsService(),
         );
 
         const result = await service.validateExecutionPermissions(orgData);
         expect(result.allowed).toBe(true);
+    });
+
+    it('should deny managed trial when review credits are exhausted', async () => {
+        const service = createService(
+            createMockLicenseService({
+                subscriptionStatus: 'trial',
+                planType: 'trial',
+                trialReviewCreditsTotal: 5,
+                trialReviewCreditsUsed: 5,
+                trialReviewCreditsRemaining: 0,
+            }),
+            createMockOrgParamsService(),
+        );
+
+        const result = await service.validateExecutionPermissions(orgData);
+        expect(result.allowed).toBe(false);
+        expect(result.errorType).toBe(ValidationErrorType.PLAN_LIMIT_EXCEEDED);
+    });
+
+    it('should allow BYOK trial even when managed review credits are exhausted', async () => {
+        const service = createService(
+            createMockLicenseService({
+                subscriptionStatus: 'trial',
+                planType: 'trial',
+                trialReviewCreditsTotal: 5,
+                trialReviewCreditsUsed: 5,
+                trialReviewCreditsRemaining: 0,
+            }),
+            createMockOrgParamsService(byokConfig),
+        );
+
+        const result = await service.validateExecutionPermissions(orgData);
+        expect(result.allowed).toBe(true);
+        expect(result.byokConfig).toEqual(byokConfig);
     });
 
     // ─── free_byok ──────────────────────────────────────────────────
@@ -112,7 +149,10 @@ describe('PermissionValidationService.validateExecutionPermissions', () => {
                 createMockOrgParamsService(byokConfig),
             );
 
-            const result = await service.validateExecutionPermissions(orgData, 'user-123');
+            const result = await service.validateExecutionPermissions(
+                orgData,
+                'user-123',
+            );
             expect(result.allowed).toBe(true);
         });
 
@@ -142,7 +182,9 @@ describe('PermissionValidationService.validateExecutionPermissions', () => {
 
     describe('teams_byok plan', () => {
         it('should allow with BYOK configured and user licensed', async () => {
-            const licenseService = createMockLicenseService({ planType: 'teams_byok' });
+            const licenseService = createMockLicenseService({
+                planType: 'teams_byok',
+            });
             licenseService.getAllUsersWithLicense.mockResolvedValue([
                 { git_id: 'user-123' },
             ]);
@@ -151,12 +193,17 @@ describe('PermissionValidationService.validateExecutionPermissions', () => {
                 createMockOrgParamsService(byokConfig),
             );
 
-            const result = await service.validateExecutionPermissions(orgData, 'user-123');
+            const result = await service.validateExecutionPermissions(
+                orgData,
+                'user-123',
+            );
             expect(result.allowed).toBe(true);
         });
 
         it('should deny when user is NOT licensed', async () => {
-            const licenseService = createMockLicenseService({ planType: 'teams_byok' });
+            const licenseService = createMockLicenseService({
+                planType: 'teams_byok',
+            });
             licenseService.getAllUsersWithLicense.mockResolvedValue([
                 { git_id: 'other-user' },
             ]);
@@ -165,9 +212,14 @@ describe('PermissionValidationService.validateExecutionPermissions', () => {
                 createMockOrgParamsService(byokConfig),
             );
 
-            const result = await service.validateExecutionPermissions(orgData, 'user-123');
+            const result = await service.validateExecutionPermissions(
+                orgData,
+                'user-123',
+            );
             expect(result.allowed).toBe(false);
-            expect(result.errorType).toBe(ValidationErrorType.USER_NOT_LICENSED);
+            expect(result.errorType).toBe(
+                ValidationErrorType.USER_NOT_LICENSED,
+            );
         });
 
         it('should deny when no userGitId provided', async () => {
@@ -188,22 +240,32 @@ describe('PermissionValidationService.validateExecutionPermissions', () => {
                 createMockOrgParamsService(),
             );
 
-            const result = await service.validateExecutionPermissions(orgData, 'user-123');
+            const result = await service.validateExecutionPermissions(
+                orgData,
+                'user-123',
+            );
             expect(result.allowed).toBe(false);
             expect(result.errorType).toBe(ValidationErrorType.BYOK_REQUIRED);
         });
 
         it('should deny when no licensed users exist at all', async () => {
-            const licenseService = createMockLicenseService({ planType: 'teams_byok' });
+            const licenseService = createMockLicenseService({
+                planType: 'teams_byok',
+            });
             licenseService.getAllUsersWithLicense.mockResolvedValue([]);
             const service = createService(
                 licenseService,
                 createMockOrgParamsService(byokConfig),
             );
 
-            const result = await service.validateExecutionPermissions(orgData, 'user-123');
+            const result = await service.validateExecutionPermissions(
+                orgData,
+                'user-123',
+            );
             expect(result.allowed).toBe(false);
-            expect(result.errorType).toBe(ValidationErrorType.USER_NOT_LICENSED);
+            expect(result.errorType).toBe(
+                ValidationErrorType.USER_NOT_LICENSED,
+            );
             expect(result.metadata?.availableUsers).toBe(0);
         });
     });
@@ -212,7 +274,9 @@ describe('PermissionValidationService.validateExecutionPermissions', () => {
 
     describe('teams_managed plan', () => {
         it('should allow when user is licensed', async () => {
-            const licenseService = createMockLicenseService({ planType: 'teams_managed' });
+            const licenseService = createMockLicenseService({
+                planType: 'teams_managed',
+            });
             licenseService.getAllUsersWithLicense.mockResolvedValue([
                 { git_id: 'user-123' },
             ]);
@@ -221,21 +285,31 @@ describe('PermissionValidationService.validateExecutionPermissions', () => {
                 createMockOrgParamsService(),
             );
 
-            const result = await service.validateExecutionPermissions(orgData, 'user-123');
+            const result = await service.validateExecutionPermissions(
+                orgData,
+                'user-123',
+            );
             expect(result.allowed).toBe(true);
         });
 
         it('should deny when user is NOT licensed', async () => {
-            const licenseService = createMockLicenseService({ planType: 'teams_managed' });
+            const licenseService = createMockLicenseService({
+                planType: 'teams_managed',
+            });
             licenseService.getAllUsersWithLicense.mockResolvedValue([]);
             const service = createService(
                 licenseService,
                 createMockOrgParamsService(),
             );
 
-            const result = await service.validateExecutionPermissions(orgData, 'user-123');
+            const result = await service.validateExecutionPermissions(
+                orgData,
+                'user-123',
+            );
             expect(result.allowed).toBe(false);
-            expect(result.errorType).toBe(ValidationErrorType.USER_NOT_LICENSED);
+            expect(result.errorType).toBe(
+                ValidationErrorType.USER_NOT_LICENSED,
+            );
         });
 
         it('should deny when no userGitId provided', async () => {
@@ -280,7 +354,10 @@ describe('PermissionValidationService.validateExecutionPermissions', () => {
                 createMockOrgParamsService(),
             );
 
-            const result = await service.validateExecutionPermissions(orgData, 'user-123');
+            const result = await service.validateExecutionPermissions(
+                orgData,
+                'user-123',
+            );
             expect(result.allowed).toBe(true);
         });
 
@@ -294,9 +371,14 @@ describe('PermissionValidationService.validateExecutionPermissions', () => {
                 createMockOrgParamsService(),
             );
 
-            const result = await service.validateExecutionPermissions(orgData, 'user-123');
+            const result = await service.validateExecutionPermissions(
+                orgData,
+                'user-123',
+            );
             expect(result.allowed).toBe(false);
-            expect(result.errorType).toBe(ValidationErrorType.USER_NOT_LICENSED);
+            expect(result.errorType).toBe(
+                ValidationErrorType.USER_NOT_LICENSED,
+            );
         });
 
         it('should allow with valid license and no userGitId', async () => {
@@ -316,13 +398,20 @@ describe('PermissionValidationService.validateExecutionPermissions', () => {
 
     describe('error handling', () => {
         it('should return BYOK_REQUIRED on BYOK_NOT_CONFIGURED exception', async () => {
-            const licenseService = createMockLicenseService({ planType: 'teams_byok' });
+            const licenseService = createMockLicenseService({
+                planType: 'teams_byok',
+            });
             const orgParamsService = createMockOrgParamsService();
-            orgParamsService.findByKey.mockRejectedValue(new Error('BYOK_NOT_CONFIGURED'));
+            orgParamsService.findByKey.mockRejectedValue(
+                new Error('BYOK_NOT_CONFIGURED'),
+            );
 
             const service = createService(licenseService, orgParamsService);
 
-            const result = await service.validateExecutionPermissions(orgData, 'user-123');
+            const result = await service.validateExecutionPermissions(
+                orgData,
+                'user-123',
+            );
             expect(result.allowed).toBe(false);
             expect(result.errorType).toBe(ValidationErrorType.BYOK_REQUIRED);
         });
@@ -337,7 +426,10 @@ describe('PermissionValidationService.validateExecutionPermissions', () => {
                 createMockOrgParamsService(),
             );
 
-            const result = await service.validateExecutionPermissions(orgData, 'user-123');
+            const result = await service.validateExecutionPermissions(
+                orgData,
+                'user-123',
+            );
             expect(result.allowed).toBe(false);
             expect(result.errorType).toBe(ValidationErrorType.INVALID_LICENSE);
         });

--- a/test/unit/ee/license/permission-validation-execution.spec.ts
+++ b/test/unit/ee/license/permission-validation-execution.spec.ts
@@ -114,6 +114,33 @@ describe('PermissionValidationService.validateExecutionPermissions', () => {
         expect(result.allowed).toBe(true);
     });
 
+    it('should NOT consume or gate a legacy trial that has no credit data (old behavior)', async () => {
+        const licenseService = createMockLicenseService({
+            subscriptionStatus: 'trial',
+            planType: 'trial',
+            // No trialReviewCredits* fields → legacy trial, pre-credit model.
+        });
+        const service = createService(
+            licenseService,
+            createMockOrgParamsService(),
+        );
+
+        const result = await service.validateExecutionPermissions(
+            orgData,
+            undefined,
+            'ValidatePrerequisitesStage',
+            {
+                consumeTrialReviewCredit: true,
+                trialReviewCreditUsageKey: 'repo-1:123',
+            },
+        );
+
+        expect(result.allowed).toBe(true);
+        expect(
+            licenseService.consumeTrialReviewCredit,
+        ).not.toHaveBeenCalled();
+    });
+
     it('should consume one managed trial credit when requested by review execution', async () => {
         const licenseService = createMockLicenseService({
             subscriptionStatus: 'trial',

--- a/test/unit/ee/license/permission-validation-execution.spec.ts
+++ b/test/unit/ee/license/permission-validation-execution.spec.ts
@@ -267,6 +267,35 @@ describe('PermissionValidationService.validateExecutionPermissions', () => {
         ).not.toHaveBeenCalled();
     });
 
+    it('does NOT block an exhausted trial when the BYOK lookup fails (fail open)', async () => {
+        // A user who burned their 5 credits and then connected BYOK must not
+        // be gated by a flaky BYOK-config read. When getBYOKConfig throws we
+        // can't rule out a key, so we neither block nor consume.
+        const licenseService = createMockLicenseService({
+            subscriptionStatus: 'trial',
+            planType: 'trial',
+            trialReviewCreditsTotal: 5,
+            trialReviewCreditsUsed: 5,
+            trialReviewCreditsRemaining: 0,
+        });
+        const flakyOrgParams = {
+            findByKey: jest.fn().mockRejectedValue(new Error('flaky DB')),
+        };
+        const service = createService(licenseService, flakyOrgParams);
+
+        const result = await service.validateExecutionPermissions(
+            orgData,
+            undefined,
+            'ValidatePrerequisitesStage',
+            { consumeTrialReviewCredit: true, trialReviewCreditUsageKey: 'r:1' },
+        );
+
+        expect(result.allowed).toBe(true);
+        expect(
+            licenseService.consumeTrialReviewCredit,
+        ).not.toHaveBeenCalled();
+    });
+
     // ─── free_byok ──────────────────────────────────────────────────
 
     describe('free_byok plan', () => {

--- a/tests/e2e/lib/__tests__/scenarios.test.ts
+++ b/tests/e2e/lib/__tests__/scenarios.test.ts
@@ -22,6 +22,7 @@ test("allScenarios: includes the registered release-gate scenarios", () => {
         "sso-cookie-domain",
         "sso-multi-user",
         "stripe-billing",
+        "trial-credits-consume",
         "trial-entitlement-gate",
         "trial-managed-review",
         "upgrade-n-1-to-n",

--- a/tests/e2e/lib/trial-provision.ts
+++ b/tests/e2e/lib/trial-provision.ts
@@ -82,6 +82,50 @@ export interface OrgLicense {
     valid?: boolean;
     subscriptionStatus?: string;
     planType?: string;
+    byok?: boolean;
+    trialReviewCreditsTotal?: number;
+    trialReviewCreditsUsed?: number;
+    trialReviewCreditsRemaining?: number;
+    trialCreditTier?: string;
+}
+
+export interface ConsumeCreditResult {
+    allowed: boolean;
+    reason?: string;
+    alreadyConsumed?: boolean;
+    trialReviewCreditsTotal?: number;
+    trialReviewCreditsUsed?: number;
+    trialReviewCreditsRemaining?: number;
+}
+
+/** Calls the billing consume endpoint exactly as the review pipeline does
+ *  (LicenseService.consumeTrialReviewCredit). Billing answers 200 when
+ *  allowed and 402 (allowed:false) when denied; both carry the credit body,
+ *  and `http` does not throw on non-2xx, so we return the body either way. */
+export async function consumeTrialReviewCredit(
+    ctx: RunContext,
+    session: KodusSession,
+    usageKey?: string,
+): Promise<ConsumeCreditResult> {
+    const target = ctx.target as TargetContext;
+    const resp = await http<ConsumeCreditResult>(
+        `${target.webBaseUrl}/api/proxy/billing/trial-review-credit/consume`,
+        {
+            method: "POST",
+            headers: { Authorization: `Bearer ${session.accessToken}` },
+            body: {
+                organizationId: session.organizationId,
+                teamId: session.teamId,
+                usageKey,
+            },
+            timeoutMs: 30_000,
+        },
+    );
+    ctx.assert(
+        resp.status === 200 || resp.status === 402,
+        `consume returned unexpected HTTP ${resp.status}: ${resp.raw.slice(0, 250)}`,
+    );
+    return resp.body ?? { allowed: false };
 }
 
 /** GET the org license exactly the way the backend's entitlement gate does

--- a/tests/e2e/matrix/fast.yml
+++ b/tests/e2e/matrix/fast.yml
@@ -37,10 +37,14 @@ scenarios:
     # the review scenarios.
     #   * trial-entitlement-gate: API-level, fails in seconds with a precise
     #     billing-level message (validate-org-license = valid + 'trial').
+    #   * trial-credits-consume: API-level credit accounting — consume
+    #     decrements, repeated usageKey is idempotent, exhaustion blocks. Fast,
+    #     no LLM; localizes credit/idempotency bugs in the gate↔billing path.
     #   * trial-managed-review: the REAL thing — throwaway repo (exclusive
     #     webhook route) + PR + managed-LLM review. The only cell exercising
     #     Kodus-managed keys; every other review cell is BYOK.
     - trial-entitlement-gate
+    - trial-credits-consume
     - trial-managed-review
     # Per-seat gate: appliesTo restricts to self-hosted × github × license-paid
     # (one cell). Skipped automatically when SH_LICENSE_KEY_PATH (default

--- a/tests/e2e/matrix/full.yml
+++ b/tests/e2e/matrix/full.yml
@@ -32,6 +32,7 @@ scenarios:
     # managed-review = throwaway repo + real managed-LLM review (the only
     # cell on Kodus-managed keys). See fast.yml for the full rationale.
     - trial-entitlement-gate
+    - trial-credits-consume
     - trial-managed-review
     # Per-seat gate: appliesTo restricts to self-hosted × github × license-paid
     # (one cell). Skipped automatically when SH_LICENSE_KEY_PATH (default

--- a/tests/e2e/scenarios/index.ts
+++ b/tests/e2e/scenarios/index.ts
@@ -16,6 +16,7 @@ import rbacUiRender from './rbac-ui-render.js';
 import ssoCookieDomain from './sso-cookie-domain.js';
 import ssoMultiUser from './sso-multi-user.js';
 import stripeBilling from './stripe-billing.js';
+import trialCreditsConsume from './trial-credits-consume.js';
 import trialEntitlementGate from './trial-entitlement-gate.js';
 import trialManagedReview from './trial-managed-review.js';
 import upgradeNMinusOneToN from './upgrade.js';
@@ -38,6 +39,7 @@ export const allScenarios: Record<string, Scenario> = {
     [ssoCookieDomain.id]: ssoCookieDomain,
     [ssoMultiUser.id]: ssoMultiUser,
     [stripeBilling.id]: stripeBilling,
+    [trialCreditsConsume.id]: trialCreditsConsume,
     [trialEntitlementGate.id]: trialEntitlementGate,
     [trialManagedReview.id]: trialManagedReview,
     [upgradeNMinusOneToN.id]: upgradeNMinusOneToN,
@@ -73,6 +75,7 @@ export {
     ssoCookieDomain,
     ssoMultiUser,
     stripeBilling,
+    trialCreditsConsume,
     trialEntitlementGate,
     trialManagedReview,
     upgradeNMinusOneToN,

--- a/tests/e2e/scenarios/trial-credits-consume.ts
+++ b/tests/e2e/scenarios/trial-credits-consume.ts
@@ -1,0 +1,119 @@
+import {
+    consumeTrialReviewCredit,
+    fetchOrgLicense,
+    provisionFreshTrialOrg,
+} from "../lib/trial-provision.js";
+import type { RunContext, Scenario } from "../lib/types.js";
+
+// ---------------------------------------------------------------------------
+// Trial review-credit mechanics (cloud-only, API-level, NO webhook).
+//
+// Fast, deterministic check of the cross-service credit contract that the
+// review gate relies on (permissionValidation.service.ts -> billing
+// /trial-review-credit/consume). No LLM, no PR — just the billing endpoint:
+//   1. a fresh trial carries credits (total === remaining > 0);
+//   2. consuming with a usageKey decrements by exactly 1;
+//   3. repeating the SAME usageKey is idempotent (no second decrement) — this
+//      is what stops a re-reviewed PR from being charged twice;
+//   4. consuming past 0 is blocked as TRIAL_REVIEW_CREDITS_EXHAUSTED.
+//
+// Sibling `trial-managed-review` proves the same gate end-to-end via a real
+// webhook review (~15 min); this one localizes credit-accounting bugs in
+// seconds. Legacy-trial (NULL credits stay unlimited) is covered by unit tests
+// on both services — it needs a NULL credit row which can't be set over the
+// remote billing API, so it is intentionally not a matrix cell.
+// ---------------------------------------------------------------------------
+
+export const trialCreditsConsume: Scenario = {
+    id: "trial-credits-consume",
+    title:
+        "Trial credits: consume decrements, repeated usageKey is idempotent, exhaustion blocks",
+    priority: "P0",
+    appliesTo: {
+        target: ["cloud"],
+        provider: ["github"],
+        license: ["trial"],
+    },
+    timeoutSec: 180,
+    async run(ctx: RunContext) {
+        const { email, session } = await provisionFreshTrialOrg(
+            ctx,
+            "e2e-trial-credits",
+        );
+
+        const license = await fetchOrgLicense(ctx, session);
+        ctx.assert(
+            license.valid === true && license.subscriptionStatus === "trial",
+            `Fresh org must be a valid trial: ${JSON.stringify(license)}`,
+        );
+
+        const total = license.trialReviewCreditsTotal;
+        ctx.assert(
+            typeof total === "number" && total > 0,
+            `A new trial must carry credits (numeric total > 0). license=${JSON.stringify(license)}`,
+        );
+        ctx.assert(
+            license.trialReviewCreditsRemaining === total,
+            `A fresh trial should have remaining === total, got remaining=${license.trialReviewCreditsRemaining}, total=${total}`,
+        );
+
+        // 1) Consume one credit with a usageKey → decrements by exactly 1.
+        const first = await consumeTrialReviewCredit(ctx, session, "e2e:pr-1");
+        ctx.assert(
+            first.allowed === true &&
+                first.trialReviewCreditsRemaining === total! - 1,
+            `First consume should allow and leave remaining=${total! - 1}: ${JSON.stringify(first)}`,
+        );
+
+        // 2) Same usageKey again → idempotent: no second decrement.
+        const repeat = await consumeTrialReviewCredit(ctx, session, "e2e:pr-1");
+        ctx.assert(
+            repeat.allowed === true &&
+                repeat.alreadyConsumed === true &&
+                repeat.trialReviewCreditsRemaining === total! - 1,
+            `Repeated usageKey must be idempotent (no second decrement): ${JSON.stringify(repeat)}`,
+        );
+
+        // 3) Drain the remaining credits with distinct keys.
+        let remaining = total! - 1;
+        let guard = total! + 2; // hard stop, never loop forever
+        for (let i = 2; remaining > 0 && guard-- > 0; i++) {
+            const r = await consumeTrialReviewCredit(
+                ctx,
+                session,
+                `e2e:pr-${i}`,
+            );
+            ctx.assert(
+                r.allowed === true,
+                `Consume while credits remain must allow: ${JSON.stringify(r)}`,
+            );
+            remaining = r.trialReviewCreditsRemaining ?? 0;
+        }
+        ctx.assert(
+            remaining === 0,
+            `Expected to drain credits to 0, got remaining=${remaining}`,
+        );
+
+        // 4) Consuming past 0 is blocked as exhausted.
+        const blocked = await consumeTrialReviewCredit(
+            ctx,
+            session,
+            "e2e:pr-over",
+        );
+        ctx.assert(
+            blocked.allowed === false &&
+                blocked.reason === "TRIAL_REVIEW_CREDITS_EXHAUSTED",
+            `Consuming past 0 must be blocked as exhausted: ${JSON.stringify(blocked)}`,
+        );
+
+        return {
+            email,
+            organizationId: session.organizationId,
+            teamId: session.teamId,
+            total,
+            finalRemaining: blocked.trialReviewCreditsRemaining,
+        };
+    },
+};
+
+export default trialCreditsConsume;


### PR DESCRIPTION
Trial gives N free **Kodus-paid** PR reviews (default 5); after that, **BYOK = unlimited on any plan** (reviews always run on the user's key). Plans differ by features, not review volume. Builds on the trial-unlock work.

## Highlights
- **Gate (API):** `permissionValidation` enforces trial credits only when billing sends numeric credit data (`usesTrialCredits`). **Legacy trials (no credit data) keep unlimited reviews** — no consume, no block. Consume is keyed by `repo:pr` (idempotent). `LicenseService.consumeTrialReviewCredit` fails closed; self-hosted always allows.
- **PR comment** on credit exhaustion is BYOK-focused (not "trial ended").
- **Request more trial reviews** → API `POST /license/trial-extension-request` → `TrialExtensionNotifierService` posts to Discord (`API_DISCORD_TRIAL_REQUEST_WEBHOOK_URL`, server-side; fails honestly if unset).
- **Web:** trial card with 3 states (BYOK / new-credits / legacy), single navbar "Team trial" badge with a scannable days+reviews tooltip, BYOK detection via `llmConfigStatus`, request-more popover, choose-plan ("reviews unlimited on your key, every plan" + license-vs-users), setup-page scroll fix + copy.
- **Env:** `API_DISCORD_TRIAL_REQUEST_WEBHOOK_URL` added to `.env.schema` (regenerated template/example/docs).
- **Docs:** rewrote `pricing.mdx` (scannable: cards, comparison table, steps), documented the trial model, SOC 2 compliant.

## Tests
- **60 unit tests** (gate legacy/consume/exhausted/byok/self-hosted, exhausted PR comment, request-extension fetch+notifier, trial utils, pure `getTrialCardState`).
- **New e2e matrix cell** `trial-credits-consume` (cloud × github × trial, HTTP-only): consume decrements → idempotent usageKey → exhaustion blocks. In `fast.yml`/`full.yml`; `scenarios.test` 17/17; dry-run scheduled.

## Cross-repo dependency
Requires **kodus-service-billing #46** — the gate keys off the credit data this branch reads from billing. Ship together.

## QA checklist
- [ ] E2E of a **new trial consuming → blocking at 0** via a real webhook review (unit + the new HTTP matrix cell cover it; the full webhook path isn't auto-verified).
- [ ] **Discord delivery** of request-more-reviews once `API_DISCORD_TRIAL_REQUEST_WEBHOOK_URL` is set.
- [ ] Legacy backward-compat live-validated manually (org stayed unlimited) — re-confirm on QA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)