### PR TITLE
fix(ci): pass github_token to mcp-manager prod build

### DIFF
--- a/.github/workflows/prod-mcp-manager-deploy.yml
+++ b/.github/workflows/prod-mcp-manager-deploy.yml
@@ -82,10 +82,15 @@ jobs:
                   ECR_REPOSITORY: kodus-mcp-manager-prod
                   IMAGE_TAG_VERSION: ${{ steps.tag.outputs.image_tag }}
                   IMAGE_TAG_SHA: ${{ github.sha }}
+                  # Authenticates @vscode/ripgrep's postinstall download via the
+                  # `github_token` build secret — anonymous GitHub API calls from
+                  # runner IPs are rate-limited (403), breaking `pnpm install`.
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   docker buildx build \
                       --file docker/Dockerfile \
                       --target mcp-manager \
+                      --secret id=github_token,env=GITHUB_TOKEN \
                       --tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG_VERSION \
                       --tag $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG_SHA \
                       --cache-from type=gha,scope=mcp-manager-prod \


### PR DESCRIPTION
## Problema
O deploy de prod do mcp-manager (`MCP Manager: Production EC2 Deploy`) estava quebrando no job **Build and push image**:

```
@vscode/ripgrep postinstall: GET https://api.github.com/repos/microsoft/ripgrep-prebuilt/releases/tags/v15.0.1
Downloading ripgrep failed after multiple retries: Error: Request failed: 403
ELIFECYCLE Command failed with exit code 1
```

### Causa raiz
- O `pnpm install` do `docker/Dockerfile` **não é filtrado** por target, então o build do mcp-manager instala o closure inteiro do workspace — incluindo `@vscode/ripgrep`, que é **dep transitiva do `@morphllm/morphsdk`** (não é usada pelo mcp-manager).
- O postinstall do `@vscode/ripgrep` baixa um binário prebuilt do GitHub Releases. O `docker buildx build` desse workflow **não passava o secret `github_token`**, então a chamada à API do GitHub era anônima → **rate limit 403** → `pnpm install` falha.
- Os builds canônicos de api/web (`prod-build-push-and-pr-green.yml`) já passam o `GITHUB_TOKEN` exatamente por causa disso; esse workflow foi portado 1:1 do repo antigo e nunca recebeu o fix.

## Fix
Passar o `GITHUB_TOKEN` (token automático do Actions) como o build secret `github_token` que o Dockerfile já espera (`--mount=type=secret,id=github_token`). Repo `microsoft/ripgrep-prebuilt` é público; `permissions: contents: read` (já presente) basta para tirar do rate-limit anônimo.

**Não requer cadastrar nenhum secret novo** — `secrets.GITHUB_TOKEN` é injetado automaticamente em todo run.

## Teste
Após o merge: re-disparar o workflow na `main` (dispatch) ou cortar um release `mcp-manager-X.Y.Z`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)