### PR TITLE
feat: add Requesty as an OpenAI-compatible provider for evals

### DIFF
--- a/evals/investigation/README.md
+++ b/evals/investigation/README.md
@@ -152,7 +152,7 @@ pnpm run eval:investigation:no-cache \
 
 Supported custom flags:
 - `--preset <name>`: use a known model preset, can be repeated
-- `--provider <google|anthropic|openai|openai-compatible|openrouter>`: custom provider
+- `--provider <google|anthropic|openai|openai-compatible|openrouter|requesty>`: custom provider
 - `--model <id>`: custom model id
 - `--label <name>`: display label for the provider row
 - `--api-key-env <ENV_VAR>`: custom API key env var
@@ -186,6 +186,17 @@ pnpm run eval:investigation:all:no-cache \
   --provider-order moonshot \
   --no-provider-fallbacks \
   --label kimi-k2.5-openrouter-moonshot
+```
+
+Run an OpenAI-compatible model through Requesty (default base URL
+`https://router.requesty.ai/v1`, key from `API_REQUESTY_KEY`,
+`provider/model` naming):
+
+```bash
+pnpm run eval:investigation:all:no-cache \
+  --provider requesty \
+  --model openai/gpt-4o-mini \
+  --label gpt-4o-mini-requesty
 ```
 
 Debug artifacts from the latest run:

--- a/evals/investigation/agent-provider.js
+++ b/evals/investigation/agent-provider.js
@@ -100,6 +100,8 @@ function defaultApiKeyEnv(provider) {
             return 'API_ANTHROPIC_API_KEY';
         case 'openrouter':
             return 'API_OPENROUTER_KEY';
+        case 'requesty':
+            return 'API_REQUESTY_KEY';
         case 'google':
         default:
             return 'API_GOOGLE_AI_API_KEY';
@@ -143,7 +145,9 @@ function buildOpenAICompatibleConfig(config, apiKey, defaultName) {
             config.baseURL ||
             (config.provider === 'openrouter'
                 ? 'https://openrouter.ai/api/v1'
-                : undefined),
+                : config.provider === 'requesty'
+                  ? 'https://router.requesty.ai/v1'
+                  : undefined),
         ...(config.headers ? { headers: config.headers } : {}),
         ...(config.queryParams ? { queryParams: config.queryParams } : {}),
         ...(openRouterProviderRouting
@@ -195,7 +199,11 @@ async function createModel(config) {
         })(model);
     }
 
