### PR TITLE
fix(agents): honor BYOK temperature/maxTokens in flow agents

### DIFF
--- a/libs/agents/infrastructure/services/kodus-flow/base-agent.provider.ts
+++ b/libs/agents/infrastructure/services/kodus-flow/base-agent.provider.ts
@@ -135,12 +135,23 @@ export abstract class BaseAgentProvider {
                                 });
                             }
                             return await builder
+                                // Per-call temperature/maxTokens must honor the
+                                // org's BYOK config FIRST. `createBYOKProvider`
+                                // uses `options.temperature` (this value), NOT
+                                // `byokConfig.main.temperature`, so a hardcoded
+                                // `defaultLLMConfig.temperature: 0` was being sent
+                                // to the BYOK model — and models like
+                                // kimi-k2.7-code reject anything but their
+                                // configured temperature (1), failing the call
+                                // and falling back to the system Gemini.
                                 .setTemperature(
-                                    options?.temperature ??
+                                    this.byokConfig?.main?.temperature ??
+                                        options?.temperature ??
                                         this.defaultLLMConfig.temperature,
                                 )
                                 .setMaxTokens(
-                                    options?.maxTokens ??
+                                    this.byokConfig?.main?.maxOutputTokens ??
+                                        options?.maxTokens ??
                                         this.defaultLLMConfig.maxTokens,
                                 )
                                 .setMaxReasoningTokens(


### PR DESCRIPTION
The flow agents (conversation, business-rules validation, context-evidence) build their LLM call via `BaseAgentProvider.createLLMAdapter`, which set `.setTemperature(options?.temperature ?? defaultLLMConfig.temperature)` — and `defaultLLMConfig.temperature` is a hardcoded `0`.

`createBYOKProvider` (kodus-common) applies the per-call `options.temperature`, NOT `byokConfig.main.temperature`, so that hardcoded `0` was sent to the org's BYOK model. Models like kimi-k2.7-code reject anything but their configured temperature ("invalid temperature: only 1 is allowed"), so the BYOK main call failed and the prompt runner fell back to the system model — which resolves to Vertex Gemini in some environments and 403s there.

Prefer the BYOK config's temperature/maxOutputTokens when present, falling back to the per-call option then the agent default. Covers conversation + business validation + context-evidence (all extend BaseAgentProvider). Review is unaffected (separate AI-SDK path that omits temperature).