### PR TITLE
fix(mcp-manager): disconnect via OAuth credential (table-drift root cause)

### DIFF
--- a/apps/mcp-manager/src/modules/mcp/mcp.service.ts
+++ b/apps/mcp-manager/src/modules/mcp/mcp.service.ts
@@ -235,43 +235,63 @@ export class McpService {
         return updatedConnection;
     }
 
+    /**
+     * Disconnect a managed integration.
+     *
+     * Disconnect is keyed on the *integration*, not on a connection row. A
+     * plugin can be "connected" purely via its managed OAuth credential
+     * (`mcp_integration_oauth`) with no row in `mcp_connections` — the two
+     * tables can drift, and the UI still shows it connected because
+     * `isConnected` is derived from the credential. In that state the web only
+     * has the integrationId (there is no connection PK to send), so this accepts
+     * **either** the connection PK or the integrationId.
+     *
+     * Clearing the managed OAuth credential is what actually disconnects the
+     * integration (it flips `hasManagedCredential` → false). The connection row,
+     * when present, is deleted too — but its absence must not block the
+     * disconnect.
+     */
     async deleteConnection(
         connectionIdOrIntegrationId: string,
         organizationId: string,
     ) {
-        // The web sends the connection PK when it can resolve it, but falls back
-        // to the integrationId (always known from the route) when the
-        // connections list failed to load. Accept either so the user can always
-        // disconnect, even when the UI never received the connection PK.
-        const connection =
-            (await this.getConnectionById(
-                connectionIdOrIntegrationId,
-                organizationId,
-            )) ??
-            (await this.connectionRepository.findOne({
-                where: {
-                    integrationId: connectionIdOrIntegrationId,
-                    organizationId,
-                },
-            }));
+        const ref = connectionIdOrIntegrationId;
 
-        if (!connection) {
-            throw new NotFoundException(
-                `Connection not found for "${connectionIdOrIntegrationId}"`,
+        // `id` is a uuid column, so only match it by `id` when the value is
+        // actually a uuid — otherwise Postgres throws "invalid input syntax for
+        // type uuid". The integrationId is always a safe lookup.
+        const isUuid =
+            /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+                ref,
             );
-        }
+        const connection = await this.connectionRepository.findOne({
+            where: isUuid
+                ? [
+                      { id: ref, organizationId },
+                      { integrationId: ref, organizationId },
+                  ]
+                : [{ integrationId: ref, organizationId }],
+        });
 
-        const provider = this.providerFactory.getProvider(connection.provider);
+        // The integration to disconnect: from the row when we have it, else the
+        // ref itself (which is the integrationId in the credential-only case).
+        const integrationId = connection?.integrationId ?? ref;
 
-        await provider.deleteConnection(connection.id);
-
-        // Remove OAuth state for the integration associated with this connection
+        // Always clear the managed OAuth credential — this is what truly
+        // disconnects the integration, even when no connection row exists.
         await this.integrationOAuthService.deleteOAuthState(
             organizationId,
-            connection.integrationId,
+            integrationId,
         );
 
-        await this.connectionRepository.delete(connection.id);
+        // Delete the connection row only when it exists.
+        if (connection) {
+            const provider = this.providerFactory.getProvider(
+                connection.provider,
+            );
+            await provider.deleteConnection(connection.id);
+            await this.connectionRepository.delete(connection.id);
+        }
 
         return { message: 'Connection deleted successfully' };
     }

--- a/apps/mcp-manager/src/modules/mcp/mcp.service.ts
+++ b/apps/mcp-manager/src/modules/mcp/mcp.service.ts
@@ -235,21 +235,35 @@ export class McpService {
         return updatedConnection;
     }
 
