### PR TITLE
feat: add Requesty as a BYOK provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -341,6 +341,11 @@ API_CEREBRAS_API_KEY=
 # (secret)
 API_OPEN_ROUTER_API_KEY=
 
+# Requesty API key. Used by BYOK provider in
+# libs/organization/.../get-models-by-provider.use-case.ts.
+# (secret)
+API_REQUESTY_API_KEY=
+
 # MorphLLM (fast-apply model). When set, the review pipeline uses MorphLLM
 # to apply LLM-suggested code edits automatically and reliably (better than
 # letting the main LLM rewrite files). Used in

--- a/.env.schema
+++ b/.env.schema
@@ -480,6 +480,12 @@ API_CEREBRAS_API_KEY=
 # kodus: audience=cloud
 API_OPEN_ROUTER_API_KEY=
 
+# Requesty API key. Used by BYOK provider in
+# libs/organization/.../get-models-by-provider.use-case.ts.
+# @optional @sensitive
+# kodus: audience=cloud
+API_REQUESTY_API_KEY=
+
 # MorphLLM (fast-apply model). When set, the review pipeline uses MorphLLM
 # to apply LLM-suggested code edits automatically and reliably (better than
 # letting the main LLM rewrite files). Used in

--- a/.env.template
+++ b/.env.template
@@ -351,6 +351,11 @@ API_CEREBRAS_API_KEY=op://Kodus-Dev/API_CEREBRAS_API_KEY/password
 # (secret)
 API_OPEN_ROUTER_API_KEY=op://Kodus-Dev/API_OPEN_ROUTER_API_KEY/password
 
+# Requesty API key. Used by BYOK provider in
+# libs/organization/.../get-models-by-provider.use-case.ts.
+# (secret)
+API_REQUESTY_API_KEY=op://Kodus-Dev/API_REQUESTY_API_KEY/password
+
 # MorphLLM (fast-apply model). When set, the review pipeline uses MorphLLM
 # to apply LLM-suggested code edits automatically and reliably (better than
 # letting the main LLM rewrite files). Used in

--- a/libs/code-review/infrastructure/agents/llm/agent-loop.ts
+++ b/libs/code-review/infrastructure/agents/llm/agent-loop.ts
@@ -235,6 +235,7 @@ const PROVIDER_OPTIONS_NAMESPACE: Partial<Record<string, string>> = {
     [BYOKProvider.GOOGLE_VERTEX]: 'google',
     [BYOKProvider.OPENAI]: 'openai',
     [BYOKProvider.OPEN_ROUTER]: 'openrouter',
+    [BYOKProvider.REQUESTY]: 'openaiCompatible',
     [BYOKProvider.OPENAI_COMPATIBLE]: 'openaiCompatible',
     [BYOKProvider.NOVITA]: 'openaiCompatible',
 };

