### PR TITLE
fix: clean up local sandbox leases

### DIFF
--- a/docs/superpowers/plans/2026-07-06-local-sandbox-cleanup-hardflow.md
+++ b/docs/superpowers/plans/2026-07-06-local-sandbox-cleanup-hardflow.md
@@ -1,0 +1,526 @@
+# Local Sandbox Cleanup Hardflow Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stop self-hosted local sandbox `/tmp/kodus-sandbox-*` directory leaks without corrupting active leases, orphaning E2B sandboxes, or weakening local sandbox security.
+
+**Architecture:** Treat the Mongo lease document as the only durable retry record. Local filesystem cleanup, E2B kill, and lease deletion must be ordered so a failed resource cleanup leaves a retryable lease, while a successful cleanup can atomically delete only inactive leases. Local sandbox behavior must be separated from E2B behavior because local paths are worker-local and E2B sandbox ids are globally reconnectable.
+
+**Tech Stack:** NestJS services, Mongoose repository, Jest unit tests, local filesystem sandbox provider, E2B SDK, cron-based reapers with distributed locks.
+
+---
+
+## Why This Restart Exists
+
+The previous PR sequence found too many real issues after publication:
+
+- #1381: 16 Kody finding threads, 22 Kody review submissions.
+- #1386: 24 Kody finding threads, 28 Kody review submissions.
+- #1463: 21 Kody finding threads, 28 Kody review submissions.
+- #1464: 3 Kody finding threads, 3 Kody review submissions.
+
+The repeated findings were not random. They clustered into these failure classes:
+
+1. Lease lifecycle races: `release`, `invalidate`, `reapExpiredLeases`, `killIdleSandboxes`, stale reconnect, and concurrent `acquire` paths were reviewed independently instead of as one state machine.
+2. Cleanup retry loss: previous changes sometimes deleted the lease document before confirming local directory cleanup or E2B kill success.
+3. Worker-local path semantics: a local `/tmp/kodus-sandbox-*` path visible on one worker may be missing on another worker; missing locally is not the same as safely cleaned globally.
+4. Security hardening regressions: shell filtering, environment isolation, symlink checks, and path validation affected existing Graph/AST callers.
+5. Mongo semantics: `modifiedCount` vs `matchedCount`, unbounded queries, schema enum/index support, and atomic delete conditions were not reviewed up front.
+
+This plan makes those classes explicit before implementation.
+
+---
+
+## Current Main Baseline
+
+Fresh worktree:
+
+- Branch: `fix/local-sandbox-cleanup-hardflow`
+- Base: `origin/main` at `62822636b`
+- Closed PR: #1464
+- Dirty old worktree retained only as reference: `.worktrees/fix-local-sandbox-tmp-cleanup-v2`
+
+Current relevant files on main:
+
+- `libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts`
+    - E2B-oriented release/invalidate/create/connect behavior.
+    - No local sandbox-specific cleanup path.
+    - `connectToExisting` assumes E2B when `API_E2B_KEY` exists.
+- `libs/sandbox/infrastructure/services/sandbox-lease-reaper.service.ts`
+    - Deletes expired and idle lease docs unconditionally after attempted E2B kill.
+    - Uses unbounded query result sets.
+- `libs/sandbox/infrastructure/repositories/sandbox-lease.repository.ts`
+    - Has `upsertAcquire`, `decrementLease`, `updateReady`, `markInvalidated`, `findExpired`, `delete`, `setKillAt`, `clearKillAt`, `findReadyToKill`.
+    - Lacks local cleanup guards such as `deleteIfNoActiveLeases`, `markDeletingIfNoActiveLeases`, and bounded ready-to-kill query.
+- `libs/sandbox/infrastructure/repositories/schemas/sandbox-lease.model.ts`
+    - Must be checked before adding any state such as `DELETING`.
+- `libs/sandbox/infrastructure/providers/local-sandbox.service.ts`
+    - Creates local sandboxes in `tmpdir()` with prefix `kodus-sandbox-`.
+    - Existing security hardening must not be broadened in this cleanup PR unless required for cleanup correctness.
+
+---
+
+## Non-Goals
+
+Do not include these in the first replacement PR:
+
+- Broad local sandbox shell/security hardening unrelated to cleanup lifecycle.
+- Graph CLI command rewriting.
+- Large dependency injection refactors.
+- Reworking all sandbox provider abstractions.
+- Solving every historical Kody finding from old PRs if it is unrelated to `/tmp` cleanup correctness.
+
+If any of those are still needed, create follow-up issues or separate PRs.
+
+---
+
+## Hard Rules
+
+1. Never delete the only durable lease record before the associated resource cleanup has succeeded, except when the resource is proven already gone.
+2. Never remove a local directory unless the lease has first been atomically blocked from new reuse.
+3. Never delete a lease document after cleanup unless an atomic guard proves `leaseCount <= 0`.
+4. Never treat a missing local path on the current worker as proof that another worker cleaned it unless the path belongs to an expired/crashed-worker recovery path.
+5. Never let E2B kill failure delete the only retry record for a still-running remote sandbox.
+6. Every state transition must have a recovery path after worker crash.
+7. Every query used by a cron must be bounded or intentionally documented as bounded by an indexed predicate.
+8. Every Kody finding class listed above must map to at least one test or explicit non-goal.
+
+---
+
+## State Model
+
+Use the current states unless a task explicitly adds `DELETING`:
+
+- `CREATING`: creator acquired the lease and is creating a sandbox.
+- `READY`: sandbox id/path is available for reuse.
+- `PAUSED`: existing state; do not expand behavior in this PR unless current callers depend on it.
+- `INVALIDATED`: PR closed/force-pushed during creation.
+- `DELETING` if added: cleanup is in progress; joiners must not reuse the sandbox and must retry or cold-start after bounded wait.
+
+Required invariant:
+
+```text
+READY + local sandbox path => directory may exist only on the worker that created it.
+READY + E2B sandbox id     => sandbox can be globally reconnected via E2B.
+DELETING                  => no caller may reuse sandboxId/path.
+deleted lease doc          => no resource remains that needs retry cleanup, or resource is proven unreachable/gone.
+```
+
+---
+
+## Failure Matrix
+
+| Path                                           | Cleanup succeeds                                                            | Cleanup fails                                     | Concurrent acquire                                                     | Worker crash                         |
+| ---------------------------------------------- | --------------------------------------------------------------------------- | ------------------------------------------------- | ---------------------------------------------------------------------- | ------------------------------------ |
+| local `release()` last lease                   | delete lease with `deleteIfNoActiveLeases`                                  | keep retryable lease                              | atomic mark/delete prevents active directory deletion                  | reaper recovers if state/doc remains |
+| local `invalidate()` READY                     | block reuse, cleanup, guarded delete                                        | keep retryable lease                              | no new reuse after block                                               | reaper recovers                      |
+| local creator path after `updateReady` failure | cleanup local dir, guarded/doc delete                                       | keep lease doc                                    | no returned sandbox                                                    | reaper recovers                      |
+| local reconnect missing path                   | rollback this acquire; cold-start only if no active leases and path missing | preserve lease on uncertain errors                | no global delete while active leases remain                            | expired reaper handles stale doc     |
+| E2B idle-kill                                  | kill remote first, then guarded delete                                      | keep lease for retry                              | `clearKillAt`/guard prevents killing active lease                      | next cron retries                    |
+| E2B expired reaper                             | kill remote or detect gone, then delete                                     | keep doc for retry unless provider says not found | expired leases may be crashed-worker leases; deletion must be explicit | next cron retries                    |
+
+---
+
+## Kody-Style Pre-Review Checklist
+
+Before opening any replacement PR, answer each item in the PR body:
+
+- Can a failed local `rm` leave a `/tmp/kodus-sandbox-*` directory without a lease record? Expected answer: no.
+- Can a concurrent `acquire` have its active local directory removed by `release`, `invalidate`, or reaper? Expected answer: no.
+- Can an E2B kill failure remove the Mongo record needed to retry kill? Expected answer: no.
+- Can a local path from worker A cause worker B to delete global state while worker A still owns the directory? Expected answer: only in expired crashed-worker recovery, with documented guard.
+- Can `setKillAt` idempotently write the same timestamp without being misread as a lost race? Expected answer: yes, guarded match result is used.
+- Are cron scans bounded? Expected answer: yes or documented with indexed low-cardinality bound.
+- Does every new Mongo state have schema enum and index support? Expected answer: yes.
+- Are existing local provider security behaviors unchanged unless covered by tests in this PR? Expected answer: yes.
+
+---
+
+## PR Split
+
+Replacement work should be split if the first implementation grows beyond cleanup lifecycle:
+
+1. PR A: local sandbox cleanup lifecycle only.
+2. PR B: E2B kill/reaper retry semantics and bounded cron queries if not needed by PR A.
+3. PR C: local sandbox provider security hardening follow-ups if still necessary.
+
+Start with PR A.
+
+---
+
+## Task 1: Baseline Tests and Existing Behavior Map
+
+**Files:**
+
+- Read: `libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts`
+- Read: `libs/sandbox/infrastructure/services/sandbox-lease-reaper.service.ts`
+- Read: `libs/sandbox/infrastructure/repositories/sandbox-lease.repository.ts`
+- Read: `libs/sandbox/infrastructure/repositories/schemas/sandbox-lease.model.ts`
+- Read: `libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts`
+- Read: `libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts`
+
+- [ ] **Step 1: Run current sandbox tests before implementation**
+
+Run:
+
+```bash
+pnpm test -- --runTestsByPath libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts libs/sandbox/infrastructure/providers/local-sandbox.exec-streams.spec.ts test/unit/code-review/pipeline/stages/create-sandbox.stage.spec.ts --no-coverage --runInBand
+```
+
+Expected: pass, or record unrelated baseline failures before code changes.
+
+- [ ] **Step 2: Record current cleanup behavior**
+
+Add a short note to this plan under "Baseline Notes" with:
+
+```text
+release local path behavior:
+invalidate local path behavior:
+expired reaper local path behavior:
+idle reaper local path behavior:
+creator failure local path behavior:
+local reconnect behavior when API_E2B_KEY exists:
+```
+
+- [ ] **Step 3: Stop if baseline has sandbox failures**
+
+If baseline sandbox tests fail, fix or explain the baseline first. Do not implement cleanup changes on a failing baseline.
+
+---
+
+## Task 2: Add Local Sandbox Path Cleanup Utility
+
+**Files:**
+
+- Create: `libs/sandbox/infrastructure/services/local-sandbox-cleanup.ts`
+- Test: `libs/sandbox/infrastructure/services/local-sandbox-cleanup.spec.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests for:
+
+```typescript
+expect(isLocalSandboxPath(join(tmpdir(), 'kodus-sandbox-abc'))).toBe(true);
+expect(isLocalSandboxPath('/var/tmp/kodus-sandbox-abc')).toBe(false);
+expect(await cleanupLocalSandboxDirectory(validExistingDir)).toBe(true);
+expect(await cleanupLocalSandboxDirectory(validMissingDir)).toBe(false);
+await expect(cleanupLocalSandboxDirectory('/etc')).resolves.toBe(false);
+```
+
+Run:
+
+```bash
+pnpm test -- --runTestsByPath libs/sandbox/infrastructure/services/local-sandbox-cleanup.spec.ts --no-coverage --runInBand
+```
+
+Expected: fail because the utility does not exist.
+
+- [ ] **Step 2: Implement utility**
+
+Required exported functions:
+
+```typescript
+export function isLocalSandboxPath(sandboxId?: string): boolean;
+export async function localSandboxDirectoryExists(
+    sandboxId?: string,
+): Promise<boolean>;
+export async function cleanupLocalSandboxDirectory(
+    sandboxId?: string,
+): Promise<boolean>;
+```
+
+Required behavior:
+
+- Accept only absolute paths whose parent directory is `resolve(tmpdir())`.
+- Require basename prefix `kodus-sandbox-`.
+- Return `false` for invalid paths.
+- Return `false` for missing local sandbox directories.
+- Throw non-`ENOENT` `lstat` errors so callers can preserve retry records.
+- Use `rm(resolved, { recursive: true, force: true })` only after existence check succeeds.
+
+- [ ] **Step 3: Verify utility tests**
+
+Run the same test command. Expected: pass.
+
+---
+
+## Task 3: Repository Atomic Guards
+
+**Files:**
+
+- Modify: `libs/sandbox/infrastructure/repositories/sandbox-lease.repository.ts`
+- Modify: `libs/sandbox/infrastructure/repositories/schemas/sandbox-lease.model.ts`
+- Test: `libs/sandbox/infrastructure/repositories/sandbox-lease.repository.spec.ts`
+
+- [ ] **Step 1: Write repository tests**
+
+Add tests using a mocked `leaseModel` for:
+
+```typescript
+deleteIfNoActiveLeases('pr') returns true when deletedCount is 1
+deleteIfNoActiveLeases('pr') returns false when deletedCount is 0
+setKillAt('pr', sameDate) returns true when matchedCount is 1 and modifiedCount is 0
+setKillAt('pr', date) returns false when matchedCount is 0
+findReadyToKill(now, limit) calls .limit(limit)
+```
+
+- [ ] **Step 2: Add guarded repository methods**
+
+Required methods:
+
+```typescript
+async deleteIfNoActiveLeases(prKey: string): Promise<boolean>
+async setKillAt(prKey: string, killAt: Date): Promise<boolean>
+async findReadyToKill(now: Date, limit: number): Promise<Array<Pick<SandboxLeaseModel, '_id' | 'sandboxId' | 'killAt'>>>
+```
+
+Required behavior:
+
+- `deleteIfNoActiveLeases` must filter `{ _id: prKey, leaseCount: { $lte: 0 } }`.
+- `setKillAt` must filter `{ _id: prKey, leaseCount: { $lte: 0 }, sandboxId: { $exists: true, $ne: '' } }`.
+- `setKillAt` must return `matchedCount > 0`, not `modifiedCount > 0`.
+- `findReadyToKill` must apply an explicit limit.
+
+- [ ] **Step 3: Verify repository tests**
+
+Run:
+
+```bash
+pnpm test -- --runTestsByPath libs/sandbox/infrastructure/repositories/sandbox-lease.repository.spec.ts --no-coverage --runInBand
+```
+
+Expected: pass.
+
+---
+
+## Task 4: Local Release and Invalidate Cleanup
+
+**Files:**
+
+- Modify: `libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts`
+- Test: `libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts`
+
+- [ ] **Step 1: Write failing manager tests**
+
+Add tests for:
+
+```typescript
+release removes local sandbox directory when last lease reaches zero
+release keeps lease when local cleanup returns false
+release does not call Sandbox.setTimeout for local sandbox paths
+release skips local cleanup when delete/mark guard reports re-acquired lease
+invalidate removes local sandbox directory before deleting inactive lease
+invalidate preserves lease when local cleanup fails
+```
+
+- [ ] **Step 2: Implement local release path**
+
+Required behavior:
+
+- Branch on `isLocalSandboxPath(updated.sandboxId)` before E2B idle-kill logic.
+- Do not call `Sandbox.setTimeout` for local paths.
+- Do not call `leaseRepo.delete(prKey)` unconditionally.
+- Cleanup local directory only after an atomic no-active guard prevents reuse.
+- Delete lease only after cleanup succeeded and `deleteIfNoActiveLeases` returns true.
+- If cleanup fails, keep the lease record for retry.
+
+- [ ] **Step 3: Implement local invalidate path**
+
+Required behavior:
+
+- For `CREATING`, preserve existing `INVALIDATED` behavior.
+- For `READY` local sandbox path, block reuse before cleanup.
+- Delete lease only when cleanup succeeded and no active leases remain.
+- If cleanup fails, keep lease for retry and log warning.
+
+- [ ] **Step 4: Verify manager tests**
+
+Run:
+
+```bash
+pnpm test -- --runTestsByPath libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts --no-coverage --runInBand
+```
+
+Expected: pass.
+
+---
+
+## Task 5: Local Creator Failure and Local Reconnect Semantics
+
+**Files:**
+
+- Modify: `libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts`
+- Test: `libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests for:
+
+```typescript
+creator-path local cleanup failure preserves the lease for reaper retry
+creator-path local cleanup success allows lease cleanup
+local reconnect missing directory rolls back this acquire and cold-starts only when no active leases remain
+local reconnect provider failure with existing directory preserves lease and rethrows original error
+local reconnect must not call Sandbox.connect for local paths even when API_E2B_KEY exists
+```
+
+- [ ] **Step 2: Implement local reconnect branch**
+
+Required behavior:
+
+- Detect local sandbox paths before E2B connect.
+- Use `sandboxProvider.connectToExistingSandbox` when available.
+- On reconnect failure:
+    - remove local `leaseId` tracking;
+    - decrement the acquire that just joined;
+    - only treat it as stale/cold-start if no active leases remain and `localSandboxDirectoryExists` returns false;
+    - if the directory exists or existence check fails, preserve the lease and rethrow.
+
+- [ ] **Step 3: Implement creator failure cleanup**
+
+Required behavior:
+
+- If a local sandbox was created and a later step fails, call local cleanup.
+- If local cleanup returns false or throws, preserve the lease document.
+- Never delete the lease document after a failed local cleanup.
+
+- [ ] **Step 4: Verify tests**
+
+Run:
+
+```bash
+pnpm test -- --runTestsByPath libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts libs/sandbox/infrastructure/services/local-sandbox-cleanup.spec.ts --no-coverage --runInBand
+```
+
+Expected: pass.
+
+---
+
+## Task 6: Reaper Local and Remote Retry Semantics
+
+**Files:**
+
+- Modify: `libs/sandbox/infrastructure/services/sandbox-lease-reaper.service.ts`
+- Modify: `libs/sandbox/infrastructure/repositories/sandbox-lease.repository.ts`
+- Test: `libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts`
+
+- [ ] **Step 1: Write failing reaper tests**
+
+Add tests for:
+
+```typescript
+expired reaper deletes local lease when local directory is missing and lease is expired
+expired reaper keeps local lease when cleanup throws non-ENOENT error
+idle reaper does not delete E2B lease when Sandbox.kill fails
+idle reaper applies bounded findReadyToKill limit
+expired reaper processes bounded batches or has explicit repository limit
+```
+
+- [ ] **Step 2: Implement reaper behavior**
+
+Required behavior:
+
+- Local expired leases may be deleted when the directory is missing because expiration is crashed-worker recovery.
+- Local non-expired idle cleanup must not delete global state just because a path is missing on the current worker.
+- E2B kill failure must keep the lease record for retry unless the provider reports not found.
+- Reaper queries must be bounded.
+
+- [ ] **Step 3: Verify reaper tests**
+
+Run:
+
+```bash
+pnpm test -- --runTestsByPath libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts --no-coverage --runInBand
+```
+
+Expected: pass.
+
+---
+
+## Task 7: Full Verification Before PR
+
+**Files:**
+
+- No implementation files unless prior tasks changed them.
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+pnpm test -- --runTestsByPath libs/sandbox/infrastructure/repositories/sandbox-lease.repository.spec.ts libs/sandbox/infrastructure/services/local-sandbox-cleanup.spec.ts libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts libs/sandbox/infrastructure/providers/local-sandbox.exec-streams.spec.ts test/unit/code-review/pipeline/stages/create-sandbox.stage.spec.ts --no-coverage --runInBand
+```
+
+Expected: pass.
+
+- [ ] **Step 2: Run formatting and lint**
+
+Run:
+
+```bash
+pnpm exec prettier --check libs/sandbox/infrastructure/repositories/sandbox-lease.repository.ts libs/sandbox/infrastructure/repositories/schemas/sandbox-lease.model.ts libs/sandbox/infrastructure/services/local-sandbox-cleanup.ts libs/sandbox/infrastructure/services/local-sandbox-cleanup.spec.ts libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts libs/sandbox/infrastructure/services/sandbox-lease-reaper.service.ts libs/sandbox/infrastructure/providers/local-sandbox.service.ts
+pnpm exec eslint libs/sandbox/infrastructure/repositories/sandbox-lease.repository.ts libs/sandbox/infrastructure/repositories/schemas/sandbox-lease.model.ts libs/sandbox/infrastructure/services/local-sandbox-cleanup.ts libs/sandbox/infrastructure/services/local-sandbox-cleanup.spec.ts libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts libs/sandbox/infrastructure/services/sandbox-lease-reaper.service.ts libs/sandbox/infrastructure/providers/local-sandbox.service.ts
+git diff --check
+```
+
+Expected: pass.
+
+- [ ] **Step 3: Run typecheck and record known failures**
+
+Run:
+
+```bash
+pnpm exec tsc --noEmit --pretty false 2>&1 | rg 'libs/sandbox|sandbox-lease|SandboxLease'
+```
+
+Expected: no new sandbox errors. If existing main has sandbox errors, record exact file/line in PR body.
+
+- [ ] **Step 4: Kody pre-review**
+
+Before creating the PR, manually answer the "Kody-Style Pre-Review Checklist" above. Do not open the PR until every answer is supported by a test, a code reference, or a documented non-goal.
+
+---
+
+## Baseline Notes
+
+```text
+release local path behavior:
+  Current main does not branch on local sandbox paths. When leaseCount reaches
+  zero and sandboxId is a local /tmp path, release writes killAt and, if
+  API_E2B_KEY exists, attempts Sandbox.setTimeout with the local path.
+
+invalidate local path behavior:
+  Current main does not branch on local sandbox paths. READY/PAUSED leases use
+  the E2B soft-drain path when API_E2B_KEY exists, then delete the lease doc
+  unconditionally. No local directory cleanup is attempted.
+
+expired reaper local path behavior:
+  Current main treats every sandboxId as E2B when API_E2B_KEY exists, attempts
+  Sandbox.kill, then deletes the lease doc unconditionally. No local directory
+  cleanup is attempted and the result set is unbounded.
+
+idle reaper local path behavior:
+  Current main treats every ready-to-kill sandboxId as E2B when API_E2B_KEY
+  exists, attempts Sandbox.kill, then deletes the lease doc unconditionally.
+  No local directory cleanup is attempted and the result set is unbounded.
+
+creator failure local path behavior:
+  Current main attempts E2B kill only when API_E2B_KEY exists, then deletes the
+  lease doc unconditionally. A local directory created before a later Mongo
+  failure can be orphaned because no local cleanup path exists.
+
+local reconnect behavior when API_E2B_KEY exists:
+  Current main has no local reconnect branch. connectToExisting uses
+  Sandbox.connect for any non-empty sandboxId when API_E2B_KEY exists, so a
+  local /tmp path can be sent to E2B. On connect failure it deletes the lease
+  and retries acquire as stale E2B.
+
+baseline focused tests:
+  2026-07-06: pnpm test -- --runTestsByPath
+  libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
+  libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts
+  libs/sandbox/infrastructure/providers/local-sandbox.exec-streams.spec.ts
+  test/unit/code-review/pipeline/stages/create-sandbox.stage.spec.ts
+  --no-coverage --runInBand
+  Result: 4 suites passed, 39 tests passed.
+```

--- a/libs/sandbox/domain/contracts/sandbox.provider.ts
+++ b/libs/sandbox/domain/contracts/sandbox.provider.ts
@@ -52,11 +52,18 @@ export interface SandboxInstance {
     /** Absolute path to the repo root inside the sandbox */
     repoDir: string;
     /** Run a shell command inside the sandbox */
-    run(command: string, opts?: { timeoutMs?: number }): Promise<SandboxRunResult>;
+    run(
+        command: string,
+        opts?: { timeoutMs?: number },
+    ): Promise<SandboxRunResult>;
     /** Read a file from the sandbox filesystem */
     readFile(path: string, opts?: { timeoutMs?: number }): Promise<string>;
     /** Write a file to the sandbox filesystem */
-    writeFile(path: string, content: string, opts?: { timeoutMs?: number }): Promise<void>;
+    writeFile(
+        path: string,
+        content: string,
+        opts?: { timeoutMs?: number },
+    ): Promise<void>;
 }
 
 export interface ISandboxProvider {
@@ -67,6 +74,15 @@ export interface ISandboxProvider {
     createSandboxWithRepo(
         params: CreateSandboxParams,
     ): Promise<SandboxInstance>;
+
+    /**
+     * Reconnect to a previously-created sandbox by sandboxId.
+     *
+     * Local sandbox ids are worker-local filesystem paths. E2B sandbox ids are
+     * globally reconnectable through the E2B API. Providers may omit this when
+     * reconnect is not supported.
+     */
+    connectToExistingSandbox?(sandboxId: string): Promise<SandboxInstance>;
 }
 
 export const SANDBOX_PROVIDER_TOKEN = Symbol('SANDBOX_PROVIDER_TOKEN');

--- a/libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts
+++ b/libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts
@@ -1,5 +1,8 @@
 import { PlatformType } from '@libs/core/domain/enums';
 import { LocalSandboxService } from './local-sandbox.service';
+import { mkdtemp, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 /**
  * buildAuthHeader is the git-over-HTTPS Authorization builder used when the
@@ -16,9 +19,10 @@ describe('LocalSandboxService.buildAuthHeader', () => {
         (service as any).buildAuthHeader(platform, token, username) as string;
 
     const decode = (header: string) =>
-        Buffer.from(header.replace('Authorization: Basic ', ''), 'base64').toString(
-            'utf8',
-        );
+        Buffer.from(
+            header.replace('Authorization: Basic ', ''),
+            'base64',
+        ).toString('utf8');
 
     it('uses x-access-token for GitHub', () => {
         expect(decode(build(PlatformType.GITHUB, 'ghtok'))).toBe(
@@ -27,7 +31,9 @@ describe('LocalSandboxService.buildAuthHeader', () => {
     });
 
     it('uses oauth2 for GitLab and Azure', () => {
-        expect(decode(build(PlatformType.GITLAB, 'gltok'))).toBe('oauth2:gltok');
+        expect(decode(build(PlatformType.GITLAB, 'gltok'))).toBe(
+            'oauth2:gltok',
+        );
         expect(decode(build(PlatformType.AZURE_REPOS, 'aztok'))).toBe(
             'oauth2:aztok',
         );
@@ -47,7 +53,9 @@ describe('LocalSandboxService.buildAuthHeader', () => {
 
         it('uses the account username for classic app passwords', () => {
             expect(
-                decode(build(PlatformType.BITBUCKET, 'classicapppw', 'kodususer')),
+                decode(
+                    build(PlatformType.BITBUCKET, 'classicapppw', 'kodususer'),
+                ),
             ).toBe('kodususer:classicapppw');
         });
 
@@ -62,5 +70,40 @@ describe('LocalSandboxService.buildAuthHeader', () => {
                 /Bitbucket authentication requires/i,
             );
         });
+    });
+});
+
+describe('LocalSandboxService.connectToExistingSandbox', () => {
+    const service = new LocalSandboxService({} as any);
+
+    it('reconnects to an existing local sandbox directory', async () => {
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        await writeFile(join(tempDir, 'README.md'), 'hello', 'utf-8');
+
+        try {
+            const sandbox = await service.connectToExistingSandbox(tempDir);
+
+            expect(sandbox.type).toBe('local');
+            expect(sandbox.sandboxId).toBe(tempDir);
+            expect(sandbox.repoDir).toBe(tempDir);
+            await expect(sandbox.readFile('README.md')).resolves.toBe('hello');
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('rejects unsafe reconnect paths', async () => {
+        await expect(
+            service.connectToExistingSandbox('/tmp/not-kodus-sandbox-test'),
+        ).rejects.toThrow(/refusing to reconnect unsafe sandbox path/i);
+    });
+
+    it('rejects missing local sandbox directories', async () => {
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        await rm(tempDir, { recursive: true, force: true });
+
+        await expect(
+            service.connectToExistingSandbox(tempDir),
+        ).rejects.toThrow();
     });
 });

--- a/libs/sandbox/infrastructure/providers/local-sandbox.service.ts
+++ b/libs/sandbox/infrastructure/providers/local-sandbox.service.ts
@@ -23,6 +23,7 @@ import {
     SandboxRunResult,
 } from '@libs/sandbox/domain/contracts/sandbox.provider';
 import { RemoteCommands } from '@libs/code-review/infrastructure/adapters/services/collectCrossFileContexts.service';
+import { isLocalSandboxPath } from '../services/local-sandbox-cleanup';
 
 const execFileAsync = promisify(execFile);
 
@@ -137,116 +138,7 @@ export class LocalSandboxService implements ISandboxProvider {
                 await this.applyLocalDiff(tempDir, unifiedDiff);
             }
 
-            const remoteCommands = this.buildRemoteCommands(tempDir);
-
-            const capturedTempDir = tempDir;
-            const cleanup = async () => {
-                try {
-                    await rm(capturedTempDir, { recursive: true, force: true });
-                } catch (error) {
-                    this.logger.warn({
-                        message: `Failed to remove temp dir ${capturedTempDir}`,
-                        context: LocalSandboxService.name,
-                        error,
-                    });
-                }
-            };
-
-            const capturedRepoDir = tempDir;
-
-            // Privileged shell exec for infrastructure callers (graph build,
-            // AST extraction, sandbox bootstrap). Unlike `remoteCommands.exec`
-            // this does NOT whitelist programs — it runs the command through
-            // /bin/sh so mkdir, pipes, redirections, etc. work. That power
-            // comes with a safety contract: **callers MUST shell-quote any
-            // value that could come (directly or transitively) from user
-            // input** (PR filenames, branch names, commit messages, etc.).
-            //
-            // As a runtime tripwire we reject command substitution (`$(...)`
-            // and backticks) on the raw string. Internal infrastructure
-            // commands have no legitimate need to spawn subshells, and a
-            // leaked `$()` is the most common path from "string concatenation
-            // bug" to RCE. The block is conservative by design — if a real
-            // use case ever needs command substitution, it should opt in
-            // explicitly instead of piggybacking on this entry point.
-            const run = async (
-                command: string,
-                opts?: { timeoutMs?: number },
-            ): Promise<SandboxRunResult> => {
-                if (/`|\$\(/.test(command)) {
-                    this.logger.warn({
-                        message:
-                            'Rejected sandbox.run command containing shell substitution',
-                        context: LocalSandboxService.name,
-                        metadata: {
-                            preview: command.slice(0, 200),
-                        },
-                    });
-                    return {
-                        stdout: '',
-                        stderr: 'Command substitution ($(...) / backticks) is not allowed in sandbox.run',
-                        exitCode: 1,
-                    };
-                }
-
-                const execAsync = promisify(exec);
-                try {
-                    const { stdout, stderr } = await execAsync(command, {
-                        cwd: capturedRepoDir,
-                        timeout: opts?.timeoutMs ?? CMD_TIMEOUT_MS,
-                        maxBuffer: MAX_BUFFER,
-                        env: process.env,
-                    });
-                    return {
-                        stdout: stdout || '',
-                        stderr: stderr || '',
-                        exitCode: 0,
-                    };
-                } catch (error: any) {
-                    return {
-                        stdout: error.stdout || '',
-                        stderr: error.stderr || '',
-                        exitCode: error.code ?? 1,
-                    };
-                }
-            };
-
-            // Path safety: reads go through `resolveSafePath` so absolute
-            // paths, `..` traversals, and symlink escapes are all rejected
-            // at the boundary. Writes can target files that don't exist
-            // yet (so `lstat`/`realpath` don't apply), but we still
-            // normalize and compare against the repo root so the final
-            // target can't escape — `validatePath` plus the prefix check
-            // covers `../..`, `/etc/...`, and embedded traversals.
-            const sandboxReadFile = async (path: string): Promise<string> => {
-                const fullPath = path.startsWith('/')
-                    ? path
-                    : join(capturedRepoDir, path);
-                return readFile(fullPath, 'utf-8');
-            };
-
-            const sandboxWriteFile = async (
-                path: string,
-                content: string,
-            ): Promise<void> => {
-                const fullPath = path.startsWith('/')
-                    ? path
-                    : join(capturedRepoDir, path);
-                const dir = join(fullPath, '..');
-                await mkdir(dir, { recursive: true });
-                await writeFile(fullPath, content, 'utf-8');
-            };
-
-            return {
-                remoteCommands,
-                cleanup,
-                type: 'local' as const,
-                sandboxId: capturedRepoDir,
-                repoDir: capturedRepoDir,
-                run,
-                readFile: sandboxReadFile,
-                writeFile: sandboxWriteFile,
-            };
+            return this.buildSandboxInstance(tempDir);
         } catch (error) {
             try {
                 await rm(tempDir, { recursive: true, force: true });
@@ -255,6 +147,136 @@ export class LocalSandboxService implements ISandboxProvider {
             }
             throw error;
         }
+    }
+
+    async connectToExistingSandbox(
+        sandboxId: string,
+    ): Promise<SandboxInstance> {
+        if (!isLocalSandboxPath(sandboxId)) {
+            throw new Error(
+                `LocalSandboxService: refusing to reconnect unsafe sandbox path "${sandboxId}"`,
+            );
+        }
+
+        const stat = await lstat(sandboxId);
+        if (!stat.isDirectory()) {
+            throw new Error(
+                `LocalSandboxService: sandbox path is not a directory "${sandboxId}"`,
+            );
+        }
+
+        return this.buildSandboxInstance(sandboxId);
+    }
+
+    private buildSandboxInstance(repoDir: string): SandboxInstance {
+        const remoteCommands = this.buildRemoteCommands(repoDir);
+        const capturedRepoDir = repoDir;
+
+        const cleanup = async () => {
+            try {
+                await rm(capturedRepoDir, { recursive: true, force: true });
+            } catch (error) {
+                this.logger.warn({
+                    message: `Failed to remove temp dir ${capturedRepoDir}`,
+                    context: LocalSandboxService.name,
+                    error,
+                });
+            }
+        };
+
+        // Privileged shell exec for infrastructure callers (graph build,
+        // AST extraction, sandbox bootstrap). Unlike `remoteCommands.exec`
+        // this does NOT whitelist programs — it runs the command through
+        // /bin/sh so mkdir, pipes, redirections, etc. work. That power
+        // comes with a safety contract: **callers MUST shell-quote any
+        // value that could come (directly or transitively) from user
+        // input** (PR filenames, branch names, commit messages, etc.).
+        //
+        // As a runtime tripwire we reject command substitution (`$(...)`
+        // and backticks) on the raw string. Internal infrastructure
+        // commands have no legitimate need to spawn subshells, and a
+        // leaked `$()` is the most common path from "string concatenation
+        // bug" to RCE. The block is conservative by design — if a real
+        // use case ever needs command substitution, it should opt in
+        // explicitly instead of piggybacking on this entry point.
+        const run = async (
+            command: string,
+            opts?: { timeoutMs?: number },
+        ): Promise<SandboxRunResult> => {
+            if (/`|\$\(/.test(command)) {
+                this.logger.warn({
+                    message:
+                        'Rejected sandbox.run command containing shell substitution',
+                    context: LocalSandboxService.name,
+                    metadata: {
+                        preview: command.slice(0, 200),
+                    },
+                });
+                return {
+                    stdout: '',
+                    stderr: 'Command substitution ($(...) / backticks) is not allowed in sandbox.run',
+                    exitCode: 1,
+                };
+            }
+
+            const execAsync = promisify(exec);
+            try {
+                const { stdout, stderr } = await execAsync(command, {
+                    cwd: capturedRepoDir,
+                    timeout: opts?.timeoutMs ?? CMD_TIMEOUT_MS,
+                    maxBuffer: MAX_BUFFER,
+                    env: process.env,
+                });
+                return {
+                    stdout: stdout || '',
+                    stderr: stderr || '',
+                    exitCode: 0,
+                };
+            } catch (error: any) {
+                return {
+                    stdout: error.stdout || '',
+                    stderr: error.stderr || '',
+                    exitCode: error.code ?? 1,
+                };
+            }
+        };
+
+        // Path safety: reads go through `resolveSafePath` so absolute
+        // paths, `..` traversals, and symlink escapes are all rejected
+        // at the boundary. Writes can target files that don't exist
+        // yet (so `lstat`/`realpath` don't apply), but we still
+        // normalize and compare against the repo root so the final
+        // target can't escape — `validatePath` plus the prefix check
+        // covers `../..`, `/etc/...`, and embedded traversals.
+        const sandboxReadFile = async (path: string): Promise<string> => {
+            const fullPath = path.startsWith('/')
+                ? path
+                : join(capturedRepoDir, path);
+            return readFile(fullPath, 'utf-8');
+        };
+
+        const sandboxWriteFile = async (
+            path: string,
+            content: string,
+        ): Promise<void> => {
+            const fullPath = path.startsWith('/')
+                ? path
+                : join(capturedRepoDir, path);
+            const dir = join(fullPath, '..');
+            await mkdir(dir, { recursive: true });
+            await writeFile(fullPath, content, 'utf-8');
+        };
+
+        return {
+            remoteCommands,
+            cleanup,
+            type: 'local' as const,
+            sandboxId: capturedRepoDir,
+            repoDir: capturedRepoDir,
+            run,
+            readFile: sandboxReadFile,
+            writeFile: sandboxWriteFile,
+        };
     }
 
     private buildRemoteCommands(repoDir: string): RemoteCommands {
@@ -600,7 +622,13 @@ export class LocalSandboxService implements ISandboxProvider {
         try {
             await execFileAsync(
                 'git',
-                ['-C', repoDir, 'config', 'user.email', 'kodus-cli@kodus.local'],
+                [
+                    '-C',
+                    repoDir,
+                    'config',
+                    'user.email',
+                    'kodus-cli@kodus.local',
+                ],
                 { timeout: 5_000 },
             );
             await execFileAsync(
@@ -626,8 +654,7 @@ export class LocalSandboxService implements ISandboxProvider {
                 { timeout: CLONE_TIMEOUT_MS },
             );
             this.logger.log({
-                message:
-                    'CLI diff applied successfully on top of merge-base',
+                message: 'CLI diff applied successfully on top of merge-base',
                 context: LocalSandboxService.name,
             });
             return;

--- a/libs/sandbox/infrastructure/repositories/sandbox-lease.repository.spec.ts
+++ b/libs/sandbox/infrastructure/repositories/sandbox-lease.repository.spec.ts
@@ -1,0 +1,263 @@
+import { SandboxLeaseRepository } from './sandbox-lease.repository';
+
+describe('SandboxLeaseRepository', () => {
+    it('upsertAcquire refreshes expiresAt on existing leases so expired reaper claims go stale', async () => {
+        const leaseModel = {
+            findOneAndUpdate: jest.fn().mockResolvedValue({}),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+
+        await repo.upsertAcquire(
+            '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:199',
+            60_000,
+            'review',
+        );
+
+        expect(leaseModel.findOneAndUpdate).toHaveBeenCalledWith(
+            { _id: '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:199' },
+            expect.objectContaining({
+                $set: expect.objectContaining({
+                    consumer: 'review',
+                    expiresAt: expect.any(Date),
+                }),
+                $setOnInsert: expect.not.objectContaining({
+                    expiresAt: expect.any(Date),
+                }),
+            }),
+            { upsert: true, new: true },
+        );
+    });
+
+    it('deleteIfNoActiveLeases returns true when the guarded delete removes a lease', async () => {
+        const leaseModel = {
+            deleteOne: jest.fn().mockResolvedValue({ deletedCount: 1 }),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+
+        await expect(
+            repo.deleteIfNoActiveLeases(
+                '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:200',
+            ),
+        ).resolves.toBe(true);
+
+        expect(leaseModel.deleteOne).toHaveBeenCalledWith({
+            _id: '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:200',
+            leaseCount: { $lte: 0 },
+        });
+    });
+
+    it('deleteIfNoActiveLeases returns false when an active lease blocks the delete', async () => {
+        const leaseModel = {
+            deleteOne: jest.fn().mockResolvedValue({ deletedCount: 0 }),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+
+        await expect(
+            repo.deleteIfNoActiveLeases(
+                '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:201',
+            ),
+        ).resolves.toBe(false);
+    });
+
+    it('markDeletingIfNoActiveLeases blocks reuse only when no active leases remain', async () => {
+        const leaseModel = {
+            updateOne: jest.fn().mockResolvedValue({ matchedCount: 1 }),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+
+        await expect(
+            repo.markDeletingIfNoActiveLeases(
+                '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:204',
+            ),
+        ).resolves.toBe(true);
+
+        expect(leaseModel.updateOne).toHaveBeenCalledWith(
+            {
+                _id: '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:204',
+                leaseCount: { $lte: 0 },
+                state: { $in: ['READY', 'PAUSED', 'INVALIDATED', 'DELETING'] },
+            },
+            { $set: { state: 'DELETING' } },
+        );
+    });
+
+    it('markDeletingIfReadyToKill claims an idle lease only when killAt still matches and no active leases remain', async () => {
+        const leaseModel = {
+            updateOne: jest.fn().mockResolvedValue({ matchedCount: 1 }),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+        const killAt = new Date('2026-01-01T00:00:00.000Z');
+
+        await expect(
+            repo.markDeletingIfReadyToKill(
+                '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:205',
+                killAt,
+            ),
+        ).resolves.toBe(true);
+
+        expect(leaseModel.updateOne).toHaveBeenCalledWith(
+            {
+                _id: '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:205',
+                killAt,
+                leaseCount: { $lte: 0 },
+                sandboxId: { $exists: true, $ne: '' },
+                state: { $in: ['READY', 'PAUSED', 'DELETING'] },
+            },
+            { $set: { state: 'DELETING' } },
+        );
+    });
+
+    it('markDeletingIfExpired claims an expired lease by its original expiresAt', async () => {
+        const leaseModel = {
+            updateOne: jest.fn().mockResolvedValue({ matchedCount: 1 }),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+        const expiresAt = new Date('2026-01-01T00:00:00.000Z');
+
+        await expect(
+            repo.markDeletingIfExpired(
+                '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:207',
+                expiresAt,
+            ),
+        ).resolves.toBe(true);
+
+        expect(leaseModel.updateOne).toHaveBeenCalledWith(
+            {
+                _id: '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:207',
+                expiresAt,
+                sandboxId: { $exists: true, $ne: '' },
+                state: { $in: ['READY', 'PAUSED', 'INVALIDATED', 'DELETING'] },
+            },
+            { $set: { state: 'DELETING' } },
+        );
+    });
+
+    it('markInvalidated blocks reuse for active READY or PAUSED leases', async () => {
+        const leaseModel = {
+            updateOne: jest.fn().mockResolvedValue({ matchedCount: 1 }),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+
+        await expect(
+            repo.markInvalidated(
+                '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:206',
+            ),
+        ).resolves.toBe(true);
+
+        expect(leaseModel.updateOne).toHaveBeenCalledWith(
+            {
+                _id: '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:206',
+                state: { $in: ['CREATING', 'READY', 'PAUSED'] },
+            },
+            { $set: { state: 'INVALIDATED' } },
+        );
+    });
+
+    it('clearKillAt preserves the retry cursor for DELETING leases', async () => {
+        const leaseModel = {
+            updateOne: jest.fn().mockResolvedValue({ modifiedCount: 1 }),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+
+        await repo.clearKillAt('7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:208');
+
+        expect(leaseModel.updateOne).toHaveBeenCalledWith(
+            {
+                _id: '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:208',
+                state: { $ne: 'DELETING' },
+            },
+            { $unset: { killAt: '' } },
+        );
+    });
+
+    it('setKillAt returns true for an idempotent matched update', async () => {
+        const leaseModel = {
+            updateOne: jest.fn().mockResolvedValue({
+                matchedCount: 1,
+                modifiedCount: 0,
+            }),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+        const killAt = new Date('2026-01-01T00:00:00.000Z');
+
+        await expect(
+            repo.setKillAt(
+                '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:202',
+                killAt,
+            ),
+        ).resolves.toBe(true);
+
+        expect(leaseModel.updateOne).toHaveBeenCalledWith(
+            {
+                _id: '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:202',
+                leaseCount: { $lte: 0 },
+                sandboxId: { $exists: true, $ne: '' },
+            },
+            { $set: { killAt } },
+        );
+    });
+
+    it('setKillAt returns false when no inactive lease matched the guard', async () => {
+        const leaseModel = {
+            updateOne: jest.fn().mockResolvedValue({
+                matchedCount: 0,
+                modifiedCount: 0,
+            }),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+
+        await expect(
+            repo.setKillAt(
+                '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:203',
+                new Date('2026-01-01T00:00:00.000Z'),
+            ),
+        ).resolves.toBe(false);
+    });
+
+    it('findExpired applies an explicit query limit', async () => {
+        const query = {
+            select: jest.fn().mockReturnThis(),
+            limit: jest.fn().mockReturnThis(),
+            lean: jest.fn().mockResolvedValue([]),
+        };
+        const leaseModel = {
+            find: jest.fn().mockReturnValue(query),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+        const now = new Date('2026-01-01T00:00:00.000Z');
+
+        await expect(repo.findExpired(now, 25)).resolves.toEqual([]);
+
+        expect(leaseModel.find).toHaveBeenCalledWith({
+            expiresAt: { $lt: now },
+        });
+        expect(query.select).toHaveBeenCalledWith(
+            '_id sandboxId state expiresAt',
+        );
+        expect(query.limit).toHaveBeenCalledWith(25);
+        expect(query.lean).toHaveBeenCalledTimes(1);
+    });
+
+    it('findReadyToKill applies an explicit query limit', async () => {
+        const query = {
+            select: jest.fn().mockReturnThis(),
+            limit: jest.fn().mockReturnThis(),
+            lean: jest.fn().mockResolvedValue([]),
+        };
+        const leaseModel = {
+            find: jest.fn().mockReturnValue(query),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+        const now = new Date('2026-01-01T00:00:00.000Z');
+
+        await expect(repo.findReadyToKill(now, 25)).resolves.toEqual([]);
+
+        expect(leaseModel.find).toHaveBeenCalledWith({
+            killAt: { $lte: now },
+            sandboxId: { $exists: true, $ne: '' },
+        });
+        expect(query.select).toHaveBeenCalledWith('_id sandboxId killAt');
+        expect(query.limit).toHaveBeenCalledWith(25);
+        expect(query.lean).toHaveBeenCalledTimes(1);
+    });
+});

--- a/libs/sandbox/infrastructure/repositories/sandbox-lease.repository.ts
+++ b/libs/sandbox/infrastructure/repositories/sandbox-lease.repository.ts
@@ -59,10 +59,11 @@ export class SandboxLeaseRepository {
      * Atomically acquire (or join) a lease for the given prKey.
      *
      * Single findOneAndUpdate with BOTH operators in one update document:
-     *   - $setOnInsert: sets initial state/timestamps on the INSERT path only
+     *   - $setOnInsert: sets initial state/createdAt on the INSERT path only
+     *   - $set: refreshes expiresAt on BOTH insert and update paths
      *   - $inc: { leaseCount: 1 } increments the counter on BOTH insert and update paths
      *
-     * On INSERT:  MongoDB applies $setOnInsert (state='CREATING', dates) and $inc
+     * On INSERT:  MongoDB applies $setOnInsert (state='CREATING', createdAt) and $inc
      *             (leaseCount 0→1). Returned doc has leaseCount === 1.
      * On UPDATE:  $setOnInsert is a no-op; $inc bumps leaseCount to N+1.
      *
@@ -87,13 +88,15 @@ export class SandboxLeaseRepository {
                 $setOnInsert: {
                     state: 'CREATING',
                     createdAt: now,
-                    expiresAt,
                     ...decomposed,
                 },
                 // Track the most recent consumer label so it's queryable in
                 // Mongo without parsing logs. Updated on every acquire (both
                 // insert and update paths).
-                $set: consumer ? { consumer } : {},
+                $set: {
+                    expiresAt,
+                    ...(consumer ? { consumer } : {}),
+                },
                 $inc: { leaseCount: 1 },
             },
             { upsert: true, new: true },
@@ -130,11 +133,13 @@ export class SandboxLeaseRepository {
      * Mark a CREATING lease as INVALIDATED (mid-create race handling).
      * The create path will check for this state after completing and kill the sandbox.
      */
-    async markInvalidated(prKey: string): Promise<void> {
-        await this.leaseModel.updateOne(
-            { _id: prKey, state: 'CREATING' },
+    async markInvalidated(prKey: string): Promise<boolean> {
+        const result = await this.leaseModel.updateOne(
+            { _id: prKey, state: { $in: ['CREATING', 'READY', 'PAUSED'] } },
             { $set: { state: 'INVALIDATED' } },
         );
+
+        return result.matchedCount > 0;
     }
 
     /**
@@ -154,10 +159,14 @@ export class SandboxLeaseRepository {
      */
     async findExpired(
         now: Date,
-    ): Promise<Pick<SandboxLeaseModel, '_id' | 'sandboxId' | 'state'>[]> {
+        limit: number,
+    ): Promise<
+        Pick<SandboxLeaseModel, '_id' | 'sandboxId' | 'state' | 'expiresAt'>[]
+    > {
         return this.leaseModel
             .find({ expiresAt: { $lt: now } })
-            .select('_id sandboxId state')
+            .select('_id sandboxId state expiresAt')
+            .limit(limit)
             .lean();
     }
 
@@ -170,6 +179,91 @@ export class SandboxLeaseRepository {
     }
 
     /**
+     * Delete a lease only when no active leases remain.
+     *
+     * Local sandbox cleanup and idle reapers can observe leaseCount <= 0 and
+     * then race with a concurrent acquire. The final delete must re-check the
+     * counter atomically so it never removes a lease another caller just joined.
+     */
+    async deleteIfNoActiveLeases(prKey: string): Promise<boolean> {
+        const result = await this.leaseModel.deleteOne({
+            _id: prKey,
+            leaseCount: { $lte: 0 },
+        });
+
+        return result.deletedCount > 0;
+    }
+
+    /**
+     * Atomically block reuse before resource cleanup.
+     *
+     * Local directories must not be removed while a concurrent acquire can
+     * still warm-reuse the READY lease. Marking DELETING first makes joiners
+     * wait/retry instead of connecting to a directory being deleted.
+     */
+    async markDeletingIfNoActiveLeases(prKey: string): Promise<boolean> {
+        const result = await this.leaseModel.updateOne(
+            {
+                _id: prKey,
+                leaseCount: { $lte: 0 },
+                state: { $in: ['READY', 'PAUSED', 'INVALIDATED', 'DELETING'] },
+            },
+            { $set: { state: 'DELETING' } },
+        );
+
+        return result.matchedCount > 0;
+    }
+
+    /**
+     * Atomically claim an idle-kill candidate before resource cleanup.
+     *
+     * The reaper reads candidates first, then cleanup can race with a fresh
+     * acquire that increments leaseCount and clears killAt. This guard
+     * re-checks both values before switching the lease to DELETING.
+     */
+    async markDeletingIfReadyToKill(
+        prKey: string,
+        killAt: Date,
+    ): Promise<boolean> {
+        const result = await this.leaseModel.updateOne(
+            {
+                _id: prKey,
+                killAt,
+                leaseCount: { $lte: 0 },
+                sandboxId: { $exists: true, $ne: '' },
+                state: { $in: ['READY', 'PAUSED', 'DELETING'] },
+            },
+            { $set: { state: 'DELETING' } },
+        );
+
+        return result.matchedCount > 0;
+    }
+
+    /**
+     * Atomically claim an expired lease before resource cleanup.
+     *
+     * Expired leases may still have leaseCount > 0 when a worker crashed before
+     * releasing. Matching the original expiresAt lets a fresh acquire extend
+     * the TTL and make this claim fail before the reaper removes anything.
+     */
+    async markDeletingIfExpired(
+        prKey: string,
+        expiresAt: Date,
+    ): Promise<boolean> {
+        const result = await this.leaseModel.updateOne(
+            {
+                _id: prKey,
+                expiresAt,
+                sandboxId: { $exists: true, $ne: '' },
+                state: { $in: ['READY', 'PAUSED', 'INVALIDATED', 'DELETING'] },
+            },
+            { $set: { state: 'DELETING' } },
+        );
+
+        return result.matchedCount > 0;
+    }
+
+    /**
      * Atomically set the `killAt` timestamp on a lease document. Used by
      * release() to schedule an idle-kill that any worker (in a multi-worker
      * deployment) can pick up via findReadyToKill().
@@ -177,14 +271,17 @@ export class SandboxLeaseRepository {
      * Only sets killAt when the lease has a real sandboxId — there's no
      * point scheduling a kill for a NullSandbox or a CREATING-only lease.
      */
-    async setKillAt(prKey: string, killAt: Date): Promise<void> {
-        await this.leaseModel.updateOne(
+    async setKillAt(prKey: string, killAt: Date): Promise<boolean> {
+        const result = await this.leaseModel.updateOne(
             {
                 _id: prKey,
+                leaseCount: { $lte: 0 },
                 sandboxId: { $exists: true, $ne: '' },
             },
             { $set: { killAt } },
         );
+
+        return result.matchedCount > 0;
     }
 
     /**
@@ -194,7 +291,7 @@ export class SandboxLeaseRepository {
      */
     async clearKillAt(prKey: string): Promise<void> {
         await this.leaseModel.updateOne(
-            { _id: prKey },
+            { _id: prKey, state: { $ne: 'DELETING' } },
             { $unset: { killAt: '' } },
         );
     }
@@ -210,6 +307,7 @@ export class SandboxLeaseRepository {
      */
     async findReadyToKill(
         now: Date,
+        limit: number,
     ): Promise<Pick<SandboxLeaseModel, '_id' | 'sandboxId' | 'killAt'>[]> {
         return this.leaseModel
             .find({
@@ -217,6 +315,7 @@ export class SandboxLeaseRepository {
                 sandboxId: { $exists: true, $ne: '' },
             })
             .select('_id sandboxId killAt')
+            .limit(limit)
             .lean();
     }
 }

--- a/libs/sandbox/infrastructure/repositories/schemas/sandbox-lease.model.ts
+++ b/libs/sandbox/infrastructure/repositories/schemas/sandbox-lease.model.ts
@@ -51,17 +51,14 @@ export class SandboxLeaseModel extends CoreDocument {
     consumer?: string; // Last consumer label ('review' | 'conversation')
 
     /**
-     * State enum. INVALIDATED is required to handle the mid-create invalidation
-     * race (RESEARCH.md Pitfall 5): when a force-push/pr-close event fires while
-     * acquire() is still in-flight (state = CREATING), invalidate() sets this to
-     * INVALIDATED instead of deleting the doc. The create path checks for this
-     * state after updateReady() and immediately kills the sandbox, preventing
-     * orphaned E2B sandboxes with no Mongo lease document.
+     * State enum. INVALIDATED handles the mid-create invalidation race.
+     * DELETING blocks warm reuse while a local directory or remote sandbox is
+     * being removed; the lease doc remains as the durable cleanup retry record.
      */
     @Prop({
         type: String,
         required: true,
-        enum: ['CREATING', 'READY', 'PAUSED', 'INVALIDATED'],
+        enum: ['CREATING', 'READY', 'PAUSED', 'INVALIDATED', 'DELETING'],
     })
     state: string;
 
@@ -93,6 +90,9 @@ export const SandboxLeaseSchema: MongooseSchema<SandboxLeaseModel> =
 
 // Reaper range scan: find all leases past their expiry regardless of state
 SandboxLeaseSchema.index({ expiresAt: 1 });
+
+// Recovery scan for cleanup operations that crashed after marking DELETING
+SandboxLeaseSchema.index({ state: 1, expiresAt: 1 });
 
 // Invalidate-by-sandboxId when prKey is unknown (sparse: unused entries have no entry)
 SandboxLeaseSchema.index({ sandboxId: 1 }, { sparse: true });

--- a/libs/sandbox/infrastructure/services/local-sandbox-cleanup.spec.ts
+++ b/libs/sandbox/infrastructure/services/local-sandbox-cleanup.spec.ts
@@ -1,0 +1,52 @@
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import {
+    cleanupLocalSandboxDirectory,
+    isLocalSandboxPath,
+    localSandboxDirectoryExists,
+} from './local-sandbox-cleanup';
+
+describe('local sandbox cleanup helpers', () => {
+    it('accepts only kodus sandbox directories directly under the OS tmp root', () => {
+        expect(isLocalSandboxPath(join(tmpdir(), 'kodus-sandbox-abc'))).toBe(
+            true,
+        );
+        expect(isLocalSandboxPath(join(tmpdir(), 'not-kodus-abc'))).toBe(false);
+        expect(isLocalSandboxPath('/var/tmp/kodus-sandbox-abc')).toBe(false);
+        expect(isLocalSandboxPath('kodus-sandbox-abc')).toBe(false);
+        expect(isLocalSandboxPath(undefined)).toBe(false);
+    });
+
+    it('removes an existing local sandbox directory and reports success', async () => {
+        const sandboxId = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+
+        await expect(localSandboxDirectoryExists(sandboxId)).resolves.toBe(
+            true,
+        );
+        await expect(cleanupLocalSandboxDirectory(sandboxId)).resolves.toBe(
+            true,
+        );
+        await expect(localSandboxDirectoryExists(sandboxId)).resolves.toBe(
+            false,
+        );
+    });
+
+    it('returns false for a missing local sandbox directory', async () => {
+        const sandboxId = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        await rm(sandboxId, { recursive: true, force: true });
+
+        await expect(localSandboxDirectoryExists(sandboxId)).resolves.toBe(
+            false,
+        );
+        await expect(cleanupLocalSandboxDirectory(sandboxId)).resolves.toBe(
+            false,
+        );
+    });
+
+    it('refuses invalid paths without attempting cleanup', async () => {
+        await expect(cleanupLocalSandboxDirectory('/etc')).resolves.toBe(false);
+        await expect(localSandboxDirectoryExists('/etc')).resolves.toBe(false);
+    });
+});

--- a/libs/sandbox/infrastructure/services/local-sandbox-cleanup.ts
+++ b/libs/sandbox/infrastructure/services/local-sandbox-cleanup.ts
@@ -1,0 +1,53 @@
+import { lstat, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { basename, dirname, isAbsolute, resolve } from 'path';
+
+const LOCAL_SANDBOX_PREFIX = 'kodus-sandbox-';
+
+export function isLocalSandboxPath(sandboxId?: string): boolean {
+    if (!sandboxId || !isAbsolute(sandboxId)) {
+        return false;
+    }
+
+    const tmpRoot = resolve(tmpdir());
+    const candidate = resolve(sandboxId);
+
+    return (
+        dirname(candidate) === tmpRoot &&
+        basename(candidate).startsWith(LOCAL_SANDBOX_PREFIX)
+    );
+}
+
+export async function localSandboxDirectoryExists(
+    sandboxId?: string,
+): Promise<boolean> {
+    if (!isLocalSandboxPath(sandboxId)) {
+        return false;
+    }
+
+    try {
+        await lstat(resolve(sandboxId!));
+        return true;
+    } catch (error: any) {
+        if (error?.code === 'ENOENT') {
+            return false;
+        }
+        throw error;
+    }
+}
+
+export async function cleanupLocalSandboxDirectory(
+    sandboxId?: string,
+): Promise<boolean> {
+    if (!isLocalSandboxPath(sandboxId)) {
+        return false;
+    }
+
+    const resolved = resolve(sandboxId!);
+    if (!(await localSandboxDirectoryExists(resolved))) {
+        return false;
+    }
+
+    await rm(resolved, { recursive: true, force: true });
+    return true;
+}

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
@@ -18,6 +18,11 @@ import { randomUUID } from 'crypto';
 import { calculateBackoffInterval } from '@libs/common/utils/polling';
 import { SandboxLeaseRepository } from '../repositories/sandbox-lease.repository';
 import { NULL_SANDBOX_INSTANCE } from '../providers/null-sandbox.service';
+import {
+    cleanupLocalSandboxDirectory,
+    isLocalSandboxPath,
+    localSandboxDirectoryExists,
+} from './local-sandbox-cleanup';
 
 /**
  * Default idle timeout applied when the last lease on a sandbox is released.
@@ -98,6 +103,20 @@ export class SandboxStaleConnectionError extends Error {
     }
 }
 
+/**
+ * Thrown when a lease is already claimed by cleanup and the resource still
+ * needs the reaper retry path. This must not be treated like a stale lease:
+ * cold-starting recursively would spin on the same DELETING doc.
+ */
+export class SandboxDeletingInProgressError extends Error {
+    constructor(prKey: string, sandboxId?: string) {
+        super(
+            `SandboxLeaseManager: deleting cleanup still in progress for prKey="${prKey}" sandboxId="${sandboxId ?? 'unknown'}"; retry later`,
+        );
+        this.name = 'SandboxDeletingInProgressError';
+    }
+}
+
 @Injectable()
 export class SandboxLeaseManager implements ISandboxLeaseManager {
     private readonly logger = createLogger(SandboxLeaseManager.name);
@@ -154,14 +173,24 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
             metadata: { prKey, consumer },
         });
 
-        const doc = await this.leaseRepo.upsertAcquire(prKey, leaseTtlMs, consumer);
+        const doc = await this.leaseRepo.upsertAcquire(
+            prKey,
+            leaseTtlMs,
+            consumer,
+        );
         const leaseId = randomUUID();
 
         // A new acquire arrived — atomically clear any pending idle-kill so
         // the warm sandbox isn't killed under us between this call and
         // connect(). Multi-worker safe: any worker that reads the doc next
         // will see killAt=null and skip.
-        await this.leaseRepo.clearKillAt(prKey);
+        //
+        // Do not clear DELETING.killAt: an idle reaper may have already
+        // claimed the lease. If its cleanup fails, killAt must remain as the
+        // durable retry cursor for the next idle-reaper tick.
+        if (doc.state !== 'DELETING') {
+            await this.leaseRepo.clearKillAt(prKey);
+        }
 
         // --- Path A: We are the creator (we just inserted the doc) ---
         // Both conditions are required:
@@ -174,12 +203,23 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
         // 1 on an existing READY doc) would wrongly cold-create another sandbox
         // instead of warm-resuming the one already on the lease doc.
         if (doc.state === 'CREATING' && doc.leaseCount === 1) {
-            return this.handleCreatorPath(prKey, leaseId, consumer, cloneParams);
+            return this.handleCreatorPath(
+                prKey,
+                leaseId,
+                consumer,
+                cloneParams,
+            );
         }
 
         // --- Path B: joiner — doc already existed or someone else is creating ---
         try {
-            return await this.handleJoinerPath(prKey, leaseId, consumer, doc.state, doc.sandboxId);
+            return await this.handleJoinerPath(
+                prKey,
+                leaseId,
+                consumer,
+                doc.state,
+                doc.sandboxId,
+            );
         } catch (err) {
             if (err instanceof SandboxStaleConnectionError) {
                 // Lease referenced a sandbox that E2B no longer has (idle-
@@ -217,10 +257,7 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
      * @kody arrives within seconds or much later; conversation uses the
      * 5min default because the user is interactive.
      */
-    async release(
-        leaseId: string,
-        opts?: { idleMs?: number },
-    ): Promise<void> {
+    async release(leaseId: string, opts?: { idleMs?: number }): Promise<void> {
         const prKey = this.leaseIdToPrKey.get(leaseId);
         if (!prKey) {
             this.logger.warn({
@@ -241,20 +278,44 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
         });
 
         if (updated && updated.leaseCount <= 0 && updated.sandboxId) {
+            if (isLocalSandboxPath(updated.sandboxId)) {
+                await this.cleanupInactiveLocalSandbox(
+                    prKey,
+                    updated.sandboxId,
+                    'release',
+                );
+                return;
+            }
+
             const idleMs = opts?.idleMs ?? IDLE_TIMEOUT_MS;
             const killAt = new Date(Date.now() + idleMs);
-            await this.leaseRepo.setKillAt(prKey, killAt);
+            const scheduled = await this.leaseRepo.setKillAt(prKey, killAt);
+            if (!scheduled) {
+                this.logger.log({
+                    message: `SandboxLeaseManager: skipped idle-kill scheduling because lease was re-acquired prKey="${prKey}"`,
+                    context: SandboxLeaseManager.name,
+                    metadata: { prKey, sandboxId: updated.sandboxId },
+                });
+                return;
+            }
 
             this.logger.log({
                 message: `SandboxLeaseManager: scheduled idle-kill at ${killAt.toISOString()} for sandboxId="${updated.sandboxId}"`,
                 context: SandboxLeaseManager.name,
-                metadata: { prKey, sandboxId: updated.sandboxId, idleTimeoutMs: idleMs, killAt },
+                metadata: {
+                    prKey,
+                    sandboxId: updated.sandboxId,
+                    idleTimeoutMs: idleMs,
+                    killAt,
+                },
             });
 
             const apiKey = this.configService.get<string>('API_E2B_KEY');
             if (apiKey) {
                 try {
-                    await Sandbox.setTimeout(updated.sandboxId, idleMs, { apiKey });
+                    await Sandbox.setTimeout(updated.sandboxId, idleMs, {
+                        apiKey,
+                    });
                 } catch (err) {
                     this.logger.warn({
                         message: `SandboxLeaseManager: failed to set E2B-side idle timeout on sandboxId="${updated.sandboxId}" (kill cron is the primary path)`,
@@ -281,10 +342,6 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
             metadata: { prKey },
         });
 
-        // Clear any pending idle-kill so the cron doesn't double-kill —
-        // invalidate already does its own kill via soft-drain + delete.
-        await this.leaseRepo.clearKillAt(prKey);
-
         const doc = await this.leaseRepo.findByPrKey(prKey);
         if (!doc) {
             // Idempotent: no lease to invalidate
@@ -292,6 +349,15 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                 message: `SandboxLeaseManager: invalidate no-op (doc not found) prKey="${prKey}"`,
                 context: SandboxLeaseManager.name,
                 metadata: { prKey },
+            });
+            return;
+        }
+
+        if (doc.state === 'DELETING') {
+            this.logger.log({
+                message: `SandboxLeaseManager: invalidate skipped because cleanup is already in progress prKey="${prKey}"`,
+                context: SandboxLeaseManager.name,
+                metadata: { prKey, sandboxId: doc.sandboxId },
             });
             return;
         }
@@ -307,8 +373,32 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
             return;
         }
 
+        const invalidated = await this.leaseRepo.markInvalidated(prKey);
+        if (!invalidated) {
+            this.logger.log({
+                message: `SandboxLeaseManager: invalidate skipped because lease state changed before claim prKey="${prKey}"`,
+                context: SandboxLeaseManager.name,
+                metadata: { prKey, sandboxId: doc.sandboxId },
+            });
+            return;
+        }
+
+        // Clear any pending idle-kill only after we won the invalidation
+        // claim. If a reaper moved the doc to DELETING first, keep killAt as
+        // the retry cursor.
+        await this.leaseRepo.clearKillAt(prKey);
+
         // READY or PAUSED: soft-drain then delete
         if (doc.sandboxId) {
+            if (isLocalSandboxPath(doc.sandboxId)) {
+                await this.cleanupInactiveLocalSandbox(
+                    prKey,
+                    doc.sandboxId,
+                    'invalidation',
+                );
+                return;
+            }
+
             const apiKey = this.configService.get<string>('API_E2B_KEY');
             if (apiKey) {
                 try {
@@ -340,6 +430,84 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
     // ---------------------------------------------------------------------------
     // Private helpers
     // ---------------------------------------------------------------------------
+
+    private async cleanupInactiveLocalSandbox(
+        prKey: string,
+        sandboxId: string,
+        reason: string,
+    ): Promise<void> {
+        const marked = await this.leaseRepo.markDeletingIfNoActiveLeases(prKey);
+        if (!marked) {
+            this.logger.log({
+                message: `SandboxLeaseManager: skipped local sandbox cleanup after ${reason} because lease was re-acquired prKey="${prKey}"`,
+                context: SandboxLeaseManager.name,
+                metadata: { prKey, sandboxId, reason },
+            });
+            return;
+        }
+
+        const cleaned = await this.cleanupLocalSandbox(
+            sandboxId,
+            prKey,
+            reason,
+        );
+        if (!cleaned) {
+            return;
+        }
+
+        const deleted = await this.leaseRepo.deleteIfNoActiveLeases(prKey);
+        if (!deleted) {
+            this.logger.log({
+                message: `SandboxLeaseManager: skipped local sandbox lease delete after ${reason} because lease was re-acquired prKey="${prKey}"`,
+                context: SandboxLeaseManager.name,
+                metadata: { prKey, sandboxId, reason },
+            });
+        }
+    }
+
+    private async cleanupLocalSandbox(
+        sandboxId: string,
+        prKey: string,
+        reason: string,
+    ): Promise<boolean> {
+        try {
+            if (
+                isLocalSandboxPath(sandboxId) &&
+                !(await localSandboxDirectoryExists(sandboxId))
+            ) {
+                this.logger.log({
+                    message: `SandboxLeaseManager: local sandbox directory was already absent after ${reason}`,
+                    context: SandboxLeaseManager.name,
+                    metadata: { prKey, sandboxId, reason },
+                });
+                return true;
+            }
+
+            const cleaned = await cleanupLocalSandboxDirectory(sandboxId);
+            if (cleaned) {
+                this.logger.log({
+                    message: `SandboxLeaseManager: removed local sandbox directory after ${reason}`,
+                    context: SandboxLeaseManager.name,
+                    metadata: { prKey, sandboxId, reason },
+                });
+            } else {
+                this.logger.warn({
+                    message: `SandboxLeaseManager: local sandbox directory was not removed after ${reason}`,
+                    context: SandboxLeaseManager.name,
+                    metadata: { prKey, sandboxId, reason },
+                });
+            }
+            return cleaned;
+        } catch (error) {
+            this.logger.warn({
+                message: `SandboxLeaseManager: failed to remove local sandbox directory after ${reason}`,
+                context: SandboxLeaseManager.name,
+                error,
+                metadata: { prKey, sandboxId, reason },
+            });
+            return false;
+        }
+    }
 
     private async handleCreatorPath(
         prKey: string,
@@ -380,13 +548,21 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                 });
                 // Kill the sandbox we just created; it is orphaned
                 if (sandboxId) {
-                    const apiKey = this.configService.get<string>('API_E2B_KEY');
-                    if (apiKey) {
-                        await Sandbox.kill(sandboxId, { apiKey }).catch(() => {});
+                    if (!isLocalSandboxPath(sandboxId)) {
+                        const apiKey =
+                            this.configService.get<string>('API_E2B_KEY');
+                        if (apiKey) {
+                            await Sandbox.kill(sandboxId, { apiKey }).catch(
+                                () => {},
+                            );
+                        }
                     }
                 }
-                // Clean up the invalidated doc
-                await this.leaseRepo.delete(prKey);
+                // Local sandbox cleanup happens in the catch block so the
+                // lease remains as a durable retry record if rm fails.
+                if (!sandboxId || !isLocalSandboxPath(sandboxId)) {
+                    await this.leaseRepo.delete(prKey);
+                }
                 throw new Error(
                     `SandboxLeaseManager: sandbox invalidated mid-create for prKey="${prKey}"`,
                 );
@@ -410,11 +586,23 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
 
             return { sandbox, leaseId, sandboxId, wasCreated: true };
         } catch (err) {
-            // If a real E2B sandbox was created but a later step failed
-            // (Mongo update, mid-create invalidation, etc.), kill it so it
-            // doesn't run for the full ceiling burning quota. Null-sandbox
-            // doesn't need killing — its sandboxId is empty.
             if (sandboxId) {
+                if (isLocalSandboxPath(sandboxId)) {
+                    const cleaned = await this.cleanupLocalSandbox(
+                        sandboxId,
+                        prKey,
+                        'creator-path failure',
+                    );
+                    if (cleaned) {
+                        await this.leaseRepo.delete(prKey).catch(() => {});
+                    }
+                    throw err;
+                }
+
+                // If a real E2B sandbox was created but a later step failed
+                // (Mongo update, mid-create invalidation, etc.), kill it so it
+                // doesn't run for the full ceiling burning quota. Null-sandbox
+                // doesn't need killing — its sandboxId is empty.
                 const apiKey = this.configService.get<string>('API_E2B_KEY');
                 if (apiKey) {
                     this.logger.warn({
@@ -425,7 +613,8 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                     await Sandbox.kill(sandboxId, { apiKey }).catch(() => {});
                 }
             }
-            // Remove the lease doc so other callers don't poll forever
+            // Remove the lease doc so other callers don't poll forever.
+            // Local sandbox cleanup above only deletes after confirmed rm.
             await this.leaseRepo.delete(prKey).catch(() => {});
             throw err;
         }
@@ -476,8 +665,21 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
         sandboxId?: string,
     ): Promise<AcquireResult> {
         if (state === 'INVALIDATED') {
+            await this.rollbackAcquire(prKey, leaseId);
             throw new Error(
                 `SandboxLeaseManager: sandbox invalidated for prKey="${prKey}"`,
+            );
+        }
+
+        if (state === 'DELETING') {
+            await this.waitForDeletingLeaseAndRollback(
+                prKey,
+                leaseId,
+                sandboxId,
+            );
+            throw new SandboxStaleConnectionError(
+                prKey,
+                sandboxId ?? 'deleting',
             );
         }
 
@@ -498,19 +700,38 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
             const doc = await this.leaseRepo.findByPrKey(prKey);
 
             if (!doc) {
-                throw new Error(
-                    `SandboxLeaseManager: lease disappeared while polling for READY prKey="${prKey}"`,
+                throw new SandboxStaleConnectionError(
+                    prKey,
+                    sandboxId ?? 'missing',
                 );
             }
 
             if (doc.state === 'INVALIDATED') {
+                await this.rollbackAcquire(prKey, leaseId);
                 throw new Error(
                     `SandboxLeaseManager: sandbox invalidated for prKey="${prKey}"`,
                 );
             }
 
+            if (doc.state === 'DELETING') {
+                await this.waitForDeletingLeaseAndRollback(
+                    prKey,
+                    leaseId,
+                    doc.sandboxId,
+                );
+                throw new SandboxStaleConnectionError(
+                    prKey,
+                    doc.sandboxId ?? 'deleting',
+                );
+            }
+
             if (doc.state === 'READY' && doc.sandboxId) {
-                return this.connectToExisting(prKey, leaseId, consumer, doc.sandboxId);
+                return this.connectToExisting(
+                    prKey,
+                    leaseId,
+                    consumer,
+                    doc.sandboxId,
+                );
             }
         }
 
@@ -523,6 +744,15 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
         consumer: string,
         sandboxId: string,
     ): Promise<AcquireResult> {
+        if (isLocalSandboxPath(sandboxId)) {
+            return this.connectToExistingLocalSandbox(
+                prKey,
+                leaseId,
+                consumer,
+                sandboxId,
+            );
+        }
+
         const apiKey = this.configService.get<string>('API_E2B_KEY');
 
         if (!apiKey) {
@@ -565,7 +795,11 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
             throw new SandboxStaleConnectionError(prKey, sandboxId);
         }
 
-        const sandbox: SandboxInstance = this.buildSandboxInstance(e2bSandbox, prKey, leaseId);
+        const sandbox: SandboxInstance = this.buildSandboxInstance(
+            e2bSandbox,
+            prKey,
+            leaseId,
+        );
         this.leaseIdToPrKey.set(leaseId, prKey);
 
         this.logger.log({
@@ -577,11 +811,179 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
         return { sandbox, leaseId, sandboxId, wasCreated: false };
     }
 
+    private async connectToExistingLocalSandbox(
+        prKey: string,
+        leaseId: string,
+        consumer: string,
+        sandboxId: string,
+    ): Promise<AcquireResult> {
+        const connect = this.sandboxProvider.connectToExistingSandbox;
+        if (!connect) {
+            const noActiveLeases = await this.rollbackLocalReconnectAcquire(
+                prKey,
+                leaseId,
+            );
+            await this.deleteMissingLocalLeaseIfInactive(
+                prKey,
+                sandboxId,
+                noActiveLeases,
+            );
+            throw new Error(
+                `SandboxLeaseManager: sandbox provider cannot reconnect local sandbox prKey="${prKey}" sandboxId="${sandboxId}"`,
+            );
+        }
+
+        try {
+            const sandbox = await connect.call(this.sandboxProvider, sandboxId);
+            this.leaseIdToPrKey.set(leaseId, prKey);
+
+            const wrappedSandbox: SandboxInstance = {
+                ...sandbox,
+                cleanup: async () => {
+                    await this.release(leaseId);
+                },
+            };
+
+            this.logger.log({
+                message: `SandboxLeaseManager: connected to existing local sandbox prKey="${prKey}" consumer="${consumer}" leaseId="${leaseId}"`,
+                context: SandboxLeaseManager.name,
+                metadata: { prKey, consumer, leaseId, sandboxId },
+            });
+
+            return {
+                sandbox: wrappedSandbox,
+                leaseId,
+                sandboxId,
+                wasCreated: false,
+            };
+        } catch (err) {
+            const noActiveLeases = await this.rollbackLocalReconnectAcquire(
+                prKey,
+                leaseId,
+            );
+            const deleted = await this.deleteMissingLocalLeaseIfInactive(
+                prKey,
+                sandboxId,
+                noActiveLeases,
+            );
+            if (deleted) {
+                throw new SandboxStaleConnectionError(prKey, sandboxId);
+            }
+            throw err;
+        }
+    }
+
+    private async rollbackLocalReconnectAcquire(
+        prKey: string,
+        leaseId: string,
+    ): Promise<boolean> {
+        return this.rollbackAcquire(prKey, leaseId);
+    }
+
+    private async rollbackAcquire(
+        prKey: string,
+        leaseId: string,
+    ): Promise<boolean> {
+        this.leaseIdToPrKey.delete(leaseId);
+
+        try {
+            const updated = await this.leaseRepo.decrementLease(prKey);
+            return !updated || updated.leaseCount <= 0;
+        } catch (error) {
+            this.logger.warn({
+                message: `SandboxLeaseManager: failed to roll back local reconnect lease prKey="${prKey}"`,
+                context: SandboxLeaseManager.name,
+                error,
+                metadata: { prKey, leaseId },
+            });
+            return false;
+        }
+    }
+
+    private async deleteMissingLocalLeaseIfInactive(
+        prKey: string,
+        sandboxId: string,
+        noActiveLeases: boolean,
+    ): Promise<boolean> {
+        if (!noActiveLeases) {
+            return false;
+        }
+
+        const exists = await this.localSandboxExists(prKey, sandboxId);
+        if (exists) {
+            return false;
+        }
+
+        try {
+            return await this.leaseRepo.deleteIfNoActiveLeases(prKey);
+        } catch (error) {
+            this.logger.warn({
+                message: `SandboxLeaseManager: failed to delete missing local sandbox lease prKey="${prKey}"`,
+                context: SandboxLeaseManager.name,
+                error,
+                metadata: { prKey, sandboxId },
+            });
+            return false;
+        }
+    }
+
+    private async localSandboxExists(
+        prKey: string,
+        sandboxId: string,
+    ): Promise<boolean> {
+        try {
+            return await localSandboxDirectoryExists(sandboxId);
+        } catch (error) {
+            this.logger.warn({
+                message: `SandboxLeaseManager: failed to inspect local sandbox directory prKey="${prKey}"`,
+                context: SandboxLeaseManager.name,
+                error,
+                metadata: { prKey, sandboxId },
+            });
+            return true;
+        }
+    }
+
+    private async waitForDeletingLeaseAndRollback(
+        prKey: string,
+        leaseId: string,
+        sandboxId?: string,
+    ): Promise<void> {
+        const noActiveLeases = await this.rollbackAcquire(prKey, leaseId);
+
+        const deadline = Date.now() + MAX_POLL_WAIT_MS;
+        while (Date.now() < deadline) {
+            const doc = await this.leaseRepo.findByPrKey(prKey);
+            if (!doc || doc.state !== 'DELETING') {
+                return;
+            }
+            if (
+                noActiveLeases &&
+                doc.sandboxId &&
+                isLocalSandboxPath(doc.sandboxId) &&
+                !(await this.localSandboxExists(prKey, doc.sandboxId))
+            ) {
+                const deleted =
+                    await this.leaseRepo.deleteIfNoActiveLeases(prKey);
+                if (deleted) {
+                    return;
+                }
+            }
+            await sleep(POLL_INTERVAL_MS);
+        }
+
+        throw new SandboxDeletingInProgressError(prKey, sandboxId);
+    }
+
     /**
      * Build a minimal SandboxInstance wrapping an existing connected E2B sandbox.
      * This is used by the joiner path when connecting to an already-READY sandbox.
      */
-    private buildSandboxInstance(e2bSandbox: Sandbox, prKey: string, leaseId: string): SandboxInstance {
+    private buildSandboxInstance(
+        e2bSandbox: Sandbox,
+        prKey: string,
+        leaseId: string,
+    ): SandboxInstance {
         return {
             remoteCommands: {
                 grep: async (pattern: string, path: string, glob?: string) => {
@@ -607,8 +1009,13 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                     return result.stdout || '';
                 },
                 exec: async (command: string) => {
-                    const result = await e2bSandbox.commands.run(command, { timeoutMs: 30_000 });
-                    return { stdout: result.stdout || '', exitCode: result.exitCode };
+                    const result = await e2bSandbox.commands.run(command, {
+                        timeoutMs: 30_000,
+                    });
+                    return {
+                        stdout: result.stdout || '',
+                        exitCode: result.exitCode,
+                    };
                 },
             },
             cleanup: async () => {
@@ -642,7 +1049,10 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
      * Build a null sandbox with a release-bound cleanup function.
      * Used when E2B is not configured or when connect is not needed.
      */
-    private buildNullSandboxWithRelease(prKey: string, leaseId: string): SandboxInstance {
+    private buildNullSandboxWithRelease(
+        prKey: string,
+        leaseId: string,
+    ): SandboxInstance {
         return {
             ...NULL_SANDBOX_INSTANCE,
             cleanup: async () => {

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
@@ -23,12 +23,16 @@
 import { Sandbox } from 'e2b';
 import { SandboxLeaseManager } from './sandbox-lease-manager.service';
 import { SandboxLeaseReaperService } from './sandbox-lease-reaper.service';
+import { localSandboxDirectoryExists } from './local-sandbox-cleanup';
 import { SandboxLeaseRepository } from '../repositories/sandbox-lease.repository';
 import {
     ISandboxProvider,
     SandboxInstance,
 } from '@libs/sandbox/domain/contracts/sandbox.provider';
 import { ConfigService } from '@nestjs/config';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 // ─── Shared test helpers ─────────────────────────────────────────────────────
 
@@ -37,17 +41,23 @@ function makeMockLeaseRepo(): jest.Mocked<SandboxLeaseRepository> {
         upsertAcquire: jest.fn(),
         decrementLease: jest.fn(),
         updateReady: jest.fn().mockResolvedValue(undefined),
-        markInvalidated: jest.fn().mockResolvedValue(undefined),
+        markInvalidated: jest.fn().mockResolvedValue(true),
         findByPrKey: jest.fn().mockResolvedValue(null),
         findExpired: jest.fn().mockResolvedValue([]),
         delete: jest.fn().mockResolvedValue(undefined),
-        setKillAt: jest.fn().mockResolvedValue(undefined),
+        deleteIfNoActiveLeases: jest.fn().mockResolvedValue(true),
+        markDeletingIfNoActiveLeases: jest.fn().mockResolvedValue(true),
+        markDeletingIfExpired: jest.fn().mockResolvedValue(true),
+        markDeletingIfReadyToKill: jest.fn().mockResolvedValue(true),
+        setKillAt: jest.fn().mockResolvedValue(true),
         clearKillAt: jest.fn().mockResolvedValue(undefined),
         findReadyToKill: jest.fn().mockResolvedValue([]),
     } as unknown as jest.Mocked<SandboxLeaseRepository>;
 }
 
-function makeMockSandboxProvider(available = true): jest.Mocked<ISandboxProvider> {
+function makeMockSandboxProvider(
+    available = true,
+): jest.Mocked<ISandboxProvider> {
     const mockSandboxInstance: SandboxInstance = {
         remoteCommands: {
             grep: jest.fn().mockResolvedValue(''),
@@ -59,7 +69,9 @@ function makeMockSandboxProvider(available = true): jest.Mocked<ISandboxProvider
         type: 'e2b',
         sandboxId: 'mock-sandbox-id',
         repoDir: '/home/user/repo',
-        run: jest.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 }),
+        run: jest
+            .fn()
+            .mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 }),
         readFile: jest.fn().mockResolvedValue(''),
         writeFile: jest.fn().mockResolvedValue(undefined),
     };
@@ -67,10 +79,35 @@ function makeMockSandboxProvider(available = true): jest.Mocked<ISandboxProvider
     return {
         isAvailable: jest.fn().mockReturnValue(available),
         createSandboxWithRepo: jest.fn().mockResolvedValue(mockSandboxInstance),
+        connectToExistingSandbox: jest.fn(),
     } as jest.Mocked<ISandboxProvider>;
 }
 
-function makeMockConfigService(e2bKey: string | undefined = 'test-e2b-key'): jest.Mocked<ConfigService> {
+function makeLocalSandboxInstance(tempDir: string): SandboxInstance {
+    return {
+        remoteCommands: {
+            grep: jest.fn().mockResolvedValue(''),
+            read: jest.fn().mockResolvedValue(''),
+            listDir: jest.fn().mockResolvedValue(''),
+            exec: jest.fn().mockResolvedValue({ stdout: '', exitCode: 0 }),
+        },
+        cleanup: jest.fn(async () => {
+            await rm(tempDir, { recursive: true, force: true });
+        }),
+        type: 'local',
+        sandboxId: tempDir,
+        repoDir: tempDir,
+        run: jest
+            .fn()
+            .mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 }),
+        readFile: jest.fn().mockResolvedValue(''),
+        writeFile: jest.fn().mockResolvedValue(undefined),
+    };
+}
+
+function makeMockConfigService(
+    e2bKey: string | undefined = 'test-e2b-key',
+): jest.Mocked<ConfigService> {
     return {
         get: jest.fn().mockReturnValue(e2bKey),
     } as unknown as jest.Mocked<ConfigService>;
@@ -138,7 +175,10 @@ describe('SandboxLeaseManager', () => {
         expect(result.sandbox).toBeDefined();
 
         // updateReady called with prKey
-        expect(leaseRepo.updateReady).toHaveBeenCalledWith(prKey, expect.any(String));
+        expect(leaseRepo.updateReady).toHaveBeenCalledWith(
+            prKey,
+            expect.any(String),
+        );
 
         // Release: decrement lease
         leaseRepo.decrementLease.mockResolvedValue({
@@ -161,6 +201,142 @@ describe('SandboxLeaseManager', () => {
 
         // kill is NEVER called on release
         expect(Sandbox.kill).not.toHaveBeenCalled();
+    });
+
+    it('release removes a local sandbox directory when the last lease is released', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:203';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'CREATING',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'READY',
+            sandboxId: '',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        const result = await manager.acquire(prKey, 'review');
+
+        leaseRepo.decrementLease.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        try {
+            await manager.release(result.leaseId, { idleMs: 30_000 });
+
+            await expect(localSandboxDirectoryExists(tempDir)).resolves.toBe(
+                false,
+            );
+            expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledWith(
+                prKey,
+            );
+            expect(leaseRepo.deleteIfNoActiveLeases).toHaveBeenCalledWith(
+                prKey,
+            );
+            expect(leaseRepo.setKillAt).not.toHaveBeenCalled();
+            expect(Sandbox.setTimeout).not.toHaveBeenCalled();
+            expect(Sandbox.kill).not.toHaveBeenCalled();
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('release deletes the local lease when the directory is already missing', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:204';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        await rm(tempDir, { recursive: true, force: true });
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'CREATING',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'READY',
+            sandboxId: '',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        const result = await manager.acquire(prKey, 'review');
+
+        leaseRepo.decrementLease.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        await manager.release(result.leaseId, { idleMs: 30_000 });
+
+        expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledWith(
+            prKey,
+        );
+        expect(leaseRepo.deleteIfNoActiveLeases).toHaveBeenCalledWith(prKey);
+        expect(leaseRepo.setKillAt).not.toHaveBeenCalled();
+        expect(Sandbox.setTimeout).not.toHaveBeenCalled();
+    });
+
+    it('release skips local cleanup when the lease was re-acquired before marking deleting', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:205';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'CREATING',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'READY',
+            sandboxId: '',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        const result = await manager.acquire(prKey, 'review');
+
+        leaseRepo.decrementLease.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.markDeletingIfNoActiveLeases.mockResolvedValue(false);
+
+        try {
+            await manager.release(result.leaseId, { idleMs: 30_000 });
+
+            await expect(localSandboxDirectoryExists(tempDir)).resolves.toBe(
+                true,
+            );
+            expect(leaseRepo.deleteIfNoActiveLeases).not.toHaveBeenCalled();
+            expect(leaseRepo.setKillAt).not.toHaveBeenCalled();
+            expect(Sandbox.setTimeout).not.toHaveBeenCalled();
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
     });
 
     // ─── Test 2: concurrent acquire — exactly one createSandboxWithRepo ───
@@ -238,10 +414,9 @@ describe('SandboxLeaseManager', () => {
 
         // Joiner (second acquire) connected to existing sandbox via Sandbox.connect
         // (creator path — without cloneParams — uses null sandbox for initial CREATING→READY)
-        expect(Sandbox.connect).toHaveBeenCalledWith(
-            'e2b-poll-sandbox',
-            { apiKey: 'test-e2b-key' },
-        );
+        expect(Sandbox.connect).toHaveBeenCalledWith('e2b-poll-sandbox', {
+            apiKey: 'test-e2b-key',
+        });
 
         // Key invariant: createSandboxWithRepo NOT called without cloneParams
         // (manager falls back to null sandbox when no clone params supplied).
@@ -277,6 +452,138 @@ describe('SandboxLeaseManager', () => {
         expect(leaseRepo.delete).toHaveBeenCalledWith(prKey);
 
         // kill is NOT called synchronously (soft-drain, not immediate kill)
+        expect(Sandbox.kill).not.toHaveBeenCalled();
+    });
+
+    it('invalidate preserves a remote lease when the invalidation claim loses to DELETING cleanup', async () => {
+        const prKey = 'org:repo:82';
+
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'READY',
+            sandboxId: 'e2b-deleting-race',
+            killAt: new Date(Date.now() - 1000),
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.markInvalidated.mockResolvedValueOnce(false);
+
+        await manager.invalidate(prKey);
+
+        expect(leaseRepo.markInvalidated).toHaveBeenCalledWith(prKey);
+        expect(leaseRepo.clearKillAt).not.toHaveBeenCalledWith(prKey);
+        expect(Sandbox.setTimeout).not.toHaveBeenCalled();
+        expect(leaseRepo.delete).not.toHaveBeenCalledWith(prKey);
+    });
+
+    it('invalidate removes a local sandbox directory before deleting an inactive lease', async () => {
+        const prKey = 'org:repo:78';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        try {
+            await manager.invalidate(prKey);
+
+            await expect(localSandboxDirectoryExists(tempDir)).resolves.toBe(
+                false,
+            );
+            expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledWith(
+                prKey,
+            );
+            expect(leaseRepo.deleteIfNoActiveLeases).toHaveBeenCalledWith(
+                prKey,
+            );
+            expect(leaseRepo.delete).not.toHaveBeenCalledWith(prKey);
+            expect(Sandbox.setTimeout).not.toHaveBeenCalled();
+            expect(Sandbox.kill).not.toHaveBeenCalled();
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('invalidate marks an active local sandbox invalidated without deleting the active directory', async () => {
+        const prKey = 'org:repo:80';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.markDeletingIfNoActiveLeases.mockResolvedValueOnce(false);
+
+        try {
+            await manager.invalidate(prKey);
+
+            expect(leaseRepo.markInvalidated).toHaveBeenCalledWith(prKey);
+            expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledWith(
+                prKey,
+            );
+            await expect(localSandboxDirectoryExists(tempDir)).resolves.toBe(
+                true,
+            );
+            expect(leaseRepo.deleteIfNoActiveLeases).not.toHaveBeenCalled();
+            expect(leaseRepo.delete).not.toHaveBeenCalledWith(prKey);
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('invalidate deletes a local lease when the directory is already missing', async () => {
+        const prKey = 'org:repo:79';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        await rm(tempDir, { recursive: true, force: true });
+
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        await manager.invalidate(prKey);
+
+        expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledWith(
+            prKey,
+        );
+        expect(leaseRepo.deleteIfNoActiveLeases).toHaveBeenCalledWith(prKey);
+        expect(leaseRepo.delete).not.toHaveBeenCalledWith(prKey);
+        expect(Sandbox.setTimeout).not.toHaveBeenCalled();
+    });
+
+    it('invalidate preserves a DELETING lease and its idle retry cursor', async () => {
+        const prKey = 'org:repo:81';
+        const killAt = new Date(Date.now() - 1000);
+
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'DELETING',
+            sandboxId: 'e2b-deleting-retry',
+            killAt,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        await manager.invalidate(prKey);
+
+        expect(leaseRepo.clearKillAt).not.toHaveBeenCalledWith(prKey);
+        expect(leaseRepo.delete).not.toHaveBeenCalledWith(prKey);
+        expect(Sandbox.setTimeout).not.toHaveBeenCalled();
         expect(Sandbox.kill).not.toHaveBeenCalled();
     });
 
@@ -326,20 +633,34 @@ describe('SandboxLeaseManager', () => {
         ['only one segment', 'foo'],
         ['two segments', 'foo:bar'],
         ['five segments', 'a:b:c:d:e'],
-        ['UUID v4-shape but invalid hex', 'gggggggg-aaaa-aaaa-aaaa-aaaaaaaaaaaa:r:1'],
-    ])('rejects malformed prKey (%s) before any side-effect', async (_label, badKey) => {
-        const leaseRepo = makeMockLeaseRepo();
-        const configService = makeMockConfigService('test-e2b-key');
-        const sandboxProvider = makeMockSandboxProvider(true);
-        const manager = makeLeaseManager(leaseRepo, sandboxProvider, configService);
+        [
+            'UUID v4-shape but invalid hex',
+            'gggggggg-aaaa-aaaa-aaaa-aaaaaaaaaaaa:r:1',
+        ],
+    ])(
+        'rejects malformed prKey (%s) before any side-effect',
+        async (_label, badKey) => {
+            const leaseRepo = makeMockLeaseRepo();
+            const configService = makeMockConfigService('test-e2b-key');
+            const sandboxProvider = makeMockSandboxProvider(true);
+            const manager = makeLeaseManager(
+                leaseRepo,
+                sandboxProvider,
+                configService,
+            );
 
-        await expect(manager.acquire(badKey, 'review')).rejects.toThrow(/Invalid prKey/);
+            await expect(manager.acquire(badKey, 'review')).rejects.toThrow(
+                /Invalid prKey/,
+            );
 
-        // CRITICAL: NO Mongo write happened, NO sandbox was created.
-        // A malformed key MUST NOT pollute the lease collection.
-        expect(leaseRepo.upsertAcquire).not.toHaveBeenCalled();
-        expect(sandboxProvider.createSandboxWithRepo).not.toHaveBeenCalled();
-    });
+            // CRITICAL: NO Mongo write happened, NO sandbox was created.
+            // A malformed key MUST NOT pollute the lease collection.
+            expect(leaseRepo.upsertAcquire).not.toHaveBeenCalled();
+            expect(
+                sandboxProvider.createSandboxWithRepo,
+            ).not.toHaveBeenCalled();
+        },
+    );
 
     // ─── Test 6: orphan kill when post-create Mongo step fails ────────────
 
@@ -378,7 +699,9 @@ describe('SandboxLeaseManager', () => {
         } as any);
 
         // updateReady fails AFTER the sandbox was created
-        leaseRepo.updateReady.mockRejectedValue(new Error('Mongo connection lost'));
+        leaseRepo.updateReady.mockRejectedValue(
+            new Error('Mongo connection lost'),
+        );
 
         await expect(
             manager.acquire(prKey, 'review', undefined, cloneParams),
@@ -390,6 +713,119 @@ describe('SandboxLeaseManager', () => {
         });
         // And the lease doc was cleaned up so other callers don't poll forever
         expect(leaseRepo.delete).toHaveBeenCalledWith(prKey);
+    });
+
+    it('cleans and deletes the lease when creator-path local cleanup succeeds after updateReady fails', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:206';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 206,
+            platform: 'GITHUB' as any,
+        };
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'CREATING',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        sandboxProvider.createSandboxWithRepo.mockResolvedValue(
+            makeLocalSandboxInstance(tempDir),
+        );
+        leaseRepo.updateReady.mockRejectedValueOnce(
+            new Error('Mongo connection lost'),
+        );
+
+        try {
+            await expect(
+                manager.acquire(prKey, 'review', undefined, cloneParams),
+            ).rejects.toThrow(/Mongo connection lost/);
+
+            await expect(localSandboxDirectoryExists(tempDir)).resolves.toBe(
+                false,
+            );
+            expect(leaseRepo.delete).toHaveBeenCalledWith(prKey);
+            expect(Sandbox.kill).not.toHaveBeenCalled();
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('deletes the lease when creator-path local cleanup finds the directory already missing', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:207';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        await rm(tempDir, { recursive: true, force: true });
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 207,
+            platform: 'GITHUB' as any,
+        };
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'CREATING',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        sandboxProvider.createSandboxWithRepo.mockResolvedValue(
+            makeLocalSandboxInstance(tempDir),
+        );
+        leaseRepo.updateReady.mockRejectedValueOnce(
+            new Error('Mongo connection lost'),
+        );
+
+        await expect(
+            manager.acquire(prKey, 'review', undefined, cloneParams),
+        ).rejects.toThrow(/Mongo connection lost/);
+
+        expect(leaseRepo.delete).toHaveBeenCalledWith(prKey);
+        expect(Sandbox.kill).not.toHaveBeenCalled();
+    });
+
+    it('deletes the lease when local cleanup after mid-create invalidation finds the directory already missing', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:213';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        await rm(tempDir, { recursive: true, force: true });
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 213,
+            platform: 'GITHUB' as any,
+        };
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'CREATING',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        sandboxProvider.createSandboxWithRepo.mockResolvedValue(
+            makeLocalSandboxInstance(tempDir),
+        );
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'INVALIDATED',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        await expect(
+            manager.acquire(prKey, 'review', undefined, cloneParams),
+        ).rejects.toThrow(/invalidated mid-create/);
+
+        expect(leaseRepo.delete).toHaveBeenCalledWith(prKey);
+        expect(Sandbox.kill).not.toHaveBeenCalled();
     });
 
     // ─── Test 7: retry succeeds on 2nd attempt ────────────────────────────
@@ -435,7 +871,12 @@ describe('SandboxLeaseManager', () => {
             } as any);
 
         jest.useFakeTimers();
-        const acquirePromise = manager.acquire(prKey, 'review', undefined, cloneParams);
+        const acquirePromise = manager.acquire(
+            prKey,
+            'review',
+            undefined,
+            cloneParams,
+        );
 
         // Fast-forward through the 60s backoff between attempt 1 and 2
         await jest.runAllTimersAsync();
@@ -534,9 +975,8 @@ describe('SandboxLeaseManager', () => {
         // killAt scheduled in Mongo — the killIdleSandboxes cron will sweep it.
         // No in-memory timer involved, so any worker can pick up the kill.
         expect(leaseRepo.setKillAt).toHaveBeenCalledTimes(1);
-        const [calledPrKey, calledKillAt] = (
-            leaseRepo.setKillAt as jest.Mock
-        ).mock.calls[0];
+        const [calledPrKey, calledKillAt] = (leaseRepo.setKillAt as jest.Mock)
+            .mock.calls[0];
         expect(calledPrKey).toBe(prKey);
         expect(calledKillAt).toBeInstanceOf(Date);
         const expectedAt = before + 30_000;
@@ -651,9 +1091,384 @@ describe('SandboxLeaseManager', () => {
         // Stale lease was deleted before cold-start
         expect(leaseRepo.delete).toHaveBeenCalledWith(prKey);
         // Cold-start succeeded — fresh sandbox created
-        expect(sandboxProvider.createSandboxWithRepo).toHaveBeenCalledWith(cloneParams);
+        expect(sandboxProvider.createSandboxWithRepo).toHaveBeenCalledWith(
+            cloneParams,
+        );
         expect(result.sandboxId).toBe('fresh-sandbox-id');
         expect(result.wasCreated).toBe(true);
+    });
+
+    it('local reconnect uses the provider and does not call E2B connect even when API_E2B_KEY exists', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:208';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        sandboxProvider.connectToExistingSandbox.mockResolvedValue(
+            makeLocalSandboxInstance(tempDir),
+        );
+
+        try {
+            const result = await manager.acquire(prKey, 'conversation');
+
+            expect(result.sandboxId).toBe(tempDir);
+            expect(result.wasCreated).toBe(false);
+            expect(
+                sandboxProvider.connectToExistingSandbox,
+            ).toHaveBeenCalledWith(tempDir);
+            expect(Sandbox.connect).not.toHaveBeenCalled();
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('local reconnect missing directory cold-starts after rollback leaves no active leases', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:209';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        await rm(tempDir, { recursive: true, force: true });
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 209,
+            platform: 'GITHUB' as any,
+        };
+
+        leaseRepo.upsertAcquire
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'READY',
+                sandboxId: tempDir,
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any)
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'CREATING',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+        leaseRepo.decrementLease.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'READY',
+            sandboxId: 'fresh-after-local-stale',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        sandboxProvider.connectToExistingSandbox.mockRejectedValueOnce(
+            new Error('local sandbox missing'),
+        );
+        sandboxProvider.createSandboxWithRepo.mockResolvedValue({
+            type: 'e2b',
+            sandboxId: 'fresh-after-local-stale',
+            cleanup: jest.fn(),
+            remoteCommands: {} as any,
+            run: jest.fn(),
+            readFile: jest.fn(),
+            writeFile: jest.fn(),
+            repoDir: '/home/user/repo',
+        } as any);
+
+        const result = await manager.acquire(
+            prKey,
+            'conversation',
+            undefined,
+            cloneParams,
+        );
+
+        expect(leaseRepo.decrementLease).toHaveBeenCalledWith(prKey);
+        expect(leaseRepo.deleteIfNoActiveLeases).toHaveBeenCalledWith(prKey);
+        expect(leaseRepo.upsertAcquire).toHaveBeenCalledTimes(2);
+        expect(result.sandboxId).toBe('fresh-after-local-stale');
+        expect(result.wasCreated).toBe(true);
+    });
+
+    it('local reconnect missing directory does not cold-start when stale lease delete loses the race', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:212';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        await rm(tempDir, { recursive: true, force: true });
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 212,
+            platform: 'GITHUB' as any,
+        };
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.decrementLease.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.deleteIfNoActiveLeases.mockResolvedValueOnce(false);
+        sandboxProvider.connectToExistingSandbox.mockRejectedValueOnce(
+            new Error('local sandbox missing'),
+        );
+
+        await expect(
+            manager.acquire(prKey, 'conversation', undefined, cloneParams),
+        ).rejects.toThrow(/local sandbox missing/);
+
+        expect(leaseRepo.deleteIfNoActiveLeases).toHaveBeenCalledWith(prKey);
+        expect(leaseRepo.upsertAcquire).toHaveBeenCalledTimes(1);
+        expect(sandboxProvider.createSandboxWithRepo).not.toHaveBeenCalled();
+    });
+
+    it('local reconnect failure with an existing directory preserves the lease and rethrows', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:210';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 210,
+            platform: 'GITHUB' as any,
+        };
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.decrementLease.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        sandboxProvider.connectToExistingSandbox.mockRejectedValueOnce(
+            new Error('local provider failed'),
+        );
+
+        try {
+            await expect(
+                manager.acquire(prKey, 'conversation', undefined, cloneParams),
+            ).rejects.toThrow(/local provider failed/);
+
+            expect(leaseRepo.decrementLease).toHaveBeenCalledWith(prKey);
+            expect(leaseRepo.deleteIfNoActiveLeases).not.toHaveBeenCalled();
+            expect(leaseRepo.upsertAcquire).toHaveBeenCalledTimes(1);
+            expect(
+                sandboxProvider.createSandboxWithRepo,
+            ).not.toHaveBeenCalled();
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('joiner retries after a DELETING lease disappears', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:211';
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 211,
+            platform: 'GITHUB' as any,
+        };
+
+        leaseRepo.upsertAcquire
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'DELETING',
+                sandboxId: '/tmp/kodus-sandbox-old',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any)
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'CREATING',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+        leaseRepo.findByPrKey
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'READY',
+                sandboxId: 'fresh-after-deleting',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+        sandboxProvider.createSandboxWithRepo.mockResolvedValue({
+            type: 'e2b',
+            sandboxId: 'fresh-after-deleting',
+            cleanup: jest.fn(),
+            remoteCommands: {} as any,
+            run: jest.fn(),
+            readFile: jest.fn(),
+            writeFile: jest.fn(),
+            repoDir: '/home/user/repo',
+        } as any);
+
+        const result = await manager.acquire(
+            prKey,
+            'conversation',
+            undefined,
+            cloneParams,
+        );
+
+        expect(leaseRepo.decrementLease).toHaveBeenCalledWith(prKey);
+        expect(leaseRepo.clearKillAt).toHaveBeenCalledTimes(1);
+        expect(leaseRepo.upsertAcquire).toHaveBeenCalledTimes(2);
+        expect(result.sandboxId).toBe('fresh-after-deleting');
+        expect(result.wasCreated).toBe(true);
+    });
+
+    it('joiner finalizes a DELETING local lease when cleanup already removed the directory', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:215';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        await rm(tempDir, { recursive: true, force: true });
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 215,
+            platform: 'GITHUB' as any,
+        };
+
+        leaseRepo.upsertAcquire
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'DELETING',
+                sandboxId: tempDir,
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any)
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'CREATING',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+        leaseRepo.decrementLease.mockResolvedValueOnce({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'DELETING',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.findByPrKey
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 0,
+                state: 'DELETING',
+                sandboxId: tempDir,
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any)
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'READY',
+                sandboxId: 'fresh-after-finalized-deleting',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+        sandboxProvider.createSandboxWithRepo.mockResolvedValue({
+            type: 'e2b',
+            sandboxId: 'fresh-after-finalized-deleting',
+            cleanup: jest.fn(),
+            remoteCommands: {} as any,
+            run: jest.fn(),
+            readFile: jest.fn(),
+            writeFile: jest.fn(),
+            repoDir: '/home/user/repo',
+        } as any);
+
+        const result = await manager.acquire(
+            prKey,
+            'conversation',
+            undefined,
+            cloneParams,
+        );
+
+        expect(leaseRepo.deleteIfNoActiveLeases).toHaveBeenCalledWith(prKey);
+        expect(leaseRepo.upsertAcquire).toHaveBeenCalledTimes(2);
+        expect(result.sandboxId).toBe('fresh-after-finalized-deleting');
+        expect(result.wasCreated).toBe(true);
+    });
+
+    it('joiner does not recursively cold-start when a remote DELETING lease is still waiting for reaper retry', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:216';
+        const dateNowSpy = jest
+            .spyOn(Date, 'now')
+            .mockReturnValueOnce(0)
+            .mockReturnValue(31_000);
+
+        leaseRepo.upsertAcquire
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'DELETING',
+                sandboxId: 'e2b-deleting-retry',
+                killAt: new Date('2026-01-01T00:00:00.000Z'),
+                createdAt: new Date('2026-01-01T00:00:00.000Z'),
+                expiresAt: new Date('2026-01-01T00:30:00.000Z'),
+            } as any)
+            .mockRejectedValueOnce(
+                new Error('recursive acquire should not run'),
+            );
+        leaseRepo.decrementLease.mockResolvedValueOnce({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'DELETING',
+            sandboxId: 'e2b-deleting-retry',
+            killAt: new Date('2026-01-01T00:00:00.000Z'),
+            createdAt: new Date('2026-01-01T00:00:00.000Z'),
+            expiresAt: new Date('2026-01-01T00:30:00.000Z'),
+        } as any);
+
+        try {
+            await expect(
+                manager.acquire(prKey, 'conversation'),
+            ).rejects.toThrow(/deleting cleanup still in progress/);
+
+            expect(leaseRepo.upsertAcquire).toHaveBeenCalledTimes(1);
+            expect(
+                sandboxProvider.createSandboxWithRepo,
+            ).not.toHaveBeenCalled();
+        } finally {
+            dateNowSpy.mockRestore();
+        }
     });
 
     // ─── Test 9a: release accepts custom idleMs (review uses 30s) ────────
@@ -792,11 +1607,174 @@ describe('SandboxLeaseReaperService', () => {
 
         await reaper.reapExpiredLeases();
 
+        expect(leaseRepo.findExpired).toHaveBeenCalledWith(
+            expect.any(Date),
+            expect.any(Number),
+        );
         // Sandbox.kill called with the expired sandbox ID
-        expect(Sandbox.kill).toHaveBeenCalledWith('e2b-123', { apiKey: 'test-e2b-key' });
+        expect(Sandbox.kill).toHaveBeenCalledWith('e2b-123', {
+            apiKey: 'test-e2b-key',
+        });
 
         // Mongo doc deleted
         expect(leaseRepo.delete).toHaveBeenCalledWith('org:repo:1');
+    });
+
+    it('reaper removes expired local sandbox directories before deleting the lease', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+
+        leaseRepo.findExpired.mockResolvedValue([
+            {
+                _id: 'org:repo:local-expired',
+                sandboxId: tempDir,
+                leaseCount: 1,
+                state: 'READY',
+                createdAt: new Date(Date.now() - 60 * 60 * 1000),
+                expiresAt: new Date(Date.now() - 10 * 60 * 1000),
+            } as any,
+        ]);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        await reaper.reapExpiredLeases();
+
+        await expect(localSandboxDirectoryExists(tempDir)).resolves.toBe(false);
+        expect(Sandbox.kill).not.toHaveBeenCalled();
+        expect(leaseRepo.delete).toHaveBeenCalledWith('org:repo:local-expired');
+    });
+
+    it('reaper deletes an expired local lease when the directory is already missing', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        await rm(tempDir, { recursive: true, force: true });
+
+        leaseRepo.findExpired.mockResolvedValue([
+            {
+                _id: 'org:repo:local-missing',
+                sandboxId: tempDir,
+                leaseCount: 1,
+                state: 'READY',
+                createdAt: new Date(Date.now() - 60 * 60 * 1000),
+                expiresAt: new Date(Date.now() - 10 * 60 * 1000),
+            } as any,
+        ]);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        await reaper.reapExpiredLeases();
+
+        expect(Sandbox.kill).not.toHaveBeenCalled();
+        expect(leaseRepo.delete).toHaveBeenCalledWith('org:repo:local-missing');
+    });
+
+    it('reaper skips a stale expired local result when the atomic claim loses the race', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        const expiresAt = new Date(Date.now() - 10 * 60 * 1000);
+
+        leaseRepo.findExpired.mockResolvedValue([
+            {
+                _id: 'org:repo:local-expired-race',
+                sandboxId: tempDir,
+                leaseCount: 1,
+                state: 'READY',
+                createdAt: new Date(Date.now() - 60 * 60 * 1000),
+                expiresAt,
+            } as any,
+        ]);
+        leaseRepo.markDeletingIfExpired.mockResolvedValueOnce(false);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        try {
+            await reaper.reapExpiredLeases();
+
+            expect(leaseRepo.markDeletingIfExpired).toHaveBeenCalledWith(
+                'org:repo:local-expired-race',
+                expiresAt,
+            );
+            await expect(localSandboxDirectoryExists(tempDir)).resolves.toBe(
+                true,
+            );
+            expect(leaseRepo.delete).not.toHaveBeenCalledWith(
+                'org:repo:local-expired-race',
+            );
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('reaper skips a stale expired E2B result when the atomic claim loses the race', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+        const expiresAt = new Date(Date.now() - 10 * 60 * 1000);
+
+        leaseRepo.findExpired.mockResolvedValue([
+            {
+                _id: 'org:repo:e2b-expired-race',
+                sandboxId: 'e2b-expired-race',
+                leaseCount: 1,
+                state: 'READY',
+                createdAt: new Date(Date.now() - 60 * 60 * 1000),
+                expiresAt,
+            } as any,
+        ]);
+        leaseRepo.markDeletingIfExpired.mockResolvedValueOnce(false);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        await reaper.reapExpiredLeases();
+
+        expect(leaseRepo.markDeletingIfExpired).toHaveBeenCalledWith(
+            'org:repo:e2b-expired-race',
+            expiresAt,
+        );
+        expect(Sandbox.kill).not.toHaveBeenCalledWith('e2b-expired-race', {
+            apiKey: 'test-e2b-key',
+        });
+        expect(leaseRepo.delete).not.toHaveBeenCalledWith(
+            'org:repo:e2b-expired-race',
+        );
     });
 
     // ─── Idle-kill cron tests ────────────────────────────────────────────
@@ -844,8 +1822,16 @@ describe('SandboxLeaseReaperService', () => {
             'CRON:SANDBOX:IDLE_KILL',
             { ttl: 25_000 },
         );
-        expect(Sandbox.kill).toHaveBeenCalledWith('e2b-idle-1', { apiKey: 'test-e2b-key' });
-        expect(Sandbox.kill).toHaveBeenCalledWith('e2b-idle-2', { apiKey: 'test-e2b-key' });
+        expect(leaseRepo.findReadyToKill).toHaveBeenCalledWith(
+            expect.any(Date),
+            expect.any(Number),
+        );
+        expect(Sandbox.kill).toHaveBeenCalledWith('e2b-idle-1', {
+            apiKey: 'test-e2b-key',
+        });
+        expect(Sandbox.kill).toHaveBeenCalledWith('e2b-idle-2', {
+            apiKey: 'test-e2b-key',
+        });
         expect(leaseRepo.delete).toHaveBeenCalledWith('org-uuid:repo:1');
         expect(leaseRepo.delete).toHaveBeenCalledWith('org-uuid:repo:2');
         expect(mockLock.release).toHaveBeenCalledTimes(1);
@@ -874,7 +1860,96 @@ describe('SandboxLeaseReaperService', () => {
         expect(leaseRepo.delete).not.toHaveBeenCalled();
     });
 
-    it('killIdleSandboxes: continues deleting Mongo doc even when Sandbox.kill fails', async () => {
+    it('killIdleSandboxes: skips a stale local idle result when the atomic claim loses the race', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        const killAt = new Date(Date.now() - 1000);
+
+        leaseRepo.findReadyToKill.mockResolvedValue([
+            {
+                _id: 'org-uuid:repo:11',
+                sandboxId: tempDir,
+                leaseCount: 0,
+                state: 'READY',
+                killAt,
+                createdAt: new Date(Date.now() - 60 * 1000),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any,
+        ]);
+        leaseRepo.markDeletingIfReadyToKill.mockResolvedValueOnce(false);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        try {
+            await reaper.killIdleSandboxes();
+
+            expect(leaseRepo.markDeletingIfReadyToKill).toHaveBeenCalledWith(
+                'org-uuid:repo:11',
+                killAt,
+            );
+            await expect(localSandboxDirectoryExists(tempDir)).resolves.toBe(
+                true,
+            );
+            expect(leaseRepo.delete).not.toHaveBeenCalledWith(
+                'org-uuid:repo:11',
+            );
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('killIdleSandboxes: skips a stale E2B idle result when the atomic claim loses the race', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+        const killAt = new Date(Date.now() - 1000);
+
+        leaseRepo.findReadyToKill.mockResolvedValue([
+            {
+                _id: 'org-uuid:repo:12',
+                sandboxId: 'e2b-race',
+                leaseCount: 0,
+                state: 'READY',
+                killAt,
+                createdAt: new Date(Date.now() - 60 * 1000),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any,
+        ]);
+        leaseRepo.markDeletingIfReadyToKill.mockResolvedValueOnce(false);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        await reaper.killIdleSandboxes();
+
+        expect(leaseRepo.markDeletingIfReadyToKill).toHaveBeenCalledWith(
+            'org-uuid:repo:12',
+            killAt,
+        );
+        expect(Sandbox.kill).not.toHaveBeenCalledWith('e2b-race', {
+            apiKey: 'test-e2b-key',
+        });
+        expect(leaseRepo.delete).not.toHaveBeenCalledWith('org-uuid:repo:12');
+    });
+
+    it('killIdleSandboxes: keeps Mongo doc when Sandbox.kill fails so the next cron can retry', async () => {
         const leaseRepo = makeMockLeaseRepo();
         const configService = makeMockConfigService('test-e2b-key');
 
@@ -908,9 +1983,41 @@ describe('SandboxLeaseReaperService', () => {
 
         await reaper.killIdleSandboxes();
 
-        // Doc deleted regardless — lease can't linger waiting for a sandbox
-        // that's already gone
-        expect(leaseRepo.delete).toHaveBeenCalledWith('org-uuid:repo:9');
+        expect(leaseRepo.delete).not.toHaveBeenCalledWith('org-uuid:repo:9');
+        expect(mockLock.release).toHaveBeenCalledTimes(1);
+    });
+
+    it('killIdleSandboxes: keeps E2B lease when API key is missing', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('');
+
+        leaseRepo.findReadyToKill.mockResolvedValue([
+            {
+                _id: 'org-uuid:repo:10',
+                sandboxId: 'e2b-no-api-key',
+                leaseCount: 0,
+                state: 'READY',
+                killAt: new Date(Date.now() - 1000),
+                createdAt: new Date(Date.now() - 60 * 1000),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any,
+        ]);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        await reaper.killIdleSandboxes();
+
+        expect(Sandbox.kill).not.toHaveBeenCalled();
+        expect(leaseRepo.delete).not.toHaveBeenCalledWith('org-uuid:repo:10');
         expect(mockLock.release).toHaveBeenCalledTimes(1);
     });
 });

--- a/libs/sandbox/infrastructure/services/sandbox-lease-reaper.service.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-reaper.service.ts
@@ -8,6 +8,13 @@ import {
     DistributedLockService,
 } from '@libs/core/workflow/infrastructure/distributed-lock.service';
 import { SandboxLeaseRepository } from '@libs/sandbox/infrastructure/repositories/sandbox-lease.repository';
+import {
+    cleanupLocalSandboxDirectory,
+    isLocalSandboxPath,
+    localSandboxDirectoryExists,
+} from './local-sandbox-cleanup';
+
+const SANDBOX_REAPER_BATCH_LIMIT = 100;
 
 @Injectable()
 export class SandboxLeaseReaperService {
@@ -28,31 +35,80 @@ export class SandboxLeaseReaperService {
         if (!lock) return;
 
         try {
-            const expired = await this.leaseRepository.findExpired(new Date());
+            const expired = await this.leaseRepository.findExpired(
+                new Date(),
+                SANDBOX_REAPER_BATCH_LIMIT,
+            );
             if (expired.length === 0) return;
 
             const apiKey = this.configService.get<string>('API_E2B_KEY');
 
             await Promise.allSettled(
                 expired.map(async (lease) => {
+                    if (lease.sandboxId) {
+                        const claimed =
+                            await this.leaseRepository.markDeletingIfExpired(
+                                lease._id,
+                                lease.expiresAt,
+                            );
+                        if (!claimed) {
+                            this.logger.log({
+                                message:
+                                    '[SANDBOX-REAPER] Skipped stale expired candidate because lease was refreshed',
+                                context: SandboxLeaseReaperService.name,
+                                metadata: {
+                                    prKey: lease._id,
+                                    sandboxId: lease.sandboxId,
+                                    expiresAt: lease.expiresAt,
+                                },
+                            });
+                            return;
+                        }
+                    }
+
                     if (
                         lease.sandboxId &&
-                        lease.state !== 'INVALIDATED' &&
-                        apiKey
+                        isLocalSandboxPath(lease.sandboxId)
                     ) {
-                        await Sandbox.kill(lease.sandboxId, { apiKey }).catch(
-                            (err) => {
-                                this.logger.warn({
-                                    message:
-                                        '[SANDBOX-REAPER] Failed to kill sandbox — continuing',
-                                    context: SandboxLeaseReaperService.name,
-                                    metadata: {
-                                        sandboxId: lease.sandboxId,
-                                        error: String(err),
-                                    },
-                                });
-                            },
+                        const cleaned = await this.cleanupLocalExpiredSandbox(
+                            lease._id,
+                            lease.sandboxId,
                         );
+                        if (!cleaned) {
+                            return;
+                        }
+
+                        await this.leaseRepository.delete(lease._id);
+                        this.logger.log({
+                            message:
+                                '[SANDBOX-REAPER] Reaped expired local lease',
+                            context: SandboxLeaseReaperService.name,
+                            metadata: {
+                                prKey: lease._id,
+                                sandboxId: lease.sandboxId,
+                                state: lease.state,
+                            },
+                        });
+                        return;
+                    }
+
+                    if (lease.sandboxId && lease.state !== 'INVALIDATED') {
+                        if (!apiKey) {
+                            this.logMissingE2BApiKey(
+                                lease._id,
+                                lease.sandboxId,
+                            );
+                            return;
+                        }
+
+                        const killed = await this.killE2BSandbox(
+                            lease.sandboxId,
+                            apiKey,
+                            '[SANDBOX-REAPER]',
+                        );
+                        if (!killed) {
+                            return;
+                        }
                     }
 
                     await this.leaseRepository.delete(lease._id);
@@ -96,27 +152,67 @@ export class SandboxLeaseReaperService {
         if (!lock) return;
 
         try {
-            const ready = await this.leaseRepository.findReadyToKill(new Date());
+            const ready = await this.leaseRepository.findReadyToKill(
+                new Date(),
+                SANDBOX_REAPER_BATCH_LIMIT,
+            );
             if (ready.length === 0) return;
 
             const apiKey = this.configService.get<string>('API_E2B_KEY');
 
             await Promise.allSettled(
                 ready.map(async (lease) => {
-                    if (lease.sandboxId && apiKey) {
-                        await Sandbox.kill(lease.sandboxId, { apiKey }).catch(
-                            (err) => {
-                                this.logger.warn({
-                                    message:
-                                        '[SANDBOX-IDLE-KILL] Failed to kill sandbox — Mongo doc still deleted; reaper will retry if E2B still has it',
-                                    context: SandboxLeaseReaperService.name,
-                                    metadata: {
-                                        sandboxId: lease.sandboxId,
-                                        error: String(err),
-                                    },
-                                });
-                            },
+                    if (!lease.killAt) {
+                        return;
+                    }
+
+                    const claimed =
+                        await this.leaseRepository.markDeletingIfReadyToKill(
+                            lease._id,
+                            lease.killAt,
                         );
+                    if (!claimed) {
+                        this.logger.log({
+                            message:
+                                '[SANDBOX-IDLE-KILL] Skipped stale idle candidate because lease was re-acquired',
+                            context: SandboxLeaseReaperService.name,
+                            metadata: {
+                                prKey: lease._id,
+                                sandboxId: lease.sandboxId,
+                                killAt: lease.killAt,
+                            },
+                        });
+                        return;
+                    }
+
+                    if (
+                        lease.sandboxId &&
+                        isLocalSandboxPath(lease.sandboxId)
+                    ) {
+                        const cleaned = await this.cleanupLocalExpiredSandbox(
+                            lease._id,
+                            lease.sandboxId,
+                        );
+                        if (!cleaned) {
+                            return;
+                        }
+
+                        await this.leaseRepository.delete(lease._id);
+                        return;
+                    }
+
+                    if (lease.sandboxId && apiKey) {
+                        const killed = await this.killE2BSandbox(
+                            lease.sandboxId,
+                            apiKey,
+                            '[SANDBOX-IDLE-KILL]',
+                        );
+                        if (!killed) {
+                            return;
+                        }
+                    } else if (lease.sandboxId) {
+                        this.logMissingE2BApiKey(lease._id, lease.sandboxId);
+                        return;
                     }
 
                     await this.leaseRepository.delete(lease._id);
@@ -154,6 +250,67 @@ export class SandboxLeaseReaperService {
             });
             return null;
         }
+    }
+
+    private async cleanupLocalExpiredSandbox(
+        prKey: string,
+        sandboxId: string,
+    ): Promise<boolean> {
+        try {
+            const exists = await localSandboxDirectoryExists(sandboxId);
+            if (!exists) {
+                return true;
+            }
+
+            const cleaned = await cleanupLocalSandboxDirectory(sandboxId);
+            if (!cleaned) {
+                this.logger.warn({
+                    message:
+                        '[SANDBOX-REAPER] Local sandbox cleanup returned false',
+                    context: SandboxLeaseReaperService.name,
+                    metadata: { prKey, sandboxId },
+                });
+            }
+            return cleaned;
+        } catch (error) {
+            this.logger.warn({
+                message: '[SANDBOX-REAPER] Failed to clean local sandbox',
+                context: SandboxLeaseReaperService.name,
+                error,
+                metadata: { prKey, sandboxId },
+            });
+            return false;
+        }
+    }
+
+    private async killE2BSandbox(
+        sandboxId: string,
+        apiKey: string,
+        logPrefix: string,
+    ): Promise<boolean> {
+        try {
+            await Sandbox.kill(sandboxId, { apiKey });
+            return true;
+        } catch (err) {
+            this.logger.warn({
+                message: `${logPrefix} Failed to kill sandbox — keeping lease for retry`,
+                context: SandboxLeaseReaperService.name,
+                metadata: {
+                    sandboxId,
+                    error: String(err),
+                },
+            });
+            return false;
+        }
+    }
+
+    private logMissingE2BApiKey(prKey: string, sandboxId: string): void {
+        this.logger.warn({
+            message:
+                '[SANDBOX-REAPER] Missing API_E2B_KEY — keeping lease for retry',
+            context: SandboxLeaseReaperService.name,
+            metadata: { prKey, sandboxId },
+        });
     }
 
     private async releaseCronLock(


### PR DESCRIPTION
## Summary

Fixes leaked self-hosted local sandbox directories under `/tmp/kodus-sandbox-*` by adding lifecycle cleanup for the local sandbox provider and making lease cleanup race-safe.

## What changed

- add a local sandbox cleanup helper that only accepts direct `/tmp/kodus-sandbox-*` paths
- allow `LocalSandboxService` to reconnect to existing local sandboxes safely
- clean local sandboxes on release, invalidation, creator failure, and expired/idle reaper paths
- add atomic lease guards for cleanup (`DELETING`, guarded delete, idle/expired cleanup claims)
- preserve reaper retry cursors and avoid recursive cold-start loops while cleanup is still in progress
- refresh lease `expiresAt` on acquire so stale expired-reaper claims lose to fresh acquires
- document the hard-flow plan and prior PR failure learnings

## Verification

Passed:

```bash
pnpm test -- --runTestsByPath libs/sandbox/infrastructure/services/local-sandbox-cleanup.spec.ts libs/sandbox/infrastructure/repositories/sandbox-lease.repository.spec.ts libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts libs/sandbox/infrastructure/providers/local-sandbox.exec-streams.spec.ts libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts test/unit/code-review/pipeline/stages/create-sandbox.stage.spec.ts --no-coverage --runInBand
# 6 passed, 83 tests

pnpm exec prettier --check docs/superpowers/plans/2026-07-06-local-sandbox-cleanup-hardflow.md libs/sandbox/domain/contracts/sandbox.provider.ts libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts libs/sandbox/infrastructure/providers/local-sandbox.service.ts libs/sandbox/infrastructure/repositories/sandbox-lease.repository.spec.ts libs/sandbox/infrastructure/repositories/sandbox-lease.repository.ts libs/sandbox/infrastructure/repositories/schemas/sandbox-lease.model.ts libs/sandbox/infrastructure/services/local-sandbox-cleanup.spec.ts libs/sandbox/infrastructure/services/local-sandbox-cleanup.ts libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts libs/sandbox/infrastructure/services/sandbox-lease-reaper.service.ts

pnpm exec eslint libs/sandbox/domain/contracts/sandbox.provider.ts libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts libs/sandbox/infrastructure/providers/local-sandbox.service.ts libs/sandbox/infrastructure/repositories/sandbox-lease.repository.spec.ts libs/sandbox/infrastructure/repositories/sandbox-lease.repository.ts libs/sandbox/infrastructure/repositories/schemas/sandbox-lease.model.ts libs/sandbox/infrastructure/services/local-sandbox-cleanup.spec.ts libs/sandbox/infrastructure/services/local-sandbox-cleanup.ts libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts libs/sandbox/infrastructure/services/sandbox-lease-reaper.service.ts

git diff --check
pnpm run typecheck:libs-gate
# No TS2304 errors in libs/
```

Known local verification limits:

- `pnpm run typecheck` currently fails on existing unrelated repo-wide type errors, mostly CLI/test typings and existing test fixtures.
- `pnpm run build:worker` and the pre-push full `pnpm test` hook fail locally because `libs/ee/configs/environment/environment` is not present in this self-hosted checkout; integration tests also require local Postgres.
