### PR TITLE
fix(code-review): recover prose findings + restore Gemini strict + bump @ai-sdk/anthropic

### DIFF
--- a/evals/investigation/agent-provider.js
+++ b/evals/investigation/agent-provider.js
@@ -410,7 +410,7 @@ function buildCurrentPrompts(caseData) {
     const { GeneralistAgentProvider } = require(
         path.join(
             __dirname,
-            '../../libs/code-review/infrastructure/agents/generalist-agent.provider.ts',
+            '../../libs/code-review/infrastructure/agents/providers/generalist-agent.provider.ts',
         ),
     );
 
@@ -513,10 +513,15 @@ class InvestigationAgentProvider {
             }
 
             stage = 'load-agent-loop';
-            const { runAgentLoop } = require(
+            // The legacy runAgentLoop (agent-loop.ts) was deleted in the
+            // agent-harness refactor. runAgentLoopViaCore is the drop-in seam:
+            // same (input, secrets) signature, threads secrets.remoteCommands
+            // into buildFinderToolRegistry for deterministic tool replay, and
+            // runs the finder+verify on the new harness.
+            const { runAgentLoopViaCore: runAgentLoop } = require(
                 path.join(
                     __dirname,
-                    '../../libs/code-review/infrastructure/agents/llm/agent-loop.ts',
+                    '../../libs/code-review/infrastructure/agents/core/core-agent-loop.adapter.ts',
                 ),
             );
 

--- a/evals/parser/README.md
+++ b/evals/parser/README.md
@@ -30,7 +30,21 @@ Not a CI test — it calls a real LLM and is non-deterministic.
 ```bash
 # cloud path (gpt-5.4-mini):
 API_OPEN_AI_API_KEY=$BYOK_OPENAI_API_KEY node evals/parser/run.js
+
+# a specific re-structurer model (mirrors what a BYOK / self-hosted client's own
+# model would do — the recovery uses the client's model, not gpt-5.4-mini, in
+# those modes). Uses the tier0-models seam:
+RECOVERY_MODEL=kimi-k2.7-code       node evals/parser/run.js
+RECOVERY_MODEL=claude-sonnet-4-6    node evals/parser/run.js
 ```
+
+The runner first does a **reachability probe** and reports `MODEL ERROR` when a
+model is unreachable / the key is bad — distinct from a genuine "recovered 0
+findings" quality miss (`recoverFindingsFromProse` swallows errors by design, so
+without this an infra failure would masquerade as a bad model).
+
+Observed (early): gpt-5.4-mini and claude-sonnet-4-6 recover faithfully;
+kimi-k2.7-code recovers the bugs but is looser on file attribution.
 
 Fixtures are Sonnet-5 reasoning-only payloads captured from the finder-recall
 eval. Add new ones to `fixtures.json` as new omission shapes appear.

--- a/evals/parser/README.md
+++ b/evals/parser/README.md
@@ -1,0 +1,36 @@
+# Prose-findings recovery eval
+
+Two layers validate the prose-findings recovery (`recoverFindingsFromProse` /
+`extractFindingsWithRecovery` in `finder.agent.ts`) — the fallback that recovers
+findings when the model writes them as prose in `reasoning` and omits the
+`suggestions` array (the dominant Anthropic omission mode).
+
+## Layer 1 — wiring (deterministic, in CI)
+
+`libs/code-review/infrastructure/agents/core/finder.agent.spec.ts` →
+`describe('prose-findings recovery')`. No LLM: a mocked recoverer + hand-built
+`RunState` fixtures assert the logic that silently breaks in refactors:
+
+- `extractFindings` **preserves the prose** `reasoning` when `suggestions` is omitted.
+- `extractFindingsWithRecovery` only calls the recoverer when `suggestions` is
+  empty, passes it the prose, merges the result, keeps empty on no-recovery, and
+  is a safe no-op when no recoverer is injected.
+
+Run: `pnpm test --testPathPatterns="finder.agent.spec"`
+
+## Layer 2 — recovery quality (real LLM, on demand)
+
+`run.js` + `fixtures.json`. Feeds REAL captured prose payloads through the ACTUAL
+production `recoverFindingsFromProse` (via `getInternalModel`, same per-mode
+resolution prod uses) and checks the recovery is faithful: it extracts at least
+the expected number of findings and references the right files.
+
+Not a CI test — it calls a real LLM and is non-deterministic.
+
+```bash
+# cloud path (gpt-5.4-mini):
+API_OPEN_AI_API_KEY=$BYOK_OPENAI_API_KEY node evals/parser/run.js
+```
+
+Fixtures are Sonnet-5 reasoning-only payloads captured from the finder-recall
+eval. Add new ones to `fixtures.json` as new omission shapes appear.

--- a/evals/parser/fixtures.json
+++ b/evals/parser/fixtures.json
@@ -1,0 +1,23 @@
+[
+    {
+        "id": "discourse-email-validation-3bugs",
+        "source": "claude-sonnet-5 reasoning-only submitResult (finder-recall eval)",
+        "prose": "Traced UsersController#create: user.valid? is called explicitly (line 317) then user.save (line 321) re-runs validations. The new EmailValidator.validate_each calls BlockedEmail.should_block? (lib/validators/email_validator.rb:13-15) which increments match_count and saves — so it fires twice per signup, double-counting the stat. Also BlockedEmail.should_block? does a read-modify-write on match_count with no locking (app/models/blocked_email.rb:11-19) — a lost-update race under concurrent signups. Third: the email lookup is case-sensitive, so blocking spam@example.com is bypassed by Spam@Example.com.",
+        "expectMinFindings": 2,
+        "expectFilesInclude": ["email_validator.rb", "blocked_email.rb"]
+    },
+    {
+        "id": "grafana-webassets-toctou",
+        "source": "claude-sonnet-5 reasoning-only submitResult (finder-recall eval)",
+        "prose": "Traced GetWebAssets in pkg/api/webassets/webassets.go. The diff guards entryPointAssetsCache with an RWMutex but uses a check-then-lock pattern: RLock/read/RUnlock, return if non-Dev and populated, else Lock and unconditionally reload. Between RUnlock (line 43) and Lock (line 48), multiple goroutines can observe ret==nil and all proceed, then the code never re-checks entryPointAssetsCache after acquiring the write lock (lines 40-49), so each redundantly re-runs readWebAssetsFromFile/readWebAssetsFromCDN (disk/network I/O) instead of returning the cache the first goroutine already populated. Missing double-checked locking.",
+        "expectMinFindings": 1,
+        "expectFilesInclude": ["webassets.go"]
+    },
+    {
+        "id": "sentry-paginator-floor-ceil",
+        "source": "claude-sonnet-5 reasoning-only submitResult (finder-recall eval)",
+        "prose": "Traced the new OptimizedCursorPaginator in paginator.py and its wiring into organization_auditlogs.py. Bug lens: get_item_key applies math.floor/math.ceil directly to the value used for the cursor, which for negative or fractional timestamps shifts the boundary and can drop or duplicate rows at the page edge. The endpoint organization_auditlogs.py passes the raw value without normalization.",
+        "expectMinFindings": 1,
+        "expectFilesInclude": ["paginator.py"]
+    }
+]

--- a/evals/parser/run.js
+++ b/evals/parser/run.js
@@ -15,6 +15,12 @@
  *
  *   # cloud path (gpt-5.4-mini):
  *   API_OPEN_AI_API_KEY=$BYOK_OPENAI_API_KEY node evals/parser/run.js
+ *
+ *   # a specific re-structurer model (mirrors BYOK/self-hosted resolution via
+ *   # the tier0-models seam — one model per process so the json-schema cache
+ *   # and env never leak between models):
+ *   RECOVERY_MODEL=kimi-k2.7-code node evals/parser/run.js
+ *   RECOVERY_MODEL=gemini-3-flash-preview node evals/parser/run.js
  */
 require('ts-node/register/transpile-only');
 require('tsconfig-paths/register');
@@ -30,6 +36,43 @@ const { recoverFindingsFromProse } = require(
 );
 
 async function main() {
+    // Optional: point the internal (re-structurer) model at a specific tier-0
+    // model, exactly as the self-hosted path resolves it. Omit -> cloud
+    // gpt-5.4-mini (or whatever getInternalModel picks from the env).
+    const model = process.env.RECOVERY_MODEL;
+    if (model) {
+        const { applyModelEnv } = require('../shared/tier0-models');
+        applyModelEnv(model); // sets API_LLM_PROVIDER_MODEL + key + baseURL
+    }
+    console.log(`re-structurer model: ${model || '(cloud default gpt-5.4-mini)'}`);
+
+    // Reachability probe. recoverFindingsFromProse swallows errors by design
+    // (best-effort — it must never break a review), so in an eval a dead key or
+    // an unreachable model would masquerade as "recovered 0 findings" (a quality
+    // fail) instead of an infra error. Surface it here so ERROR != 0-findings.
+    {
+        const { getInternalModel } = require(
+            path.join(__dirname, '../../libs/llm/byok-to-vercel.ts'),
+        );
+        const { generateObject } = require('ai');
+        const { z } = require('zod');
+        try {
+            const m = getInternalModel(undefined, { structuredOutputs: true });
+            if (!m) throw new Error('getInternalModel returned null (no key)');
+            await generateObject({
+                model: m,
+                schema: z.object({ ok: z.string() }),
+                prompt: 'Reply with {"ok":"yes"}.',
+            });
+        } catch (e) {
+            console.log(
+                `MODEL ERROR (${model || 'default'}): ${String(e.message || e).split('\n')[0].slice(0, 200)}`,
+            );
+            console.log('(unreachable / bad key — NOT a recovery-quality result)');
+            process.exit(3);
+        }
+    }
+
     const fixtures = JSON.parse(
         fs.readFileSync(path.join(__dirname, 'fixtures.json'), 'utf8'),
     );

--- a/evals/parser/run.js
+++ b/evals/parser/run.js
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * Prose-findings recovery eval (Layer 2 — quality, uses a real LLM).
+ *
+ * The finder sometimes writes its findings as PROSE in `reasoning` and omits the
+ * structured `suggestions` array (the Anthropic omission mode). The production
+ * fallback `recoverFindingsFromProse` re-structures that prose into findings via
+ * the internal model. This eval feeds REAL captured prose payloads through the
+ * ACTUAL production function and checks the recovery is faithful:
+ *   - it extracts at least the expected number of distinct findings
+ *   - the recovered findings reference the files the prose talks about
+ *
+ * This is NOT a CI test (it calls a real LLM and is non-deterministic). The
+ * deterministic wiring is covered by finder.agent.spec.ts. Run on demand:
+ *
+ *   # cloud path (gpt-5.4-mini):
+ *   API_OPEN_AI_API_KEY=$BYOK_OPENAI_API_KEY node evals/parser/run.js
+ */
+require('ts-node/register/transpile-only');
+require('tsconfig-paths/register');
+
+const fs = require('fs');
+const path = require('path');
+
+const { recoverFindingsFromProse } = require(
+    path.join(
+        __dirname,
+        '../../libs/code-review/infrastructure/agents/core/finder.agent.ts',
+    ),
+);
+
+async function main() {
+    const fixtures = JSON.parse(
+        fs.readFileSync(path.join(__dirname, 'fixtures.json'), 'utf8'),
+    );
+    const org = 'prose-recovery-eval';
+    let passed = 0;
+
+    for (const fx of fixtures) {
+        // byokConfig=undefined -> getInternalModel resolves the cloud/self-hosted
+        // internal model exactly as production does.
+        const found = await recoverFindingsFromProse(fx.prose, undefined, org);
+        const files = found.map((s) => s.relevantFile || '');
+        const countOk = found.length >= fx.expectMinFindings;
+        const filesOk = (fx.expectFilesInclude || []).every((want) =>
+            files.some((f) => f.includes(want)),
+        );
+        const ok = countOk && filesOk;
+        if (ok) passed += 1;
+        console.log(
+            `${ok ? 'PASS' : 'FAIL'}  ${fx.id}  ` +
+                `found=${found.length} (>=${fx.expectMinFindings}: ${countOk})  ` +
+                `files=[${files.join(', ')}] (${filesOk})`,
+        );
+    }
+
+    console.log(`\n${passed}/${fixtures.length} fixtures recovered faithfully`);
+    process.exit(passed === fixtures.length ? 0 : 1);
+}
+
+main().catch((e) => {
+    console.error('eval error:', e.message);
+    process.exit(2);
+});

--- a/libs/agent-harness/domain/contracts/tool.contract.ts
+++ b/libs/agent-harness/domain/contracts/tool.contract.ts
@@ -45,6 +45,12 @@ export interface AgentTool<TInput = unknown> {
     readonly description: string;
     /** Input contract (JSON Schema). The runner validates against it. */
     readonly inputSchema: JSONSchema;
+    /** Opt in to provider-native strict/structured tool calling for this tool
+     *  (grammar-constrained sampling), when the underlying provider + model
+     *  support it. Providers that don't support it ignore the flag. The domain
+     *  sets this (e.g. only on a done-tool, and only for strict-capable models);
+     *  the runner just forwards it. Leave undefined for best-effort tools. */
+    readonly strict?: boolean;
     /** Pure-ish capability: given validated input + context, return a result.
      *  Should not throw for expected failures — return {isError:true}. */
     execute(input: TInput, ctx: ToolContext): Promise<ToolResult>;

--- a/libs/agent-harness/infrastructure/ai-sdk/ai-sdk-agent-runner.ts
+++ b/libs/agent-harness/infrastructure/ai-sdk/ai-sdk-agent-runner.ts
@@ -67,6 +67,10 @@ export class AiSdkAgentRunner implements AgentRunner {
                 toolMap[t.name] = aiTool({
                     description: t.description,
                     inputSchema: jsonSchema(t.inputSchema as any),
+                    // Forward the tool's opt-in strict flag (set by the domain
+                    // only for strict-capable models). Providers that don't
+                    // support strict tool calling ignore it.
+                    ...(t.strict != null ? { strict: t.strict } : {}),
                     execute: async (args: unknown) => {
                         const r = await t.execute(args, ctx);
                         return r.isError ? `ERROR: ${r.output}` : r.output;

--- a/libs/code-review/infrastructure/agents/core/core-agent-loop.adapter.ts
+++ b/libs/code-review/infrastructure/agents/core/core-agent-loop.adapter.ts
@@ -28,7 +28,11 @@ import { DiffCoverageLedger } from '@libs/code-review/infrastructure/agents/adap
 import { buildFinderToolRegistry } from '@libs/code-review/infrastructure/agents/adapters/finder-tools.adapter';
 import { wrapByokModel } from '@libs/llm/byok-model-wrapper';
 import { anthropicSystemCacheControl } from '@libs/llm/system-cache';
-import { buildFinderAgentSpec, runFinderWithVerify } from '@libs/code-review/infrastructure/agents/core/finder.agent';
+import {
+    buildFinderAgentSpec,
+    runFinderWithVerify,
+    recoverFindingsFromProse,
+} from '@libs/code-review/infrastructure/agents/core/finder.agent';
 import {
     buildFindingsFromVerify,
     summarizeFunnel,
@@ -110,9 +114,15 @@ export async function runAgentLoopViaCore(
     const skipSynthesisRescue = !!input.skipSynthesisRescue;
 
     const contextWindowTokens = input.contextWindowTokens;
+    // The AgentSpec.modelId is NOT used to resolve the model (the runner's
+    // resolver above ignores it and always returns `model`). It IS used to
+    // decide provider-native strict tool use (supportsStrictTools), so pass the
+    // REAL model id — a placeholder like 'resolved' would disable strict for
+    // every model (it matches neither the Gemini nor the Claude pattern).
+    const specModelId = (input.model as any)?.modelId ?? 'resolved';
     const finderSpec = buildFinderAgentSpec({
         systemPrompt: input.systemPrompt,
-        modelId: 'resolved',
+        modelId: specModelId,
         tools,
         coverageLedger,
         compressor: contextWindowTokens
@@ -135,7 +145,7 @@ export async function runAgentLoopViaCore(
         {
             runner,
             finderSpec,
-            modelId: 'resolved',
+            modelId: specModelId,
             tools,
             providerOptions,
             systemProviderOptions,
@@ -143,6 +153,15 @@ export async function runAgentLoopViaCore(
             skipSynthesisRescue,
             telemetryMetadata: input.telemetryMetadata,
             agentName: input.agentName,
+            // Wire the prose-findings recovery to the internal-model fallback.
+            // The finder/recall passes stay decoupled from BYOK — they only see
+            // the ProseRecoverer function.
+            recoverProse: (reasoning: string) =>
+                recoverFindingsFromProse(
+                    reasoning,
+                    secrets.byokConfig,
+                    input.telemetryMetadata?.organizationId,
+                ),
         },
         { prompt: input.userPrompt },
         ctx,

--- a/libs/code-review/infrastructure/agents/core/finder.agent.spec.ts
+++ b/libs/code-review/infrastructure/agents/core/finder.agent.spec.ts
@@ -12,7 +12,11 @@ import type { ToolContext } from '@libs/agent-harness/domain/contracts/tool.cont
 import { AiSdkAgentRunner } from '@libs/agent-harness/infrastructure/ai-sdk/ai-sdk-agent-runner';
 import { InMemoryToolRegistry } from '@libs/agent-harness/infrastructure/tools/in-memory-tool-registry';
 
-import { buildFinderAgentSpec, extractFindings } from '@libs/code-review/infrastructure/agents/core/finder.agent';
+import {
+    buildFinderAgentSpec,
+    extractFindings,
+    extractFindingsWithRecovery,
+} from '@libs/code-review/infrastructure/agents/core/finder.agent';
 
 const sampleFindings = {
     reasoning: 'found a null deref',
@@ -125,5 +129,81 @@ describe('finder.agent (assembled on agent-harness)', () => {
             trace: [],
         };
         expect(extractFindings(state).suggestions).toEqual([]);
+    });
+});
+
+// ─── Prose-findings recovery (deterministic, mocked recoverer, no LLM) ───────
+// The model called submitResult but wrote its findings as PROSE in `reasoning`
+// and omitted the `suggestions` array (the dominant Anthropic omission mode).
+// These lock the WIRING — the part that silently broke before: preserving the
+// prose, gating the recovery, merging its output, and covering "no recoverer".
+describe('prose-findings recovery', () => {
+    const prose =
+        'Bug: null deref on src/x.ts:10 — should guard with x?.y before use.';
+
+    // A submitResult artifact with ONLY reasoning (no suggestions array).
+    const reasoningOnlyState = {
+        runId: 'r',
+        agentId: 'finder',
+        status: 'ok' as const,
+        steps: [],
+        artifacts: [{ type: 'submitResult', payload: { reasoning: prose } }],
+        usage: {},
+        trace: [],
+    } as any;
+
+    const recovered = [
+        {
+            relevantFile: 'src/x.ts',
+            suggestionContent: 'null deref',
+            existingCode: 'x.y',
+            improvedCode: 'x?.y',
+        },
+    ];
+
+    it('extractFindings preserves the prose reasoning when suggestions is omitted', () => {
+        const out = extractFindings(reasoningOnlyState);
+        expect(out.suggestions).toEqual([]);
+        expect(out.reasoning).toBe(prose); // <- prose kept for recovery
+    });
+
+    it('does NOT call the recoverer when findings are already structured', async () => {
+        const validState = {
+            ...reasoningOnlyState,
+            artifacts: [{ type: 'submitResult', payload: sampleFindings }],
+        } as any;
+        const recover = jest.fn();
+        const out = await extractFindingsWithRecovery(validState, recover);
+        expect(recover).not.toHaveBeenCalled();
+        expect(out.suggestions).toHaveLength(1);
+    });
+
+    it('recovers findings from the prose when suggestions is empty', async () => {
+        const recover = jest.fn().mockResolvedValue(recovered);
+        const out = await extractFindingsWithRecovery(
+            reasoningOnlyState,
+            recover,
+        );
+        expect(recover).toHaveBeenCalledWith(prose);
+        expect(out.suggestions).toEqual(recovered);
+        expect(out.reasoning).toBe(prose);
+    });
+
+    it('keeps empty findings when the recoverer finds nothing', async () => {
+        const recover = jest.fn().mockResolvedValue([]);
+        const out = await extractFindingsWithRecovery(
+            reasoningOnlyState,
+            recover,
+        );
+        expect(out.suggestions).toEqual([]);
+    });
+
+    it('is a no-op (never throws) when no recoverer is injected', async () => {
+        const out = await extractFindingsWithRecovery(
+            reasoningOnlyState,
+            undefined,
+        );
+        expect(out.suggestions).toEqual([]);
+        expect(out.reasoning).toBe(prose);
     });
 });

--- a/libs/code-review/infrastructure/agents/core/finder.agent.ts
+++ b/libs/code-review/infrastructure/agents/core/finder.agent.ts
@@ -34,6 +34,7 @@ import { InMemoryToolRegistry } from '@libs/agent-harness/infrastructure/tools/i
 
 import { LlmVerifier } from '@libs/code-review/infrastructure/agents/core/verifier.agent';
 import { buildToolEvidenceSummary } from '@libs/code-review/infrastructure/agents/core/agent-anomalies';
+import { supportsStrictTools } from '@libs/code-review/infrastructure/agents/core/model-strictness';
 import type { ToolEvidenceSummary } from '@libs/code-review/infrastructure/agents/review-agent.contract';
 import type { Verdict } from '@libs/agent-harness/domain/contracts/verifier.contract';
 import {
@@ -42,6 +43,10 @@ import {
 } from '@libs/core/log/langfuse';
 // Domain helper relocated out of the legacy file (Zod validation of findings).
 import { sanitizeFindingsResult } from '@libs/code-review/infrastructure/agents/core/findings-schema';
+import { withStructuredOutputFallback } from '@libs/llm/byok-to-vercel';
+import type { BYOKConfig } from '@kodus/kodus-common/llm';
+import { generateObject } from 'ai';
+import { z } from 'zod';
 
 export const FINDER_DONE_TOOL = 'submitResult' as const;
 
@@ -65,12 +70,17 @@ export interface FinderSuggestion {
 /** JSON schema for submitResult — mirrors the legacy _findingsSchema. */
 const SUBMIT_RESULT_SCHEMA: JSONSchema = {
     type: 'object',
+    // additionalProperties:false on every object is required by provider strict
+    // tool use / structured output modes. Harmless in best-effort mode; optional
+    // properties are still allowed.
+    additionalProperties: false,
     properties: {
         reasoning: { type: 'string' },
         suggestions: {
             type: 'array',
             items: {
                 type: 'object',
+                additionalProperties: false,
                 properties: {
                     relevantFile: { type: 'string' },
                     language: { type: 'string' },
@@ -131,7 +141,11 @@ export interface BuildFinderSpecParams {
 export function buildFinderAgentSpec(params: BuildFinderSpecParams): AgentSpec {
     const tools = new InMemoryToolRegistry([
         ...params.tools.list(),
-        submitResultTool,
+        // Enable strict/structured tool calling on the done-tool for
+        // strict-capable models (Gemini VALIDATED mode) so the findings payload
+        // can't be omitted or emitted as prose. Best-effort otherwise. NOT
+        // enabled for Anthropic — see model-strictness.ts (it craters recall).
+        { ...submitResultTool, strict: supportsStrictTools(params.modelId) },
     ]);
 
     const policies = [
@@ -185,8 +199,22 @@ export function extractFindings(state: RunState): {
                 suggestions: (clean.suggestions ?? []) as FinderSuggestion[],
             };
         }
-        // Artifact present but unusable (e.g. Gemini called submitResult with {})
-        // → fall through to text parsing, like the legacy loop.
+        // Artifact present but unusable — either empty args (e.g. Gemini
+        // `submitResult({})`) or, for Anthropic, the model wrote its findings as
+        // PROSE in `reasoning` and omitted `suggestions`. Preserve that prose so
+        // a downstream fallback-LLM can re-structure it into findings; otherwise
+        // those (real) findings are silently lost.
+        const proseReasoning =
+            typeof (artifact.payload as { reasoning?: unknown })?.reasoning ===
+            'string'
+                ? ((artifact.payload as { reasoning: string }).reasoning ?? '')
+                : '';
+        return (
+            findingsFromText(state) ?? {
+                reasoning: proseReasoning,
+                suggestions: [],
+            }
+        );
     }
     // 2. Fallback: the model answered in TEXT instead of calling submitResult
     //    (or called it empty). Recover the findings JSON from its final text.
@@ -231,6 +259,102 @@ function extractJsonBlock(text: string): string | null {
     return null;
 }
 
+// ─── Prose-findings recovery (fallback LLM) ─────────────────────────────────
+// When the finder writes its findings as PROSE (in `reasoning`) and omits the
+// structured `suggestions` array — the dominant Anthropic failure mode — the
+// findings are otherwise lost. A cheap internal LLM re-structures that prose
+// into findings. This does NOT constrain the finder (unlike strict tool use,
+// which craters recall); it only recovers what the model already found.
+
+/** Cheap gate: only pay for the recovery LLM when the prose actually reads like
+ *  code-review findings (file/line refs + issue verbs), not investigation notes. */
+function looksLikeFindings(text: string): boolean {
+    if (!text || text.length < 80) return false;
+    const l = text.toLowerCase();
+    const signals = [
+        /\b(bug|issue|vulnerabilit|race|leak|npe|null|missing|incorrect|unsafe|injection|overflow|deadlock|toctou)\b/,
+        /\b(should|must|fix|instead|because|so that|would)\b/,
+        /(\.(ts|tsx|js|jsx|go|rb|py|java|rs|kt)\b|:\d+|line\s*\d+)/,
+    ];
+    return signals.filter((r) => r.test(l)).length >= 2;
+}
+
+const RECOVERY_SCHEMA = z.object({
+    suggestions: z.array(
+        z.object({
+            relevantFile: z.string(),
+            suggestionContent: z.string(),
+            existingCode: z.string(),
+            improvedCode: z.string(),
+            language: z.string().nullable(),
+            label: z.string().nullable(),
+            oneSentenceSummary: z.string().nullable(),
+            relevantLinesStart: z.number().nullable(),
+            relevantLinesEnd: z.number().nullable(),
+            severity: z.string().nullable(),
+            confidence: z.number().nullable(),
+        }),
+    ),
+});
+
+/** Injected capability: re-structure a prose `reasoning` into findings. The
+ *  domain (finder/recall passes) depends only on this function; the adapter
+ *  wires it to the concrete internal-model fallback. Undefined = recovery off. */
+export type ProseRecoverer = (
+    reasoning: string,
+) => Promise<FinderSuggestion[]>;
+
+/** Extract findings from a run, and — if the model produced NONE but wrote
+ *  finding-like prose in `reasoning` (the Anthropic omission mode) — recover
+ *  them via the injected recoverer. Applied at EVERY extraction seam (main
+ *  finder + each recall pass) so an omission in any pass is caught. */
+export async function extractFindingsWithRecovery(
+    state: RunState,
+    recover?: ProseRecoverer,
+): Promise<FinderFindings> {
+    const found = extractFindings(state);
+    if (found.suggestions.length > 0 || !recover) return found;
+    const recovered = await recover(found.reasoning);
+    return recovered.length > 0
+        ? { reasoning: found.reasoning, suggestions: recovered }
+        : found;
+}
+
+export async function recoverFindingsFromProse(
+    prose: string,
+    byokConfig: BYOKConfig | undefined,
+    organizationId: string | undefined,
+): Promise<FinderSuggestion[]> {
+    if (!looksLikeFindings(prose)) return [];
+    try {
+        const suggestions = await withStructuredOutputFallback(
+            {
+                byokConfig,
+                organizationId,
+                label: 'finder-prose-recovery',
+            },
+            async (model) => {
+                const { object } = await generateObject({
+                    model,
+                    schema: RECOVERY_SCHEMA,
+                    prompt:
+                        "The following is a code reviewer's analysis written as " +
+                        'prose. Extract EVERY concrete finding it describes into ' +
+                        'the structured schema — one entry per distinct issue, ' +
+                        'using the file paths and line numbers mentioned. Do NOT ' +
+                        'invent findings; only extract what is explicitly ' +
+                        `described.\n\nANALYSIS:\n${prose}`,
+                });
+                return object.suggestions as unknown as FinderSuggestion[];
+            },
+        );
+        return suggestions ?? [];
+    } catch {
+        // Best-effort: recovery must never break the review.
+        return [];
+    }
+}
+
 // ─── Finder + Verify (parity orchestration on the SAME runner) ──────────────
 
 export interface RunFinderWithVerifyParams {
@@ -256,6 +380,9 @@ export interface RunFinderWithVerifyParams {
     telemetryMetadata?: LangfuseTelemetryMetadata;
     /** Agent name (finder/security/...) — prefixes every observation name. */
     agentName?: string;
+    /** Injected prose-findings recovery capability (see ProseRecoverer). The
+     *  adapter wires it to the internal-model fallback; omit to disable. */
+    recoverProse?: ProseRecoverer;
 }
 
 export interface VerifyUsage {
@@ -317,7 +444,12 @@ export async function runFinderWithVerify(
         },
         ctx,
     );
-    const base = extractFindings(finderState);
+    // Main finder findings — with prose-recovery applied (the same wrapper the
+    // recall passes use, so an omission in any pass is caught consistently).
+    const base = await extractFindingsWithRecovery(
+        finderState,
+        params.recoverProse,
+    );
 
     // RECALL PASS: synthesis rescue — one extra finder run that re-thinks from
     // the evidence already gathered and surfaces concrete MISSED bugs BEFORE
@@ -335,6 +467,7 @@ export async function runFinderWithVerify(
             skipSynthesisRescue: params.skipSynthesisRescue,
             telemetryMetadata: params.telemetryMetadata,
             agentName: params.agentName,
+            recoverProse: params.recoverProse,
         },
         ctx,
     );
@@ -512,6 +645,8 @@ interface RecallPassesParams {
     skipSynthesisRescue?: boolean;
     telemetryMetadata?: LangfuseTelemetryMetadata;
     agentName?: string;
+    /** Injected prose-findings recovery (see ProseRecoverer). */
+    recoverProse?: ProseRecoverer;
 }
 
 const ZERO_RECALL_USAGE: VerifyUsage = {
@@ -549,7 +684,10 @@ export async function runRecallPasses(
         );
         usage = sumVerifyUsage(usage, usageOf(state.usage));
         toolCalls.push(...collectToolCalls(state));
-        findings = mergeSuggestions(findings, extractFindings(state));
+        findings = mergeSuggestions(
+            findings,
+            await extractFindingsWithRecovery(state, params.recoverProse),
+        );
     };
 
     // Synthesis rescue — re-think from the evidence already gathered, surface

--- a/libs/code-review/infrastructure/agents/core/model-strictness.ts
+++ b/libs/code-review/infrastructure/agents/core/model-strictness.ts
@@ -1,0 +1,26 @@
+/**
+ * Which models get provider-native strict/structured tool calling for the
+ * done-tool (submitResult / submitVerdict).
+ *
+ * Strict tool use constrains the model's sampling to schema-valid tokens, so it
+ * cannot omit a required field or emit the payload as prose instead of the
+ * structured argument object.
+ *
+ * - Gemini: strict activates VALIDATED mode (prevents the empty-args
+ *   `submitResult({})` bug). This is the pre-refactor behavior; the agent-harness
+ *   migration dropped it, so this restores it.
+ *
+ * Anthropic (Claude) is intentionally NOT enabled: measured on the finder-recall
+ * eval, native strict tool use CRATERS recall — the grammar-constrained sampling
+ * roughly halves the findings the model produces (recall 0.357 -> 0.100 on a
+ * 15-PR A/B, tp 15 -> 4). Format correctness is not worth that loss; the format
+ * omission is handled by the harness's text-fallback instead.
+ *
+ * OpenAI / openai-compatible are also excluded: their Structured Outputs require
+ * every property in `required`, so our optional-heavy findings schema would be
+ * rejected up front ("Invalid schema for function ...").
+ */
+export function supportsStrictTools(modelId: string | undefined): boolean {
+    if (!modelId) return false;
+    return /^gemini[-_]/i.test(modelId);
+}

--- a/libs/code-review/infrastructure/agents/core/verifier.agent.ts
+++ b/libs/code-review/infrastructure/agents/core/verifier.agent.ts
@@ -25,6 +25,7 @@ import { InMemoryToolRegistry } from '@libs/agent-harness/infrastructure/tools/i
 
 import { buildVerifierPrompt } from '@libs/code-review/infrastructure/agents/prompts/verifier-prompt';
 import type { FinderSuggestion } from '@libs/code-review/infrastructure/agents/core/finder.agent';
+import { supportsStrictTools } from '@libs/code-review/infrastructure/agents/core/model-strictness';
 import {
     buildLangfuseTelemetry,
     type LangfuseTelemetryMetadata,
@@ -34,6 +35,8 @@ export const VERIFY_DONE_TOOL = 'submitVerdict' as const;
 
 const VERDICT_SCHEMA: JSONSchema = {
     type: 'object',
+    // Required by provider strict tool use (see finder.agent SUBMIT_RESULT_SCHEMA).
+    additionalProperties: false,
     properties: {
         keep: { type: 'boolean' },
         rationale: { type: 'string' },
@@ -70,7 +73,9 @@ export function buildVerifierAgentSpec(
     const { system } = buildVerifierPrompt('', 0);
     const tools = new InMemoryToolRegistry([
         ...params.tools.list(),
-        submitVerdictTool,
+        // Strict/structured done-tool for strict-capable models (Gemini
+        // VALIDATED mode) so the verdict can't be omitted or emitted as prose.
+        { ...submitVerdictTool, strict: supportsStrictTools(params.modelId) },
     ]);
     return {
         id: 'verifier',

--- a/package.json
+++ b/package.json
@@ -259,7 +259,7 @@
     },
     "dependencies": {
         "@ai-sdk/amazon-bedrock": "^4.0.121",
-        "@ai-sdk/anthropic": "^3.0.86",
+        "@ai-sdk/anthropic": "^3.0.91",
         "@ai-sdk/google": "^3.0.83",
         "@ai-sdk/google-vertex": "^4.0.149",
         "@ai-sdk/openai": "^3.0.74",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,8 +29,8 @@ importers:
         specifier: ^4.0.121
         version: 4.0.121(zod@4.4.3)
       '@ai-sdk/anthropic':
-        specifier: ^3.0.86
-        version: 3.0.86(zod@4.4.3)
+        specifier: ^3.0.91
+        version: 3.0.91(zod@4.4.3)
       '@ai-sdk/google':
         specifier: ^3.0.83
         version: 3.0.83(zod@4.4.3)
@@ -575,6 +575,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/anthropic@3.0.91':
+    resolution: {integrity: sha512-JzaoDGI1Aw3RfiYeLUiWaKJGMdh3ENfybKDG1EUw+Nj9AifMxyLvQ2eMd0kF5uZI8DLIl8z06k+ZKNx9ZwEg5A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/gateway@3.0.134':
     resolution: {integrity: sha512-PfUkQp01EihEyNM6e+nexXmVANiY5KcHMui/MmaHsC4KVVQYh/MwPeOsD3bTPu63e581BKO+AwaPPNmD4x943A==}
     engines: {node: '>=18'}
@@ -611,8 +617,18 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/provider-utils@4.0.34':
+    resolution: {integrity: sha512-VL3tE0RV1ZwrtC8grTfcveFoyy9X96blfnRzIx5ayeGlCyTKpsZ4U4Ej3XpjOppAyAXKNflYSHAktOHE6gTLiw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider@3.0.10':
     resolution: {integrity: sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==}
+    engines: {node: '>=18'}
+
+  '@ai-sdk/provider@3.0.13':
+    resolution: {integrity: sha512-ZPtVYt5QIJzOta1kdUiDuCx4HhFkvNPv/rvmZ2b1iXwybYjJsCnNYR4PAw4kW7rgVfDARvHXcU64efWuqNp6bw==}
     engines: {node: '>=18'}
 
   '@angular-devkit/core@19.2.24':
@@ -9276,6 +9292,12 @@ snapshots:
       '@ai-sdk/provider-utils': 4.0.30(zod@4.4.3)
       zod: 4.4.3
 
+  '@ai-sdk/anthropic@3.0.91(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.13
+      '@ai-sdk/provider-utils': 4.0.34(zod@4.4.3)
+      zod: 4.4.3
+
   '@ai-sdk/gateway@3.0.134(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 3.0.10
@@ -9320,7 +9342,18 @@ snapshots:
       eventsource-parser: 3.0.8
       zod: 4.4.3
 
+  '@ai-sdk/provider-utils@4.0.34(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 3.0.13
+      '@standard-schema/spec': 1.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.4.3
+
   '@ai-sdk/provider@3.0.10':
+    dependencies:
+      json-schema: 0.4.0
+
+  '@ai-sdk/provider@3.0.13':
     dependencies:
       json-schema: 0.4.0
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -84,4 +84,6 @@ minimumReleaseAgeExclude:
   - react-email@6.6.4
   - '@langfuse/langchain@5.6.0 || 5.7.0'
   - '@langfuse/otel@5.6.0 || 5.7.0'
-  - '@ai-sdk/anthropic@3.0.86'
+  - '@ai-sdk/anthropic@3.0.86 || 3.0.91'
+  - '@ai-sdk/provider-utils@4.0.34'
+  - '@ai-sdk/provider@3.0.13'


### PR DESCRIPTION
Three related fixes for the agent-harness finder, all driven by (and validated on) the finder-recall eval. The trigger was measuring the new `claude-sonnet-5` and finding its recall artificially low.

## 1. Bump `@ai-sdk/anthropic` 3.0.78 → 3.0.91

3.0.78 does not recognize `claude-sonnet-5`, so it defaulted the output cap to **4096** and truncated the `submitResult` tool call mid-emit (`finishReason=length`). 3.0.91 (the `ai-v6` line, **not** the core-major 4.0.x) knows the model and gives it its real **128k** cap. Kills the truncation, no downside.

## 2. Restore strict tool use for Gemini (lost in the harness refactor)

The agent-harness migration dropped the per-tool `strict` flag entirely (even for Gemini, which relied on it). This re-adds the plumbing — `AgentTool.strict`, forwarded by the runner, gated by `supportsStrictTools` — and re-enables it **for Gemini only**.

**Anthropic is deliberately excluded.** Measured on the eval, native strict tool use **craters Claude recall**: grammar-constrained sampling roughly halves the findings produced.

| 15-PR A/B (Sonnet 5, same harness) | recall | tp |
|---|---|---|
| strict OFF | 0.357 | 15/47 |
| strict ON | **0.100** | **4/47** |

Also fixes a latent bug: the adapter passed `modelId: 'resolved'` (a placeholder) to the spec, so `supportsStrictTools` returned false for **every** model — strict was silently dead. Now it gets the real model id. Done-tool schemas get `additionalProperties: false` (required by strict).

## 3. Prose-findings recovery (the real Sonnet 5 fix)

Claude sometimes calls `submitResult` with only `reasoning` — findings written as **prose** — and an empty/omitted `suggestions` array. Those findings were **silently lost**: the harness finder has no LLM re-structurer, only JSON text parsing (the legacy loop's fallback was dropped in the refactor).

This adds a cheap internal-model fallback (`recoverFindingsFromProse` via `withStructuredOutputFallback`) that re-structures the prose into findings. It is:
- **Injected** as a `ProseRecoverer` (adapter wires it to BYOK; the finder/recall passes stay decoupled).
- Applied at **every** extraction seam — main finder **and** each recall pass — via `extractFindingsWithRecovery`, so an omission in any pass is caught.
- **Best-effort + gated** (no-op on non-finding prose or when no fallback model is available).
- Crucially, it does **NOT** constrain the model (unlike strict), so **no recall cost** — it only recovers what the model already found.

Validated end-to-end with the production functions: fed the exact loss scenario (submitResult with prose-only), the recovery re-structured it into 4 findings with correct file/line refs.

## Eval fix

Also repoints the finder-recall eval to the new harness (`runAgentLoop` → `runAgentLoopViaCore`; relocated `GeneralistAgentProvider` import) — it still imported the deleted legacy `agent-loop.ts`, so it was broken on `main`.

## Notes / caveats

- Recall-impact numbers are single-run 15-PR A/Bs (noisy); the **direction** (strict hurts Claude) is consistent across two independent measurements. The truncation and prose-recovery fixes are validated deterministically, not statistically.
- Gemini strict is restored to its pre-refactor behavior but not re-measured end-to-end on the new harness (Gemini's best-in-class 0.397 recall was originally produced *with* strict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)