-    if (provider === 'openrouter' || provider === 'openai-compatible') {
+    if (
+        provider === 'openrouter' ||
+        provider === 'openai-compatible' ||
+        provider === 'requesty'
+    ) {
         const { createOpenAICompatible } = await import(
             '@ai-sdk/openai-compatible'
         );

--- a/evals/investigation/run-eval.js
+++ b/evals/investigation/run-eval.js
@@ -23,6 +23,7 @@ const DEFAULT_API_KEY_ENVS = {
     openai: 'API_OPEN_AI_API_KEY',
     'openai-compatible': 'API_OPEN_AI_API_KEY',
     openrouter: 'API_OPENROUTER_KEY',
+    requesty: 'API_REQUESTY_KEY',
 };
 
 const MODEL_PRESETS = {
@@ -119,6 +120,10 @@ function defaultApiKeyEnv(provider) {
 function defaultBaseUrl(provider) {
     if (provider === 'openrouter') {
         return 'https://openrouter.ai/api/v1';
+    }
+
+    if (provider === 'requesty') {
+        return 'https://router.requesty.ai/v1';
     }
 
     return undefined;

--- a/evals/promotion/agent-provider.js
+++ b/evals/promotion/agent-provider.js
@@ -78,6 +78,8 @@ function defaultApiKeyEnv(provider) {
             return 'API_ANTHROPIC_API_KEY';
         case 'openrouter':
             return 'API_OPENROUTER_KEY';
+        case 'requesty':
+            return 'API_REQUESTY_KEY';
         case 'google':
         default:
             return 'API_GOOGLE_AI_API_KEY';
@@ -121,7 +123,9 @@ function buildOpenAICompatibleConfig(config, apiKey, defaultName) {
             config.baseURL ||
             (config.provider === 'openrouter'
                 ? 'https://openrouter.ai/api/v1'
-                : undefined),
+                : config.provider === 'requesty'
+                  ? 'https://router.requesty.ai/v1'
+                  : undefined),
         ...(config.headers ? { headers: config.headers } : {}),
         ...(config.queryParams ? { queryParams: config.queryParams } : {}),
         ...(openRouterProviderRouting
@@ -173,7 +177,11 @@ async function createModel(config) {
         })(model);
     }
 
-    if (provider === 'openrouter' || provider === 'openai-compatible') {
+    if (
+        provider === 'openrouter' ||
+        provider === 'openai-compatible' ||
+        provider === 'requesty'
+    ) {
         const { createOpenAICompatible } = await import(
             '@ai-sdk/openai-compatible'
         );

--- a/evals/promotion/run-eval.js
+++ b/evals/promotion/run-eval.js
@@ -23,6 +23,7 @@ const DEFAULT_API_KEY_ENVS = {
     openai: 'API_OPEN_AI_API_KEY',
     'openai-compatible': 'API_OPEN_AI_API_KEY',
     openrouter: 'API_OPENROUTER_KEY',
+    requesty: 'API_REQUESTY_KEY',
 };
 
 const MODEL_PRESETS = {
@@ -119,6 +120,10 @@ function defaultApiKeyEnv(provider) {
 function defaultBaseUrl(provider) {
     if (provider === 'openrouter') {
         return 'https://openrouter.ai/api/v1';
+    }
+
+    if (provider === 'requesty') {
+        return 'https://router.requesty.ai/v1';
     }
 
     return undefined;


### PR DESCRIPTION
Closes #1375

## What

Adds **Requesty** as a selectable OpenAI-compatible provider in the eval harness, mirroring the existing **OpenRouter** eval provider.

Requesty is an OpenAI-compatible LLM gateway:
- Base URL: `https://router.requesty.ai/v1`
- Auth: `Authorization: Bearer $REQUESTY_API_KEY` (read here from `API_REQUESTY_KEY`)
- Model naming: `provider/model` (e.g. `openai/gpt-4o-mini`)

This is scoped to `evals/` only. The product runtime does not use OpenRouter; the eval harness does, so Requesty is wired alongside it as a clean mirror of the same provider-selection pattern.

## Key difference vs. OpenRouter

OpenRouter is wired with its `provider.order` / `allow_fallbacks` routing object (via `buildOpenRouterProviderRouting`). Requesty does **not** support that routing object, so it is wired on the plain **OpenAI-compatible** path:
- It gets a fixed default base URL and `API_REQUESTY_KEY`.
- It is added to the `openrouter || openai-compatible` branches that mean "use the OpenAI-compatible client", but **not** to the `buildOpenRouterProviderRouting` branch.
- In `buildOpenAICompatibleConfig`, the provider name resolves to `openai-compatible` (it is not `openrouter`).

## Files changed

- `evals/promotion/run-eval.js` — add `requesty: 'API_REQUESTY_KEY'` to `DEFAULT_API_KEY_ENVS`; add the `requesty` branch to `defaultBaseUrl()`.
- `evals/promotion/agent-provider.js` — add `case 'requesty'` to `defaultApiKeyEnv()`; add the `requesty` default base URL in `buildOpenAICompatibleConfig()`; add `requesty` to the OpenAI-compatible branch in `createModel()` (without OpenRouter routing).
- `evals/investigation/run-eval.js` — same as promotion `run-eval.js`.
- `evals/investigation/agent-provider.js` — same as promotion `agent-provider.js`.
- `evals/investigation/README.md` — add `requesty` to the `--provider` list and a short usage example.

## Verification

- `node --check` passes on every edited `.js` file:
  - `evals/promotion/run-eval.js`
  - `evals/promotion/agent-provider.js`
  - `evals/investigation/run-eval.js`
  - `evals/investigation/agent-provider.js`
- Confirmed the resolved wiring: `defaultBaseUrl('requesty') === 'https://router.requesty.ai/v1'` and `defaultApiKeyEnv('requesty') === 'API_REQUESTY_KEY'`.
- Ran a live chat completion against `https://router.requesty.ai/v1/chat/completions` with `openai/gpt-4o-mini` → HTTP 200 with a valid completion, confirming the base URL + Bearer auth + `provider/model` naming work end to end.

## Links

- https://requesty.ai
- https://docs.requesty.ai

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.