--- a/libs/code-review/infrastructure/agents/llm/byok-to-vercel.ts
+++ b/libs/code-review/infrastructure/agents/llm/byok-to-vercel.ts
@@ -171,6 +171,7 @@ const DEFAULT_MODEL = {
  * - GOOGLE_GEMINI → @ai-sdk/google
  * - GOOGLE_VERTEX → @ai-sdk/google-vertex
  * - OPEN_ROUTER → @ai-sdk/openai-compatible (OpenRouter is OpenAI-compatible)
+ * - REQUESTY → @ai-sdk/openai-compatible (Requesty is OpenAI-compatible)
  * - OPENAI_COMPATIBLE → @ai-sdk/openai-compatible
  * - NOVITA → @ai-sdk/openai-compatible
  *
@@ -424,6 +425,16 @@ export function byokToVercelModel(
                 name: 'open-router',
                 apiKey,
                 baseURL: baseURL || 'https://openrouter.ai/api/v1',
+                supportsStructuredOutputs:
+                    options.structuredOutputs === true &&
+                    shouldEnableJsonSchema(provider, model, baseURL),
+            })(model);
+
+        case BYOKProvider.REQUESTY:
+            return createOpenAICompatible({
+                name: 'requesty',
+                apiKey,
+                baseURL: baseURL || 'https://router.requesty.ai/v1',
                 supportsStructuredOutputs:
                     options.structuredOutputs === true &&
                     shouldEnableJsonSchema(provider, model, baseURL),

--- a/libs/code-review/infrastructure/agents/llm/model-context-window.ts
+++ b/libs/code-review/infrastructure/agents/llm/model-context-window.ts
@@ -56,7 +56,7 @@ const MANUAL_OVERRIDES: Record<string, number> = {
 function normalize(name: string): string {
     return name
         .toLowerCase()
-        .replace(/^(openai|anthropic|google|gemini|vertex_ai|bedrock|azure|together_ai|openrouter|novita|fireworks_ai|deepseek|mistral|moonshot|hf|huggingface)\//, '')
+        .replace(/^(openai|anthropic|google|gemini|vertex_ai|bedrock|azure|together_ai|openrouter|requesty|novita|fireworks_ai|deepseek|mistral|moonshot|hf|huggingface)\//, '')
         .replace(/[-_.\s/:]/g, '');
 }
 

--- a/libs/core/infrastructure/services/providers/provider.service.ts
+++ b/libs/core/infrastructure/services/providers/provider.service.ts
@@ -63,6 +63,14 @@ export class ProviderService {
             requiresApiKey: true,
             requiresBaseUrl: false,
         },
+        [BYOKProvider.REQUESTY]: {
+            id: BYOKProvider.REQUESTY,
+            name: 'Requesty',
+            description: 'Multiple models through Requesty',
+            supported: true,
+            requiresApiKey: true,
+            requiresBaseUrl: false,
+        },
         [BYOKProvider.NOVITA]: {
             id: BYOKProvider.NOVITA,
             name: 'Novita',

--- a/libs/organization/application/use-cases/organizationParameters/get-models-by-provider.use-case.ts
+++ b/libs/organization/application/use-cases/organizationParameters/get-models-by-provider.use-case.ts
@@ -89,6 +89,11 @@ export class GetModelsByProviderUseCase {
                     process.env.API_OPEN_ROUTER_API_KEY,
                 );
 
+            case BYOKProvider.REQUESTY:
+                return this.getRequestyModels(
+                    process.env.API_REQUESTY_API_KEY,
+                );
+
             case BYOKProvider.NOVITA:
                 return this.getNovitaModels(process.env.API_NOVITA_AI_API_KEY);
 
@@ -335,6 +340,32 @@ export class GetModelsByProviderUseCase {
         } catch (error) {
             throw new BadRequestException(
                 `Error fetching OpenRouter models: ${(error as Error).message}`,
+            );
+        }
+    }
+
+    private async getRequestyModels(apiKey?: string): Promise<ModelResponse> {
+        try {
+            const response = await axios.get<OpenAIResponse>(
+                'https://router.requesty.ai/v1/models',
+                {
+                    headers: {
+                        'Authorization': `Bearer ${apiKey}`,
+                        'Content-Type': 'application/json',
+                    },
+                },
+            );
+
+            return {
+                provider: BYOKProvider.REQUESTY,
+                models: response.data.data.map((model: OpenAIModel) => ({
+                    id: model.id,
+                    name: model.id,
+                })),
+            };
+        } catch (error) {
+            throw new BadRequestException(
+                `Error fetching Requesty models: ${(error as Error).message}`,
             );
         }
     }

--- a/libs/organization/application/use-cases/organizationParameters/test-byok-connection.use-case.ts
+++ b/libs/organization/application/use-cases/organizationParameters/test-byok-connection.use-case.ts
@@ -671,6 +671,15 @@ export class TestByokConnectionUseCase {
                     },
                 };
 
+            case BYOKProvider.REQUESTY:
+                return {
+                    url: 'https://router.requesty.ai/v1/models',
+                    headers: {
+                        Authorization: `Bearer ${apiKey}`,
+                        'Content-Type': 'application/json',
+                    },
+                };
+
             case BYOKProvider.NOVITA:
                 return {
                     url: 'https://api.novita.ai/v3/openai/models',

--- a/packages/kodus-common/src/llm/byokProvider.service.ts
+++ b/packages/kodus-common/src/llm/byokProvider.service.ts
@@ -16,6 +16,7 @@ export enum BYOKProvider {
     OPENAI_COMPATIBLE = 'openai_compatible',
     ANTHROPIC_COMPATIBLE = 'anthropic_compatible',
     OPEN_ROUTER = 'open_router',
+    REQUESTY = 'requesty',
     NOVITA = 'novita',
 }
 
@@ -150,7 +151,9 @@ export class BYOKProviderService {
                     ? baseURL
                     : provider === BYOKProvider.OPEN_ROUTER
                       ? 'https://openrouter.ai/api/v1'
-                      : undefined,
+                      : provider === BYOKProvider.REQUESTY
+                        ? 'https://router.requesty.ai/v1'
+                        : undefined,
             options: {
                 temperature: options?.temperature,
                 maxTokens: options?.maxTokens,
@@ -272,6 +275,7 @@ export class BYOKProviderService {
             [BYOKProvider.OPENAI_COMPATIBLE]: 'OpenAI Compatible',
             [BYOKProvider.ANTHROPIC_COMPATIBLE]: 'Anthropic Compatible',
             [BYOKProvider.OPEN_ROUTER]: 'OpenRouter',
+            [BYOKProvider.REQUESTY]: 'Requesty',
             [BYOKProvider.NOVITA]: 'Novita',
         };
 

--- a/packages/kodus-common/src/llm/providerAdapters/index.ts
+++ b/packages/kodus-common/src/llm/providerAdapters/index.ts
@@ -20,6 +20,7 @@ export function getAdapter(providerId: string): ProviderAdapter {
             return new OpenAIAdapter();
         case 'openai_compatible':
         case 'open_router':
+        case 'requesty':
             return new OpenAIAdapter();
         case 'anthropic':
         case 'anthropic_compatible':


### PR DESCRIPTION
Closes #1383

@malinosqui — this replaces the closed eval-only PR #1374 with the full product integration you asked for: Requesty wired as a first-class BYOK provider, not just in the evals.

## What

Adds **Requesty** ([requesty.ai](https://requesty.ai)) as a BYOK provider, mirroring the existing **OpenRouter** provider end to end. Requesty is an OpenAI-compatible LLM gateway (base `https://router.requesty.ai/v1`, `provider/model` naming like OpenRouter, model listing at `/v1/models`).

## Design note

Requesty is wired on the **generic OpenAI-compatible path** (the same path NOVITA uses) with its own fixed base URL — **not** through OpenRouter's SDK-specific request shapes. Specifically it is **not** added to `buildOpenRouterRouting` (the `openrouter: { provider: { order, allow_fallbacks } }` object) or the `openrouter: { reasoning }` providerOptions namespace, since Requesty doesn't support those. Its providerOptions namespace is `openaiCompatible`.

## Changes

**`packages/kodus-common` (BYOKProvider source of truth)**
- `src/llm/byokProvider.service.ts` — `REQUESTY = 'requesty'` enum member, fixed base URL `https://router.requesty.ai/v1` in the adapter base-URL selection (mirroring OPEN_ROUTER), and `'Requesty'` in the display-name map.
- `src/llm/providerAdapters/index.ts` — `'requesty'` added to the OpenAI-compatible adapter grouping (alongside `open_router` / `openai_compatible`).

**App (`libs/`)**
- `core/.../providers/provider.service.ts` — `REQUESTY` `ProviderInfo` entry (`requiresApiKey: true`, `requiresBaseUrl: false`).
- `code-review/.../llm/byok-to-vercel.ts` — `REQUESTY` case using `createOpenAICompatible` at the Requesty base URL; falls through to the conservative `shouldEnableJsonSchema` → false branch (like NOVITA).
- `code-review/.../llm/agent-loop.ts` — `[BYOKProvider.REQUESTY]: 'openaiCompatible'` in `PROVIDER_OPTIONS_NAMESPACE` (deliberately not in the OpenRouter routing/reasoning branches).
- `code-review/.../llm/model-context-window.ts` — `requesty` added to the `provider/`-prefix strip.
- `organization/.../get-models-by-provider.use-case.ts` — `REQUESTY` case + `getRequestyModels()` (GET `/v1/models`, mirrors `getOpenRouterModels`).
- `organization/.../test-byok-connection.use-case.ts` — `REQUESTY` case in the connection-test switch.
- `.env.example` / `.env.schema` / `.env.template` — `API_REQUESTY_API_KEY` alongside `API_OPEN_ROUTER_API_KEY`.

Eval harness left untouched (you're removing it).

## Testing

- Built `packages/kodus-common` (`pnpm run prepack`) clean — the new enum/maps/adapter compile.
- Root `tsc --noEmit --skipLibCheck` (with the rebuilt `@kodus/kodus-common` injected): **none of the edited files produce any error**, and the total error count is identical to the base branch (all pre-existing test/CLI-config issues, unrelated to this change).
- Verified live against the real endpoint:
  - `POST https://router.requesty.ai/v1/chat/completions` with `model: openai/gpt-4o-mini` → HTTP 200, real completion.
  - `GET https://router.requesty.ai/v1/models` → HTTP 200, OpenAI-shaped list (572 models) — confirms `getRequestyModels`.

Docs: https://docs.requesty.ai • Keys: https://app.requesty.ai/api-keys

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.
