### PR TITLE
fix(e2e): use valid KodyRulesOrigin value in create-rule scenarios

### DIFF
--- a/tests/e2e/scenarios/centralized-config-sync.ts
+++ b/tests/e2e/scenarios/centralized-config-sync.ts
@@ -498,7 +498,7 @@ export const centralizedConfigSync: Scenario = {
                         title: pendingTitle,
                         rule: `E2E pending-flow rule (${uniq}): created via API while centralized config is enabled; must arrive through a merged PR, never directly.`,
                         severity: "medium",
-                        origin: "user",
+                        origin: "manual",
                         path: "",
                     },
                     timeoutMs: 60_000,

--- a/tests/e2e/scenarios/kody-rules.ts
+++ b/tests/e2e/scenarios/kody-rules.ts
@@ -122,8 +122,10 @@ export const kodyRulesCreateAndApply: Scenario = {
             data?: { uuid?: string; id?: string };
         }>(
             // POST /kody-rules/create-or-update (CreateKodyRuleDto). `type`,
-            // `title`, `rule`, `severity`, `origin` are required by the DTO;
-            // severity is lowercase, origin must be 'user'|'library'|'generated'.
+            // `title`, `rule`, `severity` are required by the DTO; severity is
+            // lowercase. `origin` is optional (defaults to 'manual') and must be
+            // one of the KodyRulesOrigin values: manual, library, past_reviews,
+            // repo_file_sync, onboarding_repo_analysis, mcp_agent, cli.
             `${ctx.target.apiBaseUrl}/kody-rules/create-or-update`,
             {
                 method: "POST",
@@ -135,7 +137,7 @@ export const kodyRulesCreateAndApply: Scenario = {
                     title: ruleName,
                     rule: ruleInstruction,
                     severity: "high",
-                    origin: "user",
+                    origin: "manual",
                     path: "",
                 },
                 timeoutMs: 30_000,


### PR DESCRIPTION
## What

PR #1377 (*unify kody rules lifecycle*) renamed the `KodyRulesOrigin` enum values — `user` → `manual`, and `generated` → several new values (`past_reviews`, `repo_file_sync`, `onboarding_repo_analysis`, `mcp_agent`, `cli`).

The `create-or-update` DTO validates origin with `@IsEnum(KodyRulesOrigin)`, but two e2e scenarios still send `origin: "user"`, which no longer exists. The server now rejects it:

```
HTTP 400 — origin must be one of the following values: manual, library,
past_reviews, repo_file_sync, onboarding_repo_analysis, mcp_agent, cli
```

This broke **`kody-rules-create-and-apply`** across all four providers (github, gitlab, bitbucket, azure-devops) in the cloud matrix — see [run 28052782897](https://github.com/kodustech/kodus-ai/actions/runs/28052782897). The failure is provider-agnostic because it's pure DTO validation.

## Change

- `tests/e2e/scenarios/kody-rules.ts` — `origin: "user"` → `"manual"` + updated the stale comment listing valid enum values
- `tests/e2e/scenarios/centralized-config-sync.ts` — `origin: "user"` → `"manual"`

`origin` is now optional in the DTO (defaults to `manual`), so this realigns the tests with the new contract.

## Scope note

The CLI is unaffected: the `cli` client never sends `origin`, and the CLI controller default was already updated to `KodyRulesOrigin.CLI` in #1377. Docs and `default-kodus-config.yml` were also migrated correctly in that PR. This is the only leftover.

## Testing

`pnpm run e2e:dry-run` passes (0 failed). The HTTP path was not exercised locally (no alive target), but the fix is a deterministic enum-value correction matching the server's validation list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)