-    async deleteConnection(connectionId: string, organizationId: string) {
-        const connection = await this.getConnectionById(
-            connectionId,
-            organizationId,
-        );
+    async deleteConnection(
+        connectionIdOrIntegrationId: string,
+        organizationId: string,
+    ) {
+        // The web sends the connection PK when it can resolve it, but falls back
+        // to the integrationId (always known from the route) when the
+        // connections list failed to load. Accept either so the user can always
+        // disconnect, even when the UI never received the connection PK.
+        const connection =
+            (await this.getConnectionById(
+                connectionIdOrIntegrationId,
+                organizationId,
+            )) ??
+            (await this.connectionRepository.findOne({
+                where: {
+                    integrationId: connectionIdOrIntegrationId,
+                    organizationId,
+                },
+            }));
 
         if (!connection) {
             throw new NotFoundException(
-                `Connection with ID ${connectionId} not found`,
+                `Connection not found for "${connectionIdOrIntegrationId}"`,
             );
         }
 
         const provider = this.providerFactory.getProvider(connection.provider);
 
-        await provider.deleteConnection(connectionId);
+        await provider.deleteConnection(connection.id);
 
         // Remove OAuth state for the integration associated with this connection
         await this.integrationOAuthService.deleteOAuthState(

--- a/apps/mcp-manager/src/modules/providers/kodusMCP/kodus-mcp.provider.ts
+++ b/apps/mcp-manager/src/modules/providers/kodusMCP/kodus-mcp.provider.ts
@@ -721,8 +721,8 @@ export class KodusMCPProvider extends BaseProvider {
     private async safeGetTools(client: CustomClient): Promise<MCPTool[]> {
         // Hard timeout so one unreachable/slow managed server (expired OAuth →
         // 401, dead endpoint → 404, network stall) can't block the whole
-        // integrations listing while its transport retries. Listing many
-        // integrations fans out over every server, so an unbounded getTools()
+        // integrations listing while its transport retries. Listing integrations
+        // fans a live getTools() out over every server, so an unbounded call
         // here is what makes the registry thrash. On timeout we degrade to an
         // empty tool list instead of hanging the request.
         const TIMEOUT_MS = 8_000;

--- a/apps/mcp-manager/src/modules/providers/kodusMCP/kodus-mcp.provider.ts
+++ b/apps/mcp-manager/src/modules/providers/kodusMCP/kodus-mcp.provider.ts
@@ -719,8 +719,28 @@ export class KodusMCPProvider extends BaseProvider {
     }
 
     private async safeGetTools(client: CustomClient): Promise<MCPTool[]> {
+        // Hard timeout so one unreachable/slow managed server (expired OAuth →
+        // 401, dead endpoint → 404, network stall) can't block the whole
+        // integrations listing while its transport retries. Listing many
+        // integrations fans out over every server, so an unbounded getTools()
+        // here is what makes the registry thrash. On timeout we degrade to an
+        // empty tool list instead of hanging the request.
+        const TIMEOUT_MS = 8_000;
         try {
-            return await client.getTools();
+            return await Promise.race([
+                client.getTools(),
+                new Promise<MCPTool[]>((_, reject) =>
+                    setTimeout(
+                        () =>
+                            reject(
+                                new Error(
+                                    `getTools timed out after ${TIMEOUT_MS}ms`,
+                                ),
+                            ),
+                        TIMEOUT_MS,
+                    ),
+                ),
+            ]);
         } catch (error) {
             console.error('Failed to fetch managed Kodus MCP tools:', error);
             return [];

--- a/apps/mcp-manager/test/mcp/delete-connection-by-integration.spec.ts
+++ b/apps/mcp-manager/test/mcp/delete-connection-by-integration.spec.ts
@@ -1,0 +1,130 @@
+jest.mock('@kodus/flow', () => ({
+    createMCPAdapter: jest.fn(),
+}));
+
+import { McpService } from '../../src/modules/mcp/mcp.service';
+
+const ORG = 'org-1';
+const INTEGRATION_ID = 'atlassian-rovo-default';
+// In real data the connection PK differs from the integrationId — the crux of
+// the prod "Connection ID not found" bug.
+const CONNECTION_PK = 'd8de7d3e-9dbf-4f73-8471-62cde9d9f1a5';
+const UUID_RE =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function buildService({ hasConnectionRow = true } = {}) {
+    const connection = hasConnectionRow
+        ? {
+              id: CONNECTION_PK,
+              integrationId: INTEGRATION_ID,
+              organizationId: ORG,
+              provider: 'kodusmcp',
+          }
+        : null;
+
+    // Mirrors the real repository: found by PK OR integrationId (scoped to org),
+    // PK !== integrationId, and `id` is a uuid column — querying it with a
+    // non-uuid errors at the database, exactly like Postgres. (An earlier mock
+    // skipped this and hid a real bug.)
+    const connectionRepository = {
+        findOne: jest.fn(({ where }: any) => {
+            const conditions = Array.isArray(where) ? where : [where];
+            for (const c of conditions) {
+                if (c.organizationId !== ORG) continue;
+                if (c.id !== undefined) {
+                    if (!UUID_RE.test(c.id)) {
+                        return Promise.reject(
+                            new Error(
+                                `invalid input syntax for type uuid: "${c.id}"`,
+                            ),
+                        );
+                    }
+                    if (connection && c.id === connection.id) {
+                        return Promise.resolve(connection);
+                    }
+                }
+                if (connection && c.integrationId === connection.integrationId) {
+                    return Promise.resolve(connection);
+                }
+            }
+            return Promise.resolve(null);
+        }),
+        delete: jest.fn().mockResolvedValue({ affected: 1 }),
+    };
+
+    const provider = {
+        deleteConnection: jest.fn().mockResolvedValue(undefined),
+    };
+    const providerFactory = {
+        getProvider: jest.fn().mockReturnValue(provider),
+    };
+    const integrationOAuthService = {
+        deleteOAuthState: jest.fn().mockResolvedValue(undefined),
+    };
+
+    const service = new McpService(
+        providerFactory as any,
+        connectionRepository as any,
+        {} as any,
+        {} as any,
+        integrationOAuthService as any,
+    );
+
+    return { service, connectionRepository, integrationOAuthService };
+}
+
+describe('McpService.deleteConnection', () => {
+    it('deletes by the connection PK and clears the OAuth credential', async () => {
+        const { service, connectionRepository, integrationOAuthService } =
+            buildService();
+
+        await expect(
+            service.deleteConnection(CONNECTION_PK, ORG),
+        ).resolves.toEqual({ message: 'Connection deleted successfully' });
+
+        expect(connectionRepository.delete).toHaveBeenCalledWith(CONNECTION_PK);
+        expect(integrationOAuthService.deleteOAuthState).toHaveBeenCalledWith(
+            ORG,
+            INTEGRATION_ID,
+        );
+    });
+
+    // The web falls back to the integrationId (route param) when the connections
+    // list didn't surface the PK. The row exists, so it's deleted by its real PK
+    // and the credential is cleared.
+    it('deletes by integrationId when the UI only has the integrationId', async () => {
+        const { service, connectionRepository, integrationOAuthService } =
+            buildService();
+
+        await expect(
+            service.deleteConnection(INTEGRATION_ID, ORG),
+        ).resolves.toEqual({ message: 'Connection deleted successfully' });
+
+        expect(connectionRepository.delete).toHaveBeenCalledWith(CONNECTION_PK);
+        expect(integrationOAuthService.deleteOAuthState).toHaveBeenCalledWith(
+            ORG,
+            INTEGRATION_ID,
+        );
+    });
+
+    // The actual prod root cause: the credential exists (mcp_integration_oauth)
+    // but there is NO row in mcp_connections — the tables drifted. The plugin
+    // shows connected, the UI has only the integrationId, and disconnect must
+    // still clear the credential instead of failing with "not found".
+    it('disconnects a credential-only integration with no connection row', async () => {
+        const { service, connectionRepository, integrationOAuthService } =
+            buildService({ hasConnectionRow: false });
+
+        await expect(
+            service.deleteConnection(INTEGRATION_ID, ORG),
+        ).resolves.toEqual({ message: 'Connection deleted successfully' });
+
+        // No row to delete...
+        expect(connectionRepository.delete).not.toHaveBeenCalled();
+        // ...but the credential is cleared — this is what truly disconnects.
+        expect(integrationOAuthService.deleteOAuthState).toHaveBeenCalledWith(
+            ORG,
+            INTEGRATION_ID,
+        );
+    });
+});

--- a/apps/web/src/app/(app)/settings/plugins/[provider]/[id]/@modal/_components/modal.tsx
+++ b/apps/web/src/app/(app)/settings/plugins/[provider]/[id]/@modal/_components/modal.tsx
@@ -38,6 +38,8 @@ import {
     KODUS_ISSUES_INTEGRATION_ID,
 } from "@services/mcp-manager/types";
 import { useSelectedTeamId } from "src/core/providers/selected-team-context";
+
+import { resolveConnectionRef } from "./resolve-connection-ref";
 import { usePermission } from "@services/permissions/hooks";
 import { Action, ResourceType } from "@services/permissions/types";
 import { EditIcon, PlugIcon, RefreshCwIcon, Trash } from "lucide-react";
@@ -272,12 +274,11 @@ export const PluginModal = ({
 
     const [resetAuth, { loading: isResetAuthLoading }] = useAsyncAction(
         async () => {
-            // Prefer the resolved connection PK, but fall back to the plugin's
-            // integrationId (always known from the route). When the connections
-            // list fails to load server-side, `connectionId` is absent and a
-            // hard throw left the user unable to disconnect — the backend now
-            // accepts either identifier.
-            const connectionRef = plugin.connectionId ?? plugin.id;
+            // Fall back to the integrationId (always known from the route) when
+            // the connections list failed to load and `connectionId` is absent —
+            // otherwise the user is stuck unable to disconnect. See
+            // resolveConnectionRef.
+            const connectionRef = resolveConnectionRef(plugin);
             if (!connectionRef) {
                 throw new Error("Connection ID not found");
             }

--- a/apps/web/src/app/(app)/settings/plugins/[provider]/[id]/@modal/_components/modal.tsx
+++ b/apps/web/src/app/(app)/settings/plugins/[provider]/[id]/@modal/_components/modal.tsx
@@ -272,12 +272,18 @@ export const PluginModal = ({
 
     const [resetAuth, { loading: isResetAuthLoading }] = useAsyncAction(
         async () => {
-            if (!plugin.connectionId) {
+            // Prefer the resolved connection PK, but fall back to the plugin's
+            // integrationId (always known from the route). When the connections
+            // list fails to load server-side, `connectionId` is absent and a
+            // hard throw left the user unable to disconnect — the backend now
+            // accepts either identifier.
+            const connectionRef = plugin.connectionId ?? plugin.id;
+            if (!connectionRef) {
                 throw new Error("Connection ID not found");
             }
 
             await deleteMCPConnection({
-                connectionId: plugin.connectionId,
+                connectionId: connectionRef,
             });
 
             await revalidateServerSidePath("/settings/plugins");

--- a/apps/web/src/app/(app)/settings/plugins/[provider]/[id]/@modal/_components/resolve-connection-ref.spec.ts
+++ b/apps/web/src/app/(app)/settings/plugins/[provider]/[id]/@modal/_components/resolve-connection-ref.spec.ts
@@ -1,0 +1,33 @@
+import { resolveConnectionRef } from "./resolve-connection-ref";
+
+describe("resolveConnectionRef (plugin disconnect identifier)", () => {
+    const INTEGRATION_ID = "atlassian-rovo-default";
+    const CONNECTION_PK = "d8de7d3e-9dbf-4f73-8471-62cde9d9f1a5";
+
+    it("uses the connection PK when present", () => {
+        expect(
+            resolveConnectionRef({
+                id: INTEGRATION_ID,
+                connectionId: CONNECTION_PK,
+            }),
+        ).toBe(CONNECTION_PK);
+    });
+
+    // The prod "Connection ID not found" case: the connections list failed to
+    // load server-side, so the plugin carries no `connectionId`. The old code
+    // read only `plugin.connectionId` (undefined) and hard-threw, leaving the
+    // user unable to disconnect a plugin shown as connected.
+    it("falls back to the integrationId when connectionId is absent", () => {
+        const plugin = { id: INTEGRATION_ID, connectionId: undefined };
+
+        // Baseline of the bug: the PK alone is undefined → the old hard throw.
+        expect(plugin.connectionId).toBeUndefined();
+
+        // Fix: resolve to the integrationId so disconnect still works.
+        expect(resolveConnectionRef(plugin)).toBe(INTEGRATION_ID);
+    });
+
+    it("is undefined only when nothing identifies the plugin", () => {
+        expect(resolveConnectionRef({})).toBeUndefined();
+    });
+});

--- a/apps/web/src/app/(app)/settings/plugins/[provider]/[id]/@modal/_components/resolve-connection-ref.ts
+++ b/apps/web/src/app/(app)/settings/plugins/[provider]/[id]/@modal/_components/resolve-connection-ref.ts
@@ -1,0 +1,16 @@
+/**
+ * Resolve the identifier used to delete a plugin's MCP connection.
+ *
+ * Prefer the resolved connection PK, but fall back to the plugin's
+ * integrationId (its `id`, always known from the route). When the connections
+ * list fails to load server-side, `connectionId` is absent — without the
+ * fallback the disconnect action hard-throws "Connection ID not found" and the
+ * user is stuck on a plugin shown as connected. The mcp-manager backend accepts
+ * either identifier.
+ */
+export function resolveConnectionRef(plugin: {
+    id?: string;
+    connectionId?: string;
+}): string | undefined {
+    return plugin.connectionId ?? plugin.id;
+}


### PR DESCRIPTION
## Sintoma
Em prod, **Reset Authentication** num plugin gerenciado (ex.: Atlassian Rovo) estoura `Connection ID not found` e o usuário não consegue desconectar.

## Causa raiz (confirmada com prova real)
**Drift entre duas tabelas:** `isConnected` vem da credencial OAuth (`mcp_integration_oauth`), o `connectionId` vem de `mcp_connections`. Uma integração pode estar conectada **só pela credencial**, sem row em `mcp_connections` → a UI mostra "conectado" mas o front não tem `connectionId`. Confirmado em prod: **7 orgs** têm credencial OAuth do atlassian sem connection row (`mcp_integration_oauth` ∌ `mcp_connections`).

Validado **ponta a ponta contra um mcp-manager + Postgres reais** — o que inclusive pegou um bug `invalid input syntax for type uuid` numa 1ª tentativa que o unit test mockado tinha escondido.

## Mudanças
- **`deleteConnection`** — chaveia o disconnect na **integração**, não na connection row. Resolve a row por **PK ou integrationId** (com guard de uuid pra não bater na coluna uuid com não-uuid), **sempre limpa a credencial OAuth** (é isso que de fato desconecta) e deleta a row **só se existir**. Sem mais 404/400 quando não tem row.
- **web `resetAuth`** — fallback pro `integrationId` (sempre vem da rota) quando o `connectionId` está ausente, em vez de hard-throw. Extraído pro helper puro e testável `resolveConnectionRef`.
- **`safeGetTools`** — timeout de 8s pra um server gerenciado inalcançável não travar a listagem inteira (origem do thrash do registry nos logs de prod).

## Testes
`delete-by-PK`, `delete-by-integrationId` e o caso **credential-only** (o drift); + o helper do web. A criação da row no finalize do OAuth (`upsertManagedConnection`) já mantém conexões novas sincronizadas.

## Fora do escopo (decidido)
- Backfill das 7 orgs legadas (o disconnect já aguenta o caso sem row).
- `isConnected` "flapando": investigado — **não é bug de status** (um refresh falho não derruba o status); o timeout cobre a degradação real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)