### PR TITLE
feat(cockpit): shareable dashboard views via URL filter state

### DIFF
--- a/apps/web/src/core/components/ui/data-table.tsx
+++ b/apps/web/src/core/components/ui/data-table.tsx
@@ -64,16 +64,21 @@ export function DataTable<TData>({
         /** Show a global search box that filters across all columns. */
         searchable?: boolean;
         searchPlaceholder?: string;
-        /**
-         * Controlled search value. When provided (with `onSearchChange`),
-         * the caller owns the search state — e.g. to mirror it into the
-         * URL. Otherwise the search box is internally uncontrolled.
-         */
-        searchValue?: string;
-        onSearchChange?: (value: string) => void;
         /** Enable client-side pagination at this page size. */
         pageSize?: number;
-    }) {
+    } & (
+        | { searchValue?: undefined; onSearchChange?: undefined }
+        | {
+              /**
+               * Controlled search value. When provided, the caller owns the
+               * search state (e.g. to mirror it into the URL) and the
+               * matching `onSearchChange` handler is required — the union
+               * prevents passing one without the other.
+               */
+              searchValue: string;
+              onSearchChange: (value: string) => void;
+          }
+    )) {
     const [internalFilter, setInternalFilter] = useState("");
     const controlledSearch = searchValue !== undefined;
     const globalFilter = controlledSearch ? searchValue : internalFilter;

--- a/apps/web/src/core/components/ui/data-table.tsx
+++ b/apps/web/src/core/components/ui/data-table.tsx
@@ -50,6 +50,8 @@ export function DataTable<TData>({
     onRowClick,
     searchable,
     searchPlaceholder = "Search…",
+    searchValue,
+    onSearchChange,
     pageSize,
     ...tableProps
 }: Omit<TableOptions<TData>, "data" | "columns" | "getCoreRowModel"> &
@@ -62,10 +64,24 @@ export function DataTable<TData>({
         /** Show a global search box that filters across all columns. */
         searchable?: boolean;
         searchPlaceholder?: string;
+        /**
+         * Controlled search value. When provided (with `onSearchChange`),
+         * the caller owns the search state — e.g. to mirror it into the
+         * URL. Otherwise the search box is internally uncontrolled.
+         */
+        searchValue?: string;
+        onSearchChange?: (value: string) => void;
         /** Enable client-side pagination at this page size. */
         pageSize?: number;
     }) {
-    const [globalFilter, setGlobalFilter] = useState("");
+    const [internalFilter, setInternalFilter] = useState("");
+    const controlledSearch = searchValue !== undefined;
+    const globalFilter = controlledSearch ? searchValue : internalFilter;
+    const setGlobalFilter = (updater: string | ((prev: string) => string)) => {
+        const next =
+            typeof updater === "function" ? updater(globalFilter) : updater;
+        (controlledSearch ? onSearchChange! : setInternalFilter)(next);
+    };
     const enablePagination = typeof pageSize === "number";
 
     const table = useReactTable({

--- a/apps/web/src/core/utils/headers.ts
+++ b/apps/web/src/core/utils/headers.ts
@@ -1,7 +1,15 @@
 import { headers } from "next/headers";
 
 export const CURRENT_PATH_HEADER = "x-current-path";
+export const CURRENT_SEARCH_HEADER = "x-current-search";
 
 // depends on middleware: https://github.com/vercel/next.js/issues/43704#issuecomment-1411186664
 export const getCurrentPathnameOnServerComponents = async () =>
     (await headers()).get(CURRENT_PATH_HEADER);
+
+// The request URL's query string, mirrored into a header by middleware
+// (server components can't read `searchParams` unless it's prop-drilled
+// from a page). Returns a `URLSearchParams` — empty when there is no
+// query. The constructor strips a single leading "?" per spec.
+export const getCurrentSearchParamsOnServerComponents = async () =>
+    new URLSearchParams((await headers()).get(CURRENT_SEARCH_HEADER) ?? "");

--- a/apps/web/src/features/ee/cockpit/@kodusReviewTab/_components/feedback-section.tsx
+++ b/apps/web/src/features/ee/cockpit/@kodusReviewTab/_components/feedback-section.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { useRouter } from "next/navigation";
 import {
     Card,
@@ -20,6 +19,8 @@ import {
 } from "recharts";
 
 import { CockpitNoDataPlaceholder } from "../../_components/no-data-placeholder";
+import { COCKPIT_REVIEW_PARAM } from "../../_constants";
+import { useShallowParam } from "../../_helpers/use-shallow-param";
 import type {
     NegativeFeedbackByCategoryRow,
     NegativeFeedbackWeeklyRow,
@@ -152,7 +153,11 @@ export const FeedbackSection = ({
     byCategory: NegativeFeedbackByCategoryRow[];
     weekly: NegativeFeedbackWeeklyRow[];
 }) => {
-    const [mode, setMode] = useState<Mode>("category");
+    const [mode, setMode] = useShallowParam<Mode>(
+        COCKPIT_REVIEW_PARAM.feedbackMode,
+        "category",
+        ["category", "trend"],
+    );
 
     return (
         <Card color="lv1">

--- a/apps/web/src/features/ee/cockpit/@kodusReviewTab/_components/rate-by-severity-chart.tsx
+++ b/apps/web/src/features/ee/cockpit/@kodusReviewTab/_components/rate-by-severity-chart.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import {
     Bar,
     BarChart,
@@ -15,6 +14,8 @@ import {
 } from "recharts";
 
 import { CockpitNoDataPlaceholder } from "../../_components/no-data-placeholder";
+import { COCKPIT_REVIEW_PARAM } from "../../_constants";
+import { useShallowParam } from "../../_helpers/use-shallow-param";
 import type { ImplementationRateBySeverityRow } from "../../_services/analytics/review/fetch";
 import { SEVERITY_COLORS } from "./chart-constants";
 import { TogglePills } from "./toggle-pills";
@@ -69,7 +70,11 @@ export const RateBySeverityChart = ({
 }: {
     data: ImplementationRateBySeverityRow[];
 }) => {
-    const [source, setSource] = useState<Source>("all");
+    const [source, setSource] = useShallowParam<Source>(
+        COCKPIT_REVIEW_PARAM.severitySource,
+        "all",
+        ["all", "native"],
+    );
 
     if (!data.length) return <CockpitNoDataPlaceholder />;
 

--- a/apps/web/src/features/ee/cockpit/@kodusReviewTab/_components/repositories-health-table.tsx
+++ b/apps/web/src/features/ee/cockpit/@kodusReviewTab/_components/repositories-health-table.tsx
@@ -1,11 +1,13 @@
 "use client";
 
 import { useTransition } from "react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { DataTable } from "@components/ui/data-table";
 
 import { setCockpitRepositoryCookie } from "../../_actions/set-cockpit-repository";
 import { CockpitNoDataPlaceholder } from "../../_components/no-data-placeholder";
+import { COCKPIT_PARAM, COCKPIT_REVIEW_PARAM } from "../../_constants";
+import { useShallowParam } from "../../_helpers/use-shallow-param";
 import type { RepositoryHealthRow } from "../../_services/analytics/review/fetch";
 import { repositoriesColumns } from "./repositories-columns";
 
@@ -15,14 +17,26 @@ export const RepositoriesHealthTable = ({
     data: RepositoryHealthRow[];
 }) => {
     const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
     const [, startTransition] = useTransition();
+    const [search, setSearch] = useShallowParam<string>(
+        COCKPIT_REVIEW_PARAM.reposQuery,
+        "",
+    );
 
     if (!data.length) return <CockpitNoDataPlaceholder />;
 
+    // Push the repository onto the URL (source of truth, so the focused
+    // view is shareable and not shadowed by a stale `repository` param)
+    // and persist it to the cookie default — same contract as the
+    // top-bar repository picker.
     const focusRepository = (row: RepositoryHealthRow) => {
+        const params = new URLSearchParams(searchParams.toString());
+        params.set(COCKPIT_PARAM.repository, row.repository);
         startTransition(async () => {
             await setCockpitRepositoryCookie(row.repository);
-            router.refresh();
+            router.push(`${pathname}?${params.toString()}`);
         });
     };
 
@@ -33,6 +47,8 @@ export const RepositoriesHealthTable = ({
                 data={data}
                 searchable
                 searchPlaceholder="Search repositories…"
+                searchValue={search}
+                onSearchChange={setSearch}
                 pageSize={10}
                 getRowId={(row) => row.repository}
                 onRowClick={focusRepository}

--- a/apps/web/src/features/ee/cockpit/@kodusReviewTab/_components/rules-health-table.tsx
+++ b/apps/web/src/features/ee/cockpit/@kodusReviewTab/_components/rules-health-table.tsx
@@ -1,17 +1,20 @@
 "use client";
 
-import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { DataTable } from "@components/ui/data-table";
 import { cn } from "src/core/utils/components";
 
+import { COCKPIT_REVIEW_PARAM } from "../../_constants";
+import { useShallowParam } from "../../_helpers/use-shallow-param";
 import type {
     KodyRuleHealthRow,
     KodyRuleHealthState,
 } from "../../_services/analytics/review/fetch";
 import { rulesColumns } from "./rules-columns";
 
-const FILTERS: Array<{ value: KodyRuleHealthState | "all"; label: string }> = [
+type RuleFilter = KodyRuleHealthState | "all";
+
+const FILTERS: Array<{ value: RuleFilter; label: string }> = [
     { value: "all", label: "All" },
     { value: "healthy", label: "Healthy" },
     { value: "noisy", label: "Noisy" },
@@ -19,9 +22,19 @@ const FILTERS: Array<{ value: KodyRuleHealthState | "all"; label: string }> = [
     { value: "stale", label: "Stale" },
 ];
 
+const FILTER_VALUES = FILTERS.map((f) => f.value);
+
 export const RulesHealthTable = ({ data }: { data: KodyRuleHealthRow[] }) => {
     const router = useRouter();
-    const [filter, setFilter] = useState<KodyRuleHealthState | "all">("all");
+    const [filter, setFilter] = useShallowParam<RuleFilter>(
+        COCKPIT_REVIEW_PARAM.rulesHealth,
+        "all",
+        FILTER_VALUES,
+    );
+    const [search, setSearch] = useShallowParam<string>(
+        COCKPIT_REVIEW_PARAM.rulesQuery,
+        "",
+    );
 
     if (!data.length) {
         return (
@@ -58,6 +71,8 @@ export const RulesHealthTable = ({ data }: { data: KodyRuleHealthRow[] }) => {
                 data={filtered}
                 searchable
                 searchPlaceholder="Search rules…"
+                searchValue={search}
+                onSearchChange={setSearch}
                 pageSize={10}
                 getRowId={(row) => row.ruleId}
                 onRowClick={(row) =>

--- a/apps/web/src/features/ee/cockpit/@kodusReviewTab/_components/weekly-implementation-chart.tsx
+++ b/apps/web/src/features/ee/cockpit/@kodusReviewTab/_components/weekly-implementation-chart.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import {
     Area,
     AreaChart,
@@ -14,6 +13,8 @@ import {
 } from "recharts";
 
 import { CockpitNoDataPlaceholder } from "../../_components/no-data-placeholder";
+import { COCKPIT_REVIEW_PARAM } from "../../_constants";
+import { useShallowParam } from "../../_helpers/use-shallow-param";
 import type { ImplementationRateWeeklyRow } from "../../_services/analytics/review/fetch";
 import { ChartTooltip } from "./chart-tooltip";
 import { SEVERITY_COLORS, SEVERITY_ORDER } from "./chart-constants";
@@ -32,7 +33,11 @@ export const WeeklyImplementationChart = ({
 }: {
     data: ImplementationRateWeeklyRow[];
 }) => {
-    const [mode, setMode] = useState<Mode>("overall");
+    const [mode, setMode] = useShallowParam<Mode>(
+        COCKPIT_REVIEW_PARAM.weeklyMode,
+        "overall",
+        ["overall", "severity"],
+    );
 
     if (!data.length) return <CockpitNoDataPlaceholder />;
 

--- a/apps/web/src/features/ee/cockpit/_components/cockpit-tabs.tsx
+++ b/apps/web/src/features/ee/cockpit/_components/cockpit-tabs.tsx
@@ -32,7 +32,9 @@ export const CockpitTabs = ({ defaultTab, visibleTabs, children }: Props) => {
     const onValueChange = (next: string) => {
         setValue(next as TabValue);
 
-        const params = new URLSearchParams(searchParams.toString());
+        // Build from the live query string so a concurrent shallow filter
+        // update isn't clobbered (see useShallowParam).
+        const params = new URLSearchParams(window.location.search);
         params.set(COCKPIT_PARAM.tab, next);
         window.history.replaceState(
             null,

--- a/apps/web/src/features/ee/cockpit/_components/cockpit-tabs.tsx
+++ b/apps/web/src/features/ee/cockpit/_components/cockpit-tabs.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 import { Tabs } from "@components/ui/tabs";
 
@@ -24,14 +23,13 @@ export const CockpitTabs = ({ defaultTab, visibleTabs, children }: Props) => {
     const pathname = usePathname();
     const searchParams = useSearchParams();
 
-    const [value, setValue] = useState<TabValue>(() => {
-        const urlTab = searchParams.get(COCKPIT_PARAM.tab) as TabValue | null;
-        return urlTab && visibleTabs.includes(urlTab) ? urlTab : defaultTab;
-    });
+    // Derive the active tab from the URL every render so it stays in sync
+    // with browser back/forward and shared links (URL is source of truth).
+    const urlTab = searchParams.get(COCKPIT_PARAM.tab) as TabValue | null;
+    const value: TabValue =
+        urlTab && visibleTabs.includes(urlTab) ? urlTab : defaultTab;
 
     const onValueChange = (next: string) => {
-        setValue(next as TabValue);
-
         // Build from the live query string so a concurrent shallow filter
         // update isn't clobbered (see useShallowParam).
         const params = new URLSearchParams(window.location.search);

--- a/apps/web/src/features/ee/cockpit/_components/cockpit-tabs.tsx
+++ b/apps/web/src/features/ee/cockpit/_components/cockpit-tabs.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import { useState } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+import { Tabs } from "@components/ui/tabs";
+
+import { COCKPIT_PARAM, type TabValue } from "../_constants";
+
+type Props = React.PropsWithChildren & {
+    defaultTab: TabValue;
+    visibleTabs: TabValue[];
+};
+
+/**
+ * URL-aware wrapper around the cockpit Tabs root so the active tab is
+ * shareable (`?tab=...`). The URL is the source of truth on load; an
+ * unknown/hidden tab falls back to `defaultTab`.
+ *
+ * Switching tabs is purely visual — every panel is force-mounted — so we
+ * update the URL with `history.replaceState` (shallow) instead of a
+ * router navigation, avoiding a needless server re-render of every slot.
+ */
+export const CockpitTabs = ({ defaultTab, visibleTabs, children }: Props) => {
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+
+    const [value, setValue] = useState<TabValue>(() => {
+        const urlTab = searchParams.get(COCKPIT_PARAM.tab) as TabValue | null;
+        return urlTab && visibleTabs.includes(urlTab) ? urlTab : defaultTab;
+    });
+
+    const onValueChange = (next: string) => {
+        setValue(next as TabValue);
+
+        const params = new URLSearchParams(searchParams.toString());
+        params.set(COCKPIT_PARAM.tab, next);
+        window.history.replaceState(
+            null,
+            "",
+            `${pathname}?${params.toString()}`,
+        );
+    };
+
+    return (
+        <Tabs value={value} onValueChange={onValueChange}>
+            {children}
+        </Tabs>
+    );
+};

--- a/apps/web/src/features/ee/cockpit/_components/date-range-picker.tsx
+++ b/apps/web/src/features/ee/cockpit/_components/date-range-picker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useTransition } from "react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@components/ui/button";
 import { Calendar } from "@components/ui/calendar";
 import {
@@ -17,6 +17,7 @@ import { CalendarIcon } from "lucide-react";
 import { type PropsRange } from "react-day-picker";
 
 import { setCockpitDateRangeCookie } from "../_actions/set-cockpit-date-range";
+import { COCKPIT_PARAM } from "../_constants";
 
 type Props = Omit<PropsRange, "mode"> & {
     cookieValue: string | undefined;
@@ -69,10 +70,17 @@ const defaultItem = ranges[0];
 
 export const DateRangePicker = ({ cookieValue, ...props }: Props) => {
     const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
     const [loading, startTransition] = useTransition();
     const [open, setOpen] = useState(false);
 
     const [selectedRange, setSelectedRange] = useState<DateRangeString>(() => {
+        // URL wins: keep the trigger label in sync with a shared link.
+        const urlFrom = searchParams.get(COCKPIT_PARAM.start);
+        const urlTo = searchParams.get(COCKPIT_PARAM.end);
+        if (urlFrom && urlTo) return { from: urlFrom, to: urlTo };
+
         const cookie = cookieValue;
 
         if (!cookie) return defaultItem.range;
@@ -92,6 +100,20 @@ export const DateRangePicker = ({ cookieValue, ...props }: Props) => {
             to: cookieDateRange.to,
         };
     });
+
+    // Persist to cookie (cross-session default) and push the range onto
+    // the URL (source of truth) so the view is shareable. The navigation
+    // re-runs the server slots, which now read the range from the URL.
+    const commitRange = (range: DateRangeString) => {
+        const params = new URLSearchParams(searchParams.toString());
+        params.set(COCKPIT_PARAM.start, range.from);
+        params.set(COCKPIT_PARAM.end, range.to);
+
+        startTransition(async () => {
+            await setCockpitDateRangeCookie(range);
+            router.push(`${pathname}?${params.toString()}`);
+        });
+    };
 
     const label = ranges.find(
         (r) =>
@@ -189,15 +211,7 @@ export const DateRangePicker = ({ cookieValue, ...props }: Props) => {
 
                             setOpen(false);
                             setSelectedRange(range);
-
-                            startTransition(async () => {
-                                await setCockpitDateRangeCookie(range);
-                                // Parallel-route slots (the cockpit tabs)
-                                // don't reliably re-render from revalidateTag
-                                // alone — force a refresh so they re-read the
-                                // new range cookie.
-                                router.refresh();
-                            });
+                            commitRange(range);
                         }}
                     />
 
@@ -223,12 +237,9 @@ export const DateRangePicker = ({ cookieValue, ...props }: Props) => {
                                         from: r.range.from,
                                         to: r.range.to,
                                     });
-
-                                    startTransition(async () => {
-                                        await setCockpitDateRangeCookie(
-                                            r.range,
-                                        );
-                                        router.refresh();
+                                    commitRange({
+                                        from: r.range.from,
+                                        to: r.range.to,
                                     });
                                 }}>
                                 {r.label}

--- a/apps/web/src/features/ee/cockpit/_components/repository-picker.tsx
+++ b/apps/web/src/features/ee/cockpit/_components/repository-picker.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useCallback, useEffect, useRef, useState, useTransition } from "react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Button } from "@components/ui/button";
 import {
     Command,
@@ -22,6 +22,7 @@ import { Check, GitBranch } from "lucide-react";
 import { safeArray } from "src/core/utils/safe-array";
 
 import { setCockpitRepositoryCookie } from "../_actions/set-cockpit-repository";
+import { COCKPIT_PARAM } from "../_constants";
 
 type Props = {
     cookieValue: string | undefined;
@@ -35,6 +36,8 @@ export const RepositoryPicker = ({ cookieValue, teamId }: Props) => {
         useGetSelectedRepositories(teamId);
 
     const router = useRouter();
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
     const [loading, startTransition] = useTransition();
     const [open, setOpen] = useState(false);
     const [searchQuery, setSearchQuery] = useState("");
@@ -43,6 +46,10 @@ export const RepositoryPicker = ({ cookieValue, teamId }: Props) => {
     const isLoadingMoreRef = useRef(false);
 
     const [selectedRepository, setSelectedRepository] = useState<string>(() => {
+        // URL wins: a shared link reflects its repository in the trigger.
+        if (searchParams.has(COCKPIT_PARAM.repository)) {
+            return searchParams.get(COCKPIT_PARAM.repository) ?? "";
+        }
         if (!cookieValue) return "";
         try {
             return JSON.parse(cookieValue) as string;
@@ -50,6 +57,19 @@ export const RepositoryPicker = ({ cookieValue, teamId }: Props) => {
             return "";
         }
     });
+
+    // Persist to cookie (cross-session default) and push the selection
+    // onto the URL (source of truth) so the view is shareable. An empty
+    // value means "all repositories".
+    const commitRepository = (repositoryFullName: string) => {
+        const params = new URLSearchParams(searchParams.toString());
+        params.set(COCKPIT_PARAM.repository, repositoryFullName);
+
+        startTransition(async () => {
+            await setCockpitRepositoryCookie(repositoryFullName);
+            router.push(`${pathname}?${params.toString()}`);
+        });
+    };
 
     const filteredRepositories = safeArray(repositories).filter((r) => {
         if (!searchQuery.trim()) return true;
@@ -70,21 +90,13 @@ export const RepositoryPicker = ({ cookieValue, teamId }: Props) => {
 
         setSelectedRepository(repositoryFullName);
         setOpen(false);
-
-        startTransition(async () => {
-            await setCockpitRepositoryCookie(repositoryFullName);
-            router.refresh();
-        });
+        commitRepository(repositoryFullName);
     };
 
     const handleClearFilter = () => {
         setSelectedRepository("");
         setOpen(false);
-
-        startTransition(async () => {
-            await setCockpitRepositoryCookie("");
-            router.refresh();
-        });
+        commitRepository("");
     };
 
     useEffect(() => {

--- a/apps/web/src/features/ee/cockpit/_components/share-view-button.tsx
+++ b/apps/web/src/features/ee/cockpit/_components/share-view-button.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@components/ui/button";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "@components/ui/tooltip";
+import { useToast } from "@components/ui/toaster/use-toast";
+import { Check, Share2 } from "lucide-react";
+
+/**
+ * Copies the current cockpit URL — with every filter (tab, date range,
+ * repository, and the in-card filters synced via `useShallowParam`) — so
+ * a teammate opens the exact same view. The URL is always current because
+ * the filters push/replace it as they change.
+ */
+export const ShareViewButton = () => {
+    const { toast } = useToast();
+    const [copied, setCopied] = useState(false);
+
+    const copyLink = async () => {
+        const url = window.location.href;
+
+        try {
+            await navigator.clipboard.writeText(url);
+        } catch {
+            // navigator.clipboard requires a secure context — self-hosted
+            // instances served over plain http (non-localhost) block it.
+            // Fall back to a throwaway textarea + execCommand so the
+            // button still works there.
+            const textarea = document.createElement("textarea");
+            textarea.value = url;
+            textarea.style.position = "fixed";
+            textarea.style.opacity = "0";
+            document.body.appendChild(textarea);
+            textarea.select();
+            document.execCommand("copy");
+            document.body.removeChild(textarea);
+        }
+
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+        toast({
+            variant: "success",
+            description: "View link copied — it opens this exact dashboard.",
+        });
+    };
+
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <Button
+                    size="icon-md"
+                    variant="helper"
+                    aria-label="Copy link to this view"
+                    onClick={copyLink}>
+                    {copied ? (
+                        <Check className="text-success" />
+                    ) : (
+                        <Share2 />
+                    )}
+                </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+                {copied ? "Copied!" : "Copy link to this view"}
+            </TooltipContent>
+        </Tooltip>
+    );
+};

--- a/apps/web/src/features/ee/cockpit/_constants.ts
+++ b/apps/web/src/features/ee/cockpit/_constants.ts
@@ -8,3 +8,25 @@ export const tabs = {
     "kodus-review": "Kodus Review",
     "productivity": "Productivity",
 } satisfies Record<string, string>;
+
+// URL search-param keys that carry the dashboard's current view, so it
+// can be deep-linked/shared. The URL is the source of truth; cookies
+// only provide the cross-session default when a param is absent.
+export const COCKPIT_PARAM = {
+    repository: "repository",
+    start: "start",
+    end: "end",
+    tab: "tab",
+} as const;
+
+// In-card filter state for the Kodus Review tab. These operate on
+// already-loaded data (no server refetch), so they're synced to the URL
+// shallowly via `useShallowParam` — purely to make the view shareable.
+export const COCKPIT_REVIEW_PARAM = {
+    rulesHealth: "rulesHealth",
+    rulesQuery: "rulesQ",
+    reposQuery: "reposQ",
+    severitySource: "sevSource",
+    weeklyMode: "weeklyMode",
+    feedbackMode: "feedbackMode",
+} as const;

--- a/apps/web/src/features/ee/cockpit/_helpers/get-selected-date-range.ts
+++ b/apps/web/src/features/ee/cockpit/_helpers/get-selected-date-range.ts
@@ -1,12 +1,32 @@
 import { cookies } from "next/headers";
 import { formatDate, subWeeks } from "date-fns";
 import type { CookieName } from "src/core/utils/cookie";
+import { getCurrentSearchParamsOnServerComponents } from "src/core/utils/headers";
+
+import { COCKPIT_PARAM } from "../_constants";
+
+const ISO_DATE = /^\d{4}-\d{2}-\d{2}$/;
+
+const isValidISODate = (value: string | null): value is string =>
+    !!value && ISO_DATE.test(value) && !isNaN(new Date(value).getTime());
 
 export const getSelectedDateRange = async (): Promise<{
     startDate: string;
     endDate: string;
 }> => {
-    const cookieStore = await cookies();
+    const [cookieStore, searchParams] = await Promise.all([
+        cookies(),
+        getCurrentSearchParamsOnServerComponents(),
+    ]);
+
+    // URL wins: a shared link reproduces the exact range it encodes,
+    // regardless of the recipient's cookie.
+    const urlStart = searchParams.get(COCKPIT_PARAM.start);
+    const urlEnd = searchParams.get(COCKPIT_PARAM.end);
+    if (isValidISODate(urlStart) && isValidISODate(urlEnd)) {
+        return { startDate: urlStart, endDate: urlEnd };
+    }
+
     const selectedDateRangeFromCookie = cookieStore.get(
         "cockpit-selected-date-range" satisfies CookieName,
     )?.value;

--- a/apps/web/src/features/ee/cockpit/_helpers/get-selected-repository.ts
+++ b/apps/web/src/features/ee/cockpit/_helpers/get-selected-repository.ts
@@ -1,8 +1,20 @@
 import { cookies } from "next/headers";
 import type { CookieName } from "src/core/utils/cookie";
+import { getCurrentSearchParamsOnServerComponents } from "src/core/utils/headers";
+
+import { COCKPIT_PARAM } from "../_constants";
 
 export const getSelectedRepository = async (): Promise<string | null> => {
-    const cookieStore = await cookies();
+    const [cookieStore, searchParams] = await Promise.all([
+        cookies(),
+        getCurrentSearchParamsOnServerComponents(),
+    ]);
+
+    // URL wins. Presence of the param — even empty — is authoritative:
+    // an empty value means "all repositories" (no repo filter).
+    if (searchParams.has(COCKPIT_PARAM.repository)) {
+        return searchParams.get(COCKPIT_PARAM.repository) || null;
+    }
 
     const repositoryCookie = cookieStore.get(
         "cockpit-selected-repository" satisfies CookieName,

--- a/apps/web/src/features/ee/cockpit/_helpers/use-shallow-param.ts
+++ b/apps/web/src/features/ee/cockpit/_helpers/use-shallow-param.ts
@@ -1,0 +1,53 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { usePathname, useSearchParams } from "next/navigation";
+
+/**
+ * Shallow URL-synced state for in-card cockpit filters (segmented toggles,
+ * search boxes). The value lives in the query string so the view is
+ * shareable, but changing it only updates the URL via
+ * `history.replaceState` — no server round-trip, since these filters act
+ * on already-loaded data.
+ *
+ * The URL is the source of truth on first render; the param is dropped
+ * from the URL when it equals the default, keeping shared links clean.
+ *
+ * `allowed` guards against a hand-edited/stale param selecting an invalid
+ * option — it falls back to the default instead.
+ */
+export function useShallowParam<T extends string>(
+    key: string,
+    defaultValue: T,
+    allowed?: readonly T[],
+): [T, (next: T) => void] {
+    const pathname = usePathname();
+    const searchParams = useSearchParams();
+
+    const [value, setValue] = useState<T>(() => {
+        const raw = searchParams.get(key) as T | null;
+        if (!raw) return defaultValue;
+        if (allowed && !allowed.includes(raw)) return defaultValue;
+        return raw;
+    });
+
+    const set = useCallback(
+        (next: T) => {
+            setValue(next);
+
+            const params = new URLSearchParams(searchParams.toString());
+            if (next === defaultValue) params.delete(key);
+            else params.set(key, next);
+
+            const qs = params.toString();
+            window.history.replaceState(
+                null,
+                "",
+                qs ? `${pathname}?${qs}` : pathname,
+            );
+        },
+        [key, defaultValue, pathname, searchParams],
+    );
+
+    return [value, set];
+}

--- a/apps/web/src/features/ee/cockpit/_helpers/use-shallow-param.ts
+++ b/apps/web/src/features/ee/cockpit/_helpers/use-shallow-param.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import { usePathname, useSearchParams } from "next/navigation";
 
 /**
@@ -10,8 +10,10 @@ import { usePathname, useSearchParams } from "next/navigation";
  * `history.replaceState` — no server round-trip, since these filters act
  * on already-loaded data.
  *
- * The URL is the source of truth on first render; the param is dropped
- * from the URL when it equals the default, keeping shared links clean.
+ * The URL is the single source of truth: the value is derived from
+ * `searchParams` every render, so browser back/forward (and any other URL
+ * change) stay in sync. The param is dropped from the URL when it equals
+ * the default, keeping shared links clean.
  *
  * `allowed` guards against a hand-edited/stale param selecting an invalid
  * option — it falls back to the default instead.
@@ -24,18 +26,17 @@ export function useShallowParam<T extends string>(
     const pathname = usePathname();
     const searchParams = useSearchParams();
 
-    const [value, setValue] = useState<T>(() => {
-        const raw = searchParams.get(key) as T | null;
-        if (!raw) return defaultValue;
-        if (allowed && !allowed.includes(raw)) return defaultValue;
-        return raw;
-    });
+    const raw = searchParams.get(key) as T | null;
+    const value: T =
+        raw && (!allowed || allowed.includes(raw)) ? raw : defaultValue;
 
     const set = useCallback(
         (next: T) => {
-            setValue(next);
-
-            const params = new URLSearchParams(searchParams.toString());
+            // Build from the LIVE query string, not a captured
+            // `searchParams` snapshot: other shallow updates in the same
+            // render cycle would otherwise be clobbered, breaking the
+            // combined shareable link.
+            const params = new URLSearchParams(window.location.search);
             if (next === defaultValue) params.delete(key);
             else params.set(key, next);
 
@@ -46,7 +47,7 @@ export function useShallowParam<T extends string>(
                 qs ? `${pathname}?${qs}` : pathname,
             );
         },
-        [key, defaultValue, pathname, searchParams],
+        [key, defaultValue, pathname],
     );
 
     return [value, set];

--- a/apps/web/src/features/ee/cockpit/layout.tsx
+++ b/apps/web/src/features/ee/cockpit/layout.tsx
@@ -1,17 +1,19 @@
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import { Page } from "@components/ui/page";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@components/ui/tabs";
+import { TabsContent, TabsList, TabsTrigger } from "@components/ui/tabs";
 import { getCockpitMetricsVisibility } from "@services/organizationParameters/fetch";
 import type { CookieName } from "src/core/utils/cookie";
 import { getGlobalSelectedTeamId } from "src/core/utils/get-global-selected-team-id";
 import { greeting } from "src/core/utils/helpers";
 
 import { validateOrganizationLicense } from "../subscription/_services/billing/fetch";
+import { CockpitTabs } from "./_components/cockpit-tabs";
 import { DateRangePicker } from "./_components/date-range-picker";
 import { ExpandableCardsLayout } from "./_components/expandable-cards-layout";
 import { CockpitNoDataBanner } from "./_components/no-data-banner";
 import { RepositoryPicker } from "./_components/repository-picker";
+import { ShareViewButton } from "./_components/share-view-button";
 import { tabs, type TabValue } from "./_constants";
 import { extractApiData } from "./_helpers/api-data-extractor";
 import { isCockpitTierAllowed } from "./_helpers/tier-policy";
@@ -96,6 +98,10 @@ export default async function Layout({
         ? "kodus-review"
         : "productivity";
 
+    const visibleTabs = (Object.keys(tabsVisibility) as TabValue[]).filter(
+        (tab) => tabsVisibility[tab],
+    );
+
     const entries = Object.entries(tabs);
 
     return (
@@ -110,12 +116,15 @@ export default async function Layout({
                         teamId={selectedTeamId}
                     />
                     <DateRangePicker cookieValue={dateRangeCookieValue} />
+                    <ShareViewButton />
                 </div>
             </Page.Header>
 
             <Page.Content className="max-w-full px-6">
                 <div>
-                    <Tabs defaultValue={defaultTab}>
+                    <CockpitTabs
+                        defaultTab={defaultTab}
+                        visibleTabs={visibleTabs}>
                         <TabsList>
                             {/* TODO: add JIRA tab */}
                             {entries.map(([value, name]) => {
@@ -187,7 +196,7 @@ export default async function Layout({
                             {kodusReviewTab}
                         </TabsContent>
                         )}
-                    </Tabs>
+                    </CockpitTabs>
                 </div>
 
                 {children}

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -56,10 +56,19 @@ export default auth(async (req) => {
     // add a new header which can be used on Server Components
     const headers = new Headers(req.headers);
     headers.set(CURRENT_PATH_HEADER, pathname);
-    // Mirror the query string too so server components can treat URL
-    // params as the source of truth (e.g. Cockpit's shareable filter
-    // state) without prop-drilling `searchParams` from every page/slot.
-    headers.set(CURRENT_SEARCH_HEADER, req.nextUrl.search);
+    // Mirror the query string so server components can treat URL params as
+    // the source of truth (Cockpit's shareable filter state) without
+    // prop-drilling `searchParams` from every page/slot. Scope it to the
+    // cockpit routes that consume it — mirroring globally would copy
+    // sensitive auth tokens (password-reset / email-confirmation query
+    // params) into a header reachable by every server component and any
+    // logging layer.
+    if (
+        pathname.startsWith("/cockpit") ||
+        pathname.startsWith("/organization/cockpit")
+    ) {
+        headers.set(CURRENT_SEARCH_HEADER, req.nextUrl.search);
+    }
 
     const next = NextResponse.next({ request: { headers } });
 

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -2,7 +2,10 @@ import { NextResponse } from "next/server";
 import { UserStatus } from "@enums";
 
 import { auth } from "./core/config/auth";
-import { CURRENT_PATH_HEADER } from "./core/utils/headers";
+import {
+    CURRENT_PATH_HEADER,
+    CURRENT_SEARCH_HEADER,
+} from "./core/utils/headers";
 import { handleAuthenticated } from "./core/utils/permissions";
 
 // Public routes that don't need authentication
@@ -53,6 +56,10 @@ export default auth(async (req) => {
     // add a new header which can be used on Server Components
     const headers = new Headers(req.headers);
     headers.set(CURRENT_PATH_HEADER, pathname);
+    // Mirror the query string too so server components can treat URL
+    // params as the source of truth (e.g. Cockpit's shareable filter
+    // state) without prop-drilling `searchParams` from every page/slot.
+    headers.set(CURRENT_SEARCH_HEADER, req.nextUrl.search);
 
     const next = NextResponse.next({ request: { headers } });
 


### PR DESCRIPTION
## Why

Users couldn't link people to a specific Cockpit view: the dashboard's filter state lived only in cookies + in-memory React state, never in the URL. A shared link always landed on the recipient's default — the exact gap reported ("the parameters for what the dash is currently showing aren't in the URL").

## What

All filter state now lives in the URL, with **URL as source of truth and cookie as the cross-session default**.

**Top bar** (`tab`, `start`/`end` date range, `repository`):
- `middleware.ts` mirrors the request query string into an `x-current-search` header (additive, doesn't touch the auth flow). `getSelectedDateRange` / `getSelectedRepository` read URL params from it with precedence over the cookie — so every server slot honors the URL **without threading `searchParams` through the fetch layer**.
- Pickers push the params (`router.push`) and still write the cookie for cross-session persistence.
- Tab is controlled by `?tab=` via a small `CockpitTabs` client wrapper using `history.replaceState` (shallow — panels are already `forceMount`, so no server refetch).

**Kodus Review in-card filters** — synced shallowly via a new `useShallowParam` hook (`history.replaceState`, no refetch; they operate on already-loaded data). Params drop from the URL when at default to keep links clean:
- Rules-health segmented (`rulesHealth`) + search (`rulesQ`)
- Repositories-health search (`reposQ`)
- Severity source (`sevSource`), weekly mode (`weeklyMode`), feedback mode (`feedbackMode`)

**Other:**
- Repositories-health row click now pushes `?repository=` (so the focused view is shareable and not shadowed by the URL-wins rule).
- `DataTable` gains opt-in controlled search props (`searchValue` / `onSearchChange`) so the cockpit tables mirror search into the URL — other `DataTable` usages are unaffected.
- New share icon in the header copies the exact view URL (+ success toast), with an `execCommand` fallback for non-secure-context (self-hosted http).

## Example deep link

```
/cockpit?tab=kodus-review&start=2026-06-01&end=2026-06-15&repository=owner/repo&rulesHealth=ignored&rulesQ=security&sevSource=native
```

## Testing

- `next build` compiles cleanly (web).
- `tsc --noEmit` at repo baseline — zero new type errors in touched files.
- Ran live in the dev web container against the running backend; all controls reflect into the URL and a pasted link reproduces the exact view.

## Notes / out of scope

- The 4 productivity summary cards (deploy frequency, PR cycle time, bug ratio, PR size) hardcode a 2-week window and ignore the date range — pre-existing behavior, left untouched.
- Expandable-card state and saved-views/scheduled-delivery were considered but deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)