### PR TITLE
fix: cleanup local sandbox directories

### DIFF
--- a/libs/code-review/infrastructure/adapters/services/graph/graph-context.service.ts
+++ b/libs/code-review/infrastructure/adapters/services/graph/graph-context.service.ts
@@ -298,7 +298,7 @@ export class GraphContextService {
 
             const extractResult = await sandbox.run(
                 [
-                    `cd ${sandbox.repoDir}`,
+                    `cd ${shSingleQuote(sandbox.repoDir)}`,
                     `rm -rf ${BASE_FILES_DIR} && mkdir -p ${BASE_FILES_DIR}`,
                     // `${f%/*}` is POSIX parameter expansion — it strips the
                     // last `/...` from the path without spawning a subshell.
@@ -444,9 +444,12 @@ export class GraphContextService {
         }
         const diffContent = patches.join('\n');
         const diffPath = `${sandbox.repoDir}/${GRAPH_DIR}/pr.diff`;
-        await sandbox.run(`mkdir -p ${sandbox.repoDir}/${GRAPH_DIR}`, {
-            timeoutMs: 5_000,
-        });
+        await sandbox.run(
+            `mkdir -p ${shSingleQuote(`${sandbox.repoDir}/${GRAPH_DIR}`)}`,
+            {
+                timeoutMs: 5_000,
+            },
+        );
         await sandbox.writeFile(diffPath, diffContent);
         this.logger.log({
             message: `[KODUS-GRAPH] Diff written to sandbox: ${diffContent.length} chars, ${patches.length} files`,

--- a/libs/code-review/infrastructure/adapters/services/graph/kodus-graph-cli.ts
+++ b/libs/code-review/infrastructure/adapters/services/graph/kodus-graph-cli.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { SandboxInstance } from '@libs/sandbox/domain/contracts/sandbox.provider';
 import { shSingleQuote } from '../shell-quote';
 
-export const KODUS_GRAPH_VERSION = '0.2.19';
+export const KODUS_GRAPH_VERSION: string = '0.2.19';
 
 export const KODUS_GRAPH_TIMEOUTS = {
     install: 120_000,
@@ -97,7 +97,7 @@ export class KodusGraphCli {
         const result = await sandbox.run(
             [
                 BUN_PATH_PREFIX,
-                `cd ${sandbox.repoDir}`,
+                `cd ${shSingleQuote(sandbox.repoDir)}`,
                 `mkdir -p ${shSingleQuote(outDir)}`,
                 cmd,
             ].join(' && '),
@@ -133,7 +133,7 @@ export class KodusGraphCli {
         const result = await sandbox.run(
             [
                 BUN_PATH_PREFIX,
-                `cd ${sandbox.repoDir}`,
+                `cd ${shSingleQuote(sandbox.repoDir)}`,
                 `mkdir -p ${shSingleQuote(outDir)}`,
                 `kodus-graph parse --files ${filesArg} --repo-dir ${shSingleQuote(repoDir)} --out ${shSingleQuote(outPath)}`,
             ].join(' && '),
@@ -174,7 +174,7 @@ export class KodusGraphCli {
         const result = await sandbox.run(
             [
                 BUN_PATH_PREFIX,
-                `cd ${sandbox.repoDir}`,
+                `cd ${shSingleQuote(sandbox.repoDir)}`,
                 `mkdir -p ${shSingleQuote(outDir)}`,
                 cmd,
             ].join(' && '),

--- a/libs/core/workflow/domain/contracts/distributed-lock.service.contract.ts
+++ b/libs/core/workflow/domain/contracts/distributed-lock.service.contract.ts
@@ -1,0 +1,20 @@
+export const DISTRIBUTED_LOCK_SERVICE_TOKEN = Symbol('DistributedLockService');
+
+export interface DistributedLockOptions {
+    ttl?: number;
+}
+
+export interface IDistributedLock {
+    release(): Promise<void>;
+
+    isReleased(): boolean;
+}
+
+export interface IDistributedLockService {
+    acquire(
+        key: string,
+        options?: DistributedLockOptions,
+    ): Promise<IDistributedLock | null>;
+
+    isLocked(key: string): Promise<boolean>;
+}

--- a/libs/core/workflow/infrastructure/distributed-lock.service.ts
+++ b/libs/core/workflow/infrastructure/distributed-lock.service.ts
@@ -1,12 +1,16 @@
 import { createLogger } from '@kodus/flow';
 import { Injectable } from '@nestjs/common';
 import { DataSource, QueryRunner } from 'typeorm';
+import {
+    IDistributedLock,
+    IDistributedLockService,
+} from '../domain/contracts/distributed-lock.service.contract';
 
 export interface DistributedLockOptions {
     ttl?: number; // Time to live in ms (optional, for auto-release)
 }
 
-export class DistributedLock {
+export class DistributedLock implements IDistributedLock {
     private released = false;
     private ttlTimer?: NodeJS.Timeout;
 
@@ -92,7 +96,7 @@ export class DistributedLock {
 }
 
 @Injectable()
-export class DistributedLockService {
+export class DistributedLockService implements IDistributedLockService {
     private readonly logger = createLogger(DistributedLockService.name);
 
     constructor(private readonly dataSource: DataSource) {}

--- a/libs/core/workflow/modules/workflow-core.module.ts
+++ b/libs/core/workflow/modules/workflow-core.module.ts
@@ -22,6 +22,7 @@ import { JOB_STATUS_SERVICE_TOKEN } from '../domain/contracts/job-status.service
 import { WORKFLOW_JOB_REPOSITORY_TOKEN } from '../domain/contracts/workflow-job.repository.contract';
 import { OUTBOX_MESSAGE_REPOSITORY_TOKEN } from '../domain/contracts/outbox-message.repository.contract';
 import { INBOX_MESSAGE_REPOSITORY_TOKEN } from '../domain/contracts/inbox-message.repository.contract';
+import { DISTRIBUTED_LOCK_SERVICE_TOKEN } from '../domain/contracts/distributed-lock.service.contract';
 
 const coreProviders = [
     // Repositories
@@ -53,6 +54,10 @@ const coreProviders = [
 
     // Distributed Lock
     DistributedLockService,
+    {
+        provide: DISTRIBUTED_LOCK_SERVICE_TOKEN,
+        useExisting: DistributedLockService,
+    },
 ];
 
 @Global()

--- a/libs/sandbox/domain/contracts/sandbox-lease.repository.contract.ts
+++ b/libs/sandbox/domain/contracts/sandbox-lease.repository.contract.ts
@@ -1,0 +1,57 @@
+export const SANDBOX_LEASE_REPOSITORY_TOKEN = Symbol('SandboxLeaseRepository');
+
+export interface SandboxLeaseRecord {
+    _id: string;
+    sandboxId?: string;
+    state: string;
+    leaseCount: number;
+    createdAt: Date;
+    expiresAt: Date;
+    killAt?: Date;
+}
+
+export type SandboxLeaseLookup = Pick<
+    SandboxLeaseRecord,
+    '_id' | 'state' | 'sandboxId'
+>;
+
+export interface ISandboxLeaseRepository {
+    upsertAcquire(
+        prKey: string,
+        leaseTtlMs: number,
+        consumer?: string,
+    ): Promise<SandboxLeaseRecord>;
+
+    decrementLease(prKey: string): Promise<SandboxLeaseRecord | null>;
+
+    updateReady(prKey: string, sandboxId: string): Promise<void>;
+
+    markInvalidated(prKey: string): Promise<void>;
+
+    findByPrKey(prKey: string): Promise<SandboxLeaseLookup | null>;
+
+    findExpired(
+        now: Date,
+        limit?: number,
+    ): Promise<Pick<SandboxLeaseRecord, '_id' | 'sandboxId' | 'state'>[]>;
+
+    delete(prKey: string): Promise<void>;
+
+    markDeletingIfNoActiveLeases(prKey: string): Promise<boolean>;
+
+    markExpiredDeletingIfNotRenewed(
+        prKey: string,
+        expiredBefore: Date,
+    ): Promise<boolean>;
+
+    deleteIfNoActiveLeases(prKey: string): Promise<boolean>;
+
+    setKillAt(prKey: string, killAt: Date): Promise<boolean>;
+
+    clearKillAt(prKey: string): Promise<void>;
+
+    findReadyToKill(
+        now: Date,
+        limit?: number,
+    ): Promise<Pick<SandboxLeaseRecord, '_id' | 'sandboxId' | 'killAt'>[]>;
+}

--- a/libs/sandbox/domain/contracts/sandbox.provider.ts
+++ b/libs/sandbox/domain/contracts/sandbox.provider.ts
@@ -43,8 +43,9 @@ export interface SandboxInstance {
     /**
      * Stable identifier the lease manager persists on the lease doc so a
      * second consumer can warm-resume by reconnecting via the provider.
-     * For e2b this is the E2B sandboxId; for local it is a generated id;
-     * for null it is the empty string (marker for "no real sandbox").
+     * For e2b this is the E2B sandboxId; for local it is the worker-local
+     * temp directory path; for null it is the empty string (marker for
+     * "no real sandbox").
      */
     sandboxId: string;
     /** Base branch fetched in the sandbox (e.g. "main"). Allows tools to run git diff origin/${baseBranch}...HEAD */
@@ -52,11 +53,18 @@ export interface SandboxInstance {
     /** Absolute path to the repo root inside the sandbox */
     repoDir: string;
     /** Run a shell command inside the sandbox */
-    run(command: string, opts?: { timeoutMs?: number }): Promise<SandboxRunResult>;
+    run(
+        command: string,
+        opts?: { timeoutMs?: number },
+    ): Promise<SandboxRunResult>;
     /** Read a file from the sandbox filesystem */
     readFile(path: string, opts?: { timeoutMs?: number }): Promise<string>;
     /** Write a file to the sandbox filesystem */
-    writeFile(path: string, content: string, opts?: { timeoutMs?: number }): Promise<void>;
+    writeFile(
+        path: string,
+        content: string,
+        opts?: { timeoutMs?: number },
+    ): Promise<void>;
 }
 
 export interface ISandboxProvider {
@@ -67,6 +75,14 @@ export interface ISandboxProvider {
     createSandboxWithRepo(
         params: CreateSandboxParams,
     ): Promise<SandboxInstance>;
+
+    /**
+     * Reconnect to a previously-created sandbox by sandboxId.
+     *
+     * Providers that cannot reconnect may omit this method; the lease manager
+     * treats a missing reconnect as a stale lease and cold-starts instead.
+     */
+    connectToExistingSandbox?(sandboxId: string): Promise<SandboxInstance>;
 }
 
 export const SANDBOX_PROVIDER_TOKEN = Symbol('SANDBOX_PROVIDER_TOKEN');

--- a/libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts
+++ b/libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts
@@ -1,5 +1,8 @@
 import { PlatformType } from '@libs/core/domain/enums';
 import { LocalSandboxService } from './local-sandbox.service';
+import { mkdtemp, readFile, rm, stat, symlink, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 /**
  * buildAuthHeader is the git-over-HTTPS Authorization builder used when the
@@ -16,9 +19,10 @@ describe('LocalSandboxService.buildAuthHeader', () => {
         (service as any).buildAuthHeader(platform, token, username) as string;
 
     const decode = (header: string) =>
-        Buffer.from(header.replace('Authorization: Basic ', ''), 'base64').toString(
-            'utf8',
-        );
+        Buffer.from(
+            header.replace('Authorization: Basic ', ''),
+            'base64',
+        ).toString('utf8');
 
     it('uses x-access-token for GitHub', () => {
         expect(decode(build(PlatformType.GITHUB, 'ghtok'))).toBe(
@@ -27,7 +31,9 @@ describe('LocalSandboxService.buildAuthHeader', () => {
     });
 
     it('uses oauth2 for GitLab and Azure', () => {
-        expect(decode(build(PlatformType.GITLAB, 'gltok'))).toBe('oauth2:gltok');
+        expect(decode(build(PlatformType.GITLAB, 'gltok'))).toBe(
+            'oauth2:gltok',
+        );
         expect(decode(build(PlatformType.AZURE_REPOS, 'aztok'))).toBe(
             'oauth2:aztok',
         );
@@ -47,7 +53,9 @@ describe('LocalSandboxService.buildAuthHeader', () => {
 
         it('uses the account username for classic app passwords', () => {
             expect(
-                decode(build(PlatformType.BITBUCKET, 'classicapppw', 'kodususer')),
+                decode(
+                    build(PlatformType.BITBUCKET, 'classicapppw', 'kodususer'),
+                ),
             ).toBe('kodususer:classicapppw');
         });
 
@@ -62,5 +70,381 @@ describe('LocalSandboxService.buildAuthHeader', () => {
                 /Bitbucket authentication requires/i,
             );
         });
+    });
+});
+
+describe('LocalSandboxService.connectToExistingSandbox', () => {
+    const service = new LocalSandboxService({} as any);
+
+    it('reconnects to an existing local sandbox directory', async () => {
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-test-'));
+
+        try {
+            await writeFile(join(tempDir, 'README.md'), 'hello', 'utf-8');
+
+            const sandbox = await service.connectToExistingSandbox(tempDir);
+
+            expect(sandbox.type).toBe('local');
+            expect(sandbox.sandboxId).toBe(tempDir);
+            expect(sandbox.repoDir).toBe(tempDir);
+            await expect(sandbox.readFile('README.md')).resolves.toBe('hello');
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('rejects unsafe reconnect paths', async () => {
+        await expect(
+            service.connectToExistingSandbox('/tmp/not-kodus-sandbox-test'),
+        ).rejects.toThrow(/unsafe sandbox path/i);
+    });
+
+    it('keeps local read and write operations inside the sandbox directory', async () => {
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-test-'));
+
+        try {
+            const sandbox = await service.connectToExistingSandbox(tempDir);
+
+            await sandbox.writeFile('src/file.txt', 'content');
+            await expect(
+                readFile(join(tempDir, 'src/file.txt'), 'utf-8'),
+            ).resolves.toBe('content');
+
+            await expect(sandbox.readFile('/etc/passwd')).rejects.toThrow(
+                /absolute paths/i,
+            );
+            await expect(
+                sandbox.writeFile('../outside.txt', 'content'),
+            ).rejects.toThrow(/path traversal/i);
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('keeps required runtime env but does not expose host secrets to sandbox.run commands', async () => {
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-test-'));
+        const oldSecret = process.env.KODUS_LOCAL_SANDBOX_SECRET_TEST;
+        const oldHome = process.env.HOME;
+        const oldUser = process.env.USER;
+        const oldTmpdir = process.env.TMPDIR;
+
+        try {
+            process.env.KODUS_LOCAL_SANDBOX_SECRET_TEST = 'secret-value';
+            process.env.HOME = '/tmp/kodus-home-test';
+            process.env.USER = 'kodus-user-test';
+            process.env.TMPDIR = '/tmp/kodus-tmp-test';
+
+            const sandbox = await service.connectToExistingSandbox(tempDir);
+            const result = await sandbox.run(
+                'node -e "process.stdout.write(JSON.stringify({home:process.env.HOME,user:process.env.USER,tmpdir:process.env.TMPDIR,secret:process.env.KODUS_LOCAL_SANDBOX_SECRET_TEST || \'\'}))"',
+            );
+
+            expect(result.exitCode).toBe(0);
+            expect(JSON.parse(result.stdout)).toEqual({
+                home: '/tmp/kodus-home-test',
+                user: 'kodus-user-test',
+                tmpdir: '/tmp/kodus-tmp-test',
+                secret: '',
+            });
+        } finally {
+            if (oldSecret === undefined) {
+                delete process.env.KODUS_LOCAL_SANDBOX_SECRET_TEST;
+            } else {
+                process.env.KODUS_LOCAL_SANDBOX_SECRET_TEST = oldSecret;
+            }
+            if (oldHome === undefined) {
+                delete process.env.HOME;
+            } else {
+                process.env.HOME = oldHome;
+            }
+            if (oldUser === undefined) {
+                delete process.env.USER;
+            } else {
+                process.env.USER = oldUser;
+            }
+            if (oldTmpdir === undefined) {
+                delete process.env.TMPDIR;
+            } else {
+                process.env.TMPDIR = oldTmpdir;
+            }
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('allows infrastructure shell operators but rejects command substitution in sandbox.run commands', async () => {
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-test-'));
+
+        try {
+            const sandbox = await service.connectToExistingSandbox(tempDir);
+
+            await expect(
+                sandbox.run('echo safe; echo unsafe'),
+            ).resolves.toMatchObject({
+                exitCode: 0,
+                stdout: expect.stringContaining('unsafe'),
+            });
+            await expect(
+                sandbox.run('echo safe && echo unsafe'),
+            ).resolves.toMatchObject({
+                exitCode: 0,
+                stdout: expect.stringContaining('unsafe'),
+            });
+            await expect(sandbox.run('echo $HOME')).resolves.toMatchObject({
+                exitCode: 0,
+            });
+            await expect(
+                sandbox.run('echo safe\necho unsafe'),
+            ).resolves.toMatchObject({
+                exitCode: 0,
+                stdout: expect.stringContaining('unsafe'),
+            });
+            await expect(sandbox.run('echo $(pwd)')).resolves.toMatchObject({
+                exitCode: 1,
+                stderr: expect.stringContaining('Command substitution'),
+            });
+            await expect(sandbox.run('echo "$(pwd)"')).resolves.toMatchObject({
+                exitCode: 1,
+                stderr: expect.stringContaining('Command substitution'),
+            });
+            await expect(
+                sandbox.run('echo "it\'s $(pwd)"'),
+            ).resolves.toMatchObject({
+                exitCode: 1,
+                stderr: expect.stringContaining('Command substitution'),
+            });
+            await expect(
+                sandbox.run('echo \\"literal\\" && echo $(pwd)'),
+            ).resolves.toMatchObject({
+                exitCode: 1,
+                stderr: expect.stringContaining('Command substitution'),
+            });
+            await expect(sandbox.run('echo `pwd`')).resolves.toMatchObject({
+                exitCode: 1,
+                stderr: expect.stringContaining('Command substitution'),
+            });
+            await expect(
+                sandbox.run("echo 'literal $(pwd)'"),
+            ).resolves.toMatchObject({
+                exitCode: 0,
+                stdout: expect.stringContaining('literal $(pwd)'),
+            });
+            await expect(
+                sandbox.run("echo 'literal `pwd`'"),
+            ).resolves.toMatchObject({
+                exitCode: 0,
+                stdout: expect.stringContaining('literal `pwd`'),
+            });
+            await expect(
+                sandbox.run("echo 'feature'\\''s $(name).ts'"),
+            ).resolves.toMatchObject({
+                exitCode: 0,
+                stdout: expect.stringContaining("feature's $(name).ts"),
+            });
+            await expect(
+                sandbox.run("echo 'feature'\\''s `name`.ts'"),
+            ).resolves.toMatchObject({
+                exitCode: 0,
+                stdout: expect.stringContaining("feature's `name`.ts"),
+            });
+            await expect(
+                sandbox.run("echo 'literal \\\\ $(pwd)'"),
+            ).resolves.toMatchObject({
+                exitCode: 0,
+                stdout: expect.stringContaining('literal \\ $(pwd)'),
+            });
+            await expect(
+                sandbox.run("echo 'literal \\\\' && echo $(pwd)"),
+            ).resolves.toMatchObject({
+                exitCode: 1,
+                stderr: expect.stringContaining('Command substitution'),
+            });
+            await expect(
+                sandbox.run('echo "literal ; is allowed"'),
+            ).resolves.toMatchObject({
+                exitCode: 0,
+                stdout: expect.stringContaining('literal ; is allowed'),
+            });
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('returns empty search results for missing local paths without escaping the sandbox', async () => {
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-test-'));
+
+        try {
+            const sandbox = await service.connectToExistingSandbox(tempDir);
+
+            await expect(
+                sandbox.remoteCommands.listDir('missing-dir', 2),
+            ).resolves.toBe('');
+            await expect(
+                sandbox.remoteCommands.grep('needle', 'missing-dir'),
+            ).resolves.toBe('');
+            await expect(
+                sandbox.remoteCommands.listDir('../outside', 2),
+            ).rejects.toThrow(/path traversal/i);
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('keeps remoteCommands.exec read-only even for whitelisted finder and ast-grep tools', async () => {
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-test-'));
+
+        try {
+            await writeFile(join(tempDir, 'README.md'), 'hello', 'utf-8');
+            const sandbox = await service.connectToExistingSandbox(tempDir);
+
+            await expect(
+                sandbox.remoteCommands.exec('cat README.md'),
+            ).resolves.toMatchObject({
+                exitCode: 0,
+                stdout: 'hello',
+            });
+            await expect(
+                sandbox.remoteCommands.exec('cat missing-file.txt'),
+            ).resolves.toMatchObject({
+                exitCode: 1,
+            });
+            await expect(
+                sandbox.remoteCommands.exec(
+                    'find . -exec sh -c "echo pwn" {} +',
+                ),
+            ).resolves.toMatchObject({
+                exitCode: 1,
+                stdout: expect.stringContaining('is not allowed'),
+            });
+            await expect(
+                sandbox.remoteCommands.exec('find . -delete'),
+            ).resolves.toMatchObject({
+                exitCode: 1,
+                stdout: expect.stringContaining('is not allowed'),
+            });
+            await expect(
+                sandbox.remoteCommands.exec('fd --exec sh README'),
+            ).resolves.toMatchObject({
+                exitCode: 1,
+                stdout: expect.stringContaining('is not allowed'),
+            });
+            await expect(
+                sandbox.remoteCommands.exec(
+                    'ast-grep --pattern console --rewrite alert',
+                ),
+            ).resolves.toMatchObject({
+                exitCode: 1,
+                stdout: expect.stringContaining('is not allowed'),
+            });
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('keeps remoteCommands.exec file readers from following symlinks outside the sandbox', async () => {
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-test-'));
+        const outsideDir = await mkdtemp(join(tmpdir(), 'kodus-outside-test-'));
+        const outsideFile = join(outsideDir, 'outside.txt');
+
+        try {
+            await writeFile(outsideFile, 'secret outside content', 'utf-8');
+            await symlink(outsideFile, join(tempDir, 'linked.txt'));
+
+            const sandbox = await service.connectToExistingSandbox(tempDir);
+            const result = await sandbox.remoteCommands.exec('cat linked.txt');
+
+            expect(result.exitCode).toBe(1);
+            expect(result.stdout).toContain('not allowed');
+            expect(result.stdout).not.toContain('secret outside content');
+
+            const catWithFlagResult =
+                await sandbox.remoteCommands.exec('cat -n linked.txt');
+
+            expect(catWithFlagResult.exitCode).toBe(1);
+            expect(catWithFlagResult.stdout).toContain('not allowed');
+            expect(catWithFlagResult.stdout).not.toContain(
+                'secret outside content',
+            );
+
+            const grepResult = await sandbox.remoteCommands.exec(
+                'grep secret linked.txt',
+            );
+
+            expect(grepResult.exitCode).toBe(1);
+            expect(grepResult.stdout).toContain('not allowed');
+            expect(grepResult.stdout).not.toContain('secret outside content');
+
+            const grepPatternResult = await sandbox.remoteCommands.exec(
+                "grep '$A..$B' README.md",
+            );
+
+            expect(grepPatternResult.stdout).not.toContain('not allowed');
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+            await rm(outsideDir, { recursive: true, force: true });
+        }
+    });
+
+    it('refuses to read through a symlink that points outside the sandbox directory', async () => {
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-test-'));
+        const outsideDir = await mkdtemp(join(tmpdir(), 'kodus-outside-test-'));
+        const outsideFile = join(outsideDir, 'outside.txt');
+
+        try {
+            await writeFile(outsideFile, 'secret outside content', 'utf-8');
+            await symlink(outsideFile, join(tempDir, 'linked.txt'));
+
+            const sandbox = await service.connectToExistingSandbox(tempDir);
+
+            await expect(sandbox.readFile('linked.txt')).rejects.toBeDefined();
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+            await rm(outsideDir, { recursive: true, force: true });
+        }
+    });
+
+    it('refuses to write through a symlink that points outside the sandbox directory', async () => {
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-test-'));
+        const outsideDir = await mkdtemp(join(tmpdir(), 'kodus-outside-test-'));
+        const outsideFile = join(outsideDir, 'outside.txt');
+
+        try {
+            await writeFile(outsideFile, 'original', 'utf-8');
+            await symlink(outsideFile, join(tempDir, 'linked.txt'));
+
+            const sandbox = await service.connectToExistingSandbox(tempDir);
+
+            await expect(
+                sandbox.writeFile('linked.txt', 'overwritten'),
+            ).rejects.toBeDefined();
+            await expect(readFile(outsideFile, 'utf-8')).resolves.toBe(
+                'original',
+            );
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+            await rm(outsideDir, { recursive: true, force: true });
+        }
+    });
+
+    it('refuses to create parent directories through a symlink outside the sandbox directory', async () => {
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-test-'));
+        const outsideDir = await mkdtemp(join(tmpdir(), 'kodus-outside-test-'));
+
+        try {
+            await symlink(outsideDir, join(tempDir, 'linked-dir'));
+
+            const sandbox = await service.connectToExistingSandbox(tempDir);
+
+            await expect(
+                sandbox.writeFile('linked-dir/new-dir/file.txt', 'content'),
+            ).rejects.toThrow(/path escapes repo boundary/i);
+            await expect(
+                stat(join(outsideDir, 'new-dir')),
+            ).rejects.toMatchObject({
+                code: 'ENOENT',
+            });
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+            await rm(outsideDir, { recursive: true, force: true });
+        }
     });
 });

--- a/libs/sandbox/infrastructure/providers/local-sandbox.service.ts
+++ b/libs/sandbox/infrastructure/providers/local-sandbox.service.ts
@@ -3,17 +3,18 @@ import { PlatformType } from '@libs/core/domain/enums';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { exec, execFile, ExecFileOptions, spawn } from 'child_process';
+import { constants } from 'fs';
 import {
     lstat,
+    mkdir,
     mkdtemp,
-    readFile,
+    open,
     realpath,
     rm,
     writeFile,
-    mkdir,
 } from 'fs/promises';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { dirname, join, resolve } from 'path';
 import { promisify } from 'util';
 
 import {
@@ -23,12 +24,58 @@ import {
     SandboxRunResult,
 } from '@libs/sandbox/domain/contracts/sandbox.provider';
 import { RemoteCommands } from '@libs/code-review/infrastructure/adapters/services/collectCrossFileContexts.service';
+import { isLocalSandboxPath } from '../services/local-sandbox-cleanup';
 
 const execFileAsync = promisify(execFile);
 
 const CLONE_TIMEOUT_MS = 120_000;
 const CMD_TIMEOUT_MS = 30_000;
 const MAX_BUFFER = 5 * 1024 * 1024; // 5 MB — cap output to prevent memory issues
+const SANDBOX_RUN_ENV_KEYS = ['HOME', 'USER', 'TMPDIR'] as const;
+const FIND_DISALLOWED_ARGS = new Set([
+    '-delete',
+    '-exec',
+    '-execdir',
+    '-ok',
+    '-okdir',
+    '-fprint',
+    '-fprintf',
+    '-fls',
+    '-follow',
+    '-L',
+    '-H',
+]);
+const FD_DISALLOWED_ARGS = new Set([
+    '-x',
+    '--exec',
+    '-X',
+    '--exec-batch',
+    '-L',
+    '--follow',
+]);
+const AST_GREP_DISALLOWED_ARGS = new Set(['-r', '--rewrite', '--update-all']);
+const AST_GREP_VALUE_OPTIONS = new Set([
+    '-p',
+    '--pattern',
+    '--lang',
+    '--selector',
+    '--globs',
+]);
+
+function buildSandboxRunEnv(): NodeJS.ProcessEnv {
+    const env: NodeJS.ProcessEnv = {
+        PATH: process.env.PATH ?? '',
+        NODE_ENV: process.env.NODE_ENV ?? 'production',
+    };
+
+    for (const key of SANDBOX_RUN_ENV_KEYS) {
+        if (process.env[key] !== undefined) {
+            env[key] = process.env[key];
+        }
+    }
+
+    return env;
+}
 
 @Injectable()
 export class LocalSandboxService implements ISandboxProvider {
@@ -137,8 +184,6 @@ export class LocalSandboxService implements ISandboxProvider {
                 await this.applyLocalDiff(tempDir, unifiedDiff);
             }
 
-            const remoteCommands = this.buildRemoteCommands(tempDir);
-
             const capturedTempDir = tempDir;
             const cleanup = async () => {
                 try {
@@ -152,101 +197,7 @@ export class LocalSandboxService implements ISandboxProvider {
                 }
             };
 
-            const capturedRepoDir = tempDir;
-
-            // Privileged shell exec for infrastructure callers (graph build,
-            // AST extraction, sandbox bootstrap). Unlike `remoteCommands.exec`
-            // this does NOT whitelist programs — it runs the command through
-            // /bin/sh so mkdir, pipes, redirections, etc. work. That power
-            // comes with a safety contract: **callers MUST shell-quote any
-            // value that could come (directly or transitively) from user
-            // input** (PR filenames, branch names, commit messages, etc.).
-            //
-            // As a runtime tripwire we reject command substitution (`$(...)`
-            // and backticks) on the raw string. Internal infrastructure
-            // commands have no legitimate need to spawn subshells, and a
-            // leaked `$()` is the most common path from "string concatenation
-            // bug" to RCE. The block is conservative by design — if a real
-            // use case ever needs command substitution, it should opt in
-            // explicitly instead of piggybacking on this entry point.
-            const run = async (
-                command: string,
-                opts?: { timeoutMs?: number },
-            ): Promise<SandboxRunResult> => {
-                if (/`|\$\(/.test(command)) {
-                    this.logger.warn({
-                        message:
-                            'Rejected sandbox.run command containing shell substitution',
-                        context: LocalSandboxService.name,
-                        metadata: {
-                            preview: command.slice(0, 200),
-                        },
-                    });
-                    return {
-                        stdout: '',
-                        stderr: 'Command substitution ($(...) / backticks) is not allowed in sandbox.run',
-                        exitCode: 1,
-                    };
-                }
-
-                const execAsync = promisify(exec);
-                try {
-                    const { stdout, stderr } = await execAsync(command, {
-                        cwd: capturedRepoDir,
-                        timeout: opts?.timeoutMs ?? CMD_TIMEOUT_MS,
-                        maxBuffer: MAX_BUFFER,
-                        env: process.env,
-                    });
-                    return {
-                        stdout: stdout || '',
-                        stderr: stderr || '',
-                        exitCode: 0,
-                    };
-                } catch (error: any) {
-                    return {
-                        stdout: error.stdout || '',
-                        stderr: error.stderr || '',
-                        exitCode: error.code ?? 1,
-                    };
-                }
-            };
-
-            // Path safety: reads go through `resolveSafePath` so absolute
-            // paths, `..` traversals, and symlink escapes are all rejected
-            // at the boundary. Writes can target files that don't exist
-            // yet (so `lstat`/`realpath` don't apply), but we still
-            // normalize and compare against the repo root so the final
-            // target can't escape — `validatePath` plus the prefix check
-            // covers `../..`, `/etc/...`, and embedded traversals.
-            const sandboxReadFile = async (path: string): Promise<string> => {
-                const fullPath = path.startsWith('/')
-                    ? path
-                    : join(capturedRepoDir, path);
-                return readFile(fullPath, 'utf-8');
-            };
-
-            const sandboxWriteFile = async (
-                path: string,
-                content: string,
-            ): Promise<void> => {
-                const fullPath = path.startsWith('/')
-                    ? path
-                    : join(capturedRepoDir, path);
-                const dir = join(fullPath, '..');
-                await mkdir(dir, { recursive: true });
-                await writeFile(fullPath, content, 'utf-8');
-            };
-
-            return {
-                remoteCommands,
-                cleanup,
-                type: 'local' as const,
-                sandboxId: capturedRepoDir,
-                repoDir: capturedRepoDir,
-                run,
-                readFile: sandboxReadFile,
-                writeFile: sandboxWriteFile,
-            };
+            return this.buildSandboxInstance(tempDir, cleanup);
         } catch (error) {
             try {
                 await rm(tempDir, { recursive: true, force: true });
@@ -257,14 +208,214 @@ export class LocalSandboxService implements ISandboxProvider {
         }
     }
 
+    async connectToExistingSandbox(
+        sandboxId: string,
+    ): Promise<SandboxInstance> {
+        if (!isLocalSandboxPath(sandboxId)) {
+            throw new Error(
+                `LocalSandboxService: refusing to reconnect unsafe sandbox path "${sandboxId}"`,
+            );
+        }
+
+        const stat = await lstat(sandboxId);
+        if (!stat.isDirectory()) {
+            throw new Error(
+                `LocalSandboxService: sandbox path is not a directory "${sandboxId}"`,
+            );
+        }
+
+        return this.buildSandboxInstance(sandboxId, async () => {
+            try {
+                await rm(sandboxId, { recursive: true, force: true });
+            } catch (error) {
+                this.logger.warn({
+                    message: `Failed to remove temp dir ${sandboxId}`,
+                    context: LocalSandboxService.name,
+                    error,
+                });
+            }
+        });
+    }
+
+    private buildSandboxInstance(
+        repoDir: string,
+        cleanup: () => Promise<void>,
+    ): SandboxInstance {
+        const remoteCommands = this.buildRemoteCommands(repoDir);
+
+        // Privileged shell exec for infrastructure callers (graph build,
+        // AST extraction, sandbox bootstrap). Unlike `remoteCommands.exec`
+        // this does NOT whitelist programs — it runs the command through
+        // /bin/sh so mkdir, pipes, redirections, etc. work. That power
+        // comes with a safety contract: **callers MUST shell-quote any
+        // value that could come (directly or transitively) from user
+        // input** (PR filenames, branch names, commit messages, etc.).
+        //
+        // As a runtime tripwire we reject command substitution (`$(...)`
+        // and backticks) unless the token is inside single quotes. Shell
+        // chains/redirection are intentionally allowed: graph bootstrap and
+        // context extraction rely on them.
+        const run = async (
+            command: string,
+            opts?: { timeoutMs?: number },
+        ): Promise<SandboxRunResult> => {
+            if (this.containsShellSubstitution(command)) {
+                this.logger.warn({
+                    message:
+                        'Rejected sandbox.run command containing shell substitution',
+                    context: LocalSandboxService.name,
+                    metadata: {
+                        preview: command.slice(0, 200),
+                    },
+                });
+                return {
+                    stdout: '',
+                    stderr: 'Command substitution ($(...) / backticks) is not allowed in sandbox.run',
+                    exitCode: 1,
+                };
+            }
+
+            const execAsync = promisify(exec);
+            try {
+                const { stdout, stderr } = await execAsync(command, {
+                    cwd: repoDir,
+                    timeout: opts?.timeoutMs ?? CMD_TIMEOUT_MS,
+                    maxBuffer: MAX_BUFFER,
+                    env: buildSandboxRunEnv(),
+                });
+                return {
+                    stdout: stdout || '',
+                    stderr: stderr || '',
+                    exitCode: 0,
+                };
+            } catch (error: any) {
+                return {
+                    stdout: error.stdout || '',
+                    stderr: error.stderr || '',
+                    exitCode: error.code ?? 1,
+                };
+            }
+        };
+
+        // Path safety: reads go through `resolveSafePath` so absolute
+        // paths, `..` traversals, and symlink escapes are all rejected
+        // at the boundary. Writes can target files that don't exist
+        // yet (so `lstat`/`realpath` don't apply), but we still
+        // normalize and compare against the repo root so the final
+        // target can't escape — `validatePath` plus the prefix check
+        // covers `../..`, `/etc/...`, and embedded traversals.
+        const sandboxReadFile = async (path: string): Promise<string> => {
+            const fullPath = await this.resolveSafePath(repoDir, path);
+            const file = await open(
+                fullPath,
+                constants.O_RDONLY | constants.O_NOFOLLOW,
+            );
+            try {
+                return await file.readFile('utf-8');
+            } finally {
+                await file.close();
+            }
+        };
+
+        const sandboxWriteFile = async (
+            path: string,
+            content: string,
+        ): Promise<void> => {
+            const fullPath = await this.resolveWritablePath(repoDir, path);
+            await this.assertWritableParentInsideRepo(repoDir, fullPath, path);
+            const file = await open(
+                fullPath,
+                constants.O_WRONLY |
+                    constants.O_CREAT |
+                    constants.O_TRUNC |
+                    constants.O_NOFOLLOW,
+                0o666,
+            );
+            try {
+                await file.writeFile(content, 'utf-8');
+            } finally {
+                await file.close();
+            }
+        };
+
+        return {
+            remoteCommands,
+            cleanup,
+            type: 'local' as const,
+            sandboxId: repoDir,
+            repoDir,
+            run,
+            readFile: sandboxReadFile,
+            writeFile: sandboxWriteFile,
+        };
+    }
+
+    private containsShellSubstitution(command: string): boolean {
+        let inSingleQuotes = false;
+        let inDoubleQuotes = false;
+        let escaped = false;
+
+        for (let i = 0; i < command.length; i++) {
+            const char = command[i];
+
+            if (inSingleQuotes) {
+                if (char === "'") {
+                    inSingleQuotes = false;
+                }
+                continue;
+            }
+
+            if (escaped) {
+                escaped = false;
+                continue;
+            }
+
+            if (char === '\\') {
+                // Handles shSingleQuote's '\'' sequence: after a single-quoted
+                // segment closes, the backslash escapes the literal apostrophe
+                // and the next apostrophe re-enters single-quoted text.
+                escaped = true;
+                continue;
+            }
+
+            if (char === "'" && !inDoubleQuotes) {
+                inSingleQuotes = true;
+                continue;
+            }
+
+            if (char === '"') {
+                inDoubleQuotes = !inDoubleQuotes;
+                continue;
+            }
+
+            if (char === '`') {
+                return true;
+            }
+
+            if (char === '$' && command[i + 1] === '(') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private buildRemoteCommands(repoDir: string): RemoteCommands {
+        const sandboxEnv = buildSandboxRunEnv();
+
         return {
             grep: async (
                 pattern: string,
                 path: string,
                 glob?: string,
             ): Promise<string> => {
-                await this.resolveSafePath(repoDir, path);
+                const safePath = await this.validatePathWithinRepo(
+                    repoDir,
+                    path,
+                );
+                if (!(await this.pathExists(safePath))) {
+                    return '';
+                }
 
                 // rg with --no-follow ensures symlinks are not followed during search.
                 // cwd = repoDir so rg outputs relative paths (downstream expects "./src/foo.ts")
@@ -282,6 +433,7 @@ export class LocalSandboxService implements ISandboxProvider {
                 try {
                     const { stdout } = await execFileAsync('rg', args, {
                         cwd: repoDir,
+                        env: sandboxEnv,
                         timeout: CMD_TIMEOUT_MS,
                         maxBuffer: MAX_BUFFER,
                     });
@@ -289,6 +441,7 @@ export class LocalSandboxService implements ISandboxProvider {
                 } catch (error: any) {
                     // rg exits with code 1 when no matches found
                     if (error.code === 1) return '';
+                    if (this.isMissingPathSearchError(error)) return '';
                     throw error;
                 }
             },
@@ -303,6 +456,7 @@ export class LocalSandboxService implements ISandboxProvider {
                 // GNU sed rejects address 0 so we must avoid `sed -n '0,0p'`.
                 if (start === 0 && end === 0) {
                     const { stdout } = await execFileAsync('cat', [safePath], {
+                        env: sandboxEnv,
                         timeout: CMD_TIMEOUT_MS,
                         maxBuffer: MAX_BUFFER,
                     });
@@ -311,7 +465,11 @@ export class LocalSandboxService implements ISandboxProvider {
                 const { stdout } = await execFileAsync(
                     'sed',
                     ['-n', `${start < 1 ? 1 : start},${end}p`, safePath],
-                    { timeout: CMD_TIMEOUT_MS, maxBuffer: MAX_BUFFER },
+                    {
+                        env: sandboxEnv,
+                        timeout: CMD_TIMEOUT_MS,
+                        maxBuffer: MAX_BUFFER,
+                    },
                 );
                 return stdout;
             },
@@ -320,28 +478,40 @@ export class LocalSandboxService implements ISandboxProvider {
                 path: string,
                 maxDepth: number,
             ): Promise<string> => {
-                await this.resolveSafePath(repoDir, path);
+                const safePath = await this.validatePathWithinRepo(
+                    repoDir,
+                    path,
+                );
+                if (!(await this.pathExists(safePath))) {
+                    return '';
+                }
                 // Use relative path with cwd so output paths are relative (consistent with grep)
                 // -not -type l excludes symlinks from results
-                const { stdout } = await execFileAsync(
-                    'find',
-                    [
-                        path,
-                        '-maxdepth',
-                        String(maxDepth),
-                        '-type',
-                        'f',
-                        '-not',
-                        '-type',
-                        'l',
-                    ],
-                    {
-                        cwd: repoDir,
-                        timeout: CMD_TIMEOUT_MS,
-                        maxBuffer: MAX_BUFFER,
-                    },
-                );
-                return stdout;
+                try {
+                    const { stdout } = await execFileAsync(
+                        'find',
+                        [
+                            path,
+                            '-maxdepth',
+                            String(maxDepth),
+                            '-type',
+                            'f',
+                            '-not',
+                            '-type',
+                            'l',
+                        ],
+                        {
+                            cwd: repoDir,
+                            env: sandboxEnv,
+                            timeout: CMD_TIMEOUT_MS,
+                            maxBuffer: MAX_BUFFER,
+                        },
+                    );
+                    return stdout;
+                } catch (error: any) {
+                    if (error.code === 1) return '';
+                    throw error;
+                }
             },
 
             exec: async (
@@ -434,6 +604,28 @@ export class LocalSandboxService implements ISandboxProvider {
                         };
                     }
 
+                    const disallowedReadOnlyArg =
+                        this.findDisallowedReadOnlyToolArg(program, args);
+                    if (disallowedReadOnlyArg) {
+                        return {
+                            stdout: `Argument "${disallowedReadOnlyArg}" is not allowed for "${program}" in local sandbox because remoteCommands.exec is read-only.`,
+                            exitCode: 1,
+                        };
+                    }
+
+                    const unsafePathArg =
+                        await this.findUnsafeReadOnlyToolPathArg(
+                            repoDir,
+                            program,
+                            args,
+                        );
+                    if (unsafePathArg) {
+                        return {
+                            stdout: `Path "${unsafePathArg}" is not allowed in local sandbox.`,
+                            exitCode: 1,
+                        };
+                    }
+
                     // Block path traversal anywhere in the argument list. The
                     // old implementation tried to skip flags + their values,
                     // but it assumed every flag takes a value — so a valueless
@@ -468,6 +660,7 @@ export class LocalSandboxService implements ISandboxProvider {
                             validated[0].args,
                             {
                                 cwd: repoDir,
+                                env: sandboxEnv,
                                 timeout: CMD_TIMEOUT_MS,
                                 maxBuffer: MAX_BUFFER,
                             },
@@ -488,6 +681,7 @@ export class LocalSandboxService implements ISandboxProvider {
                     const children = validated.map(({ program, args }, idx) =>
                         spawn(program, args, {
                             cwd: repoDir,
+                            env: sandboxEnv,
                             stdio: [
                                 idx === 0 ? 'ignore' : 'pipe',
                                 'pipe',
@@ -545,6 +739,266 @@ export class LocalSandboxService implements ISandboxProvider {
         };
     }
 
+    private findDisallowedReadOnlyToolArg(
+        program: string,
+        args: string[],
+    ): string | null {
+        const normalized = args.map((arg) => arg.split('=')[0]);
+
+        if (program === 'find') {
+            return (
+                normalized.find((arg) => FIND_DISALLOWED_ARGS.has(arg)) ?? null
+            );
+        }
+
+        if (program === 'fd') {
+            return (
+                normalized.find((arg) => FD_DISALLOWED_ARGS.has(arg)) ?? null
+            );
+        }
+
+        if (program === 'sg' || program === 'ast-grep') {
+            return (
+                normalized.find((arg) => AST_GREP_DISALLOWED_ARGS.has(arg)) ??
+                null
+            );
+        }
+
+        return null;
+    }
+
+    private async findUnsafeReadOnlyToolPathArg(
+        repoDir: string,
+        program: string,
+        args: string[],
+    ): Promise<string | null> {
+        const pathArgs = this.extractReadOnlyToolPathArgs(program, args);
+        for (const pathArg of pathArgs) {
+            try {
+                await this.resolveSafePath(repoDir, pathArg);
+            } catch (error: any) {
+                if (error?.code === 'ENOENT') {
+                    continue;
+                }
+                return pathArg;
+            }
+        }
+
+        return null;
+    }
+
+    private extractReadOnlyToolPathArgs(
+        program: string,
+        args: string[],
+    ): string[] {
+        if (
+            ![
+                'cat',
+                'head',
+                'tail',
+                'wc',
+                'file',
+                'grep',
+                'find',
+                'fd',
+                'sg',
+                'ast-grep',
+            ].includes(program)
+        ) {
+            return [];
+        }
+
+        if (program === 'grep') {
+            return this.extractGrepPathArgs(args);
+        }
+
+        if (program === 'fd') {
+            return this.extractFdPathArgs(args);
+        }
+
+        if (program === 'sg' || program === 'ast-grep') {
+            return this.extractAstGrepPathArgs(args);
+        }
+
+        const paths: string[] = [];
+        for (let i = 0; i < args.length; i++) {
+            const arg = args[i];
+            if (arg === '--') {
+                paths.push(
+                    ...args.slice(i + 1).filter((value) => value !== '-'),
+                );
+                break;
+            }
+
+            if (
+                (program === 'head' ||
+                    program === 'tail' ||
+                    program === 'wc') &&
+                (arg === '-n' || arg === '-c' || arg === '--lines')
+            ) {
+                i++;
+                continue;
+            }
+
+            if (arg.startsWith('-')) {
+                continue;
+            }
+
+            if (arg !== '-') {
+                paths.push(arg);
+            }
+        }
+
+        return paths;
+    }
+
+    private extractGrepPathArgs(args: string[]): string[] {
+        const paths: string[] = [];
+        let patternSeen = false;
+
+        for (let i = 0; i < args.length; i++) {
+            const arg = args[i];
+            if (arg === '--') {
+                if (i + 1 < args.length && !patternSeen) {
+                    paths.push(
+                        ...args.slice(i + 2).filter((value) => value !== '-'),
+                    );
+                } else {
+                    paths.push(
+                        ...args.slice(i + 1).filter((value) => value !== '-'),
+                    );
+                }
+                break;
+            }
+
+            if (arg === '-e' || arg === '--regexp') {
+                i++;
+                patternSeen = true;
+                continue;
+            }
+
+            if (arg === '-f' || arg === '--file') {
+                const patternFile = args[i + 1];
+                if (patternFile && patternFile !== '-') {
+                    paths.push(patternFile);
+                }
+                i++;
+                patternSeen = true;
+                continue;
+            }
+
+            if (arg.startsWith('-e') || arg.startsWith('--regexp=')) {
+                patternSeen = true;
+                continue;
+            }
+
+            if (arg.startsWith('-f')) {
+                const patternFile = arg.slice(2);
+                if (patternFile) {
+                    paths.push(patternFile);
+                }
+                patternSeen = true;
+                continue;
+            }
+
+            if (arg.startsWith('--file=')) {
+                paths.push(arg.slice('--file='.length));
+                patternSeen = true;
+                continue;
+            }
+
+            if (arg.startsWith('-')) {
+                continue;
+            }
+
+            if (!patternSeen) {
+                patternSeen = true;
+                continue;
+            }
+
+            if (arg !== '-') {
+                paths.push(arg);
+            }
+        }
+
+        return paths;
+    }
+
+    private extractFdPathArgs(args: string[]): string[] {
+        const paths: string[] = [];
+        let patternSeen = false;
+
+        for (let i = 0; i < args.length; i++) {
+            const arg = args[i];
+            if (arg === '--') {
+                if (i + 1 < args.length && !patternSeen) {
+                    paths.push(
+                        ...args.slice(i + 2).filter((value) => value !== '-'),
+                    );
+                } else {
+                    paths.push(
+                        ...args.slice(i + 1).filter((value) => value !== '-'),
+                    );
+                }
+                break;
+            }
+
+            if (arg.startsWith('-')) {
+                continue;
+            }
+
+            if (!patternSeen) {
+                patternSeen = true;
+                continue;
+            }
+
+            if (arg !== '-') {
+                paths.push(arg);
+            }
+        }
+
+        return paths;
+    }
+
+    private extractAstGrepPathArgs(args: string[]): string[] {
+        const paths: string[] = [];
+
+        for (let i = 0; i < args.length; i++) {
+            const arg = args[i];
+            if (arg === '--') {
+                paths.push(
+                    ...args.slice(i + 1).filter((value) => value !== '-'),
+                );
+                break;
+            }
+
+            if (AST_GREP_VALUE_OPTIONS.has(arg)) {
+                i++;
+                continue;
+            }
+
+            if (
+                arg.startsWith('-p=') ||
+                arg.startsWith('--pattern=') ||
+                arg.startsWith('--lang=') ||
+                arg.startsWith('--selector=') ||
+                arg.startsWith('--globs=')
+            ) {
+                continue;
+            }
+
+            if (arg.startsWith('-')) {
+                continue;
+            }
+
+            if (arg !== '-') {
+                paths.push(arg);
+            }
+        }
+
+        return paths;
+    }
+
     /**
      * Apply a unified diff on top of the currently-checked-out commit. Used
      * in CLI mode so the agent sees the user's actual local working state.
@@ -575,7 +1029,13 @@ export class LocalSandboxService implements ISandboxProvider {
         try {
             await execFileAsync(
                 'git',
-                ['-C', repoDir, 'config', 'user.email', 'kodus-cli@kodus.local'],
+                [
+                    '-C',
+                    repoDir,
+                    'config',
+                    'user.email',
+                    'kodus-cli@kodus.local',
+                ],
                 { timeout: 5_000 },
             );
             await execFileAsync(
@@ -601,8 +1061,7 @@ export class LocalSandboxService implements ISandboxProvider {
                 { timeout: CLONE_TIMEOUT_MS },
             );
             this.logger.log({
-                message:
-                    'CLI diff applied successfully on top of merge-base',
+                message: 'CLI diff applied successfully on top of merge-base',
                 context: LocalSandboxService.name,
             });
             return;
@@ -653,6 +1112,67 @@ export class LocalSandboxService implements ISandboxProvider {
         }
     }
 
+    private async validatePathWithinRepo(
+        repoDir: string,
+        path: string,
+    ): Promise<string> {
+        this.validatePath(path);
+        const repoReal = await realpath(repoDir);
+        const candidate = resolve(repoReal, path);
+        if (!candidate.startsWith(repoReal + '/') && candidate !== repoReal) {
+            throw new Error(`Path escapes repo boundary: ${path}`);
+        }
+
+        let current = candidate;
+        while (
+            current.startsWith(repoReal + '/') &&
+            current.length > repoReal.length
+        ) {
+            try {
+                const stat = await lstat(current);
+                if (stat.isSymbolicLink()) {
+                    throw new Error(
+                        `Symlink detected, refusing to follow: ${path}`,
+                    );
+                }
+
+                const real = await realpath(current);
+                if (!real.startsWith(repoReal + '/') && real !== repoReal) {
+                    throw new Error(`Path escapes repo boundary: ${path}`);
+                }
+                return candidate;
+            } catch (error: any) {
+                if (error.code !== 'ENOENT') {
+                    throw error;
+                }
+                current = dirname(current);
+            }
+        }
+
+        return candidate;
+    }
+
+    private isMissingPathSearchError(error: any): boolean {
+        if (error?.code !== 2) {
+            return false;
+        }
+
+        const output = `${error.stderr ?? ''}\n${error.message ?? ''}`;
+        return /No such file or directory|os error 2/i.test(output);
+    }
+
+    private async pathExists(path: string): Promise<boolean> {
+        try {
+            await lstat(path);
+            return true;
+        } catch (error: any) {
+            if (error.code === 'ENOENT') {
+                return false;
+            }
+            throw error;
+        }
+    }
+
     /**
      * Resolve a relative path within the repo, ensuring the real path
      * stays inside repoDir (prevents symlink escapes).
@@ -678,6 +1198,69 @@ export class LocalSandboxService implements ISandboxProvider {
         }
 
         return candidate;
+    }
+
+    private async resolveWritablePath(
+        repoDir: string,
+        path: string,
+    ): Promise<string> {
+        this.validatePath(path);
+
+        const repoReal = await realpath(repoDir);
+        const fullPath = resolve(repoReal, path);
+        if (!fullPath.startsWith(repoReal + '/') && fullPath !== repoReal) {
+            throw new Error(`Path escapes repo boundary: ${path}`);
+        }
+
+        const parentDir = dirname(fullPath);
+        await this.ensureWritableAncestorInsideRepo(repoReal, parentDir, path);
+        await mkdir(parentDir, { recursive: true });
+        const parentReal = await realpath(parentDir);
+        if (!parentReal.startsWith(repoReal + '/') && parentReal !== repoReal) {
+            throw new Error(`Path escapes repo boundary: ${path}`);
+        }
+
+        return fullPath;
+    }
+
+    private async assertWritableParentInsideRepo(
+        repoDir: string,
+        fullPath: string,
+        path: string,
+    ): Promise<void> {
+        const repoReal = await realpath(repoDir);
+        const parentReal = await realpath(dirname(fullPath));
+        if (!parentReal.startsWith(repoReal + '/') && parentReal !== repoReal) {
+            throw new Error(`Path escapes repo boundary: ${path}`);
+        }
+    }
+
+    private async ensureWritableAncestorInsideRepo(
+        repoReal: string,
+        parentDir: string,
+        path: string,
+    ): Promise<void> {
+        let current = parentDir;
+
+        while (current !== repoReal && current !== dirname(current)) {
+            try {
+                await lstat(current);
+                break;
+            } catch (error: any) {
+                if (error.code !== 'ENOENT') {
+                    throw error;
+                }
+                current = dirname(current);
+            }
+        }
+
+        const ancestorReal = await realpath(current);
+        if (
+            !ancestorReal.startsWith(repoReal + '/') &&
+            ancestorReal !== repoReal
+        ) {
+            throw new Error(`Path escapes repo boundary: ${path}`);
+        }
     }
 
     private buildAuthHeader(

--- a/libs/sandbox/infrastructure/repositories/sandbox-lease.repository.ts
+++ b/libs/sandbox/infrastructure/repositories/sandbox-lease.repository.ts
@@ -3,6 +3,10 @@ import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 
 import { SandboxLeaseModel } from './schemas/sandbox-lease.model';
+import {
+    ISandboxLeaseRepository,
+    SandboxLeaseLookup,
+} from '@libs/sandbox/domain/contracts/sandbox-lease.repository.contract';
 
 /**
  * Decompose a prKey ("{orgId}:{repoId}:{prNumber}") into its parts.
@@ -49,7 +53,7 @@ function decomposePrKey(prKey: string): {
 }
 
 @Injectable()
-export class SandboxLeaseRepository {
+export class SandboxLeaseRepository implements ISandboxLeaseRepository {
     constructor(
         @InjectModel(SandboxLeaseModel.name)
         private readonly leaseModel: Model<SandboxLeaseModel>,
@@ -60,11 +64,13 @@ export class SandboxLeaseRepository {
      *
      * Single findOneAndUpdate with BOTH operators in one update document:
      *   - $setOnInsert: sets initial state/timestamps on the INSERT path only
+     *   - $set: refreshes expiresAt and consumer on BOTH insert and update paths
      *   - $inc: { leaseCount: 1 } increments the counter on BOTH insert and update paths
      *
-     * On INSERT:  MongoDB applies $setOnInsert (state='CREATING', dates) and $inc
+     * On INSERT:  MongoDB applies $setOnInsert (state='CREATING', createdAt) and $inc
      *             (leaseCount 0→1). Returned doc has leaseCount === 1.
-     * On UPDATE:  $setOnInsert is a no-op; $inc bumps leaseCount to N+1.
+     * On UPDATE:  $setOnInsert is a no-op; $set refreshes expiresAt and $inc
+     *             bumps leaseCount to N+1.
      *
      * Caller identifies itself as creator when doc.leaseCount === 1.
      * Caller must poll when doc.leaseCount > 1 and doc.state === 'CREATING'.
@@ -87,13 +93,15 @@ export class SandboxLeaseRepository {
                 $setOnInsert: {
                     state: 'CREATING',
                     createdAt: now,
-                    expiresAt,
                     ...decomposed,
                 },
-                // Track the most recent consumer label so it's queryable in
-                // Mongo without parsing logs. Updated on every acquire (both
-                // insert and update paths).
-                $set: consumer ? { consumer } : {},
+                // Track the most recent consumer label and refresh the lease
+                // expiry on every acquire. The expired-lease reaper uses this
+                // timestamp as its atomic "not re-acquired" guard.
+                $set: {
+                    expiresAt,
+                    ...(consumer ? { consumer } : {}),
+                },
                 $inc: { leaseCount: 1 },
             },
             { upsert: true, new: true },
@@ -140,13 +148,19 @@ export class SandboxLeaseRepository {
     /**
      * Find a lease document by its prKey (_id).
      */
-    async findByPrKey(prKey: string): Promise<SandboxLeaseModel | null> {
-        return this.leaseModel.findOne({ _id: prKey });
+    async findByPrKey(prKey: string): Promise<SandboxLeaseLookup | null> {
+        return this.leaseModel
+            .findOne({ _id: prKey })
+            .select('_id state sandboxId')
+            .lean<SandboxLeaseLookup>()
+            .exec();
     }
 
     /**
-     * Find all leases past their expiry date. Used by the reaper regardless
-     * of leaseCount — crashed-worker leases stay at leaseCount > 0 forever.
+     * Find a bounded batch of leases past their expiry date, plus any lease
+     * already stuck in the transient DELETING state. Used by the reaper
+     * regardless of leaseCount — crashed-worker leases stay at leaseCount > 0
+     * forever, and cleanup/delete crashes leave DELETING docs behind.
      *
      * Read-only: projection keeps the response narrow and `.lean()` skips
      * Mongoose hydration since the reaper only reads the values, never
@@ -154,37 +168,122 @@ export class SandboxLeaseRepository {
      */
     async findExpired(
         now: Date,
+        limit?: number,
     ): Promise<Pick<SandboxLeaseModel, '_id' | 'sandboxId' | 'state'>[]> {
-        return this.leaseModel
-            .find({ expiresAt: { $lt: now } })
+        const query = this.leaseModel
+            .find({
+                $or: [{ expiresAt: { $lt: now } }, { state: 'DELETING' }],
+            })
+            .sort({ expiresAt: 1 })
             .select('_id sandboxId state')
             .lean();
+
+        if (limit !== undefined) {
+            query.limit(limit);
+        }
+
+        return query;
     }
 
     /**
-     * Delete a lease document by prKey. Called by invalidate() after soft-drain
-     * and by the reaper after killing the E2B sandbox.
+     * Delete a lease document by prKey. Used when the caller has already made
+     * the lease non-reusable (for example invalidation, expired reaper cleanup,
+     * or stale remote reconnect recovery). Normal local release/idle cleanup
+     * uses deleteIfNoActiveLeases() instead.
      */
     async delete(prKey: string): Promise<void> {
         await this.leaseModel.deleteOne({ _id: prKey });
     }
 
     /**
-     * Atomically set the `killAt` timestamp on a lease document. Used by
-     * release() to schedule an idle-kill that any worker (in a multi-worker
-     * deployment) can pick up via findReadyToKill().
+     * Move an idle lease into a transient deleting state only when no active
+     * leases remain. Local cleanup removes the worker-local directory first
+     * and deletes the Mongo doc only after that succeeds, so failed rm attempts
+     * can be retried by the expired reaper. E2B idle-kill uses the same state
+     * to block warm reuse while the remote sandbox is being killed.
+     */
+    async markDeletingIfNoActiveLeases(prKey: string): Promise<boolean> {
+        const result = await this.leaseModel.updateOne(
+            {
+                _id: prKey,
+                leaseCount: { $lte: 0 },
+            },
+            {
+                $set: { state: 'DELETING' },
+                $unset: { killAt: '' },
+            },
+        );
+
+        return result.matchedCount > 0;
+    }
+
+    /**
+     * Move an expired lease into a transient deleting state only if no acquire
+     * has renewed it since the reaper read the expired batch. Already-DELETING
+     * docs are matched regardless of expiresAt so the reaper can recover from a
+     * crash between cleanup and final delete. Unlike
+     * markDeletingIfNoActiveLeases(), this intentionally allows leaseCount > 0:
+     * those are the crashed-worker or over-TTL leases the expired reaper exists
+     * to clean.
+     */
+    async markExpiredDeletingIfNotRenewed(
+        prKey: string,
+        expiredBefore: Date,
+    ): Promise<boolean> {
+        const result = await this.leaseModel.updateOne(
+            {
+                _id: prKey,
+                $or: [
+                    { expiresAt: { $lt: expiredBefore } },
+                    { state: 'DELETING' },
+                ],
+            },
+            {
+                $set: { state: 'DELETING' },
+                $unset: { killAt: '' },
+            },
+        );
+
+        return result.matchedCount > 0;
+    }
+
+    /**
+     * Delete a lease only when no active leases remain.
+     *
+     * Used after local sandbox directory cleanup. The lease count can be
+     * incremented by a concurrent acquire after release()/idle-kill observes
+     * leaseCount <= 0, so the final document delete must re-check the counter
+     * atomically to avoid deleting a lease another caller just joined.
+     */
+    async deleteIfNoActiveLeases(prKey: string): Promise<boolean> {
+        const result = await this.leaseModel.deleteOne({
+            _id: prKey,
+            leaseCount: { $lte: 0 },
+        });
+
+        return result.deletedCount > 0;
+    }
+
+    /**
+     * Atomically set the `killAt` timestamp on a lease document only when
+     * no active leases remain. Used by release() to schedule an idle-kill
+     * that any worker (in a multi-worker deployment) can pick up via
+     * findReadyToKill().
      *
      * Only sets killAt when the lease has a real sandboxId — there's no
      * point scheduling a kill for a NullSandbox or a CREATING-only lease.
      */
-    async setKillAt(prKey: string, killAt: Date): Promise<void> {
-        await this.leaseModel.updateOne(
+    async setKillAt(prKey: string, killAt: Date): Promise<boolean> {
+        const result = await this.leaseModel.updateOne(
             {
                 _id: prKey,
+                leaseCount: { $lte: 0 },
                 sandboxId: { $exists: true, $ne: '' },
             },
             { $set: { killAt } },
         );
+
+        return result.modifiedCount > 0;
     }
 
     /**
@@ -210,13 +309,20 @@ export class SandboxLeaseRepository {
      */
     async findReadyToKill(
         now: Date,
+        limit?: number,
     ): Promise<Pick<SandboxLeaseModel, '_id' | 'sandboxId' | 'killAt'>[]> {
-        return this.leaseModel
+        const query = this.leaseModel
             .find({
                 killAt: { $lte: now },
                 sandboxId: { $exists: true, $ne: '' },
             })
             .select('_id sandboxId killAt')
             .lean();
+
+        if (limit !== undefined) {
+            query.limit(limit);
+        }
+
+        return query;
     }
 }

--- a/libs/sandbox/infrastructure/repositories/schemas/sandbox-lease.model.ts
+++ b/libs/sandbox/infrastructure/repositories/schemas/sandbox-lease.model.ts
@@ -51,17 +51,15 @@ export class SandboxLeaseModel extends CoreDocument {
     consumer?: string; // Last consumer label ('review' | 'conversation')
 
     /**
-     * State enum. INVALIDATED is required to handle the mid-create invalidation
-     * race (RESEARCH.md Pitfall 5): when a force-push/pr-close event fires while
-     * acquire() is still in-flight (state = CREATING), invalidate() sets this to
-     * INVALIDATED instead of deleting the doc. The create path checks for this
-     * state after updateReady() and immediately kills the sandbox, preventing
-     * orphaned E2B sandboxes with no Mongo lease document.
+     * State enum. INVALIDATED handles the mid-create invalidation race
+     * (force-push/pr-close while acquire() is still in-flight). DELETING is a
+     * transient cleanup state used to block warm reuse while local directories
+     * or remote sandboxes are being removed.
      */
     @Prop({
         type: String,
         required: true,
-        enum: ['CREATING', 'READY', 'PAUSED', 'INVALIDATED'],
+        enum: ['CREATING', 'READY', 'PAUSED', 'INVALIDATED', 'DELETING'],
     })
     state: string;
 
@@ -93,6 +91,9 @@ export const SandboxLeaseSchema: MongooseSchema<SandboxLeaseModel> =
 
 // Reaper range scan: find all leases past their expiry regardless of state
 SandboxLeaseSchema.index({ expiresAt: 1 });
+
+// Reaper recovery scan: find docs stuck in DELETING without scanning the whole collection
+SandboxLeaseSchema.index({ state: 1, expiresAt: 1 });
 
 // Invalidate-by-sandboxId when prKey is unknown (sparse: unused entries have no entry)
 SandboxLeaseSchema.index({ sandboxId: 1 }, { sparse: true });

--- a/libs/sandbox/infrastructure/services/local-sandbox-cleanup.spec.ts
+++ b/libs/sandbox/infrastructure/services/local-sandbox-cleanup.spec.ts
@@ -1,0 +1,57 @@
+import { lstat, mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+    cleanupLocalSandboxDirectory,
+    isLocalSandboxPath,
+    localSandboxDirectoryExists,
+} from './local-sandbox-cleanup';
+
+describe('local sandbox cleanup guards', () => {
+    it('accepts direct kodus sandbox children under the OS temp directory', () => {
+        expect(
+            isLocalSandboxPath(join(tmpdir(), 'kodus-sandbox-test-abc')),
+        ).toBe(true);
+    });
+
+    it.each([
+        ['relative path', 'kodus-sandbox-test-abc'],
+        ['wrong prefix', join(tmpdir(), 'not-kodus-sandbox-test-abc')],
+        [
+            'nested temp child',
+            join(tmpdir(), 'nested', 'kodus-sandbox-test-abc'),
+        ],
+        ['outside temp directory', '/var/tmp/kodus-sandbox-test-abc'],
+    ])('rejects unsafe local sandbox path: %s', (_label, sandboxId) => {
+        expect(isLocalSandboxPath(sandboxId)).toBe(false);
+    });
+
+    it('removes an existing local sandbox directory and reports success', async () => {
+        const sandboxId = await mkdtemp(join(tmpdir(), 'kodus-sandbox-test-'));
+
+        await expect(cleanupLocalSandboxDirectory(sandboxId)).resolves.toBe(
+            true,
+        );
+        await expect(lstat(sandboxId)).rejects.toMatchObject({
+            code: 'ENOENT',
+        });
+    });
+
+    it('reports false when the local sandbox directory is missing', async () => {
+        const sandboxId = await mkdtemp(join(tmpdir(), 'kodus-sandbox-test-'));
+        await rm(sandboxId, { recursive: true, force: true });
+
+        await expect(cleanupLocalSandboxDirectory(sandboxId)).resolves.toBe(
+            false,
+        );
+        await expect(localSandboxDirectoryExists(sandboxId)).resolves.toBe(
+            false,
+        );
+    });
+
+    it('reports false for unsafe paths without touching them', async () => {
+        await expect(
+            cleanupLocalSandboxDirectory('/var/tmp/kodus-sandbox-test-abc'),
+        ).resolves.toBe(false);
+    });
+});

--- a/libs/sandbox/infrastructure/services/local-sandbox-cleanup.ts
+++ b/libs/sandbox/infrastructure/services/local-sandbox-cleanup.ts
@@ -1,0 +1,53 @@
+import { lstat, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { basename, dirname, isAbsolute, resolve } from 'path';
+
+const LOCAL_SANDBOX_PREFIX = 'kodus-sandbox-';
+
+export function isLocalSandboxPath(sandboxId?: string): boolean {
+    if (!sandboxId || !isAbsolute(sandboxId)) {
+        return false;
+    }
+
+    const tmpRoot = resolve(tmpdir());
+    const candidate = resolve(sandboxId);
+
+    return (
+        dirname(candidate) === tmpRoot &&
+        basename(candidate).startsWith(LOCAL_SANDBOX_PREFIX)
+    );
+}
+
+export async function cleanupLocalSandboxDirectory(
+    sandboxId?: string,
+): Promise<boolean> {
+    if (!isLocalSandboxPath(sandboxId)) {
+        return false;
+    }
+
+    const resolved = resolve(sandboxId!);
+    if (!(await localSandboxDirectoryExists(resolved))) {
+        return false;
+    }
+
+    await rm(resolved, { recursive: true, force: true });
+    return true;
+}
+
+export async function localSandboxDirectoryExists(
+    sandboxId?: string,
+): Promise<boolean> {
+    if (!isLocalSandboxPath(sandboxId)) {
+        return false;
+    }
+
+    try {
+        await lstat(resolve(sandboxId!));
+        return true;
+    } catch (error: any) {
+        if (error?.code === 'ENOENT') {
+            return false;
+        }
+        throw error;
+    }
+}

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
@@ -10,14 +10,23 @@ import {
     SandboxInstance,
     SANDBOX_PROVIDER_TOKEN,
 } from '@libs/sandbox/domain/contracts/sandbox.provider';
+import {
+    ISandboxLeaseRepository,
+    SandboxLeaseRecord,
+    SANDBOX_LEASE_REPOSITORY_TOKEN,
+} from '@libs/sandbox/domain/contracts/sandbox-lease.repository.contract';
 import { Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { Sandbox } from 'e2b';
 import { randomUUID } from 'crypto';
 
 import { calculateBackoffInterval } from '@libs/common/utils/polling';
-import { SandboxLeaseRepository } from '../repositories/sandbox-lease.repository';
+import { shSingleQuote } from '@libs/code-review/infrastructure/adapters/services/shell-quote';
 import { NULL_SANDBOX_INSTANCE } from '../providers/null-sandbox.service';
+import {
+    cleanupLocalSandboxDirectory,
+    isLocalSandboxPath,
+} from './local-sandbox-cleanup';
 
 /**
  * Default idle timeout applied when the last lease on a sandbox is released.
@@ -70,6 +79,8 @@ const CREATE_BACKOFF_OPTIONS = {
     jitterFactor: 0,
 } as const;
 
+const MAX_STALE_SANDBOX_REACQUIRE_ATTEMPTS = 3;
+
 /**
  * Thrown when polling for a CREATING sandbox exceeds MAX_POLL_WAIT_MS.
  * Callers should treat this as a signal to fall back to self-contained mode.
@@ -84,15 +95,16 @@ export class SandboxCreateTimeoutError extends Error {
 }
 
 /**
- * Thrown internally when Sandbox.connect() fails because the sandbox no
- * longer exists in E2B (idle-kill, reaper, or external termination). The
- * acquire() loop catches this, retries from scratch, and only surfaces it
- * if the cold-start retry also fails.
+ * Thrown internally when reconnecting to a persisted sandbox fails because
+ * the provider can no longer attach to it (idle-kill, reaper, worker-local
+ * temp cleanup, or external termination). The acquire() loop catches this,
+ * retries from scratch, and only surfaces it if the cold-start retry also
+ * fails.
  */
 export class SandboxStaleConnectionError extends Error {
     constructor(prKey: string, sandboxId: string) {
         super(
-            `SandboxLeaseManager: stale sandbox connection — sandboxId="${sandboxId}" no longer exists for prKey="${prKey}"; lease cleaned, retry expected`,
+            `SandboxLeaseManager: stale sandbox connection — sandboxId="${sandboxId}" can no longer be reconnected for prKey="${prKey}"; lease cleaned, retry expected`,
         );
         this.name = 'SandboxStaleConnectionError';
     }
@@ -116,7 +128,8 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
     constructor(
         @Inject(SANDBOX_PROVIDER_TOKEN)
         private readonly sandboxProvider: ISandboxProvider,
-        private readonly leaseRepo: SandboxLeaseRepository,
+        @Inject(SANDBOX_LEASE_REPOSITORY_TOKEN)
+        private readonly leaseRepo: ISandboxLeaseRepository,
         private readonly configService: ConfigService,
     ) {}
 
@@ -154,7 +167,11 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
             metadata: { prKey, consumer },
         });
 
-        const doc = await this.leaseRepo.upsertAcquire(prKey, leaseTtlMs, consumer);
+        const doc = await this.leaseRepo.upsertAcquire(
+            prKey,
+            leaseTtlMs,
+            consumer,
+        );
         const leaseId = randomUUID();
 
         // A new acquire arrived — atomically clear any pending idle-kill so
@@ -163,49 +180,27 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
         // will see killAt=null and skip.
         await this.leaseRepo.clearKillAt(prKey);
 
-        // --- Path A: We are the creator (we just inserted the doc) ---
-        // Both conditions are required:
-        //  - state === 'CREATING' is set only by $setOnInsert in upsertAcquire
-        //    (a doc that already existed in READY/PAUSED won't have its state
-        //    overwritten), so it filters out fresh acquires on existing leases.
-        //  - leaseCount === 1 distinguishes "we just inserted" from "we joined a
-        //    concurrent in-flight create" (where leaseCount would be > 1).
-        // Without state === 'CREATING', a release-then-reacquire (count back to
-        // 1 on an existing READY doc) would wrongly cold-create another sandbox
-        // instead of warm-resuming the one already on the lease doc.
-        if (doc.state === 'CREATING' && doc.leaseCount === 1) {
-            return this.handleCreatorPath(prKey, leaseId, consumer, cloneParams);
-        }
-
-        // --- Path B: joiner — doc already existed or someone else is creating ---
-        try {
-            return await this.handleJoinerPath(prKey, leaseId, consumer, doc.state, doc.sandboxId);
-        } catch (err) {
-            if (err instanceof SandboxStaleConnectionError) {
-                // Lease referenced a sandbox that E2B no longer has (idle-
-                // kill timer, reaper, or external termination). The
-                // joiner path already deleted the stale lease — restart
-                // acquire from scratch so this caller becomes the creator.
-                this.logger.log({
-                    message: `SandboxLeaseManager: re-acquiring after stale sandbox prKey="${prKey}" consumer="${consumer}"`,
-                    context: SandboxLeaseManager.name,
-                    metadata: { prKey, consumer },
-                });
-                return this.acquire(prKey, consumer, leaseTtlMs, cloneParams);
-            }
-            throw err;
-        }
+        return this.resolveAcquiredLease(
+            prKey,
+            leaseId,
+            consumer,
+            leaseTtlMs,
+            cloneParams,
+            doc,
+        );
     }
 
     /**
      * Release a lease. Decrements leaseCount atomically.
      *
-     * When leaseCount reaches 0, schedules an idle-kill by writing
+     * When leaseCount reaches 0, local sandboxes are deleted immediately
+     * because their working tree lives in the worker's OS temp directory.
+     * E2B sandboxes keep the warm-reuse behavior: write
      * `killAt = now + idleMs` on the lease doc (via leaseRepo.setKillAt).
      * The `killIdleSandboxes` cron (any worker, coordinated via Postgres
      * advisory lock) picks up the doc once the timestamp elapses and
-     * issues Sandbox.kill + delete. This makes idle-kill multi-worker safe
-     * — no in-memory state required.
+     * issues Sandbox.kill + delete. This makes E2B idle-kill multi-worker
+     * safe without in-memory state.
      *
      * `Sandbox.setTimeout(idleMs)` is also called as defence-in-depth: the
      * provider keeps `lifecycle: { onTimeout: 'pause' }`, so even if Mongo
@@ -217,10 +212,7 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
      * @kody arrives within seconds or much later; conversation uses the
      * 5min default because the user is interactive.
      */
-    async release(
-        leaseId: string,
-        opts?: { idleMs?: number },
-    ): Promise<void> {
+    async release(leaseId: string, opts?: { idleMs?: number }): Promise<void> {
         const prKey = this.leaseIdToPrKey.get(leaseId);
         if (!prKey) {
             this.logger.warn({
@@ -241,20 +233,62 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
         });
 
         if (updated && updated.leaseCount <= 0 && updated.sandboxId) {
+            if (isLocalSandboxPath(updated.sandboxId)) {
+                const marked =
+                    await this.leaseRepo.markDeletingIfNoActiveLeases(prKey);
+                if (!marked) {
+                    this.logger.log({
+                        message: `SandboxLeaseManager: skipped local sandbox cleanup because lease was re-acquired prKey="${prKey}"`,
+                        context: SandboxLeaseManager.name,
+                        metadata: { prKey, sandboxId: updated.sandboxId },
+                    });
+                    return;
+                }
+
+                const cleaned = await this.cleanupLocalSandbox(
+                    updated.sandboxId,
+                    prKey,
+                    'release',
+                );
+                if (cleaned) {
+                    await this.deleteMarkedLocalLeaseIfStillInactive(
+                        prKey,
+                        updated.sandboxId,
+                        'release',
+                    );
+                }
+                return;
+            }
+
             const idleMs = opts?.idleMs ?? IDLE_TIMEOUT_MS;
             const killAt = new Date(Date.now() + idleMs);
-            await this.leaseRepo.setKillAt(prKey, killAt);
+            const scheduled = await this.leaseRepo.setKillAt(prKey, killAt);
+            if (!scheduled) {
+                this.logger.log({
+                    message: `SandboxLeaseManager: skipped idle-kill scheduling because lease was re-acquired prKey="${prKey}"`,
+                    context: SandboxLeaseManager.name,
+                    metadata: { prKey, sandboxId: updated.sandboxId },
+                });
+                return;
+            }
 
             this.logger.log({
                 message: `SandboxLeaseManager: scheduled idle-kill at ${killAt.toISOString()} for sandboxId="${updated.sandboxId}"`,
                 context: SandboxLeaseManager.name,
-                metadata: { prKey, sandboxId: updated.sandboxId, idleTimeoutMs: idleMs, killAt },
+                metadata: {
+                    prKey,
+                    sandboxId: updated.sandboxId,
+                    idleTimeoutMs: idleMs,
+                    killAt,
+                },
             });
 
             const apiKey = this.configService.get<string>('API_E2B_KEY');
             if (apiKey) {
                 try {
-                    await Sandbox.setTimeout(updated.sandboxId, idleMs, { apiKey });
+                    await Sandbox.setTimeout(updated.sandboxId, idleMs, {
+                        apiKey,
+                    });
                 } catch (err) {
                     this.logger.warn({
                         message: `SandboxLeaseManager: failed to set E2B-side idle timeout on sandboxId="${updated.sandboxId}" (kill cron is the primary path)`,
@@ -271,7 +305,10 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
      *
      * - state === CREATING: mark as INVALIDATED; the in-flight create path will
      *   detect this and kill the sandbox after it finishes (preventing orphans).
-     * - state === READY or PAUSED: soft-drain (60s setTimeout) then delete doc.
+     * - local READY/PAUSED: mark DELETING only if no active leases, remove the
+     *   worker-local directory, then delete the doc. If cleanup fails, the
+     *   DELETING doc remains for the expired reaper to retry.
+     * - remote READY/PAUSED: soft-drain (60s setTimeout) then delete doc.
      * - doc not found: no-op (idempotent).
      */
     async invalidate(prKey: string): Promise<void> {
@@ -281,8 +318,8 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
             metadata: { prKey },
         });
 
-        // Clear any pending idle-kill so the cron doesn't double-kill —
-        // invalidate already does its own kill via soft-drain + delete.
+        // Clear any pending idle-kill so the cron doesn't double-clean —
+        // invalidate owns cleanup for both local and remote sandboxes.
         await this.leaseRepo.clearKillAt(prKey);
 
         const doc = await this.leaseRepo.findByPrKey(prKey);
@@ -307,8 +344,36 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
             return;
         }
 
-        // READY or PAUSED: soft-drain then delete
+        // READY or PAUSED: local cleanup is immediate; remote cleanup uses
+        // a short E2B soft-drain before deleting the lease document.
         if (doc.sandboxId) {
+            if (isLocalSandboxPath(doc.sandboxId)) {
+                const marked =
+                    await this.leaseRepo.markDeletingIfNoActiveLeases(prKey);
+                if (!marked) {
+                    this.logger.log({
+                        message: `SandboxLeaseManager: skipped local sandbox invalidation cleanup because lease was re-acquired prKey="${prKey}"`,
+                        context: SandboxLeaseManager.name,
+                        metadata: { prKey, sandboxId: doc.sandboxId },
+                    });
+                    return;
+                }
+
+                const cleaned = await this.cleanupLocalSandbox(
+                    doc.sandboxId,
+                    prKey,
+                    'invalidate',
+                );
+                if (cleaned) {
+                    await this.deleteMarkedLocalLeaseIfStillInactive(
+                        prKey,
+                        doc.sandboxId,
+                        'invalidate',
+                    );
+                }
+                return;
+            }
+
             const apiKey = this.configService.get<string>('API_E2B_KEY');
             if (apiKey) {
                 try {
@@ -341,6 +406,93 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
     // Private helpers
     // ---------------------------------------------------------------------------
 
+    private async resolveAcquiredLease(
+        prKey: string,
+        leaseId: string,
+        consumer: string,
+        leaseTtlMs: number,
+        cloneParams: CreateSandboxParams | undefined,
+        initialDoc: SandboxLeaseRecord,
+    ): Promise<AcquireResult> {
+        let doc = initialDoc;
+
+        for (
+            let staleAttempt = 0;
+            staleAttempt <= MAX_STALE_SANDBOX_REACQUIRE_ATTEMPTS;
+            staleAttempt++
+        ) {
+            try {
+                // --- Path A: We are the creator (we just inserted the doc) ---
+                // Both conditions are required:
+                //  - state === 'CREATING' is set only by $setOnInsert in upsertAcquire
+                //    (a doc that already existed in READY/PAUSED won't have its state
+                //    overwritten), so it filters out fresh acquires on existing leases.
+                //  - leaseCount === 1 distinguishes "we just inserted" from "we joined a
+                //    concurrent in-flight create" (where leaseCount would be > 1).
+                // Without state === 'CREATING', a release-then-reacquire (count back to
+                // 1 on an existing READY doc) would wrongly cold-create another sandbox
+                // instead of warm-resuming the one already on the lease doc.
+                if (doc.state === 'CREATING' && doc.leaseCount === 1) {
+                    return await this.handleCreatorPath(
+                        prKey,
+                        leaseId,
+                        consumer,
+                        cloneParams,
+                    );
+                }
+
+                // --- Path B: joiner — doc already existed or someone else is creating ---
+                return await this.handleJoinerPath(
+                    prKey,
+                    leaseId,
+                    consumer,
+                    doc.state,
+                    doc.sandboxId,
+                );
+            } catch (err) {
+                if (
+                    !this.isStaleConnectionError(err) ||
+                    staleAttempt === MAX_STALE_SANDBOX_REACQUIRE_ATTEMPTS
+                ) {
+                    throw err;
+                }
+
+                // Lease referenced a sandbox the provider can no longer
+                // reconnect to, or a DELETING lease finished cleanup while this
+                // acquire was waiting. Recreate explicitly and keep the same
+                // leaseId through the retry so cleanup() releases the sandbox
+                // that this acquire eventually returns.
+                this.logger.log({
+                    message: `SandboxLeaseManager: re-acquiring after stale sandbox prKey="${prKey}" consumer="${consumer}" attempt=${staleAttempt + 1}`,
+                    context: SandboxLeaseManager.name,
+                    metadata: {
+                        prKey,
+                        consumer,
+                        staleAttempt: staleAttempt + 1,
+                    },
+                });
+                doc = await this.leaseRepo.upsertAcquire(
+                    prKey,
+                    leaseTtlMs,
+                    consumer,
+                );
+                await this.leaseRepo.clearKillAt(prKey);
+            }
+        }
+
+        throw new SandboxCreateTimeoutError(prKey);
+    }
+
+    private isStaleConnectionError(
+        error: unknown,
+    ): error is SandboxStaleConnectionError {
+        return (
+            error instanceof SandboxStaleConnectionError ||
+            (error instanceof Error &&
+                error.name === 'SandboxStaleConnectionError')
+        );
+    }
+
     private async handleCreatorPath(
         prKey: string,
         leaseId: string,
@@ -357,6 +509,9 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
         // but a later step failed" and kill the orphan before re-throwing.
         let sandbox: SandboxInstance | undefined;
         let sandboxId: string | undefined;
+        let preserveLeaseDocOnFailure = false;
+        let sandboxCleanupHandled = false;
+        let leaseDocDeleteHandled = false;
 
         try {
             if (this.sandboxProvider.isAvailable() && cloneParams) {
@@ -370,23 +525,62 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
 
             await this.leaseRepo.updateReady(prKey, sandboxId);
 
-            // Check for mid-create invalidation (Pitfall 5)
+            // Check for mid-create invalidation/deletion (Pitfall 5)
             const latestDoc = await this.leaseRepo.findByPrKey(prKey);
-            if (latestDoc?.state === 'INVALIDATED') {
+            if (
+                latestDoc?.state === 'INVALIDATED' ||
+                latestDoc?.state === 'DELETING'
+            ) {
                 this.logger.warn({
-                    message: `SandboxLeaseManager: sandbox created but lease was INVALIDATED mid-create prKey="${prKey}"`,
+                    message: `SandboxLeaseManager: sandbox created but lease was ${latestDoc.state} mid-create prKey="${prKey}"`,
                     context: SandboxLeaseManager.name,
                     metadata: { prKey, sandboxId },
                 });
                 // Kill the sandbox we just created; it is orphaned
                 if (sandboxId) {
-                    const apiKey = this.configService.get<string>('API_E2B_KEY');
-                    if (apiKey) {
-                        await Sandbox.kill(sandboxId, { apiKey }).catch(() => {});
+                    if (isLocalSandboxPath(sandboxId)) {
+                        const cleaned = await this.cleanupLocalSandbox(
+                            sandboxId,
+                            prKey,
+                            'mid-create invalidation',
+                        );
+                        if (!cleaned) {
+                            preserveLeaseDocOnFailure = true;
+                            throw new Error(
+                                `SandboxLeaseManager: failed to clean local sandbox mid-create for prKey="${prKey}" sandboxId="${sandboxId}"`,
+                            );
+                        }
+                        sandboxCleanupHandled = true;
+                    } else {
+                        const apiKey =
+                            this.configService.get<string>('API_E2B_KEY');
+                        let killed = false;
+                        if (apiKey) {
+                            try {
+                                await Sandbox.kill(sandboxId, { apiKey });
+                                killed = true;
+                            } catch (error) {
+                                killed = /not found|404/i.test(String(error));
+                            }
+                        }
+                        if (!killed) {
+                            preserveLeaseDocOnFailure = true;
+                            throw new Error(
+                                `SandboxLeaseManager: failed to kill sandbox mid-create for prKey="${prKey}" sandboxId="${sandboxId}"`,
+                            );
+                        }
+                        sandboxCleanupHandled = true;
                     }
                 }
                 // Clean up the invalidated doc
                 await this.leaseRepo.delete(prKey);
+                leaseDocDeleteHandled = true;
+                if (latestDoc.state === 'DELETING') {
+                    throw new SandboxStaleConnectionError(
+                        prKey,
+                        sandboxId ?? 'deleting',
+                    );
+                }
                 throw new Error(
                     `SandboxLeaseManager: sandbox invalidated mid-create for prKey="${prKey}"`,
                 );
@@ -410,24 +604,84 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
 
             return { sandbox, leaseId, sandboxId, wasCreated: true };
         } catch (err) {
-            // If a real E2B sandbox was created but a later step failed
-            // (Mongo update, mid-create invalidation, etc.), kill it so it
-            // doesn't run for the full ceiling burning quota. Null-sandbox
-            // doesn't need killing — its sandboxId is empty.
-            if (sandboxId) {
-                const apiKey = this.configService.get<string>('API_E2B_KEY');
-                if (apiKey) {
-                    this.logger.warn({
-                        message: `SandboxLeaseManager: killing orphaned sandbox after creator-path failure prKey="${prKey}" sandboxId="${sandboxId}"`,
-                        context: SandboxLeaseManager.name,
-                        metadata: { prKey, sandboxId },
-                    });
-                    await Sandbox.kill(sandboxId, { apiKey }).catch(() => {});
+            // If a real sandbox was created but a later step failed (Mongo
+            // update, mid-create invalidation, etc.), clean it up so it
+            // doesn't run for the full ceiling / leak host disk. Null-sandbox
+            // doesn't need cleanup — its sandboxId is empty.
+            if (
+                sandboxId &&
+                !preserveLeaseDocOnFailure &&
+                !sandboxCleanupHandled
+            ) {
+                if (isLocalSandboxPath(sandboxId)) {
+                    await this.cleanupLocalSandbox(
+                        sandboxId,
+                        prKey,
+                        'creator-path failure',
+                    );
+                } else {
+                    const apiKey =
+                        this.configService.get<string>('API_E2B_KEY');
+                    if (apiKey) {
+                        this.logger.warn({
+                            message: `SandboxLeaseManager: killing orphaned sandbox after creator-path failure prKey="${prKey}" sandboxId="${sandboxId}"`,
+                            context: SandboxLeaseManager.name,
+                            metadata: { prKey, sandboxId },
+                        });
+                        await Sandbox.kill(sandboxId, { apiKey }).catch(
+                            () => {},
+                        );
+                    }
                 }
             }
             // Remove the lease doc so other callers don't poll forever
-            await this.leaseRepo.delete(prKey).catch(() => {});
+            if (!preserveLeaseDocOnFailure && !leaseDocDeleteHandled) {
+                await this.leaseRepo.delete(prKey).catch(() => {});
+            }
             throw err;
+        }
+    }
+
+    private async cleanupLocalSandbox(
+        sandboxId: string,
+        prKey: string,
+        reason: string,
+    ): Promise<boolean> {
+        if (!isLocalSandboxPath(sandboxId)) {
+            return false;
+        }
+
+        try {
+            const cleaned = await cleanupLocalSandboxDirectory(sandboxId);
+            this.logger.log({
+                message: `SandboxLeaseManager: removed local sandbox directory after ${reason}`,
+                context: SandboxLeaseManager.name,
+                metadata: { prKey, sandboxId, reason },
+            });
+            return cleaned;
+        } catch (error) {
+            this.logger.warn({
+                message: `SandboxLeaseManager: failed to remove local sandbox directory after ${reason}`,
+                context: SandboxLeaseManager.name,
+                error,
+                metadata: { prKey, sandboxId, reason },
+            });
+            return false;
+        }
+    }
+
+    private async deleteMarkedLocalLeaseIfStillInactive(
+        prKey: string,
+        sandboxId: string,
+        reason: string,
+    ): Promise<void> {
+        const deleted = await this.leaseRepo.deleteIfNoActiveLeases(prKey);
+        if (!deleted) {
+            this.logger.log({
+                message: `SandboxLeaseManager: skipped local sandbox lease delete after ${reason} because lease was re-acquired; expired reaper will retry prKey="${prKey}"`,
+                context: SandboxLeaseManager.name,
+                metadata: { prKey, sandboxId, reason },
+            });
         }
     }
 
@@ -481,7 +735,19 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
             );
         }
 
-        if (state === 'READY' && sandboxId) {
+        if (state === 'DELETING') {
+            await this.waitForDeletingLeaseAndRollback(
+                prKey,
+                leaseId,
+                sandboxId,
+            );
+            throw new SandboxStaleConnectionError(
+                prKey,
+                sandboxId ?? 'deleting',
+            );
+        }
+
+        if (state === 'READY' && sandboxId !== undefined) {
             return this.connectToExisting(prKey, leaseId, consumer, sandboxId);
         }
 
@@ -509,12 +775,50 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                 );
             }
 
-            if (doc.state === 'READY' && doc.sandboxId) {
-                return this.connectToExisting(prKey, leaseId, consumer, doc.sandboxId);
+            if (doc.state === 'DELETING') {
+                await this.waitForDeletingLeaseAndRollback(
+                    prKey,
+                    leaseId,
+                    doc.sandboxId,
+                );
+                throw new SandboxStaleConnectionError(
+                    prKey,
+                    doc.sandboxId ?? 'deleting',
+                );
+            }
+
+            if (doc.state === 'READY' && doc.sandboxId !== undefined) {
+                return this.connectToExisting(
+                    prKey,
+                    leaseId,
+                    consumer,
+                    doc.sandboxId,
+                );
             }
         }
 
         throw new SandboxCreateTimeoutError(prKey);
+    }
+
+    private async waitForDeletingLeaseAndRollback(
+        prKey: string,
+        leaseId: string,
+        sandboxId?: string,
+    ): Promise<void> {
+        this.leaseIdToPrKey.delete(leaseId);
+        await this.leaseRepo.decrementLease(prKey).catch(() => null);
+
+        const deadline = Date.now() + MAX_POLL_WAIT_MS;
+        while (Date.now() < deadline) {
+            const doc = await this.leaseRepo.findByPrKey(prKey);
+            if (!doc || doc.state !== 'DELETING') {
+                return;
+            }
+
+            await sleep(POLL_INTERVAL_MS);
+        }
+
+        throw new SandboxStaleConnectionError(prKey, sandboxId ?? 'deleting');
     }
 
     private async connectToExisting(
@@ -523,10 +827,25 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
         consumer: string,
         sandboxId: string,
     ): Promise<AcquireResult> {
-        const apiKey = this.configService.get<string>('API_E2B_KEY');
+        if (!sandboxId) {
+            // Null sandbox marker — return a release-bound null sandbox for
+            // self-contained callers and READY leases with empty sandboxId.
+            const sandbox = this.buildNullSandboxWithRelease(prKey, leaseId);
+            this.leaseIdToPrKey.set(leaseId, prKey);
+            return { sandbox, leaseId, sandboxId, wasCreated: false };
+        }
 
+        if (isLocalSandboxPath(sandboxId)) {
+            return this.connectToExistingLocalSandbox(
+                prKey,
+                leaseId,
+                consumer,
+                sandboxId,
+            );
+        }
+
+        const apiKey = this.configService.get<string>('API_E2B_KEY');
         if (!apiKey) {
-            // No E2B key — return null sandbox (callers in self-contained mode)
             const sandbox = this.buildNullSandboxWithRelease(prKey, leaseId);
             this.leaseIdToPrKey.set(leaseId, prKey);
             return { sandbox, leaseId, sandboxId, wasCreated: false };
@@ -565,7 +884,11 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
             throw new SandboxStaleConnectionError(prKey, sandboxId);
         }
 
-        const sandbox: SandboxInstance = this.buildSandboxInstance(e2bSandbox, prKey, leaseId);
+        const sandbox: SandboxInstance = this.buildSandboxInstance(
+            e2bSandbox,
+            prKey,
+            leaseId,
+        );
         this.leaseIdToPrKey.set(leaseId, prKey);
 
         this.logger.log({
@@ -577,38 +900,121 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
         return { sandbox, leaseId, sandboxId, wasCreated: false };
     }
 
+    private async connectToExistingLocalSandbox(
+        prKey: string,
+        leaseId: string,
+        consumer: string,
+        sandboxId: string,
+    ): Promise<AcquireResult> {
+        if (!this.sandboxProvider.connectToExistingSandbox) {
+            this.logger.warn({
+                message: `SandboxLeaseManager: local sandbox reconnect unsupported for sandboxId="${sandboxId}" prKey="${prKey}"`,
+                context: SandboxLeaseManager.name,
+                metadata: { prKey, consumer, sandboxId },
+            });
+            this.leaseIdToPrKey.delete(leaseId);
+            await this.rollbackLocalReconnectAcquire(prKey, sandboxId);
+            throw new Error(
+                `SandboxLeaseManager: local sandbox reconnect unsupported for prKey="${prKey}" sandboxId="${sandboxId}"`,
+            );
+        }
+
+        this.logger.log({
+            message: `SandboxLeaseManager: reconnecting to existing local sandbox sandboxId="${sandboxId}" prKey="${prKey}" consumer="${consumer}"`,
+            context: SandboxLeaseManager.name,
+            metadata: { prKey, consumer, sandboxId },
+        });
+
+        let providerSandbox: SandboxInstance;
+        try {
+            providerSandbox =
+                await this.sandboxProvider.connectToExistingSandbox(sandboxId);
+        } catch (err) {
+            this.logger.warn({
+                message: `SandboxLeaseManager: local sandbox reconnect failed for sandboxId="${sandboxId}" prKey="${prKey}" (expected in multi-node setups without shared /tmp)`,
+                context: SandboxLeaseManager.name,
+                error: err,
+                metadata: { prKey, sandboxId },
+            });
+            this.leaseIdToPrKey.delete(leaseId);
+            await this.rollbackLocalReconnectAcquire(prKey, sandboxId);
+            throw err;
+        }
+
+        const sandbox: SandboxInstance = {
+            ...providerSandbox,
+            cleanup: async () => {
+                await this.release(leaseId);
+            },
+        };
+        this.leaseIdToPrKey.set(leaseId, prKey);
+
+        this.logger.log({
+            message: `SandboxLeaseManager: reconnected to existing local sandbox prKey="${prKey}" consumer="${consumer}" leaseId="${leaseId}"`,
+            context: SandboxLeaseManager.name,
+            metadata: { prKey, consumer, leaseId, sandboxId },
+        });
+
+        return { sandbox, leaseId, sandboxId, wasCreated: false };
+    }
+
+    private async rollbackLocalReconnectAcquire(
+        prKey: string,
+        sandboxId: string,
+    ): Promise<void> {
+        try {
+            await this.leaseRepo.decrementLease(prKey);
+        } catch (error) {
+            this.logger.warn({
+                message: `SandboxLeaseManager: failed to rollback local reconnect acquire for sandboxId="${sandboxId}" prKey="${prKey}"`,
+                context: SandboxLeaseManager.name,
+                error,
+                metadata: { prKey, sandboxId },
+            });
+        }
+    }
+
     /**
      * Build a minimal SandboxInstance wrapping an existing connected E2B sandbox.
      * This is used by the joiner path when connecting to an already-READY sandbox.
      */
-    private buildSandboxInstance(e2bSandbox: Sandbox, prKey: string, leaseId: string): SandboxInstance {
+    private buildSandboxInstance(
+        e2bSandbox: Sandbox,
+        prKey: string,
+        leaseId: string,
+    ): SandboxInstance {
         return {
             remoteCommands: {
                 grep: async (pattern: string, path: string, glob?: string) => {
-                    const globArg = glob ? `--glob '${glob}'` : '';
+                    const globArg = glob ? `--glob ${shSingleQuote(glob)}` : '';
                     const result = await e2bSandbox.commands.run(
-                        `rg --no-heading -n ${globArg} -e '${pattern}' '${path}' 2>/dev/null || true`,
+                        `rg --no-heading -n ${globArg} -e ${shSingleQuote(pattern)} ${shSingleQuote(path)} 2>/dev/null || true`,
                         { timeoutMs: 30_000 },
                     );
                     return result.stdout || '';
                 },
                 read: async (path: string, start: number, end: number) => {
                     const result = await e2bSandbox.commands.run(
-                        `sed -n '${start},${end}p' '${path}' 2>/dev/null || true`,
+                        `sed -n '${start},${end}p' ${shSingleQuote(path)} 2>/dev/null || true`,
                         { timeoutMs: 10_000 },
                     );
                     return result.stdout || '';
                 },
                 listDir: async (path: string, maxDepth: number) => {
                     const result = await e2bSandbox.commands.run(
-                        `find '${path}' -maxdepth ${maxDepth} 2>/dev/null | head -200 || true`,
+                        `find ${shSingleQuote(path)} -maxdepth ${maxDepth} 2>/dev/null | head -200 || true`,
                         { timeoutMs: 10_000 },
                     );
                     return result.stdout || '';
                 },
                 exec: async (command: string) => {
-                    const result = await e2bSandbox.commands.run(command, { timeoutMs: 30_000 });
-                    return { stdout: result.stdout || '', exitCode: result.exitCode };
+                    const result = await e2bSandbox.commands.run(command, {
+                        timeoutMs: 30_000,
+                    });
+                    return {
+                        stdout: result.stdout || '',
+                        exitCode: result.exitCode,
+                    };
                 },
             },
             cleanup: async () => {
@@ -642,7 +1048,10 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
      * Build a null sandbox with a release-bound cleanup function.
      * Used when E2B is not configured or when connect is not needed.
      */
-    private buildNullSandboxWithRelease(prKey: string, leaseId: string): SandboxInstance {
+    private buildNullSandboxWithRelease(
+        prKey: string,
+        leaseId: string,
+    ): SandboxInstance {
         return {
             ...NULL_SANDBOX_INSTANCE,
             cleanup: async () => {

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
@@ -29,25 +29,34 @@ import {
     SandboxInstance,
 } from '@libs/sandbox/domain/contracts/sandbox.provider';
 import { ConfigService } from '@nestjs/config';
+import { mkdtemp, rm, stat } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { SandboxLeaseSchema } from '../repositories/schemas/sandbox-lease.model';
 
 // ─── Shared test helpers ─────────────────────────────────────────────────────
 
 function makeMockLeaseRepo(): jest.Mocked<SandboxLeaseRepository> {
     return {
         upsertAcquire: jest.fn(),
-        decrementLease: jest.fn(),
+        decrementLease: jest.fn().mockResolvedValue(null),
         updateReady: jest.fn().mockResolvedValue(undefined),
         markInvalidated: jest.fn().mockResolvedValue(undefined),
         findByPrKey: jest.fn().mockResolvedValue(null),
         findExpired: jest.fn().mockResolvedValue([]),
         delete: jest.fn().mockResolvedValue(undefined),
-        setKillAt: jest.fn().mockResolvedValue(undefined),
+        markDeletingIfNoActiveLeases: jest.fn().mockResolvedValue(true),
+        markExpiredDeletingIfNotRenewed: jest.fn().mockResolvedValue(true),
+        deleteIfNoActiveLeases: jest.fn().mockResolvedValue(true),
+        setKillAt: jest.fn().mockResolvedValue(true),
         clearKillAt: jest.fn().mockResolvedValue(undefined),
         findReadyToKill: jest.fn().mockResolvedValue([]),
     } as unknown as jest.Mocked<SandboxLeaseRepository>;
 }
 
-function makeMockSandboxProvider(available = true): jest.Mocked<ISandboxProvider> {
+function makeMockSandboxProvider(
+    available = true,
+): jest.Mocked<ISandboxProvider> {
     const mockSandboxInstance: SandboxInstance = {
         remoteCommands: {
             grep: jest.fn().mockResolvedValue(''),
@@ -59,7 +68,9 @@ function makeMockSandboxProvider(available = true): jest.Mocked<ISandboxProvider
         type: 'e2b',
         sandboxId: 'mock-sandbox-id',
         repoDir: '/home/user/repo',
-        run: jest.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 }),
+        run: jest
+            .fn()
+            .mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 }),
         readFile: jest.fn().mockResolvedValue(''),
         writeFile: jest.fn().mockResolvedValue(undefined),
     };
@@ -67,10 +78,35 @@ function makeMockSandboxProvider(available = true): jest.Mocked<ISandboxProvider
     return {
         isAvailable: jest.fn().mockReturnValue(available),
         createSandboxWithRepo: jest.fn().mockResolvedValue(mockSandboxInstance),
+        connectToExistingSandbox: jest.fn(),
     } as jest.Mocked<ISandboxProvider>;
 }
 
-function makeMockConfigService(e2bKey: string | undefined = 'test-e2b-key'): jest.Mocked<ConfigService> {
+function makeLocalSandboxInstance(tempDir: string): SandboxInstance {
+    return {
+        remoteCommands: {
+            grep: jest.fn().mockResolvedValue(''),
+            read: jest.fn().mockResolvedValue(''),
+            listDir: jest.fn().mockResolvedValue(''),
+            exec: jest.fn().mockResolvedValue({ stdout: '', exitCode: 0 }),
+        },
+        cleanup: jest.fn(async () => {
+            await rm(tempDir, { recursive: true, force: true });
+        }),
+        type: 'local',
+        sandboxId: tempDir,
+        repoDir: tempDir,
+        run: jest
+            .fn()
+            .mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 }),
+        readFile: jest.fn().mockResolvedValue(''),
+        writeFile: jest.fn().mockResolvedValue(undefined),
+    };
+}
+
+function makeMockConfigService(
+    e2bKey: string | undefined = 'test-e2b-key',
+): jest.Mocked<ConfigService> {
     return {
         get: jest.fn().mockReturnValue(e2bKey),
     } as unknown as jest.Mocked<ConfigService>;
@@ -90,6 +126,16 @@ function makeLeaseManager(
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('SandboxLeaseModel', () => {
+    it('indexes the expired reaper DELETING recovery query', () => {
+        const indexFields = SandboxLeaseSchema.indexes().map(
+            ([fields]) => fields,
+        );
+
+        expect(indexFields).toContainEqual({ state: 1, expiresAt: 1 });
+    });
+});
 
 describe('SandboxLeaseManager', () => {
     let leaseRepo: jest.Mocked<SandboxLeaseRepository>;
@@ -138,7 +184,10 @@ describe('SandboxLeaseManager', () => {
         expect(result.sandbox).toBeDefined();
 
         // updateReady called with prKey
-        expect(leaseRepo.updateReady).toHaveBeenCalledWith(prKey, expect.any(String));
+        expect(leaseRepo.updateReady).toHaveBeenCalledWith(
+            prKey,
+            expect.any(String),
+        );
 
         // Release: decrement lease
         leaseRepo.decrementLease.mockResolvedValue({
@@ -238,16 +287,72 @@ describe('SandboxLeaseManager', () => {
 
         // Joiner (second acquire) connected to existing sandbox via Sandbox.connect
         // (creator path — without cloneParams — uses null sandbox for initial CREATING→READY)
-        expect(Sandbox.connect).toHaveBeenCalledWith(
-            'e2b-poll-sandbox',
-            { apiKey: 'test-e2b-key' },
-        );
+        expect(Sandbox.connect).toHaveBeenCalledWith('e2b-poll-sandbox', {
+            apiKey: 'test-e2b-key',
+        });
 
         // Key invariant: createSandboxWithRepo NOT called without cloneParams
         // (manager falls back to null sandbox when no clone params supplied).
         // The concurrency assertion is: Sandbox.connect is called exactly once
         // (only the joiner path connects; the creator took null-sandbox path).
         expect(Sandbox.connect).toHaveBeenCalledTimes(1);
+    });
+
+    it('joiner connects to READY null sandbox leases with empty sandboxId', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:100';
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 2,
+            state: 'READY',
+            sandboxId: '',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        const result = await manager.acquire(prKey, 'conversation');
+
+        expect(result.sandbox.type).toBe('null');
+        expect(result.sandboxId).toBe('');
+        expect(result.wasCreated).toBe(false);
+        expect(Sandbox.connect).not.toHaveBeenCalled();
+        expect(leaseRepo.findByPrKey).not.toHaveBeenCalled();
+    });
+
+    it('joiner reconnects to READY local sandbox leases instead of returning null or calling E2B', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:101';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-test-'));
+        const localSandbox = makeLocalSandboxInstance(tempDir);
+
+        configService = makeMockConfigService('test-e2b-key');
+        sandboxProvider.connectToExistingSandbox = jest
+            .fn()
+            .mockResolvedValue(localSandbox);
+        manager = makeLeaseManager(leaseRepo, sandboxProvider, configService);
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 2,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        try {
+            const result = await manager.acquire(prKey, 'conversation');
+
+            expect(result.sandbox.type).toBe('local');
+            expect(result.sandboxId).toBe(tempDir);
+            expect(result.wasCreated).toBe(false);
+            expect(
+                sandboxProvider.connectToExistingSandbox,
+            ).toHaveBeenCalledWith(tempDir);
+            expect(Sandbox.connect).not.toHaveBeenCalled();
+            expect(leaseRepo.findByPrKey).not.toHaveBeenCalled();
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
     });
 
     // ─── Test 3: invalidate via PR-close (soft-drain + delete) ───────────
@@ -278,6 +383,67 @@ describe('SandboxLeaseManager', () => {
 
         // kill is NOT called synchronously (soft-drain, not immediate kill)
         expect(Sandbox.kill).not.toHaveBeenCalled();
+    });
+
+    it('invalidate: removes local sandbox directory after marking the lease as deleting', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:78';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-test-'));
+
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        try {
+            await manager.invalidate(prKey);
+
+            expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledWith(
+                prKey,
+            );
+            await expect(stat(tempDir)).rejects.toMatchObject({
+                code: 'ENOENT',
+            });
+            expect(leaseRepo.deleteIfNoActiveLeases).toHaveBeenCalledWith(
+                prKey,
+            );
+            expect(leaseRepo.delete).not.toHaveBeenCalled();
+            expect(Sandbox.setTimeout).not.toHaveBeenCalled();
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('invalidate: does not clean a local sandbox when the deleting mark loses the race', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:80';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-test-'));
+
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.markDeletingIfNoActiveLeases.mockResolvedValue(false);
+
+        try {
+            await manager.invalidate(prKey);
+
+            expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledWith(
+                prKey,
+            );
+            await expect(stat(tempDir)).resolves.toBeDefined();
+            expect(leaseRepo.delete).not.toHaveBeenCalled();
+            expect(leaseRepo.deleteIfNoActiveLeases).not.toHaveBeenCalled();
+            expect(Sandbox.setTimeout).not.toHaveBeenCalled();
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
     });
 
     // ─── Test 4: NullSandbox fallback when provider unavailable ──────────
@@ -326,20 +492,34 @@ describe('SandboxLeaseManager', () => {
         ['only one segment', 'foo'],
         ['two segments', 'foo:bar'],
         ['five segments', 'a:b:c:d:e'],
-        ['UUID v4-shape but invalid hex', 'gggggggg-aaaa-aaaa-aaaa-aaaaaaaaaaaa:r:1'],
-    ])('rejects malformed prKey (%s) before any side-effect', async (_label, badKey) => {
-        const leaseRepo = makeMockLeaseRepo();
-        const configService = makeMockConfigService('test-e2b-key');
-        const sandboxProvider = makeMockSandboxProvider(true);
-        const manager = makeLeaseManager(leaseRepo, sandboxProvider, configService);
+        [
+            'UUID v4-shape but invalid hex',
+            'gggggggg-aaaa-aaaa-aaaa-aaaaaaaaaaaa:r:1',
+        ],
+    ])(
+        'rejects malformed prKey (%s) before any side-effect',
+        async (_label, badKey) => {
+            const leaseRepo = makeMockLeaseRepo();
+            const configService = makeMockConfigService('test-e2b-key');
+            const sandboxProvider = makeMockSandboxProvider(true);
+            const manager = makeLeaseManager(
+                leaseRepo,
+                sandboxProvider,
+                configService,
+            );
 
-        await expect(manager.acquire(badKey, 'review')).rejects.toThrow(/Invalid prKey/);
+            await expect(manager.acquire(badKey, 'review')).rejects.toThrow(
+                /Invalid prKey/,
+            );
 
-        // CRITICAL: NO Mongo write happened, NO sandbox was created.
-        // A malformed key MUST NOT pollute the lease collection.
-        expect(leaseRepo.upsertAcquire).not.toHaveBeenCalled();
-        expect(sandboxProvider.createSandboxWithRepo).not.toHaveBeenCalled();
-    });
+            // CRITICAL: NO Mongo write happened, NO sandbox was created.
+            // A malformed key MUST NOT pollute the lease collection.
+            expect(leaseRepo.upsertAcquire).not.toHaveBeenCalled();
+            expect(
+                sandboxProvider.createSandboxWithRepo,
+            ).not.toHaveBeenCalled();
+        },
+    );
 
     // ─── Test 6: orphan kill when post-create Mongo step fails ────────────
 
@@ -378,7 +558,9 @@ describe('SandboxLeaseManager', () => {
         } as any);
 
         // updateReady fails AFTER the sandbox was created
-        leaseRepo.updateReady.mockRejectedValue(new Error('Mongo connection lost'));
+        leaseRepo.updateReady.mockRejectedValue(
+            new Error('Mongo connection lost'),
+        );
 
         await expect(
             manager.acquire(prKey, 'review', undefined, cloneParams),
@@ -435,7 +617,12 @@ describe('SandboxLeaseManager', () => {
             } as any);
 
         jest.useFakeTimers();
-        const acquirePromise = manager.acquire(prKey, 'review', undefined, cloneParams);
+        const acquirePromise = manager.acquire(
+            prKey,
+            'review',
+            undefined,
+            cloneParams,
+        );
 
         // Fast-forward through the 60s backoff between attempt 1 and 2
         await jest.runAllTimersAsync();
@@ -534,9 +721,8 @@ describe('SandboxLeaseManager', () => {
         // killAt scheduled in Mongo — the killIdleSandboxes cron will sweep it.
         // No in-memory timer involved, so any worker can pick up the kill.
         expect(leaseRepo.setKillAt).toHaveBeenCalledTimes(1);
-        const [calledPrKey, calledKillAt] = (
-            leaseRepo.setKillAt as jest.Mock
-        ).mock.calls[0];
+        const [calledPrKey, calledKillAt] = (leaseRepo.setKillAt as jest.Mock)
+            .mock.calls[0];
         expect(calledPrKey).toBe(prKey);
         expect(calledKillAt).toBeInstanceOf(Date);
         const expectedAt = before + 30_000;
@@ -552,6 +738,244 @@ describe('SandboxLeaseManager', () => {
         // No synchronous kill — that's the cron's job
         expect(Sandbox.kill).not.toHaveBeenCalled();
         expect(leaseRepo.delete).not.toHaveBeenCalled();
+    });
+
+    it('release skips E2B idle timeout when the lease is re-acquired before conditional killAt update', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:206';
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'CREATING',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'READY',
+            sandboxId: '',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        const result = await manager.acquire(prKey, 'review');
+
+        leaseRepo.decrementLease.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'READY',
+            sandboxId: 'reacquired-e2b-sandbox',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.setKillAt.mockResolvedValue(false);
+
+        await manager.release(result.leaseId, { idleMs: 30_000 });
+
+        expect(leaseRepo.setKillAt).toHaveBeenCalledWith(
+            prKey,
+            expect.any(Date),
+        );
+        expect(Sandbox.setTimeout).not.toHaveBeenCalled();
+        expect(Sandbox.kill).not.toHaveBeenCalled();
+        expect(leaseRepo.delete).not.toHaveBeenCalled();
+    });
+
+    it('release removes local sandbox directory when the last lease is released', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:203';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-test-'));
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 203,
+            platform: 'GITHUB' as any,
+        };
+
+        const localSandbox = makeLocalSandboxInstance(tempDir);
+        configService = makeMockConfigService('');
+        sandboxProvider.createSandboxWithRepo.mockResolvedValue(localSandbox);
+        manager = makeLeaseManager(leaseRepo, sandboxProvider, configService);
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'CREATING',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        const result = await manager.acquire(
+            prKey,
+            'review',
+            undefined,
+            cloneParams,
+        );
+
+        leaseRepo.decrementLease.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        try {
+            await manager.release(result.leaseId, { idleMs: 30_000 });
+
+            await expect(stat(tempDir)).rejects.toMatchObject({
+                code: 'ENOENT',
+            });
+            expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledWith(
+                prKey,
+            );
+            expect(leaseRepo.deleteIfNoActiveLeases).toHaveBeenCalledWith(
+                prKey,
+            );
+            expect(leaseRepo.delete).not.toHaveBeenCalled();
+            expect(leaseRepo.setKillAt).not.toHaveBeenCalled();
+            expect(Sandbox.setTimeout).not.toHaveBeenCalled();
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('release leaves the deleting lease for retry when local directory cleanup fails', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:204';
+        const sandboxId = join(tmpdir(), 'kodus-sandbox-\0cleanup-fails');
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 204,
+            platform: 'GITHUB' as any,
+        };
+
+        const localSandbox = makeLocalSandboxInstance(sandboxId);
+        configService = makeMockConfigService('test-e2b-key');
+        sandboxProvider.createSandboxWithRepo.mockResolvedValue(localSandbox);
+        manager = makeLeaseManager(leaseRepo, sandboxProvider, configService);
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'CREATING',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'READY',
+            sandboxId,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        const result = await manager.acquire(
+            prKey,
+            'review',
+            undefined,
+            cloneParams,
+        );
+
+        leaseRepo.decrementLease.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'READY',
+            sandboxId,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        await manager.release(result.leaseId, { idleMs: 30_000 });
+
+        expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledWith(
+            prKey,
+        );
+        expect(leaseRepo.delete).not.toHaveBeenCalled();
+        expect(leaseRepo.deleteIfNoActiveLeases).not.toHaveBeenCalled();
+        expect(leaseRepo.setKillAt).not.toHaveBeenCalled();
+        expect(Sandbox.setTimeout).not.toHaveBeenCalled();
+    });
+
+    it('release leaves a marked lease for the reaper when final delete loses the race', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:205';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-test-'));
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 205,
+            platform: 'GITHUB' as any,
+        };
+
+        const localSandbox = makeLocalSandboxInstance(tempDir);
+        configService = makeMockConfigService('test-e2b-key');
+        sandboxProvider.createSandboxWithRepo.mockResolvedValue(localSandbox);
+        manager = makeLeaseManager(leaseRepo, sandboxProvider, configService);
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'CREATING',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        const result = await manager.acquire(
+            prKey,
+            'review',
+            undefined,
+            cloneParams,
+        );
+
+        leaseRepo.decrementLease.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.deleteIfNoActiveLeases.mockResolvedValue(false);
+
+        try {
+            await manager.release(result.leaseId, { idleMs: 30_000 });
+
+            await expect(stat(tempDir)).rejects.toMatchObject({
+                code: 'ENOENT',
+            });
+            expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledWith(
+                prKey,
+            );
+            expect(leaseRepo.deleteIfNoActiveLeases).toHaveBeenCalledWith(
+                prKey,
+            );
+            expect(leaseRepo.delete).not.toHaveBeenCalled();
+            expect(leaseRepo.setKillAt).not.toHaveBeenCalled();
+            expect(Sandbox.setTimeout).not.toHaveBeenCalled();
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
     });
 
     // ─── Test 9d: acquire clears killAt atomically (warm reuse) ───────────
@@ -578,6 +1002,55 @@ describe('SandboxLeaseManager', () => {
         expect(Sandbox.connect).toHaveBeenCalledWith('warm-sandbox', {
             apiKey: 'test-e2b-key',
         });
+    });
+
+    it('connected E2B remote commands shell-quote grep and read inputs', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:202';
+        const commandRun = jest
+            .fn()
+            .mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 });
+
+        (Sandbox.connect as jest.Mock).mockResolvedValueOnce({
+            sandboxId: 'quoted-sandbox',
+            commands: { run: commandRun },
+            files: {
+                read: jest.fn(),
+                write: jest.fn(),
+            },
+        });
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 2,
+            state: 'READY',
+            sandboxId: 'quoted-sandbox',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        const result = await manager.acquire(prKey, 'conversation');
+
+        await result.sandbox.remoteCommands.grep(
+            "method('bar')",
+            "src/feature's/file.ts",
+            "**/*'spec.ts",
+        );
+        await result.sandbox.remoteCommands.read("src/feature's/file.ts", 1, 5);
+        await result.sandbox.remoteCommands.listDir("src/feature's", 2);
+
+        expect(commandRun.mock.calls[0][0]).toContain(
+            "'method('\\''bar'\\'')'",
+        );
+        expect(commandRun.mock.calls[0][0]).toContain(
+            "'src/feature'\\''s/file.ts'",
+        );
+        expect(commandRun.mock.calls[0][0]).toContain(
+            "--glob '**/*'\\''spec.ts'",
+        );
+        expect(commandRun.mock.calls[1][0]).toContain(
+            "'src/feature'\\''s/file.ts'",
+        );
+        expect(commandRun.mock.calls[2][0]).toContain("'src/feature'\\''s'");
     });
 
     // ─── Test 9e: stale connect → delete lease + cold-start ───────────────
@@ -651,9 +1124,200 @@ describe('SandboxLeaseManager', () => {
         // Stale lease was deleted before cold-start
         expect(leaseRepo.delete).toHaveBeenCalledWith(prKey);
         // Cold-start succeeded — fresh sandbox created
-        expect(sandboxProvider.createSandboxWithRepo).toHaveBeenCalledWith(cloneParams);
+        expect(sandboxProvider.createSandboxWithRepo).toHaveBeenCalledWith(
+            cloneParams,
+        );
         expect(result.sandboxId).toBe('fresh-sandbox-id');
         expect(result.wasCreated).toBe(true);
+    });
+
+    it('joiner retries bounded stale E2B reconnects while preserving the same leaseId', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:208';
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 208,
+            platform: 'GITHUB' as any,
+        };
+
+        leaseRepo.upsertAcquire
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'READY',
+                sandboxId: 'dead-sandbox-1',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any)
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'READY',
+                sandboxId: 'dead-sandbox-2',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any)
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'CREATING',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'READY',
+            sandboxId: 'fresh-after-stale-retries',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        (Sandbox.connect as jest.Mock)
+            .mockRejectedValueOnce(new Error('sandbox not found 1'))
+            .mockRejectedValueOnce(new Error('sandbox not found 2'));
+        sandboxProvider.createSandboxWithRepo.mockResolvedValue({
+            type: 'e2b',
+            sandboxId: 'fresh-after-stale-retries',
+            cleanup: jest.fn(),
+            remoteCommands: {} as any,
+            run: jest.fn(),
+            readFile: jest.fn(),
+            writeFile: jest.fn(),
+            repoDir: '/home/user/repo',
+        } as any);
+
+        const result = await manager.acquire(
+            prKey,
+            'conversation',
+            undefined,
+            cloneParams,
+        );
+
+        expect(leaseRepo.upsertAcquire).toHaveBeenCalledTimes(3);
+        expect(leaseRepo.delete).toHaveBeenCalledTimes(2);
+        expect(result.sandboxId).toBe('fresh-after-stale-retries');
+        expect(result.wasCreated).toBe(true);
+    });
+
+    it('joiner does not reuse a DELETING lease and retries after the old doc disappears', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:209';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-test-'));
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 209,
+            platform: 'GITHUB' as any,
+        };
+
+        leaseRepo.upsertAcquire
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'DELETING',
+                sandboxId: tempDir,
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any)
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'CREATING',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+        leaseRepo.findByPrKey
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'READY',
+                sandboxId: 'fresh-after-deleting',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+        sandboxProvider.createSandboxWithRepo.mockResolvedValue({
+            type: 'e2b',
+            sandboxId: 'fresh-after-deleting',
+            cleanup: jest.fn(),
+            remoteCommands: {} as any,
+            run: jest.fn(),
+            readFile: jest.fn(),
+            writeFile: jest.fn(),
+            repoDir: '/home/user/repo',
+        } as any);
+
+        try {
+            const result = await manager.acquire(
+                prKey,
+                'conversation',
+                undefined,
+                cloneParams,
+            );
+
+            expect(leaseRepo.decrementLease).toHaveBeenCalledWith(prKey);
+            expect(
+                sandboxProvider.connectToExistingSandbox,
+            ).not.toHaveBeenCalled();
+            expect(result.sandboxId).toBe('fresh-after-deleting');
+            expect(result.wasCreated).toBe(true);
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('local reconnect failure does not delete the global lease or cold-start on another worker', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:207';
+        const staleTempDir = await mkdtemp(
+            join(tmpdir(), 'kodus-sandbox-test-'),
+        );
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 207,
+            platform: 'GITHUB' as any,
+        };
+
+        configService = makeMockConfigService('test-e2b-key');
+        sandboxProvider.connectToExistingSandbox = jest
+            .fn()
+            .mockRejectedValue(new Error('local sandbox dir missing'));
+        manager = makeLeaseManager(leaseRepo, sandboxProvider, configService);
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 2,
+            state: 'READY',
+            sandboxId: staleTempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.decrementLease.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'READY',
+            sandboxId: staleTempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        try {
+            await expect(
+                manager.acquire(prKey, 'conversation', undefined, cloneParams),
+            ).rejects.toThrow(/local sandbox dir missing/);
+
+            expect(leaseRepo.delete).not.toHaveBeenCalled();
+            expect(leaseRepo.upsertAcquire).toHaveBeenCalledTimes(1);
+            expect(leaseRepo.decrementLease).toHaveBeenCalledWith(prKey);
+            expect(leaseRepo.updateReady).not.toHaveBeenCalled();
+            expect(
+                sandboxProvider.createSandboxWithRepo,
+            ).not.toHaveBeenCalled();
+        } finally {
+            await rm(staleTempDir, { recursive: true, force: true });
+        }
     });
 
     // ─── Test 9a: release accepts custom idleMs (review uses 30s) ────────
@@ -754,6 +1418,177 @@ describe('SandboxLeaseManager', () => {
         // Doc cleaned up
         expect(leaseRepo.delete).toHaveBeenCalledWith(prKey);
     });
+
+    it('keeps lease doc when local sandbox cleanup fails mid-create invalidation', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:89';
+        const missingDir = join(
+            tmpdir(),
+            `kodus-sandbox-test-missing-mid-create-${Date.now()}`,
+        );
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 89,
+            platform: 'GITHUB' as any,
+        };
+
+        await rm(missingDir, { recursive: true, force: true });
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'CREATING',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        sandboxProvider.createSandboxWithRepo.mockResolvedValue(
+            makeLocalSandboxInstance(missingDir),
+        );
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'INVALIDATED',
+            sandboxId: missingDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        await expect(
+            manager.acquire(prKey, 'review', undefined, cloneParams),
+        ).rejects.toThrow(/failed to clean local sandbox mid-create/);
+
+        expect(leaseRepo.delete).not.toHaveBeenCalled();
+        expect(Sandbox.kill).not.toHaveBeenCalled();
+    });
+
+    it('keeps lease doc when remote sandbox kill fails mid-create invalidation', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:90';
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 90,
+            platform: 'GITHUB' as any,
+        };
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'CREATING',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        sandboxProvider.createSandboxWithRepo.mockResolvedValue({
+            type: 'e2b',
+            sandboxId: 'mid-create-kill-fails',
+            cleanup: jest.fn(),
+            remoteCommands: {} as any,
+            run: jest.fn(),
+            readFile: jest.fn(),
+            writeFile: jest.fn(),
+            repoDir: '/home/user/repo',
+        } as any);
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'INVALIDATED',
+            sandboxId: 'mid-create-kill-fails',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        (Sandbox.kill as jest.Mock).mockRejectedValueOnce(
+            new Error('rate limited'),
+        );
+
+        await expect(
+            manager.acquire(prKey, 'review', undefined, cloneParams),
+        ).rejects.toThrow(/failed to kill sandbox mid-create/);
+
+        expect(leaseRepo.delete).not.toHaveBeenCalled();
+    });
+
+    it('kills sandbox and retries when lease was marked deleting mid-create', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:78';
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 78,
+            platform: 'GITHUB' as any,
+        };
+
+        leaseRepo.upsertAcquire
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'CREATING',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any)
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'CREATING',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+        sandboxProvider.createSandboxWithRepo
+            .mockResolvedValueOnce({
+                type: 'e2b',
+                sandboxId: 'mid-create-deleting-sandbox-id',
+                cleanup: jest.fn(),
+                remoteCommands: {} as any,
+                run: jest.fn(),
+                readFile: jest.fn(),
+                writeFile: jest.fn(),
+                repoDir: '/home/user/repo',
+            } as any)
+            .mockResolvedValueOnce({
+                type: 'e2b',
+                sandboxId: 'fresh-after-mid-create-deleting',
+                cleanup: jest.fn(),
+                remoteCommands: {} as any,
+                run: jest.fn(),
+                readFile: jest.fn(),
+                writeFile: jest.fn(),
+                repoDir: '/home/user/repo',
+            } as any);
+        leaseRepo.findByPrKey
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 0,
+                state: 'DELETING',
+                sandboxId: 'mid-create-deleting-sandbox-id',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any)
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'READY',
+                sandboxId: 'fresh-after-mid-create-deleting',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+
+        const result = await manager.acquire(
+            prKey,
+            'review',
+            undefined,
+            cloneParams,
+        );
+
+        expect(Sandbox.kill).toHaveBeenCalledWith(
+            'mid-create-deleting-sandbox-id',
+            {
+                apiKey: 'test-e2b-key',
+            },
+        );
+        expect(leaseRepo.delete).toHaveBeenCalledWith(prKey);
+        expect(sandboxProvider.createSandboxWithRepo).toHaveBeenCalledTimes(2);
+        expect(result.sandboxId).toBe('fresh-after-mid-create-deleting');
+        expect(result.wasCreated).toBe(true);
+    });
 });
 
 // ─── Test 5: Reaper cleans crashed-worker lease ───────────────────────────
@@ -792,11 +1627,268 @@ describe('SandboxLeaseReaperService', () => {
 
         await reaper.reapExpiredLeases();
 
+        expect(leaseRepo.findExpired).toHaveBeenCalledWith(
+            expect.any(Date),
+            100,
+        );
+        expect(leaseRepo.markExpiredDeletingIfNotRenewed).toHaveBeenCalledWith(
+            'org:repo:1',
+            expect.any(Date),
+        );
         // Sandbox.kill called with the expired sandbox ID
-        expect(Sandbox.kill).toHaveBeenCalledWith('e2b-123', { apiKey: 'test-e2b-key' });
+        expect(Sandbox.kill).toHaveBeenCalledWith('e2b-123', {
+            apiKey: 'test-e2b-key',
+        });
 
-        // Mongo doc deleted
         expect(leaseRepo.delete).toHaveBeenCalledWith('org:repo:1');
+    });
+
+    it('reaper removes expired local sandbox directory after a crashed worker', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('');
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-test-'));
+
+        leaseRepo.findExpired.mockResolvedValue([
+            {
+                _id: 'org:repo:local',
+                sandboxId: tempDir,
+                leaseCount: 1,
+                state: 'READY',
+                createdAt: new Date(Date.now() - 60 * 60 * 1000),
+                expiresAt: new Date(Date.now() - 10 * 60 * 1000),
+            } as any,
+        ]);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        try {
+            await reaper.reapExpiredLeases();
+
+            await expect(stat(tempDir)).rejects.toMatchObject({
+                code: 'ENOENT',
+            });
+            expect(Sandbox.kill).not.toHaveBeenCalled();
+            expect(
+                leaseRepo.markExpiredDeletingIfNotRenewed,
+            ).toHaveBeenCalledWith('org:repo:local', expect.any(Date));
+            expect(leaseRepo.delete).toHaveBeenCalledWith('org:repo:local');
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('reaper deletes expired local lease even when the directory is absent on this worker', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('');
+        const missingDir = join(
+            tmpdir(),
+            `kodus-sandbox-test-missing-${Date.now()}`,
+        );
+
+        await rm(missingDir, { recursive: true, force: true });
+        leaseRepo.findExpired.mockResolvedValue([
+            {
+                _id: 'org:repo:local-missing',
+                sandboxId: missingDir,
+                leaseCount: 1,
+                state: 'READY',
+                createdAt: new Date(Date.now() - 60 * 60 * 1000),
+                expiresAt: new Date(Date.now() - 10 * 60 * 1000),
+            } as any,
+        ]);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        await reaper.reapExpiredLeases();
+
+        expect(leaseRepo.markExpiredDeletingIfNotRenewed).toHaveBeenCalledWith(
+            'org:repo:local-missing',
+            expect.any(Date),
+        );
+        expect(leaseRepo.delete).toHaveBeenCalledWith('org:repo:local-missing');
+        expect(Sandbox.kill).not.toHaveBeenCalled();
+    });
+
+    it('reaper keeps expired E2B lease when remote kill fails transiently', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+
+        leaseRepo.findExpired.mockResolvedValue([
+            {
+                _id: 'org:repo:e2b-kill-fails',
+                sandboxId: 'e2b-kill-fails',
+                leaseCount: 1,
+                state: 'READY',
+                createdAt: new Date(Date.now() - 60 * 60 * 1000),
+                expiresAt: new Date(Date.now() - 10 * 60 * 1000),
+            } as any,
+        ]);
+        (Sandbox.kill as jest.Mock).mockRejectedValueOnce(
+            new Error('transient E2B failure'),
+        );
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        await reaper.reapExpiredLeases();
+
+        expect(leaseRepo.markExpiredDeletingIfNotRenewed).toHaveBeenCalledWith(
+            'org:repo:e2b-kill-fails',
+            expect.any(Date),
+        );
+        expect(leaseRepo.delete).not.toHaveBeenCalled();
+    });
+
+    it('reaper deletes expired E2B lease when remote sandbox is already gone', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+
+        leaseRepo.findExpired.mockResolvedValue([
+            {
+                _id: 'org:repo:e2b-not-found',
+                sandboxId: 'e2b-not-found',
+                leaseCount: 1,
+                state: 'READY',
+                createdAt: new Date(Date.now() - 60 * 60 * 1000),
+                expiresAt: new Date(Date.now() - 10 * 60 * 1000),
+            } as any,
+        ]);
+        (Sandbox.kill as jest.Mock).mockRejectedValueOnce(
+            new Error('sandbox not found'),
+        );
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        await reaper.reapExpiredLeases();
+
+        expect(leaseRepo.markExpiredDeletingIfNotRenewed).toHaveBeenCalledWith(
+            'org:repo:e2b-not-found',
+            expect.any(Date),
+        );
+        expect(leaseRepo.delete).toHaveBeenCalledWith('org:repo:e2b-not-found');
+    });
+
+    it('reaper skips expired sandbox cleanup when the lease was renewed before conditional delete', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-test-'));
+
+        leaseRepo.findExpired.mockResolvedValue([
+            {
+                _id: 'org:repo:renewed',
+                sandboxId: tempDir,
+                leaseCount: 1,
+                state: 'READY',
+                createdAt: new Date(Date.now() - 60 * 60 * 1000),
+                expiresAt: new Date(Date.now() - 10 * 60 * 1000),
+            } as any,
+        ]);
+        leaseRepo.markExpiredDeletingIfNotRenewed.mockResolvedValue(false);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        try {
+            await reaper.reapExpiredLeases();
+
+            await expect(stat(tempDir)).resolves.toBeDefined();
+            expect(Sandbox.kill).not.toHaveBeenCalled();
+            expect(leaseRepo.delete).not.toHaveBeenCalled();
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('reaper limits expired lease batch size and cleanup concurrency', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+        const leases = Array.from({ length: 6 }, (_, index) => ({
+            _id: `org:repo:${index}`,
+            sandboxId: `e2b-${index}`,
+            leaseCount: 1,
+            state: 'READY',
+            createdAt: new Date(Date.now() - 60 * 60 * 1000),
+            expiresAt: new Date(Date.now() - 10 * 60 * 1000),
+        })) as any[];
+
+        let activeDeletes = 0;
+        let maxActiveDeletes = 0;
+        leaseRepo.findExpired.mockResolvedValue(leases);
+        leaseRepo.markExpiredDeletingIfNotRenewed.mockImplementation(
+            async () => {
+                activeDeletes++;
+                maxActiveDeletes = Math.max(maxActiveDeletes, activeDeletes);
+                await new Promise((resolve) => setTimeout(resolve, 10));
+                activeDeletes--;
+                return false;
+            },
+        );
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        await reaper.reapExpiredLeases();
+
+        expect(leaseRepo.findExpired).toHaveBeenCalledWith(
+            expect.any(Date),
+            100,
+        );
+        expect(leaseRepo.markExpiredDeletingIfNotRenewed).toHaveBeenCalledTimes(
+            6,
+        );
+        expect(maxActiveDeletes).toBeLessThanOrEqual(5);
+        expect(Sandbox.kill).not.toHaveBeenCalled();
     });
 
     // ─── Idle-kill cron tests ────────────────────────────────────────────
@@ -844,8 +1936,22 @@ describe('SandboxLeaseReaperService', () => {
             'CRON:SANDBOX:IDLE_KILL',
             { ttl: 25_000 },
         );
-        expect(Sandbox.kill).toHaveBeenCalledWith('e2b-idle-1', { apiKey: 'test-e2b-key' });
-        expect(Sandbox.kill).toHaveBeenCalledWith('e2b-idle-2', { apiKey: 'test-e2b-key' });
+        expect(leaseRepo.findReadyToKill).toHaveBeenCalledWith(
+            expect.any(Date),
+            100,
+        );
+        expect(Sandbox.kill).toHaveBeenCalledWith('e2b-idle-1', {
+            apiKey: 'test-e2b-key',
+        });
+        expect(Sandbox.kill).toHaveBeenCalledWith('e2b-idle-2', {
+            apiKey: 'test-e2b-key',
+        });
+        expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledWith(
+            'org-uuid:repo:1',
+        );
+        expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledWith(
+            'org-uuid:repo:2',
+        );
         expect(leaseRepo.delete).toHaveBeenCalledWith('org-uuid:repo:1');
         expect(leaseRepo.delete).toHaveBeenCalledWith('org-uuid:repo:2');
         expect(mockLock.release).toHaveBeenCalledTimes(1);
@@ -872,6 +1978,223 @@ describe('SandboxLeaseReaperService', () => {
         expect(leaseRepo.findReadyToKill).not.toHaveBeenCalled();
         expect(Sandbox.kill).not.toHaveBeenCalled();
         expect(leaseRepo.delete).not.toHaveBeenCalled();
+    });
+
+    it('killIdleSandboxes: skips killing when the lease was re-acquired before conditional delete', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+
+        leaseRepo.findReadyToKill.mockResolvedValue([
+            {
+                _id: 'org-uuid:repo:reacquired',
+                sandboxId: 'e2b-reacquired',
+                leaseCount: 0,
+                state: 'READY',
+                killAt: new Date(Date.now() - 1000),
+                createdAt: new Date(Date.now() - 60 * 1000),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any,
+        ]);
+        leaseRepo.markDeletingIfNoActiveLeases.mockResolvedValue(false);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        await reaper.killIdleSandboxes();
+
+        expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledWith(
+            'org-uuid:repo:reacquired',
+        );
+        expect(Sandbox.kill).not.toHaveBeenCalled();
+        expect(leaseRepo.delete).not.toHaveBeenCalled();
+        expect(mockLock.release).toHaveBeenCalledTimes(1);
+    });
+
+    it('killIdleSandboxes: removes local sandbox directory after marking the lease as deleting', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('');
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-test-'));
+
+        leaseRepo.findReadyToKill.mockResolvedValue([
+            {
+                _id: 'org-uuid:repo:local-idle',
+                sandboxId: tempDir,
+                leaseCount: 0,
+                state: 'READY',
+                killAt: new Date(Date.now() - 1000),
+                createdAt: new Date(Date.now() - 60 * 1000),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any,
+        ]);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        try {
+            await reaper.killIdleSandboxes();
+
+            expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledWith(
+                'org-uuid:repo:local-idle',
+            );
+            await expect(stat(tempDir)).rejects.toMatchObject({
+                code: 'ENOENT',
+            });
+            expect(leaseRepo.deleteIfNoActiveLeases).toHaveBeenCalledWith(
+                'org-uuid:repo:local-idle',
+            );
+            expect(leaseRepo.delete).not.toHaveBeenCalled();
+            expect(Sandbox.kill).not.toHaveBeenCalled();
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('killIdleSandboxes: keeps local idle lease when the directory is absent on this worker', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('');
+        const missingDir = join(
+            tmpdir(),
+            `kodus-sandbox-test-missing-idle-${Date.now()}`,
+        );
+
+        await rm(missingDir, { recursive: true, force: true });
+        leaseRepo.findReadyToKill.mockResolvedValue([
+            {
+                _id: 'org-uuid:repo:local-idle-missing',
+                sandboxId: missingDir,
+                leaseCount: 0,
+                state: 'READY',
+                killAt: new Date(Date.now() - 1000),
+                createdAt: new Date(Date.now() - 60 * 1000),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any,
+        ]);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        await reaper.killIdleSandboxes();
+
+        expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledWith(
+            'org-uuid:repo:local-idle-missing',
+        );
+        expect(leaseRepo.deleteIfNoActiveLeases).not.toHaveBeenCalled();
+        expect(leaseRepo.delete).not.toHaveBeenCalled();
+        expect(Sandbox.kill).not.toHaveBeenCalled();
+    });
+
+    it('killIdleSandboxes: leaves a marked local lease for the reaper when final delete loses the race', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('');
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-test-'));
+
+        leaseRepo.findReadyToKill.mockResolvedValue([
+            {
+                _id: 'org-uuid:repo:local-idle-race',
+                sandboxId: tempDir,
+                leaseCount: 0,
+                state: 'READY',
+                killAt: new Date(Date.now() - 1000),
+                createdAt: new Date(Date.now() - 60 * 1000),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any,
+        ]);
+        leaseRepo.deleteIfNoActiveLeases.mockResolvedValue(false);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        try {
+            await reaper.killIdleSandboxes();
+
+            expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledWith(
+                'org-uuid:repo:local-idle-race',
+            );
+            await expect(stat(tempDir)).rejects.toMatchObject({
+                code: 'ENOENT',
+            });
+            expect(leaseRepo.delete).not.toHaveBeenCalled();
+            expect(leaseRepo.deleteIfNoActiveLeases).toHaveBeenCalledWith(
+                'org-uuid:repo:local-idle-race',
+            );
+            expect(Sandbox.kill).not.toHaveBeenCalled();
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('killIdleSandboxes: limits concurrent idle cleanup work', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+        const leases = Array.from({ length: 6 }, (_, index) => ({
+            _id: `org-uuid:repo:idle-${index}`,
+            sandboxId: `e2b-idle-${index}`,
+            leaseCount: 0,
+            state: 'READY',
+            killAt: new Date(Date.now() - 1000),
+            createdAt: new Date(Date.now() - 60 * 1000),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        })) as any[];
+
+        let activeDeletes = 0;
+        let maxActiveDeletes = 0;
+        leaseRepo.findReadyToKill.mockResolvedValue(leases);
+        leaseRepo.markDeletingIfNoActiveLeases.mockImplementation(async () => {
+            activeDeletes++;
+            maxActiveDeletes = Math.max(maxActiveDeletes, activeDeletes);
+            await new Promise((resolve) => setTimeout(resolve, 10));
+            activeDeletes--;
+            return false;
+        });
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        await reaper.killIdleSandboxes();
+
+        expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledTimes(6);
+        expect(maxActiveDeletes).toBeLessThanOrEqual(5);
+        expect(Sandbox.kill).not.toHaveBeenCalled();
     });
 
     it('killIdleSandboxes: continues deleting Mongo doc even when Sandbox.kill fails', async () => {
@@ -908,9 +2231,49 @@ describe('SandboxLeaseReaperService', () => {
 
         await reaper.killIdleSandboxes();
 
-        // Doc deleted regardless — lease can't linger waiting for a sandbox
-        // that's already gone
+        expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledWith(
+            'org-uuid:repo:9',
+        );
         expect(leaseRepo.delete).toHaveBeenCalledWith('org-uuid:repo:9');
+        expect(mockLock.release).toHaveBeenCalledTimes(1);
+    });
+
+    it('killIdleSandboxes: keeps E2B lease doc when remote kill fails transiently', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+
+        leaseRepo.findReadyToKill.mockResolvedValue([
+            {
+                _id: 'org-uuid:repo:transient-kill-failure',
+                sandboxId: 'e2b-transient-failure',
+                leaseCount: 0,
+                state: 'READY',
+                killAt: new Date(Date.now() - 1000),
+                createdAt: new Date(Date.now() - 60 * 1000),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any,
+        ]);
+        (Sandbox.kill as jest.Mock).mockRejectedValueOnce(
+            new Error('rate limited'),
+        );
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        await reaper.killIdleSandboxes();
+
+        expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledWith(
+            'org-uuid:repo:transient-kill-failure',
+        );
+        expect(leaseRepo.delete).not.toHaveBeenCalled();
         expect(mockLock.release).toHaveBeenCalledTimes(1);
     });
 });

--- a/libs/sandbox/infrastructure/services/sandbox-lease-reaper.service.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-reaper.service.ts
@@ -1,21 +1,38 @@
-import { Injectable } from '@nestjs/common';
+import { Inject, Injectable } from '@nestjs/common';
 import { Cron, CronExpression } from '@nestjs/schedule';
 import { ConfigService } from '@nestjs/config';
 import { createLogger } from '@kodus/flow';
 import { Sandbox } from 'e2b';
 import {
-    DistributedLock,
-    DistributedLockService,
-} from '@libs/core/workflow/infrastructure/distributed-lock.service';
-import { SandboxLeaseRepository } from '@libs/sandbox/infrastructure/repositories/sandbox-lease.repository';
+    DISTRIBUTED_LOCK_SERVICE_TOKEN,
+    IDistributedLock,
+    IDistributedLockService,
+} from '@libs/core/workflow/domain/contracts/distributed-lock.service.contract';
+import {
+    ISandboxLeaseRepository,
+    SandboxLeaseRecord,
+    SANDBOX_LEASE_REPOSITORY_TOKEN,
+} from '@libs/sandbox/domain/contracts/sandbox-lease.repository.contract';
+import {
+    cleanupLocalSandboxDirectory,
+    isLocalSandboxPath,
+    localSandboxDirectoryExists,
+} from './local-sandbox-cleanup';
+
+const EXPIRED_LEASE_REAPER_BATCH_SIZE = 100;
+const EXPIRED_LEASE_REAPER_CONCURRENCY = 5;
+const IDLE_KILL_BATCH_SIZE = 100;
+const IDLE_KILL_CONCURRENCY = 5;
 
 @Injectable()
 export class SandboxLeaseReaperService {
     private readonly logger = createLogger(SandboxLeaseReaperService.name);
 
     constructor(
-        private readonly leaseRepository: SandboxLeaseRepository,
-        private readonly distributedLockService: DistributedLockService,
+        @Inject(SANDBOX_LEASE_REPOSITORY_TOKEN)
+        private readonly leaseRepository: ISandboxLeaseRepository,
+        @Inject(DISTRIBUTED_LOCK_SERVICE_TOKEN)
+        private readonly distributedLockService: IDistributedLockService,
         private readonly configService: ConfigService,
     ) {}
 
@@ -28,45 +45,22 @@ export class SandboxLeaseReaperService {
         if (!lock) return;
 
         try {
-            const expired = await this.leaseRepository.findExpired(new Date());
+            const now = new Date();
+            const expired = await this.leaseRepository.findExpired(
+                now,
+                EXPIRED_LEASE_REAPER_BATCH_SIZE,
+            );
             if (expired.length === 0) return;
 
             const apiKey = this.configService.get<string>('API_E2B_KEY');
 
-            await Promise.allSettled(
-                expired.map(async (lease) => {
-                    if (
-                        lease.sandboxId &&
-                        lease.state !== 'INVALIDATED' &&
-                        apiKey
-                    ) {
-                        await Sandbox.kill(lease.sandboxId, { apiKey }).catch(
-                            (err) => {
-                                this.logger.warn({
-                                    message:
-                                        '[SANDBOX-REAPER] Failed to kill sandbox — continuing',
-                                    context: SandboxLeaseReaperService.name,
-                                    metadata: {
-                                        sandboxId: lease.sandboxId,
-                                        error: String(err),
-                                    },
-                                });
-                            },
-                        );
-                    }
-
-                    await this.leaseRepository.delete(lease._id);
-
-                    this.logger.log({
-                        message: '[SANDBOX-REAPER] Reaped expired lease',
-                        context: SandboxLeaseReaperService.name,
-                        metadata: {
-                            prKey: lease._id,
-                            sandboxId: lease.sandboxId,
-                            state: lease.state,
-                        },
-                    });
-                }),
+            await this.processWithConcurrency(
+                expired,
+                EXPIRED_LEASE_REAPER_CONCURRENCY,
+                async (lease) => {
+                    await this.reapExpiredLease(lease, now, apiKey);
+                },
+                '[SANDBOX-REAPER]',
             );
         } finally {
             await this.releaseCronLock(
@@ -96,41 +90,21 @@ export class SandboxLeaseReaperService {
         if (!lock) return;
 
         try {
-            const ready = await this.leaseRepository.findReadyToKill(new Date());
+            const ready = await this.leaseRepository.findReadyToKill(
+                new Date(),
+                IDLE_KILL_BATCH_SIZE,
+            );
             if (ready.length === 0) return;
 
             const apiKey = this.configService.get<string>('API_E2B_KEY');
 
-            await Promise.allSettled(
-                ready.map(async (lease) => {
-                    if (lease.sandboxId && apiKey) {
-                        await Sandbox.kill(lease.sandboxId, { apiKey }).catch(
-                            (err) => {
-                                this.logger.warn({
-                                    message:
-                                        '[SANDBOX-IDLE-KILL] Failed to kill sandbox — Mongo doc still deleted; reaper will retry if E2B still has it',
-                                    context: SandboxLeaseReaperService.name,
-                                    metadata: {
-                                        sandboxId: lease.sandboxId,
-                                        error: String(err),
-                                    },
-                                });
-                            },
-                        );
-                    }
-
-                    await this.leaseRepository.delete(lease._id);
-
-                    this.logger.log({
-                        message: '[SANDBOX-IDLE-KILL] Killed idle sandbox',
-                        context: SandboxLeaseReaperService.name,
-                        metadata: {
-                            prKey: lease._id,
-                            sandboxId: lease.sandboxId,
-                            killAt: lease.killAt,
-                        },
-                    });
-                }),
+            await this.processWithConcurrency(
+                ready,
+                IDLE_KILL_CONCURRENCY,
+                async (lease) => {
+                    await this.killIdleSandbox(lease, apiKey);
+                },
+                '[SANDBOX-IDLE-KILL]',
             );
         } finally {
             await this.releaseCronLock(
@@ -140,10 +114,198 @@ export class SandboxLeaseReaperService {
         }
     }
 
+    private async reapExpiredLease(
+        lease: Pick<SandboxLeaseRecord, '_id' | 'sandboxId' | 'state'>,
+        expiredBefore: Date,
+        apiKey?: string,
+    ): Promise<void> {
+        const marked =
+            await this.leaseRepository.markExpiredDeletingIfNotRenewed(
+                lease._id,
+                expiredBefore,
+            );
+        if (!marked) {
+            this.logger.log({
+                message:
+                    '[SANDBOX-REAPER] Skipped expired lease because it was renewed',
+                context: SandboxLeaseReaperService.name,
+                metadata: {
+                    prKey: lease._id,
+                    sandboxId: lease.sandboxId,
+                },
+            });
+            return;
+        }
+
+        let cleaned: boolean;
+        if (lease.sandboxId && isLocalSandboxPath(lease.sandboxId)) {
+            cleaned = await this.cleanupLocalSandbox(
+                lease.sandboxId,
+                '[SANDBOX-REAPER]',
+            );
+            if (!cleaned) {
+                cleaned = !(await localSandboxDirectoryExists(lease.sandboxId));
+            }
+        } else if (lease.sandboxId && lease.state !== 'INVALIDATED' && apiKey) {
+            const killed = await this.killRemoteSandbox(
+                lease.sandboxId,
+                apiKey,
+                '[SANDBOX-REAPER]',
+            );
+            if (!killed) {
+                return;
+            }
+            cleaned = true;
+        } else {
+            cleaned = true;
+        }
+
+        if (!cleaned) {
+            return;
+        }
+
+        // Do not use deleteIfNoActiveLeases() here. The expired reaper is the
+        // recovery path for crashed workers and over-TTL leases, which can keep
+        // leaseCount > 0 forever. Once marked DELETING, new acquires roll back
+        // and retry after this document disappears.
+        await this.leaseRepository.delete(lease._id);
+
+        this.logger.log({
+            message: '[SANDBOX-REAPER] Reaped expired lease',
+            context: SandboxLeaseReaperService.name,
+            metadata: {
+                prKey: lease._id,
+                sandboxId: lease.sandboxId,
+                state: lease.state,
+            },
+        });
+    }
+
+    private async killIdleSandbox(
+        lease: Pick<SandboxLeaseRecord, '_id' | 'sandboxId' | 'killAt'>,
+        apiKey?: string,
+    ): Promise<void> {
+        if (lease.sandboxId && isLocalSandboxPath(lease.sandboxId)) {
+            const marked =
+                await this.leaseRepository.markDeletingIfNoActiveLeases(
+                    lease._id,
+                );
+            if (!marked) {
+                this.logger.log({
+                    message:
+                        '[SANDBOX-IDLE-KILL] Skipped sandbox because lease was re-acquired',
+                    context: SandboxLeaseReaperService.name,
+                    metadata: {
+                        prKey: lease._id,
+                        sandboxId: lease.sandboxId,
+                        killAt: lease.killAt,
+                    },
+                });
+                return;
+            }
+
+            const cleaned = await this.cleanupLocalSandbox(
+                lease.sandboxId,
+                '[SANDBOX-IDLE-KILL]',
+            );
+            if (!cleaned) {
+                return;
+            }
+
+            const deleted = await this.leaseRepository.deleteIfNoActiveLeases(
+                lease._id,
+            );
+            if (!deleted) {
+                this.logger.log({
+                    message:
+                        '[SANDBOX-IDLE-KILL] Skipped local sandbox lease delete because lease was re-acquired; expired reaper will retry',
+                    context: SandboxLeaseReaperService.name,
+                    metadata: {
+                        prKey: lease._id,
+                        sandboxId: lease.sandboxId,
+                        killAt: lease.killAt,
+                    },
+                });
+                return;
+            }
+        } else {
+            const marked =
+                await this.leaseRepository.markDeletingIfNoActiveLeases(
+                    lease._id,
+                );
+            if (!marked) {
+                this.logger.log({
+                    message:
+                        '[SANDBOX-IDLE-KILL] Skipped sandbox because lease was re-acquired',
+                    context: SandboxLeaseReaperService.name,
+                    metadata: {
+                        prKey: lease._id,
+                        sandboxId: lease.sandboxId,
+                        killAt: lease.killAt,
+                    },
+                });
+                return;
+            }
+
+            if (lease.sandboxId && apiKey) {
+                const killed = await this.killRemoteSandbox(
+                    lease.sandboxId,
+                    apiKey,
+                    '[SANDBOX-IDLE-KILL]',
+                );
+                if (!killed) {
+                    return;
+                }
+            }
+
+            await this.leaseRepository.delete(lease._id);
+        }
+
+        this.logger.log({
+            message: '[SANDBOX-IDLE-KILL] Killed idle sandbox',
+            context: SandboxLeaseReaperService.name,
+            metadata: {
+                prKey: lease._id,
+                sandboxId: lease.sandboxId,
+                killAt: lease.killAt,
+            },
+        });
+    }
+
+    private async processWithConcurrency<T>(
+        items: T[],
+        concurrency: number,
+        task: (item: T) => Promise<void>,
+        logPrefix: string,
+    ): Promise<void> {
+        let nextIndex = 0;
+        const workerCount = Math.min(concurrency, items.length);
+
+        await Promise.all(
+            Array.from({ length: workerCount }, async () => {
+                while (nextIndex < items.length) {
+                    const item = items[nextIndex++];
+
+                    try {
+                        await task(item);
+                    } catch (error) {
+                        this.logger.warn({
+                            message: `${logPrefix} Failed to process lease - continuing`,
+                            context: SandboxLeaseReaperService.name,
+                            metadata: {
+                                error: String(error),
+                            },
+                        });
+                    }
+                }
+            }),
+        );
+    }
+
     private async acquireCronLock(
         key: string,
         ttl: number,
-    ): Promise<DistributedLock | null> {
+    ): Promise<IDistributedLock | null> {
         try {
             return await this.distributedLockService.acquire(key, { ttl });
         } catch (error) {
@@ -156,8 +318,52 @@ export class SandboxLeaseReaperService {
         }
     }
 
+    private async cleanupLocalSandbox(
+        sandboxId: string,
+        logPrefix: string,
+    ): Promise<boolean> {
+        try {
+            return await cleanupLocalSandboxDirectory(sandboxId);
+        } catch (err) {
+            this.logger.warn({
+                message: `${logPrefix} Failed to remove local sandbox directory - continuing`,
+                context: SandboxLeaseReaperService.name,
+                metadata: {
+                    sandboxId,
+                    error: String(err),
+                },
+            });
+            return false;
+        }
+    }
+
+    private async killRemoteSandbox(
+        sandboxId: string,
+        apiKey: string,
+        logPrefix: string,
+    ): Promise<boolean> {
+        try {
+            await Sandbox.kill(sandboxId, { apiKey });
+            return true;
+        } catch (err) {
+            if (/not found|404/i.test(String(err))) {
+                return true;
+            }
+
+            this.logger.warn({
+                message: `${logPrefix} Failed to kill sandbox - continuing`,
+                context: SandboxLeaseReaperService.name,
+                metadata: {
+                    sandboxId,
+                    error: String(err),
+                },
+            });
+            return false;
+        }
+    }
+
     private async releaseCronLock(
-        lock: DistributedLock | null,
+        lock: IDistributedLock | null,
         errorMessage: string,
     ): Promise<void> {
         if (!lock) return;

--- a/libs/sandbox/modules/sandbox.module.ts
+++ b/libs/sandbox/modules/sandbox.module.ts
@@ -4,6 +4,7 @@ import { MongooseModule } from '@nestjs/mongoose';
 
 import { SANDBOX_PROVIDER_TOKEN } from '@libs/sandbox/domain/contracts/sandbox.provider';
 import { SANDBOX_LEASE_MANAGER_TOKEN } from '@libs/sandbox/domain/contracts/sandbox-lease-manager.contract';
+import { SANDBOX_LEASE_REPOSITORY_TOKEN } from '@libs/sandbox/domain/contracts/sandbox-lease.repository.contract';
 import { E2BSandboxService } from '@libs/sandbox/infrastructure/providers/e2b-sandbox.service';
 import { LocalSandboxService } from '@libs/sandbox/infrastructure/providers/local-sandbox.service';
 import { NullSandboxProvider } from '@libs/sandbox/infrastructure/providers/null-sandbox.service';
@@ -51,7 +52,10 @@ import { SandboxLeaseReaperService } from '@libs/sandbox/infrastructure/services
             },
             inject: [ConfigService],
         },
-        SandboxLeaseRepository,
+        {
+            provide: SANDBOX_LEASE_REPOSITORY_TOKEN,
+            useClass: SandboxLeaseRepository,
+        },
         {
             provide: SANDBOX_LEASE_MANAGER_TOKEN,
             useClass: SandboxLeaseManager,

--- a/test/unit/code-review/infrastructure/adapters/services/graph/graph-indexer.service.spec.ts
+++ b/test/unit/code-review/infrastructure/adapters/services/graph/graph-indexer.service.spec.ts
@@ -196,7 +196,7 @@ describe('GraphIndexerService', () => {
                 cmd.includes('kodus-graph parse --all'),
             );
             const parseCmd = runCmd(customSandbox, parseIdx);
-            expect(parseCmd).toContain('cd /workspace/my-repo');
+            expect(parseCmd).toContain("cd '/workspace/my-repo'");
             expect(parseCmd).not.toContain('/home/user/repo');
 
             const readFilePath = customSandbox.readFile.mock
@@ -436,7 +436,7 @@ describe('GraphIndexerService', () => {
                 cmd.includes('kodus-graph parse --files'),
             );
             const parseCmd = runCmd(customSandbox, parseIdx);
-            expect(parseCmd).toContain('cd /workspace/project');
+            expect(parseCmd).toContain("cd '/workspace/project'");
         });
     });
 });


### PR DESCRIPTION
## Summary
- clean up local sandbox /tmp directories across release, invalidate, idle-kill, and expired reaper paths
- harden local sandbox command/read/write boundaries for self-hosted workers
- add DELETING lease state recovery, bounded reaper batches, and supporting indexes

Supersedes #1386 and #1463.

## Verification
- pnpm test -- --runTestsByPath libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts libs/sandbox/infrastructure/services/local-sandbox-cleanup.spec.ts --no-coverage
- pnpm exec prettier --check ...changed sandbox files
- pnpm exec eslint ...changed sandbox files
- git diff --check
- pnpm exec tsc --noEmit --pretty false | rg ... still reports existing SandboxLeaseModel._id/CoreDocument mismatch
