### PR TITLE
fix(cockpit): show all label categories in suggestions filter

### DIFF
--- a/apps/web/src/features/ee/cockpit/review-suggestions/_components/explorer-filters.tsx
+++ b/apps/web/src/features/ee/cockpit/review-suggestions/_components/explorer-filters.tsx
@@ -5,17 +5,26 @@ import { Card } from "@components/ui/card";
 
 import type { ExplorerSearchParams } from "../page";
 
+// Keep in sync with LabelType in
+// libs/common/utils/codeManagement/labels.ts — suggestions are stored with
+// any of these label values, and the cockpit feedback widgets link here with
+// `?category=<label>`. Missing values (e.g. "bug") made those links land on a
+// filter the dropdown couldn't represent, silently showing "Category: all".
 const CATEGORIES = [
     "security",
     "potential_issues",
     "error_handling",
     "performance_and_optimization",
+    "performance",
     "maintainability",
     "refactoring",
     "code_style",
     "documentation_and_comments",
     "kody_rules",
     "breaking_changes",
+    "bug",
+    "cross_file",
+    "business_logic",
 ];
 
 const SEVERITIES = ["critical", "high", "medium", "low"];
@@ -67,6 +76,12 @@ export const ExplorerFilters = ({
                     apply({ category: e.target.value || undefined })
                 }>
                 <option value="">Category: all</option>
+                {/* A category that arrived via the URL but isn't in the
+                    canonical list still renders, so the active filter is
+                    visible instead of falling back to "Category: all". */}
+                {params.category && !CATEGORIES.includes(params.category) && (
+                    <option value={params.category}>{params.category}</option>
+                )}
                 {CATEGORIES.map((c) => (
                     <option key={c} value={c}>
                         {c}


### PR DESCRIPTION
## Problem

The Cockpit → Suggestions filter dropdown only listed **10 of the 14** `LabelType` values, omitting `bug`, `performance`, `cross_file` and `business_logic`.

Suggestions are stored with any of those labels, and the cockpit **Negative feedback (👎) → By category** and **Rate by category** widgets link to `/review-suggestions?category=<label>` using the raw stored label. Clicking a `bug` bar landed on `?category=bug` — a value the dropdown couldn't represent.

Two things then combined to make it look like the filter "fell back to all":

1. The `searchSuggestions` query **did** apply `AND s."label" = 'bug'`, so the table was genuinely filtered.
2. The controlled `<select value="bug">` had no matching `<option>`, so the browser rendered the first option, **"Category: all"** — hiding that a filter was active and giving no way to clear it.

## Fix

- Sync `CATEGORIES` with the canonical `LabelType` enum (`libs/common/utils/codeManagement/labels.ts`), adding the 4 missing values.
- Make the `<select>` tolerant: any out-of-list `category` arriving via the URL still renders as the selected option, so the active filter stays visible instead of silently reading as "all". This also covers future data/UI taxonomy drift.

## Scope

Single file: `apps/web/.../review-suggestions/_components/explorer-filters.tsx`. No backend/query changes.

## Follow-up (not in this PR)

Could derive `CATEGORIES` from `Object.values(LabelType)` to drop the manual sync, but that import pulls `labels.json` into the web bundle — left out deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)