### PR TITLE
fix: clean up local sandbox leases

### DIFF
--- a/libs/sandbox/domain/contracts/sandbox.provider.ts
+++ b/libs/sandbox/domain/contracts/sandbox.provider.ts
@@ -52,11 +52,18 @@ export interface SandboxInstance {
     /** Absolute path to the repo root inside the sandbox */
     repoDir: string;
     /** Run a shell command inside the sandbox */
-    run(command: string, opts?: { timeoutMs?: number }): Promise<SandboxRunResult>;
+    run(
+        command: string,
+        opts?: { timeoutMs?: number },
+    ): Promise<SandboxRunResult>;
     /** Read a file from the sandbox filesystem */
     readFile(path: string, opts?: { timeoutMs?: number }): Promise<string>;
     /** Write a file to the sandbox filesystem */
-    writeFile(path: string, content: string, opts?: { timeoutMs?: number }): Promise<void>;
+    writeFile(
+        path: string,
+        content: string,
+        opts?: { timeoutMs?: number },
+    ): Promise<void>;
 }
 
 export interface ISandboxProvider {
@@ -67,6 +74,15 @@ export interface ISandboxProvider {
     createSandboxWithRepo(
         params: CreateSandboxParams,
     ): Promise<SandboxInstance>;
+
+    /**
+     * Reconnect to a previously-created sandbox by sandboxId.
+     *
+     * Local sandbox ids are worker-local filesystem paths. E2B sandbox ids are
+     * globally reconnectable through the E2B API. Providers may omit this when
+     * reconnect is not supported.
+     */
+    connectToExistingSandbox?(sandboxId: string): Promise<SandboxInstance>;
 }
 
 export const SANDBOX_PROVIDER_TOKEN = Symbol('SANDBOX_PROVIDER_TOKEN');

--- a/libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts
+++ b/libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts
@@ -1,5 +1,8 @@
 import { PlatformType } from '@libs/core/domain/enums';
 import { LocalSandboxService } from './local-sandbox.service';
+import { mkdtemp, readFile, rm, symlink, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 /**
  * buildAuthHeader is the git-over-HTTPS Authorization builder used when the
@@ -16,9 +19,10 @@ describe('LocalSandboxService.buildAuthHeader', () => {
         (service as any).buildAuthHeader(platform, token, username) as string;
 
     const decode = (header: string) =>
-        Buffer.from(header.replace('Authorization: Basic ', ''), 'base64').toString(
-            'utf8',
-        );
+        Buffer.from(
+            header.replace('Authorization: Basic ', ''),
+            'base64',
+        ).toString('utf8');
 
     it('uses x-access-token for GitHub', () => {
         expect(decode(build(PlatformType.GITHUB, 'ghtok'))).toBe(
@@ -27,7 +31,9 @@ describe('LocalSandboxService.buildAuthHeader', () => {
     });
 
     it('uses oauth2 for GitLab and Azure', () => {
-        expect(decode(build(PlatformType.GITLAB, 'gltok'))).toBe('oauth2:gltok');
+        expect(decode(build(PlatformType.GITLAB, 'gltok'))).toBe(
+            'oauth2:gltok',
+        );
         expect(decode(build(PlatformType.AZURE_REPOS, 'aztok'))).toBe(
             'oauth2:aztok',
         );
@@ -47,7 +53,9 @@ describe('LocalSandboxService.buildAuthHeader', () => {
 
         it('uses the account username for classic app passwords', () => {
             expect(
-                decode(build(PlatformType.BITBUCKET, 'classicapppw', 'kodususer')),
+                decode(
+                    build(PlatformType.BITBUCKET, 'classicapppw', 'kodususer'),
+                ),
             ).toBe('kodususer:classicapppw');
         });
 
@@ -62,5 +70,106 @@ describe('LocalSandboxService.buildAuthHeader', () => {
                 /Bitbucket authentication requires/i,
             );
         });
+    });
+});
+
+describe('LocalSandboxService.connectToExistingSandbox', () => {
+    const service = new LocalSandboxService({} as any);
+
+    it('reconnects to an existing local sandbox directory', async () => {
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        await writeFile(join(tempDir, 'README.md'), 'hello', 'utf-8');
+
+        try {
+            const sandbox = await service.connectToExistingSandbox(tempDir);
+
+            expect(sandbox.type).toBe('local');
+            expect(sandbox.sandboxId).toBe(tempDir);
+            expect(sandbox.repoDir).toBe(tempDir);
+            await expect(sandbox.readFile('README.md')).resolves.toBe('hello');
+            await sandbox.writeFile('nested/result.txt', 'saved');
+            await expect(
+                readFile(join(tempDir, 'nested/result.txt'), 'utf-8'),
+            ).resolves.toBe('saved');
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('rejects absolute and traversal paths for local read/write helpers', async () => {
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        await writeFile(join(tempDir, 'README.md'), 'hello', 'utf-8');
+
+        try {
+            const sandbox = await service.connectToExistingSandbox(tempDir);
+
+            await expect(sandbox.readFile('/etc/passwd')).rejects.toThrow(
+                /absolute paths/i,
+            );
+            await expect(
+                sandbox.writeFile('../escaped.txt', 'bad'),
+            ).rejects.toThrow(/path traversal/i);
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('rejects local writes through symlinked parent directories', async () => {
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        const outsideDir = await mkdtemp(join(tmpdir(), 'kodus-outside-'));
+
+        try {
+            await symlink(outsideDir, join(tempDir, 'escape-link'));
+            const sandbox = await service.connectToExistingSandbox(tempDir);
+
+            await expect(
+                sandbox.writeFile('escape-link/result.txt', 'bad'),
+            ).rejects.toThrow(/symlink detected/i);
+            await expect(
+                readFile(join(outsideDir, 'result.txt'), 'utf-8'),
+            ).rejects.toThrow();
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+            await rm(outsideDir, { recursive: true, force: true });
+        }
+    });
+
+    it('rejects local writes through a symlinked target file', async () => {
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        const outsideDir = await mkdtemp(join(tmpdir(), 'kodus-outside-'));
+        await writeFile(join(outsideDir, 'target.txt'), 'outside', 'utf-8');
+
+        try {
+            await symlink(
+                join(outsideDir, 'target.txt'),
+                join(tempDir, 'target-link.txt'),
+            );
+            const sandbox = await service.connectToExistingSandbox(tempDir);
+
+            await expect(
+                sandbox.writeFile('target-link.txt', 'bad'),
+            ).rejects.toThrow(/symlink detected/i);
+            await expect(
+                readFile(join(outsideDir, 'target.txt'), 'utf-8'),
+            ).resolves.toBe('outside');
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+            await rm(outsideDir, { recursive: true, force: true });
+        }
+    });
+
+    it('rejects unsafe reconnect paths', async () => {
+        await expect(
+            service.connectToExistingSandbox('/tmp/not-kodus-sandbox-test'),
+        ).rejects.toThrow(/refusing to reconnect unsafe sandbox path/i);
+    });
+
+    it('rejects missing local sandbox directories', async () => {
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        await rm(tempDir, { recursive: true, force: true });
+
+        await expect(
+            service.connectToExistingSandbox(tempDir),
+        ).rejects.toThrow();
     });
 });

--- a/libs/sandbox/infrastructure/providers/local-sandbox.service.ts
+++ b/libs/sandbox/infrastructure/providers/local-sandbox.service.ts
@@ -13,7 +13,7 @@ import {
     mkdir,
 } from 'fs/promises';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { join, resolve, sep } from 'path';
 import { promisify } from 'util';
 
 import {
@@ -23,6 +23,7 @@ import {
     SandboxRunResult,
 } from '@libs/sandbox/domain/contracts/sandbox.provider';
 import { RemoteCommands } from '@libs/code-review/infrastructure/adapters/services/collectCrossFileContexts.service';
+import { isLocalSandboxPath } from '../services/local-sandbox-cleanup';
 
 const execFileAsync = promisify(execFile);
 
@@ -137,116 +138,7 @@ export class LocalSandboxService implements ISandboxProvider {
                 await this.applyLocalDiff(tempDir, unifiedDiff);
             }
 
-            const remoteCommands = this.buildRemoteCommands(tempDir);
-
-            const capturedTempDir = tempDir;
-            const cleanup = async () => {
-                try {
-                    await rm(capturedTempDir, { recursive: true, force: true });
-                } catch (error) {
-                    this.logger.warn({
-                        message: `Failed to remove temp dir ${capturedTempDir}`,
-                        context: LocalSandboxService.name,
-                        error,
-                    });
-                }
-            };
-
-            const capturedRepoDir = tempDir;
-
-            // Privileged shell exec for infrastructure callers (graph build,
-            // AST extraction, sandbox bootstrap). Unlike `remoteCommands.exec`
-            // this does NOT whitelist programs — it runs the command through
-            // /bin/sh so mkdir, pipes, redirections, etc. work. That power
-            // comes with a safety contract: **callers MUST shell-quote any
-            // value that could come (directly or transitively) from user
-            // input** (PR filenames, branch names, commit messages, etc.).
-            //
-            // As a runtime tripwire we reject command substitution (`$(...)`
-            // and backticks) on the raw string. Internal infrastructure
-            // commands have no legitimate need to spawn subshells, and a
-            // leaked `$()` is the most common path from "string concatenation
-            // bug" to RCE. The block is conservative by design — if a real
-            // use case ever needs command substitution, it should opt in
-            // explicitly instead of piggybacking on this entry point.
-            const run = async (
-                command: string,
-                opts?: { timeoutMs?: number },
-            ): Promise<SandboxRunResult> => {
-                if (/`|\$\(/.test(command)) {
-                    this.logger.warn({
-                        message:
-                            'Rejected sandbox.run command containing shell substitution',
-                        context: LocalSandboxService.name,
-                        metadata: {
-                            preview: command.slice(0, 200),
-                        },
-                    });
-                    return {
-                        stdout: '',
-                        stderr: 'Command substitution ($(...) / backticks) is not allowed in sandbox.run',
-                        exitCode: 1,
-                    };
-                }
-
-                const execAsync = promisify(exec);
-                try {
-                    const { stdout, stderr } = await execAsync(command, {
-                        cwd: capturedRepoDir,
-                        timeout: opts?.timeoutMs ?? CMD_TIMEOUT_MS,
-                        maxBuffer: MAX_BUFFER,
-                        env: process.env,
-                    });
-                    return {
-                        stdout: stdout || '',
-                        stderr: stderr || '',
-                        exitCode: 0,
-                    };
-                } catch (error: any) {
-                    return {
-                        stdout: error.stdout || '',
-                        stderr: error.stderr || '',
-                        exitCode: error.code ?? 1,
-                    };
-                }
-            };
-
-            // Path safety: reads go through `resolveSafePath` so absolute
-            // paths, `..` traversals, and symlink escapes are all rejected
-            // at the boundary. Writes can target files that don't exist
-            // yet (so `lstat`/`realpath` don't apply), but we still
-            // normalize and compare against the repo root so the final
-            // target can't escape — `validatePath` plus the prefix check
-            // covers `../..`, `/etc/...`, and embedded traversals.
-            const sandboxReadFile = async (path: string): Promise<string> => {
-                const fullPath = path.startsWith('/')
-                    ? path
-                    : join(capturedRepoDir, path);
-                return readFile(fullPath, 'utf-8');
-            };
-
-            const sandboxWriteFile = async (
-                path: string,
-                content: string,
-            ): Promise<void> => {
-                const fullPath = path.startsWith('/')
-                    ? path
-                    : join(capturedRepoDir, path);
-                const dir = join(fullPath, '..');
-                await mkdir(dir, { recursive: true });
-                await writeFile(fullPath, content, 'utf-8');
-            };
-
-            return {
-                remoteCommands,
-                cleanup,
-                type: 'local' as const,
-                sandboxId: capturedRepoDir,
-                repoDir: capturedRepoDir,
-                run,
-                readFile: sandboxReadFile,
-                writeFile: sandboxWriteFile,
-            };
+            return this.buildSandboxInstance(tempDir);
         } catch (error) {
             try {
                 await rm(tempDir, { recursive: true, force: true });
@@ -255,6 +147,128 @@ export class LocalSandboxService implements ISandboxProvider {
             }
             throw error;
         }
+    }
+
+    async connectToExistingSandbox(
+        sandboxId: string,
+    ): Promise<SandboxInstance> {
+        if (!isLocalSandboxPath(sandboxId)) {
+            throw new Error(
+                `LocalSandboxService: refusing to reconnect unsafe sandbox path "${sandboxId}"`,
+            );
+        }
+
+        const stat = await lstat(sandboxId);
+        if (!stat.isDirectory()) {
+            throw new Error(
+                `LocalSandboxService: sandbox path is not a directory "${sandboxId}"`,
+            );
+        }
+
+        return this.buildSandboxInstance(sandboxId);
+    }
+
+    private buildSandboxInstance(repoDir: string): SandboxInstance {
+        const remoteCommands = this.buildRemoteCommands(repoDir);
+        const capturedRepoDir = repoDir;
+
+        const cleanup = async () => {
+            try {
+                await rm(capturedRepoDir, { recursive: true, force: true });
+            } catch (error) {
+                this.logger.warn({
+                    message: `Failed to remove temp dir ${capturedRepoDir}`,
+                    context: LocalSandboxService.name,
+                    error,
+                });
+            }
+        };
+
+        // Privileged shell exec for infrastructure callers (graph build,
+        // AST extraction, sandbox bootstrap). Unlike `remoteCommands.exec`
+        // this does NOT whitelist programs — it runs the command through
+        // /bin/sh so mkdir, pipes, redirections, etc. work. That power
+        // comes with a safety contract: **callers MUST shell-quote any
+        // value that could come (directly or transitively) from user
+        // input** (PR filenames, branch names, commit messages, etc.).
+        //
+        // As a runtime tripwire we reject command substitution (`$(...)`
+        // and backticks) on the raw string. Internal infrastructure
+        // commands have no legitimate need to spawn subshells, and a
+        // leaked `$()` is the most common path from "string concatenation
+        // bug" to RCE. The block is conservative by design — if a real
+        // use case ever needs command substitution, it should opt in
+        // explicitly instead of piggybacking on this entry point.
+        const run = async (
+            command: string,
+            opts?: { timeoutMs?: number },
+        ): Promise<SandboxRunResult> => {
+            if (/`|\$\(/.test(command)) {
+                this.logger.warn({
+                    message:
+                        'Rejected sandbox.run command containing shell substitution',
+                    context: LocalSandboxService.name,
+                    metadata: {
+                        preview: command.slice(0, 200),
+                    },
+                });
+                return {
+                    stdout: '',
+                    stderr: 'Command substitution ($(...) / backticks) is not allowed in sandbox.run',
+                    exitCode: 1,
+                };
+            }
+
+            const execAsync = promisify(exec);
+            try {
+                const { stdout, stderr } = await execAsync(command, {
+                    cwd: capturedRepoDir,
+                    timeout: opts?.timeoutMs ?? CMD_TIMEOUT_MS,
+                    maxBuffer: MAX_BUFFER,
+                    env: process.env,
+                });
+                return {
+                    stdout: stdout || '',
+                    stderr: stderr || '',
+                    exitCode: 0,
+                };
+            } catch (error: any) {
+                return {
+                    stdout: error.stdout || '',
+                    stderr: error.stderr || '',
+                    exitCode: error.code ?? 1,
+                };
+            }
+        };
+
+        const sandboxReadFile = async (path: string): Promise<string> => {
+            const fullPath = await this.resolveSafePath(capturedRepoDir, path);
+            return readFile(fullPath, 'utf-8');
+        };
+
+        const sandboxWriteFile = async (
+            path: string,
+            content: string,
+        ): Promise<void> => {
+            const fullPath = await this.resolveSafeWritePath(
+                capturedRepoDir,
+                path,
+            );
+            const dir = join(fullPath, '..');
+            await mkdir(dir, { recursive: true });
+            await writeFile(fullPath, content, 'utf-8');
+        };
+
+        return {
+            remoteCommands,
+            cleanup,
+            type: 'local' as const,
+            sandboxId: capturedRepoDir,
+            repoDir: capturedRepoDir,
+            run,
+            readFile: sandboxReadFile,
+            writeFile: sandboxWriteFile,
+        };
     }
 
     private buildRemoteCommands(repoDir: string): RemoteCommands {
@@ -600,7 +614,13 @@ export class LocalSandboxService implements ISandboxProvider {
         try {
             await execFileAsync(
                 'git',
-                ['-C', repoDir, 'config', 'user.email', 'kodus-cli@kodus.local'],
+                [
+                    '-C',
+                    repoDir,
+                    'config',
+                    'user.email',
+                    'kodus-cli@kodus.local',
+                ],
                 { timeout: 5_000 },
             );
             await execFileAsync(
@@ -626,8 +646,7 @@ export class LocalSandboxService implements ISandboxProvider {
                 { timeout: CLONE_TIMEOUT_MS },
             );
             this.logger.log({
-                message:
-                    'CLI diff applied successfully on top of merge-base',
+                message: 'CLI diff applied successfully on top of merge-base',
                 context: LocalSandboxService.name,
             });
             return;
@@ -703,6 +722,63 @@ export class LocalSandboxService implements ISandboxProvider {
         }
 
         return candidate;
+    }
+
+    private async resolveSafeWritePath(
+        repoDir: string,
+        path: string,
+    ): Promise<string> {
+        this.validatePath(path);
+
+        const repoReal = await realpath(repoDir);
+        const target = resolve(repoReal, path);
+        if (!this.isPathInside(target, repoReal)) {
+            throw new Error(`Path escapes repo boundary: ${path}`);
+        }
+
+        const segments = path.split('/').filter(Boolean);
+        let current = repoReal;
+        for (const segment of segments.slice(0, -1)) {
+            current = join(current, segment);
+
+            try {
+                const stat = await lstat(current);
+                if (stat.isSymbolicLink()) {
+                    throw new Error(
+                        `Symlink detected, refusing to write through: ${path}`,
+                    );
+                }
+                if (!stat.isDirectory()) {
+                    throw new Error(
+                        `Parent path is not a directory: ${segment}`,
+                    );
+                }
+            } catch (error: any) {
+                if (error?.code === 'ENOENT') {
+                    break;
+                }
+                throw error;
+            }
+        }
+
+        try {
+            const stat = await lstat(target);
+            if (stat.isSymbolicLink()) {
+                throw new Error(
+                    `Symlink detected, refusing to write through: ${path}`,
+                );
+            }
+        } catch (error: any) {
+            if (error?.code !== 'ENOENT') {
+                throw error;
+            }
+        }
+
+        return target;
+    }
+
+    private isPathInside(candidate: string, root: string): boolean {
+        return candidate === root || candidate.startsWith(root + sep);
     }
 
     private buildAuthHeader(

--- a/libs/sandbox/infrastructure/repositories/sandbox-lease.repository.spec.ts
+++ b/libs/sandbox/infrastructure/repositories/sandbox-lease.repository.spec.ts
@@ -1,0 +1,464 @@
+import { SandboxLeaseRepository } from './sandbox-lease.repository';
+
+describe('SandboxLeaseRepository', () => {
+    it('upsertAcquire refreshes expiresAt on existing leases so expired reaper claims go stale', async () => {
+        const leaseModel = {
+            findOneAndUpdate: jest.fn().mockResolvedValue({}),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+
+        await repo.upsertAcquire(
+            '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:199',
+            60_000,
+            'review',
+        );
+
+        expect(leaseModel.findOneAndUpdate).toHaveBeenCalledWith(
+            { _id: '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:199' },
+            [
+                {
+                    $set: expect.objectContaining({
+                        consumer: 'review',
+                        expiresAt: {
+                            $cond: [
+                                { $in: ['$state', ['READY', 'PAUSED']] },
+                                expect.any(Date),
+                                {
+                                    $ifNull: ['$expiresAt', expect.any(Date)],
+                                },
+                            ],
+                        },
+                    }),
+                },
+            ],
+            { upsert: true, new: true },
+        );
+    });
+
+    it('upsertAcquire preserves expiresAt for non-reusable leases so cleanup retries are not postponed', async () => {
+        const leaseModel = {
+            findOneAndUpdate: jest.fn().mockResolvedValue({}),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+
+        await repo.upsertAcquire(
+            '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:299',
+            60_000,
+            'review',
+        );
+
+        const [, update] = leaseModel.findOneAndUpdate.mock.calls[0];
+        expect(Array.isArray(update)).toBe(true);
+        expect(JSON.stringify(update)).toContain('"$cond"');
+        expect(JSON.stringify(update)).toContain('"READY"');
+        expect(JSON.stringify(update)).toContain('"PAUSED"');
+        expect(JSON.stringify(update)).toContain('"$expiresAt"');
+    });
+
+    it('deleteIfNoActiveLeases returns true when the guarded delete removes a lease', async () => {
+        const leaseModel = {
+            deleteOne: jest.fn().mockResolvedValue({ deletedCount: 1 }),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+
+        await expect(
+            repo.deleteIfNoActiveLeases(
+                '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:200',
+            ),
+        ).resolves.toBe(true);
+
+        expect(leaseModel.deleteOne).toHaveBeenCalledWith({
+            _id: '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:200',
+            leaseCount: { $lte: 0 },
+        });
+    });
+
+    it('deleteIfNoActiveLeases returns false when an active lease blocks the delete', async () => {
+        const leaseModel = {
+            deleteOne: jest.fn().mockResolvedValue({ deletedCount: 0 }),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+
+        await expect(
+            repo.deleteIfNoActiveLeases(
+                '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:201',
+            ),
+        ).resolves.toBe(false);
+    });
+
+    it('deleteIfNoActiveLeases can guard the delete by sandbox id', async () => {
+        const leaseModel = {
+            deleteOne: jest.fn().mockResolvedValue({ deletedCount: 1 }),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+
+        await expect(
+            repo.deleteIfNoActiveLeases(
+                '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:202',
+                '/tmp/kodus-sandbox-missing',
+            ),
+        ).resolves.toBe(true);
+
+        expect(leaseModel.deleteOne).toHaveBeenCalledWith({
+            _id: '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:202',
+            leaseCount: { $lte: 0 },
+            sandboxId: '/tmp/kodus-sandbox-missing',
+        });
+    });
+
+    it('deleteDeletingWithSandboxId removes only the claimed DELETING lease', async () => {
+        const leaseModel = {
+            deleteOne: jest.fn().mockResolvedValue({ deletedCount: 1 }),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+
+        await expect(
+            repo.deleteDeletingWithSandboxId(
+                '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:213',
+                '/tmp/kodus-sandbox-claimed',
+            ),
+        ).resolves.toBe(true);
+
+        expect(leaseModel.deleteOne).toHaveBeenCalledWith({
+            _id: '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:213',
+            state: 'DELETING',
+            sandboxId: '/tmp/kodus-sandbox-claimed',
+        });
+    });
+
+    it('markDeletingIfNoActiveLeases blocks reuse only when no active leases remain', async () => {
+        const leaseModel = {
+            updateOne: jest.fn().mockResolvedValue({ matchedCount: 1 }),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+
+        await expect(
+            repo.markDeletingIfNoActiveLeases(
+                '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:204',
+                '/tmp/kodus-sandbox-204',
+            ),
+        ).resolves.toBe(true);
+
+        expect(leaseModel.updateOne).toHaveBeenCalledWith(
+            {
+                _id: '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:204',
+                sandboxId: '/tmp/kodus-sandbox-204',
+                leaseCount: { $lte: 0 },
+                state: { $in: ['READY', 'PAUSED', 'INVALIDATED', 'DELETING'] },
+            },
+            { $set: { state: 'DELETING' } },
+        );
+    });
+
+    it('markDeletingIfReadyToKill claims inactive idle leases and DELETING retry records', async () => {
+        const leaseModel = {
+            updateOne: jest.fn().mockResolvedValue({ matchedCount: 1 }),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+        const killAt = new Date('2026-01-01T00:00:00.000Z');
+
+        await expect(
+            repo.markDeletingIfReadyToKill(
+                '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:205',
+                killAt,
+            ),
+        ).resolves.toBe(true);
+
+        expect(leaseModel.updateOne).toHaveBeenCalledWith(
+            {
+                _id: '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:205',
+                killAt,
+                sandboxId: { $exists: true, $ne: '' },
+                $or: [
+                    {
+                        state: { $in: ['READY', 'PAUSED'] },
+                        leaseCount: { $lte: 0 },
+                    },
+                    { state: 'DELETING' },
+                ],
+            },
+            { $set: { state: 'DELETING' } },
+        );
+    });
+
+    it('markDeletingIfExpired claims an expired lease by its original expiresAt', async () => {
+        const leaseModel = {
+            updateOne: jest.fn().mockResolvedValue({ matchedCount: 1 }),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+        const expiresAt = new Date('2026-01-01T00:00:00.000Z');
+
+        await expect(
+            repo.markDeletingIfExpired(
+                '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:207',
+                expiresAt,
+            ),
+        ).resolves.toBe(true);
+
+        expect(leaseModel.updateOne).toHaveBeenCalledWith(
+            {
+                _id: '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:207',
+                expiresAt,
+                state: {
+                    $in: [
+                        'CREATING',
+                        'READY',
+                        'PAUSED',
+                        'INVALIDATED',
+                        'DELETING',
+                    ],
+                },
+            },
+            { $set: { state: 'DELETING' } },
+        );
+    });
+
+    it('markInvalidated blocks reuse for active READY or PAUSED leases', async () => {
+        const leaseModel = {
+            updateOne: jest.fn().mockResolvedValue({ matchedCount: 1 }),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+
+        await expect(
+            repo.markInvalidated(
+                '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:206',
+            ),
+        ).resolves.toBe(true);
+
+        expect(leaseModel.updateOne).toHaveBeenCalledWith(
+            {
+                _id: '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:206',
+                state: { $in: ['READY', 'PAUSED'] },
+            },
+            { $set: { state: 'INVALIDATED' } },
+        );
+    });
+
+    it('markInvalidatedIfCreating only invalidates leases that are still CREATING', async () => {
+        const leaseModel = {
+            updateOne: jest.fn().mockResolvedValue({ matchedCount: 1 }),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+
+        await expect(
+            repo.markInvalidatedIfCreating(
+                '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:209',
+            ),
+        ).resolves.toBe(true);
+
+        expect(leaseModel.updateOne).toHaveBeenCalledWith(
+            {
+                _id: '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:209',
+                state: 'CREATING',
+            },
+            { $set: { state: 'INVALIDATED' } },
+        );
+    });
+
+    it('clearKillAt preserves the retry cursor for DELETING leases', async () => {
+        const leaseModel = {
+            updateOne: jest.fn().mockResolvedValue({ modifiedCount: 1 }),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+
+        await repo.clearKillAt('7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:208');
+
+        expect(leaseModel.updateOne).toHaveBeenCalledWith(
+            {
+                _id: '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:208',
+                state: { $ne: 'DELETING' },
+            },
+            { $unset: { killAt: '' } },
+        );
+    });
+
+    it('setKillAt returns true for an idempotent matched update', async () => {
+        const leaseModel = {
+            updateOne: jest.fn().mockResolvedValue({
+                matchedCount: 1,
+                modifiedCount: 0,
+            }),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+        const killAt = new Date('2026-01-01T00:00:00.000Z');
+
+        await expect(
+            repo.setKillAt(
+                '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:202',
+                killAt,
+            ),
+        ).resolves.toBe(true);
+
+        expect(leaseModel.updateOne).toHaveBeenCalledWith(
+            {
+                _id: '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:202',
+                leaseCount: { $lte: 0 },
+                sandboxId: { $exists: true, $ne: '' },
+            },
+            { $set: { killAt } },
+        );
+    });
+
+    it('setKillAt returns false when no inactive lease matched the guard', async () => {
+        const leaseModel = {
+            updateOne: jest.fn().mockResolvedValue({
+                matchedCount: 0,
+                modifiedCount: 0,
+            }),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+
+        await expect(
+            repo.setKillAt(
+                '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:203',
+                new Date('2026-01-01T00:00:00.000Z'),
+            ),
+        ).resolves.toBe(false);
+    });
+
+    it('scheduleCleanupRetry sets killAt only for DELETING leases with a sandbox', async () => {
+        const leaseModel = {
+            updateOne: jest.fn().mockResolvedValue({
+                matchedCount: 1,
+                modifiedCount: 1,
+            }),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+        const retryAt = new Date('2026-01-01T00:01:00.000Z');
+
+        await expect(
+            repo.scheduleCleanupRetry(
+                '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:210',
+                retryAt,
+            ),
+        ).resolves.toBe(true);
+
+        expect(leaseModel.updateOne).toHaveBeenCalledWith(
+            {
+                _id: '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:210',
+                state: 'DELETING',
+                sandboxId: { $exists: true, $ne: '' },
+            },
+            { $set: { killAt: retryAt } },
+        );
+    });
+
+    it('markDeletingWithSandboxId persists a local orphan path for cleanup retry', async () => {
+        const leaseModel = {
+            updateOne: jest.fn().mockResolvedValue({
+                matchedCount: 1,
+                modifiedCount: 1,
+            }),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+        const retryAt = new Date('2026-01-01T00:01:00.000Z');
+
+        await expect(
+            repo.markDeletingWithSandboxId(
+                '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:211',
+                '/tmp/kodus-sandbox-orphan',
+                retryAt,
+            ),
+        ).resolves.toBe(true);
+
+        expect(leaseModel.updateOne).toHaveBeenCalledWith(
+            {
+                _id: '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:211',
+                state: { $in: ['CREATING', 'INVALIDATED', 'DELETING'] },
+            },
+            {
+                $set: {
+                    state: 'DELETING',
+                    sandboxId: '/tmp/kodus-sandbox-orphan',
+                    killAt: retryAt,
+                },
+            },
+        );
+    });
+
+    it('markDeletingWithSandboxIdIfNoActiveLeases preserves active INVALIDATED joiners', async () => {
+        const leaseModel = {
+            updateOne: jest.fn().mockResolvedValue({
+                matchedCount: 1,
+                modifiedCount: 1,
+            }),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+        const retryAt = new Date('2026-01-01T00:01:00.000Z');
+
+        await expect(
+            repo.markDeletingWithSandboxIdIfNoActiveLeases(
+                '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:214',
+                '/tmp/kodus-sandbox-invalidated',
+                retryAt,
+            ),
+        ).resolves.toBe(true);
+
+        expect(leaseModel.updateOne).toHaveBeenCalledWith(
+            {
+                _id: '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:214',
+                state: 'INVALIDATED',
+                sandboxId: '/tmp/kodus-sandbox-invalidated',
+                leaseCount: { $lte: 0 },
+            },
+            {
+                $set: {
+                    state: 'DELETING',
+                    killAt: retryAt,
+                },
+            },
+        );
+    });
+
+    it('findExpired applies an explicit query limit', async () => {
+        const query = {
+            select: jest.fn().mockReturnThis(),
+            limit: jest.fn().mockReturnThis(),
+            lean: jest.fn().mockResolvedValue([]),
+        };
+        const leaseModel = {
+            find: jest.fn().mockReturnValue(query),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+        const now = new Date('2026-01-01T00:00:00.000Z');
+
+        await expect(repo.findExpired(now, 25)).resolves.toEqual([]);
+
+        expect(leaseModel.find).toHaveBeenCalledWith({
+            expiresAt: { $lt: now },
+            $or: [
+                { state: { $ne: 'DELETING' } },
+                { killAt: { $exists: false } },
+                { killAt: { $lte: now } },
+            ],
+        });
+        expect(query.select).toHaveBeenCalledWith(
+            '_id sandboxId state expiresAt',
+        );
+        expect(query.limit).toHaveBeenCalledWith(25);
+        expect(query.lean).toHaveBeenCalledTimes(1);
+    });
+
+    it('findReadyToKill applies an explicit query limit', async () => {
+        const query = {
+            select: jest.fn().mockReturnThis(),
+            limit: jest.fn().mockReturnThis(),
+            lean: jest.fn().mockResolvedValue([]),
+        };
+        const leaseModel = {
+            find: jest.fn().mockReturnValue(query),
+        };
+        const repo = new SandboxLeaseRepository(leaseModel as any);
+        const now = new Date('2026-01-01T00:00:00.000Z');
+
+        await expect(repo.findReadyToKill(now, 25)).resolves.toEqual([]);
+
+        expect(leaseModel.find).toHaveBeenCalledWith({
+            killAt: { $lte: now },
+            sandboxId: { $exists: true, $ne: '' },
+        });
+        expect(query.select).toHaveBeenCalledWith('_id sandboxId killAt');
+        expect(query.limit).toHaveBeenCalledWith(25);
+        expect(query.lean).toHaveBeenCalledTimes(1);
+    });
+});

--- a/libs/sandbox/infrastructure/repositories/sandbox-lease.repository.ts
+++ b/libs/sandbox/infrastructure/repositories/sandbox-lease.repository.ts
@@ -58,13 +58,15 @@ export class SandboxLeaseRepository {
     /**
      * Atomically acquire (or join) a lease for the given prKey.
      *
-     * Single findOneAndUpdate with BOTH operators in one update document:
-     *   - $setOnInsert: sets initial state/timestamps on the INSERT path only
-     *   - $inc: { leaseCount: 1 } increments the counter on BOTH insert and update paths
+     * Single findOneAndUpdate with an aggregation pipeline:
+     *   - Missing fields are initialized on the INSERT path only via $ifNull
+     *   - leaseCount increments on BOTH insert and update paths
+     *   - expiresAt refreshes on normal acquires but is preserved for DELETING
+     *     leases so failed cleanup retry cursors are not postponed by user retries
      *
-     * On INSERT:  MongoDB applies $setOnInsert (state='CREATING', dates) and $inc
-     *             (leaseCount 0→1). Returned doc has leaseCount === 1.
-     * On UPDATE:  $setOnInsert is a no-op; $inc bumps leaseCount to N+1.
+     * On INSERT:  MongoDB applies defaults (state='CREATING', dates) and increments
+     *             leaseCount 0→1. Returned doc has leaseCount === 1.
+     * On UPDATE:  Existing defaults are preserved; leaseCount bumps to N+1.
      *
      * Caller identifies itself as creator when doc.leaseCount === 1.
      * Caller must poll when doc.leaseCount > 1 and doc.state === 'CREATING'.
@@ -81,21 +83,36 @@ export class SandboxLeaseRepository {
         const expiresAt = new Date(now.getTime() + leaseTtlMs);
         const decomposed = decomposePrKey(prKey);
 
+        const setStage: Record<string, unknown> = {
+            state: { $ifNull: ['$state', 'CREATING'] },
+            createdAt: { $ifNull: ['$createdAt', now] },
+            organizationId: {
+                $ifNull: ['$organizationId', decomposed.organizationId],
+            },
+            repositoryId: {
+                $ifNull: ['$repositoryId', decomposed.repositoryId],
+            },
+            expiresAt: {
+                $cond: [
+                    { $in: ['$state', ['READY', 'PAUSED']] },
+                    expiresAt,
+                    { $ifNull: ['$expiresAt', expiresAt] },
+                ],
+            },
+            leaseCount: { $add: [{ $ifNull: ['$leaseCount', 0] }, 1] },
+        };
+
+        if (decomposed.prNumber !== undefined) {
+            setStage.prNumber = { $ifNull: ['$prNumber', decomposed.prNumber] };
+        }
+
+        if (consumer) {
+            setStage.consumer = consumer;
+        }
+
         const doc = await this.leaseModel.findOneAndUpdate(
             { _id: prKey },
-            {
-                $setOnInsert: {
-                    state: 'CREATING',
-                    createdAt: now,
-                    expiresAt,
-                    ...decomposed,
-                },
-                // Track the most recent consumer label so it's queryable in
-                // Mongo without parsing logs. Updated on every acquire (both
-                // insert and update paths).
-                $set: consumer ? { consumer } : {},
-                $inc: { leaseCount: 1 },
-            },
+            [{ $set: setStage }],
             { upsert: true, new: true },
         );
 
@@ -130,11 +147,27 @@ export class SandboxLeaseRepository {
      * Mark a CREATING lease as INVALIDATED (mid-create race handling).
      * The create path will check for this state after completing and kill the sandbox.
      */
-    async markInvalidated(prKey: string): Promise<void> {
-        await this.leaseModel.updateOne(
+    async markInvalidated(prKey: string): Promise<boolean> {
+        const result = await this.leaseModel.updateOne(
+            { _id: prKey, state: { $in: ['READY', 'PAUSED'] } },
+            { $set: { state: 'INVALIDATED' } },
+        );
+
+        return result.matchedCount > 0;
+    }
+
+    /**
+     * Mark a lease INVALIDATED only while it is still CREATING.
+     * Used by invalidate() to avoid overwriting a concurrent CREATING→READY
+     * transition with INVALIDATED after a sandbox has already become usable.
+     */
+    async markInvalidatedIfCreating(prKey: string): Promise<boolean> {
+        const result = await this.leaseModel.updateOne(
             { _id: prKey, state: 'CREATING' },
             { $set: { state: 'INVALIDATED' } },
         );
+
+        return result.matchedCount > 0;
     }
 
     /**
@@ -154,10 +187,21 @@ export class SandboxLeaseRepository {
      */
     async findExpired(
         now: Date,
-    ): Promise<Pick<SandboxLeaseModel, '_id' | 'sandboxId' | 'state'>[]> {
+        limit: number,
+    ): Promise<
+        Pick<SandboxLeaseModel, '_id' | 'sandboxId' | 'state' | 'expiresAt'>[]
+    > {
         return this.leaseModel
-            .find({ expiresAt: { $lt: now } })
-            .select('_id sandboxId state')
+            .find({
+                expiresAt: { $lt: now },
+                $or: [
+                    { state: { $ne: 'DELETING' } },
+                    { killAt: { $exists: false } },
+                    { killAt: { $lte: now } },
+                ],
+            })
+            .select('_id sandboxId state expiresAt')
+            .limit(limit)
             .lean();
     }
 
@@ -170,6 +214,147 @@ export class SandboxLeaseRepository {
     }
 
     /**
+     * Delete a lease only when no active leases remain.
+     *
+     * Local sandbox cleanup and idle reapers can observe leaseCount <= 0 and
+     * then race with a concurrent acquire. The final delete must re-check the
+     * counter atomically so it never removes a lease another caller just joined.
+     */
+    async deleteIfNoActiveLeases(
+        prKey: string,
+        sandboxId?: string,
+    ): Promise<boolean> {
+        const query: Record<string, unknown> = {
+            _id: prKey,
+            leaseCount: { $lte: 0 },
+        };
+
+        if (sandboxId) {
+            query.sandboxId = sandboxId;
+        }
+
+        const result = await this.leaseModel.deleteOne(query);
+
+        return result.deletedCount > 0;
+    }
+
+    /**
+     * Delete only the lease document that was previously claimed as DELETING.
+     *
+     * Reapers can race with a waiter that deletes the DELETING document and
+     * immediately creates a fresh lease for the same prKey. Guarding by state
+     * and sandboxId prevents the reaper from deleting that new lease.
+     */
+    async deleteDeletingWithSandboxId(
+        prKey: string,
+        sandboxId?: string,
+    ): Promise<boolean> {
+        const query: Record<string, unknown> = {
+            _id: prKey,
+            state: 'DELETING',
+        };
+
+        if (sandboxId) {
+            query.sandboxId = sandboxId;
+        } else {
+            query.$or = [
+                { sandboxId: { $exists: false } },
+                { sandboxId: '' },
+                { sandboxId: null },
+            ];
+        }
+
+        const result = await this.leaseModel.deleteOne(query);
+
+        return result.deletedCount > 0;
+    }
+
+    /**
+     * Atomically block reuse before resource cleanup.
+     *
+     * Local directories must not be removed while a concurrent acquire can
+     * still warm-reuse the READY lease. Marking DELETING first makes joiners
+     * wait/retry instead of connecting to a directory being deleted.
+     */
+    async markDeletingIfNoActiveLeases(
+        prKey: string,
+        sandboxId: string,
+    ): Promise<boolean> {
+        const result = await this.leaseModel.updateOne(
+            {
+                _id: prKey,
+                sandboxId,
+                leaseCount: { $lte: 0 },
+                state: { $in: ['READY', 'PAUSED', 'INVALIDATED', 'DELETING'] },
+            },
+            { $set: { state: 'DELETING' } },
+        );
+
+        return result.matchedCount > 0;
+    }
+
+    /**
+     * Atomically claim an idle-kill candidate before resource cleanup.
+     *
+     * The reaper reads candidates first, then cleanup can race with a fresh
+     * acquire that increments leaseCount and clears killAt. This guard
+     * re-checks both values before switching the lease to DELETING.
+     */
+    async markDeletingIfReadyToKill(
+        prKey: string,
+        killAt: Date,
+    ): Promise<boolean> {
+        const result = await this.leaseModel.updateOne(
+            {
+                _id: prKey,
+                killAt,
+                sandboxId: { $exists: true, $ne: '' },
+                $or: [
+                    {
+                        state: { $in: ['READY', 'PAUSED'] },
+                        leaseCount: { $lte: 0 },
+                    },
+                    { state: 'DELETING' },
+                ],
+            },
+            { $set: { state: 'DELETING' } },
+        );
+
+        return result.matchedCount > 0;
+    }
+
+    /**
+     * Atomically claim an expired lease before resource cleanup.
+     *
+     * Expired leases may still have leaseCount > 0 when a worker crashed before
+     * releasing. Matching the original expiresAt lets a fresh acquire extend
+     * the TTL and make this claim fail before the reaper removes anything.
+     */
+    async markDeletingIfExpired(
+        prKey: string,
+        expiresAt: Date,
+    ): Promise<boolean> {
+        const result = await this.leaseModel.updateOne(
+            {
+                _id: prKey,
+                expiresAt,
+                state: {
+                    $in: [
+                        'CREATING',
+                        'READY',
+                        'PAUSED',
+                        'INVALIDATED',
+                        'DELETING',
+                    ],
+                },
+            },
+            { $set: { state: 'DELETING' } },
+        );
+
+        return result.matchedCount > 0;
+    }
+
+    /**
      * Atomically set the `killAt` timestamp on a lease document. Used by
      * release() to schedule an idle-kill that any worker (in a multi-worker
      * deployment) can pick up via findReadyToKill().
@@ -177,14 +362,95 @@ export class SandboxLeaseRepository {
      * Only sets killAt when the lease has a real sandboxId — there's no
      * point scheduling a kill for a NullSandbox or a CREATING-only lease.
      */
-    async setKillAt(prKey: string, killAt: Date): Promise<void> {
-        await this.leaseModel.updateOne(
+    async setKillAt(prKey: string, killAt: Date): Promise<boolean> {
+        const result = await this.leaseModel.updateOne(
             {
                 _id: prKey,
+                leaseCount: { $lte: 0 },
                 sandboxId: { $exists: true, $ne: '' },
             },
             { $set: { killAt } },
         );
+
+        return result.matchedCount > 0;
+    }
+
+    /**
+     * Schedule a near-term cleanup retry for a lease that is already DELETING.
+     *
+     * Unlike setKillAt(), this intentionally does not require leaseCount <= 0:
+     * expired crashed-worker leases can still have a positive count, but once
+     * they are claimed as DELETING they still need a retry cursor when resource
+     * cleanup fails.
+     */
+    async scheduleCleanupRetry(prKey: string, retryAt: Date): Promise<boolean> {
+        const result = await this.leaseModel.updateOne(
+            {
+                _id: prKey,
+                state: 'DELETING',
+                sandboxId: { $exists: true, $ne: '' },
+            },
+            { $set: { killAt: retryAt } },
+        );
+
+        return result.matchedCount > 0;
+    }
+
+    /**
+     * Persist the sandboxId for a creator-path local orphan and move the lease
+     * into DELETING so cleanup can be retried by the idle-kill cursor.
+     *
+     * This is intentionally limited to states used before/around creator-path
+     * completion. READY/PAUSED cleanup should use the normal guarded deletion
+     * flow that checks active lease counts.
+     */
+    async markDeletingWithSandboxId(
+        prKey: string,
+        sandboxId: string,
+        retryAt: Date,
+    ): Promise<boolean> {
+        const result = await this.leaseModel.updateOne(
+            {
+                _id: prKey,
+                state: { $in: ['CREATING', 'INVALIDATED', 'DELETING'] },
+            },
+            {
+                $set: {
+                    state: 'DELETING',
+                    sandboxId,
+                    killAt: retryAt,
+                },
+            },
+        );
+
+        return result.matchedCount > 0;
+    }
+
+    /**
+     * Retry cleanup for an INVALIDATED local lease only when no active joiner
+     * remains at the exact update moment.
+     */
+    async markDeletingWithSandboxIdIfNoActiveLeases(
+        prKey: string,
+        sandboxId: string,
+        retryAt: Date,
+    ): Promise<boolean> {
+        const result = await this.leaseModel.updateOne(
+            {
+                _id: prKey,
+                state: 'INVALIDATED',
+                sandboxId,
+                leaseCount: { $lte: 0 },
+            },
+            {
+                $set: {
+                    state: 'DELETING',
+                    killAt: retryAt,
+                },
+            },
+        );
+
+        return result.matchedCount > 0;
     }
 
     /**
@@ -194,7 +460,7 @@ export class SandboxLeaseRepository {
      */
     async clearKillAt(prKey: string): Promise<void> {
         await this.leaseModel.updateOne(
-            { _id: prKey },
+            { _id: prKey, state: { $ne: 'DELETING' } },
             { $unset: { killAt: '' } },
         );
     }
@@ -210,6 +476,7 @@ export class SandboxLeaseRepository {
      */
     async findReadyToKill(
         now: Date,
+        limit: number,
     ): Promise<Pick<SandboxLeaseModel, '_id' | 'sandboxId' | 'killAt'>[]> {
         return this.leaseModel
             .find({
@@ -217,6 +484,7 @@ export class SandboxLeaseRepository {
                 sandboxId: { $exists: true, $ne: '' },
             })
             .select('_id sandboxId killAt')
+            .limit(limit)
             .lean();
     }
 }

--- a/libs/sandbox/infrastructure/repositories/schemas/sandbox-lease.model.ts
+++ b/libs/sandbox/infrastructure/repositories/schemas/sandbox-lease.model.ts
@@ -1,4 +1,3 @@
-import { CoreDocument } from '@libs/core/infrastructure/repositories/model/mongodb';
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Schema as MongooseSchema } from 'mongoose';
 
@@ -19,7 +18,7 @@ const PR_KEY_REGEX: RegExp =
  * cleaned up properly.
  */
 @Schema({ collection: 'sandbox_leases', timestamps: false })
-export class SandboxLeaseModel extends CoreDocument {
+export class SandboxLeaseModel {
     // prKey: "{orgId}:{repoId}:{prNumber}" — used as the document _id.
     // SECURITY: regex enforces that the first segment is a UUID (the
     // organizationId) so a malformed prKey can never reach Mongo. A doc
@@ -51,17 +50,14 @@ export class SandboxLeaseModel extends CoreDocument {
     consumer?: string; // Last consumer label ('review' | 'conversation')
 
     /**
-     * State enum. INVALIDATED is required to handle the mid-create invalidation
-     * race (RESEARCH.md Pitfall 5): when a force-push/pr-close event fires while
-     * acquire() is still in-flight (state = CREATING), invalidate() sets this to
-     * INVALIDATED instead of deleting the doc. The create path checks for this
-     * state after updateReady() and immediately kills the sandbox, preventing
-     * orphaned E2B sandboxes with no Mongo lease document.
+     * State enum. INVALIDATED handles the mid-create invalidation race.
+     * DELETING blocks warm reuse while a local directory or remote sandbox is
+     * being removed; the lease doc remains as the durable cleanup retry record.
      */
     @Prop({
         type: String,
         required: true,
-        enum: ['CREATING', 'READY', 'PAUSED', 'INVALIDATED'],
+        enum: ['CREATING', 'READY', 'PAUSED', 'INVALIDATED', 'DELETING'],
     })
     state: string;
 
@@ -93,6 +89,9 @@ export const SandboxLeaseSchema: MongooseSchema<SandboxLeaseModel> =
 
 // Reaper range scan: find all leases past their expiry regardless of state
 SandboxLeaseSchema.index({ expiresAt: 1 });
+
+// Recovery scan for cleanup operations that crashed after marking DELETING
+SandboxLeaseSchema.index({ state: 1, expiresAt: 1 });
 
 // Invalidate-by-sandboxId when prKey is unknown (sparse: unused entries have no entry)
 SandboxLeaseSchema.index({ sandboxId: 1 }, { sparse: true });

--- a/libs/sandbox/infrastructure/services/local-sandbox-cleanup.spec.ts
+++ b/libs/sandbox/infrastructure/services/local-sandbox-cleanup.spec.ts
@@ -1,0 +1,71 @@
+import { mkdtemp, readFile, rm, writeFile } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import {
+    cleanupLocalSandboxDirectory,
+    isLocalSandboxPath,
+    localSandboxDirectoryExists,
+} from './local-sandbox-cleanup';
+
+describe('local sandbox cleanup helpers', () => {
+    it('accepts only kodus sandbox directories directly under the OS tmp root', () => {
+        expect(isLocalSandboxPath(join(tmpdir(), 'kodus-sandbox-abc'))).toBe(
+            true,
+        );
+        expect(isLocalSandboxPath(join(tmpdir(), 'not-kodus-abc'))).toBe(false);
+        expect(isLocalSandboxPath('/var/tmp/kodus-sandbox-abc')).toBe(false);
+        expect(isLocalSandboxPath('kodus-sandbox-abc')).toBe(false);
+        expect(isLocalSandboxPath(undefined)).toBe(false);
+    });
+
+    it('removes an existing local sandbox directory and reports success', async () => {
+        const sandboxId = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+
+        await expect(localSandboxDirectoryExists(sandboxId)).resolves.toBe(
+            true,
+        );
+        await expect(cleanupLocalSandboxDirectory(sandboxId)).resolves.toBe(
+            true,
+        );
+        await expect(localSandboxDirectoryExists(sandboxId)).resolves.toBe(
+            false,
+        );
+    });
+
+    it('returns false for a missing local sandbox directory', async () => {
+        const sandboxId = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        await rm(sandboxId, { recursive: true, force: true });
+
+        await expect(localSandboxDirectoryExists(sandboxId)).resolves.toBe(
+            false,
+        );
+        await expect(cleanupLocalSandboxDirectory(sandboxId)).resolves.toBe(
+            false,
+        );
+    });
+
+    it('refuses a matching local sandbox path when it is not a directory', async () => {
+        const sandboxId = join(tmpdir(), `kodus-sandbox-file-${Date.now()}`);
+        await writeFile(sandboxId, 'not a directory', 'utf-8');
+
+        try {
+            await expect(localSandboxDirectoryExists(sandboxId)).resolves.toBe(
+                false,
+            );
+            await expect(cleanupLocalSandboxDirectory(sandboxId)).resolves.toBe(
+                false,
+            );
+            await expect(readFile(sandboxId, 'utf-8')).resolves.toBe(
+                'not a directory',
+            );
+        } finally {
+            await rm(sandboxId, { force: true });
+        }
+    });
+
+    it('refuses invalid paths without attempting cleanup', async () => {
+        await expect(cleanupLocalSandboxDirectory('/etc')).resolves.toBe(false);
+        await expect(localSandboxDirectoryExists('/etc')).resolves.toBe(false);
+    });
+});

--- a/libs/sandbox/infrastructure/services/local-sandbox-cleanup.ts
+++ b/libs/sandbox/infrastructure/services/local-sandbox-cleanup.ts
@@ -1,0 +1,53 @@
+import { lstat, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { basename, dirname, isAbsolute, resolve } from 'path';
+
+const LOCAL_SANDBOX_PREFIX = 'kodus-sandbox-';
+
+export function isLocalSandboxPath(sandboxId?: string): boolean {
+    if (!sandboxId || !isAbsolute(sandboxId)) {
+        return false;
+    }
+
+    const tmpRoot = resolve(tmpdir());
+    const candidate = resolve(sandboxId);
+
+    return (
+        dirname(candidate) === tmpRoot &&
+        basename(candidate).startsWith(LOCAL_SANDBOX_PREFIX)
+    );
+}
+
+export async function localSandboxDirectoryExists(
+    sandboxId?: string,
+): Promise<boolean> {
+    if (!isLocalSandboxPath(sandboxId)) {
+        return false;
+    }
+
+    try {
+        const stat = await lstat(resolve(sandboxId!));
+        return stat.isDirectory();
+    } catch (error: any) {
+        if (error?.code === 'ENOENT') {
+            return false;
+        }
+        throw error;
+    }
+}
+
+export async function cleanupLocalSandboxDirectory(
+    sandboxId?: string,
+): Promise<boolean> {
+    if (!isLocalSandboxPath(sandboxId)) {
+        return false;
+    }
+
+    const resolved = resolve(sandboxId!);
+    if (!(await localSandboxDirectoryExists(resolved))) {
+        return false;
+    }
+
+    await rm(resolved, { recursive: true, force: true });
+    return true;
+}

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
@@ -18,6 +18,11 @@ import { randomUUID } from 'crypto';
 import { calculateBackoffInterval } from '@libs/common/utils/polling';
 import { SandboxLeaseRepository } from '../repositories/sandbox-lease.repository';
 import { NULL_SANDBOX_INSTANCE } from '../providers/null-sandbox.service';
+import {
+    cleanupLocalSandboxDirectory,
+    isLocalSandboxPath,
+    localSandboxDirectoryExists,
+} from './local-sandbox-cleanup';
 
 /**
  * Default idle timeout applied when the last lease on a sandbox is released.
@@ -37,6 +42,13 @@ const IDLE_TIMEOUT_MS = 300_000; // 5 minutes — default for conversation flow
  * expiresAt has passed — this guards against crashed-worker leaks.
  */
 const DEFAULT_LEASE_TTL_MS = 30 * 60 * 1000; // 30 minutes
+
+/**
+ * Retry cursor used when cleanup has already claimed a lease as DELETING but
+ * the filesystem/resource cleanup failed. Keeps failed local cleanup from
+ * blocking a PR until the full acquire TTL expires.
+ */
+const CLEANUP_RETRY_DELAY_MS = 60_000;
 
 /**
  * How often to poll when waiting for a concurrent creator to finish.
@@ -98,6 +110,20 @@ export class SandboxStaleConnectionError extends Error {
     }
 }
 
+/**
+ * Thrown when a lease is already claimed by cleanup and the resource still
+ * needs the reaper retry path. This must not be treated like a stale lease:
+ * cold-starting recursively would spin on the same DELETING doc.
+ */
+export class SandboxDeletingInProgressError extends Error {
+    constructor(prKey: string, sandboxId?: string) {
+        super(
+            `SandboxLeaseManager: deleting cleanup still in progress for prKey="${prKey}" sandboxId="${sandboxId ?? 'unknown'}"; retry later`,
+        );
+        this.name = 'SandboxDeletingInProgressError';
+    }
+}
+
 @Injectable()
 export class SandboxLeaseManager implements ISandboxLeaseManager {
     private readonly logger = createLogger(SandboxLeaseManager.name);
@@ -154,14 +180,24 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
             metadata: { prKey, consumer },
         });
 
-        const doc = await this.leaseRepo.upsertAcquire(prKey, leaseTtlMs, consumer);
+        const doc = await this.leaseRepo.upsertAcquire(
+            prKey,
+            leaseTtlMs,
+            consumer,
+        );
         const leaseId = randomUUID();
 
         // A new acquire arrived — atomically clear any pending idle-kill so
         // the warm sandbox isn't killed under us between this call and
         // connect(). Multi-worker safe: any worker that reads the doc next
         // will see killAt=null and skip.
-        await this.leaseRepo.clearKillAt(prKey);
+        //
+        // Do not clear DELETING.killAt: an idle reaper may have already
+        // claimed the lease. If its cleanup fails, killAt must remain as the
+        // durable retry cursor for the next idle-reaper tick.
+        if (doc.state !== 'DELETING') {
+            await this.leaseRepo.clearKillAt(prKey);
+        }
 
         // --- Path A: We are the creator (we just inserted the doc) ---
         // Both conditions are required:
@@ -174,12 +210,23 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
         // 1 on an existing READY doc) would wrongly cold-create another sandbox
         // instead of warm-resuming the one already on the lease doc.
         if (doc.state === 'CREATING' && doc.leaseCount === 1) {
-            return this.handleCreatorPath(prKey, leaseId, consumer, cloneParams);
+            return this.handleCreatorPath(
+                prKey,
+                leaseId,
+                consumer,
+                cloneParams,
+            );
         }
 
         // --- Path B: joiner — doc already existed or someone else is creating ---
         try {
-            return await this.handleJoinerPath(prKey, leaseId, consumer, doc.state, doc.sandboxId);
+            return await this.handleJoinerPath(
+                prKey,
+                leaseId,
+                consumer,
+                doc.state,
+                doc.sandboxId,
+            );
         } catch (err) {
             if (err instanceof SandboxStaleConnectionError) {
                 // Lease referenced a sandbox that E2B no longer has (idle-
@@ -217,10 +264,7 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
      * @kody arrives within seconds or much later; conversation uses the
      * 5min default because the user is interactive.
      */
-    async release(
-        leaseId: string,
-        opts?: { idleMs?: number },
-    ): Promise<void> {
+    async release(leaseId: string, opts?: { idleMs?: number }): Promise<void> {
         const prKey = this.leaseIdToPrKey.get(leaseId);
         if (!prKey) {
             this.logger.warn({
@@ -241,20 +285,44 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
         });
 
         if (updated && updated.leaseCount <= 0 && updated.sandboxId) {
+            if (isLocalSandboxPath(updated.sandboxId)) {
+                await this.cleanupInactiveLocalSandbox(
+                    prKey,
+                    updated.sandboxId,
+                    'release',
+                );
+                return;
+            }
+
             const idleMs = opts?.idleMs ?? IDLE_TIMEOUT_MS;
             const killAt = new Date(Date.now() + idleMs);
-            await this.leaseRepo.setKillAt(prKey, killAt);
+            const scheduled = await this.leaseRepo.setKillAt(prKey, killAt);
+            if (!scheduled) {
+                this.logger.log({
+                    message: `SandboxLeaseManager: skipped idle-kill scheduling because lease was re-acquired prKey="${prKey}"`,
+                    context: SandboxLeaseManager.name,
+                    metadata: { prKey, sandboxId: updated.sandboxId },
+                });
+                return;
+            }
 
             this.logger.log({
                 message: `SandboxLeaseManager: scheduled idle-kill at ${killAt.toISOString()} for sandboxId="${updated.sandboxId}"`,
                 context: SandboxLeaseManager.name,
-                metadata: { prKey, sandboxId: updated.sandboxId, idleTimeoutMs: idleMs, killAt },
+                metadata: {
+                    prKey,
+                    sandboxId: updated.sandboxId,
+                    idleTimeoutMs: idleMs,
+                    killAt,
+                },
             });
 
             const apiKey = this.configService.get<string>('API_E2B_KEY');
             if (apiKey) {
                 try {
-                    await Sandbox.setTimeout(updated.sandboxId, idleMs, { apiKey });
+                    await Sandbox.setTimeout(updated.sandboxId, idleMs, {
+                        apiKey,
+                    });
                 } catch (err) {
                     this.logger.warn({
                         message: `SandboxLeaseManager: failed to set E2B-side idle timeout on sandboxId="${updated.sandboxId}" (kill cron is the primary path)`,
@@ -269,8 +337,8 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
     /**
      * Invalidate a lease for the given prKey, called on PR-close or force-push.
      *
-     * - state === CREATING: mark as INVALIDATED; the in-flight create path will
-     *   detect this and kill the sandbox after it finishes (preventing orphans).
+     * - state === CREATING: atomically mark as INVALIDATED only if it is still
+     *   CREATING; otherwise re-read and fall through to active-lease cleanup.
      * - state === READY or PAUSED: soft-drain (60s setTimeout) then delete doc.
      * - doc not found: no-op (idempotent).
      */
@@ -281,11 +349,7 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
             metadata: { prKey },
         });
 
-        // Clear any pending idle-kill so the cron doesn't double-kill —
-        // invalidate already does its own kill via soft-drain + delete.
-        await this.leaseRepo.clearKillAt(prKey);
-
-        const doc = await this.leaseRepo.findByPrKey(prKey);
+        let doc = await this.leaseRepo.findByPrKey(prKey);
         if (!doc) {
             // Idempotent: no lease to invalidate
             this.logger.log({
@@ -296,19 +360,73 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
             return;
         }
 
-        if (doc.state === 'CREATING') {
-            // Mid-create race: mark as INVALIDATED so the create path can detect and kill
-            await this.leaseRepo.markInvalidated(prKey);
+        if (doc.state === 'DELETING') {
             this.logger.log({
-                message: `SandboxLeaseManager: marked INVALIDATED (mid-create) prKey="${prKey}"`,
+                message: `SandboxLeaseManager: invalidate skipped because cleanup is already in progress prKey="${prKey}"`,
                 context: SandboxLeaseManager.name,
-                metadata: { prKey },
+                metadata: { prKey, sandboxId: doc.sandboxId },
             });
             return;
         }
 
+        if (doc.state === 'CREATING') {
+            const invalidated =
+                await this.leaseRepo.markInvalidatedIfCreating(prKey);
+            if (invalidated) {
+                this.logger.log({
+                    message: `SandboxLeaseManager: marked INVALIDATED (mid-create) prKey="${prKey}"`,
+                    context: SandboxLeaseManager.name,
+                    metadata: { prKey },
+                });
+                return;
+            }
+
+            doc = await this.leaseRepo.findByPrKey(prKey);
+            if (!doc) {
+                this.logger.log({
+                    message: `SandboxLeaseManager: invalidate no-op after CREATING claim lost (doc not found) prKey="${prKey}"`,
+                    context: SandboxLeaseManager.name,
+                    metadata: { prKey },
+                });
+                return;
+            }
+
+            if (doc.state === 'DELETING') {
+                this.logger.log({
+                    message: `SandboxLeaseManager: invalidate skipped after CREATING claim lost because cleanup is already in progress prKey="${prKey}"`,
+                    context: SandboxLeaseManager.name,
+                    metadata: { prKey, sandboxId: doc.sandboxId },
+                });
+                return;
+            }
+        }
+
+        const invalidated = await this.leaseRepo.markInvalidated(prKey);
+        if (!invalidated) {
+            this.logger.log({
+                message: `SandboxLeaseManager: invalidate skipped because lease state changed before claim prKey="${prKey}"`,
+                context: SandboxLeaseManager.name,
+                metadata: { prKey, sandboxId: doc.sandboxId },
+            });
+            return;
+        }
+
+        // Clear any pending idle-kill only after we won the invalidation
+        // claim. If a reaper moved the doc to DELETING first, keep killAt as
+        // the retry cursor.
+        await this.leaseRepo.clearKillAt(prKey);
+
         // READY or PAUSED: soft-drain then delete
         if (doc.sandboxId) {
+            if (isLocalSandboxPath(doc.sandboxId)) {
+                await this.cleanupInactiveLocalSandbox(
+                    prKey,
+                    doc.sandboxId,
+                    'invalidation',
+                );
+                return;
+            }
+
             const apiKey = this.configService.get<string>('API_E2B_KEY');
             if (apiKey) {
                 try {
@@ -340,6 +458,166 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
     // ---------------------------------------------------------------------------
     // Private helpers
     // ---------------------------------------------------------------------------
+
+    private async cleanupInactiveLocalSandbox(
+        prKey: string,
+        sandboxId: string,
+        reason: string,
+    ): Promise<void> {
+        const marked = await this.leaseRepo.markDeletingIfNoActiveLeases(
+            prKey,
+            sandboxId,
+        );
+        if (!marked) {
+            const retryScheduled =
+                await this.scheduleInactiveInvalidatedLocalCleanupRetry(
+                    prKey,
+                    sandboxId,
+                    reason,
+                );
+            if (retryScheduled) {
+                return;
+            }
+
+            this.logger.log({
+                message: `SandboxLeaseManager: skipped local sandbox cleanup after ${reason} because lease was re-acquired prKey="${prKey}"`,
+                context: SandboxLeaseManager.name,
+                metadata: { prKey, sandboxId, reason },
+            });
+            return;
+        }
+
+        const cleaned = await this.cleanupLocalSandbox(
+            sandboxId,
+            prKey,
+            reason,
+        );
+        if (!cleaned) {
+            await this.scheduleCleanupRetry(prKey, sandboxId, reason);
+            return;
+        }
+
+        const deleted = await this.leaseRepo.deleteDeletingWithSandboxId(
+            prKey,
+            sandboxId,
+        );
+        if (!deleted) {
+            this.logger.log({
+                message: `SandboxLeaseManager: skipped local sandbox lease delete after ${reason} because lease was re-acquired prKey="${prKey}"`,
+                context: SandboxLeaseManager.name,
+                metadata: { prKey, sandboxId, reason },
+            });
+        }
+    }
+
+    private async cleanupLocalSandbox(
+        sandboxId: string,
+        prKey: string,
+        reason: string,
+    ): Promise<boolean> {
+        try {
+            if (
+                isLocalSandboxPath(sandboxId) &&
+                !(await localSandboxDirectoryExists(sandboxId))
+            ) {
+                this.logger.log({
+                    message: `SandboxLeaseManager: local sandbox directory was already absent after ${reason}`,
+                    context: SandboxLeaseManager.name,
+                    metadata: { prKey, sandboxId, reason },
+                });
+                return true;
+            }
+
+            const cleaned = await cleanupLocalSandboxDirectory(sandboxId);
+            if (cleaned) {
+                this.logger.log({
+                    message: `SandboxLeaseManager: removed local sandbox directory after ${reason}`,
+                    context: SandboxLeaseManager.name,
+                    metadata: { prKey, sandboxId, reason },
+                });
+            } else {
+                this.logger.warn({
+                    message: `SandboxLeaseManager: local sandbox directory was not removed after ${reason}`,
+                    context: SandboxLeaseManager.name,
+                    metadata: { prKey, sandboxId, reason },
+                });
+            }
+            return cleaned;
+        } catch (error) {
+            this.logger.warn({
+                message: `SandboxLeaseManager: failed to remove local sandbox directory after ${reason}`,
+                context: SandboxLeaseManager.name,
+                error,
+                metadata: { prKey, sandboxId, reason },
+            });
+            return false;
+        }
+    }
+
+    private async scheduleInactiveInvalidatedLocalCleanupRetry(
+        prKey: string,
+        sandboxId: string,
+        reason: string,
+    ): Promise<boolean> {
+        if (reason !== 'invalidation') {
+            return false;
+        }
+
+        const latest = await this.leaseRepo.findByPrKey(prKey);
+        if (
+            latest?.state !== 'INVALIDATED' ||
+            latest.sandboxId !== sandboxId ||
+            (latest.leaseCount ?? 0) > 0
+        ) {
+            return false;
+        }
+
+        const retryAt = new Date(Date.now() + CLEANUP_RETRY_DELAY_MS);
+        const scheduled =
+            await this.leaseRepo.markDeletingWithSandboxIdIfNoActiveLeases(
+                prKey,
+                sandboxId,
+                retryAt,
+            );
+
+        if (!scheduled) {
+            return false;
+        }
+
+        this.logger.warn({
+            message: `SandboxLeaseManager: scheduled inactive INVALIDATED local cleanup retry after ${reason}`,
+            context: SandboxLeaseManager.name,
+            metadata: { prKey, sandboxId, reason, retryAt },
+        });
+        return true;
+    }
+
+    private async scheduleCleanupRetry(
+        prKey: string,
+        sandboxId: string,
+        reason: string,
+    ): Promise<void> {
+        const retryAt = new Date(Date.now() + CLEANUP_RETRY_DELAY_MS);
+        const scheduled = await this.leaseRepo.scheduleCleanupRetry(
+            prKey,
+            retryAt,
+        );
+
+        if (!scheduled) {
+            this.logger.log({
+                message: `SandboxLeaseManager: skipped cleanup retry schedule after ${reason} because lease state changed prKey="${prKey}"`,
+                context: SandboxLeaseManager.name,
+                metadata: { prKey, sandboxId, reason, retryAt },
+            });
+            return;
+        }
+
+        this.logger.warn({
+            message: `SandboxLeaseManager: scheduled cleanup retry after ${reason}`,
+            context: SandboxLeaseManager.name,
+            metadata: { prKey, sandboxId, reason, retryAt },
+        });
+    }
 
     private async handleCreatorPath(
         prKey: string,
@@ -380,13 +658,21 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                 });
                 // Kill the sandbox we just created; it is orphaned
                 if (sandboxId) {
-                    const apiKey = this.configService.get<string>('API_E2B_KEY');
-                    if (apiKey) {
-                        await Sandbox.kill(sandboxId, { apiKey }).catch(() => {});
+                    if (!isLocalSandboxPath(sandboxId)) {
+                        const apiKey =
+                            this.configService.get<string>('API_E2B_KEY');
+                        if (apiKey) {
+                            await Sandbox.kill(sandboxId, { apiKey }).catch(
+                                () => {},
+                            );
+                        }
                     }
                 }
-                // Clean up the invalidated doc
-                await this.leaseRepo.delete(prKey);
+                // Local sandbox cleanup happens in the catch block so the
+                // lease remains as a durable retry record if rm fails.
+                if (!sandboxId || !isLocalSandboxPath(sandboxId)) {
+                    await this.leaseRepo.delete(prKey);
+                }
                 throw new Error(
                     `SandboxLeaseManager: sandbox invalidated mid-create for prKey="${prKey}"`,
                 );
@@ -410,11 +696,37 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
 
             return { sandbox, leaseId, sandboxId, wasCreated: true };
         } catch (err) {
-            // If a real E2B sandbox was created but a later step failed
-            // (Mongo update, mid-create invalidation, etc.), kill it so it
-            // doesn't run for the full ceiling burning quota. Null-sandbox
-            // doesn't need killing — its sandboxId is empty.
             if (sandboxId) {
+                if (isLocalSandboxPath(sandboxId)) {
+                    const cleaned = await this.cleanupLocalSandbox(
+                        sandboxId,
+                        prKey,
+                        'creator-path failure',
+                    );
+                    if (cleaned) {
+                        await this.leaseRepo.delete(prKey).catch(() => {});
+                    } else {
+                        const persisted =
+                            await this.persistLocalCreatorCleanupRetry(
+                                prKey,
+                                sandboxId,
+                                'creator-path failure',
+                            );
+                        if (!persisted) {
+                            this.logger.error({
+                                message: `SandboxLeaseManager: local sandbox directory may be orphaned after creator-path failure prKey="${prKey}" sandboxId="${sandboxId}"`,
+                                context: SandboxLeaseManager.name,
+                                metadata: { prKey, sandboxId },
+                            });
+                        }
+                    }
+                    throw err;
+                }
+
+                // If a real E2B sandbox was created but a later step failed
+                // (Mongo update, mid-create invalidation, etc.), kill it so it
+                // doesn't run for the full ceiling burning quota. Null-sandbox
+                // doesn't need killing — its sandboxId is empty.
                 const apiKey = this.configService.get<string>('API_E2B_KEY');
                 if (apiKey) {
                     this.logger.warn({
@@ -425,9 +737,49 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                     await Sandbox.kill(sandboxId, { apiKey }).catch(() => {});
                 }
             }
-            // Remove the lease doc so other callers don't poll forever
+            // Remove the lease doc so other callers don't poll forever.
+            // Local sandbox cleanup above only deletes after confirmed rm.
             await this.leaseRepo.delete(prKey).catch(() => {});
             throw err;
+        }
+    }
+
+    private async persistLocalCreatorCleanupRetry(
+        prKey: string,
+        sandboxId: string,
+        reason: string,
+    ): Promise<boolean> {
+        const retryAt = new Date(Date.now() + CLEANUP_RETRY_DELAY_MS);
+
+        try {
+            const marked = await this.leaseRepo.markDeletingWithSandboxId(
+                prKey,
+                sandboxId,
+                retryAt,
+            );
+            if (!marked) {
+                this.logger.log({
+                    message: `SandboxLeaseManager: skipped local creator cleanup retry after ${reason} because lease state changed prKey="${prKey}"`,
+                    context: SandboxLeaseManager.name,
+                    metadata: { prKey, sandboxId, reason, retryAt },
+                });
+                return false;
+            }
+
+            this.logger.warn({
+                message: `SandboxLeaseManager: persisted local creator cleanup retry after ${reason}`,
+                context: SandboxLeaseManager.name,
+                metadata: { prKey, sandboxId, reason, retryAt },
+            });
+            return true;
+        } catch (error) {
+            this.logger.warn({
+                message: `SandboxLeaseManager: failed to persist local creator cleanup retry after ${reason}`,
+                context: SandboxLeaseManager.name,
+                error,
+                metadata: { prKey, sandboxId, reason, retryAt },
+            });
+            return false;
         }
     }
 
@@ -476,8 +828,21 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
         sandboxId?: string,
     ): Promise<AcquireResult> {
         if (state === 'INVALIDATED') {
+            await this.rollbackAcquire(prKey, leaseId);
             throw new Error(
                 `SandboxLeaseManager: sandbox invalidated for prKey="${prKey}"`,
+            );
+        }
+
+        if (state === 'DELETING') {
+            await this.waitForDeletingLeaseAndRollback(
+                prKey,
+                leaseId,
+                sandboxId,
+            );
+            throw new SandboxStaleConnectionError(
+                prKey,
+                sandboxId ?? 'deleting',
             );
         }
 
@@ -498,19 +863,38 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
             const doc = await this.leaseRepo.findByPrKey(prKey);
 
             if (!doc) {
-                throw new Error(
-                    `SandboxLeaseManager: lease disappeared while polling for READY prKey="${prKey}"`,
+                throw new SandboxStaleConnectionError(
+                    prKey,
+                    sandboxId ?? 'missing',
                 );
             }
 
             if (doc.state === 'INVALIDATED') {
+                await this.rollbackAcquire(prKey, leaseId);
                 throw new Error(
                     `SandboxLeaseManager: sandbox invalidated for prKey="${prKey}"`,
                 );
             }
 
+            if (doc.state === 'DELETING') {
+                await this.waitForDeletingLeaseAndRollback(
+                    prKey,
+                    leaseId,
+                    doc.sandboxId,
+                );
+                throw new SandboxStaleConnectionError(
+                    prKey,
+                    doc.sandboxId ?? 'deleting',
+                );
+            }
+
             if (doc.state === 'READY' && doc.sandboxId) {
-                return this.connectToExisting(prKey, leaseId, consumer, doc.sandboxId);
+                return this.connectToExisting(
+                    prKey,
+                    leaseId,
+                    consumer,
+                    doc.sandboxId,
+                );
             }
         }
 
@@ -523,6 +907,15 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
         consumer: string,
         sandboxId: string,
     ): Promise<AcquireResult> {
+        if (isLocalSandboxPath(sandboxId)) {
+            return this.connectToExistingLocalSandbox(
+                prKey,
+                leaseId,
+                consumer,
+                sandboxId,
+            );
+        }
+
         const apiKey = this.configService.get<string>('API_E2B_KEY');
 
         if (!apiKey) {
@@ -565,7 +958,11 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
             throw new SandboxStaleConnectionError(prKey, sandboxId);
         }
 
-        const sandbox: SandboxInstance = this.buildSandboxInstance(e2bSandbox, prKey, leaseId);
+        const sandbox: SandboxInstance = this.buildSandboxInstance(
+            e2bSandbox,
+            prKey,
+            leaseId,
+        );
         this.leaseIdToPrKey.set(leaseId, prKey);
 
         this.logger.log({
@@ -577,11 +974,185 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
         return { sandbox, leaseId, sandboxId, wasCreated: false };
     }
 
+    private async connectToExistingLocalSandbox(
+        prKey: string,
+        leaseId: string,
+        consumer: string,
+        sandboxId: string,
+    ): Promise<AcquireResult> {
+        const connect = this.sandboxProvider.connectToExistingSandbox;
+        if (!connect) {
+            const noActiveLeases = await this.rollbackLocalReconnectAcquire(
+                prKey,
+                leaseId,
+            );
+            await this.deleteMissingLocalLeaseIfInactive(
+                prKey,
+                sandboxId,
+                noActiveLeases,
+            );
+            throw new Error(
+                `SandboxLeaseManager: sandbox provider cannot reconnect local sandbox prKey="${prKey}" sandboxId="${sandboxId}"`,
+            );
+        }
+
+        try {
+            const sandbox = await connect.call(this.sandboxProvider, sandboxId);
+            this.leaseIdToPrKey.set(leaseId, prKey);
+
+            const wrappedSandbox: SandboxInstance = {
+                ...sandbox,
+                cleanup: async () => {
+                    await this.release(leaseId);
+                },
+            };
+
+            this.logger.log({
+                message: `SandboxLeaseManager: connected to existing local sandbox prKey="${prKey}" consumer="${consumer}" leaseId="${leaseId}"`,
+                context: SandboxLeaseManager.name,
+                metadata: { prKey, consumer, leaseId, sandboxId },
+            });
+
+            return {
+                sandbox: wrappedSandbox,
+                leaseId,
+                sandboxId,
+                wasCreated: false,
+            };
+        } catch (err) {
+            const noActiveLeases = await this.rollbackLocalReconnectAcquire(
+                prKey,
+                leaseId,
+            );
+            const deleted = await this.deleteMissingLocalLeaseIfInactive(
+                prKey,
+                sandboxId,
+                noActiveLeases,
+            );
+            if (deleted) {
+                throw new SandboxStaleConnectionError(prKey, sandboxId);
+            }
+            throw err;
+        }
+    }
+
+    private async rollbackLocalReconnectAcquire(
+        prKey: string,
+        leaseId: string,
+    ): Promise<boolean> {
+        return this.rollbackAcquire(prKey, leaseId);
+    }
+
+    private async rollbackAcquire(
+        prKey: string,
+        leaseId: string,
+    ): Promise<boolean> {
+        this.leaseIdToPrKey.delete(leaseId);
+
+        try {
+            const updated = await this.leaseRepo.decrementLease(prKey);
+            return !updated || updated.leaseCount <= 0;
+        } catch (error) {
+            this.logger.warn({
+                message: `SandboxLeaseManager: failed to roll back local reconnect lease prKey="${prKey}"`,
+                context: SandboxLeaseManager.name,
+                error,
+                metadata: { prKey, leaseId },
+            });
+            return false;
+        }
+    }
+
+    private async deleteMissingLocalLeaseIfInactive(
+        prKey: string,
+        sandboxId: string,
+        noActiveLeases: boolean,
+    ): Promise<boolean> {
+        if (!noActiveLeases) {
+            return false;
+        }
+
+        const exists = await this.localSandboxExists(prKey, sandboxId);
+        if (exists) {
+            return false;
+        }
+
+        try {
+            return await this.leaseRepo.deleteIfNoActiveLeases(
+                prKey,
+                sandboxId,
+            );
+        } catch (error) {
+            this.logger.warn({
+                message: `SandboxLeaseManager: failed to delete missing local sandbox lease prKey="${prKey}"`,
+                context: SandboxLeaseManager.name,
+                error,
+                metadata: { prKey, sandboxId },
+            });
+            return false;
+        }
+    }
+
+    private async localSandboxExists(
+        prKey: string,
+        sandboxId: string,
+    ): Promise<boolean> {
+        try {
+            return await localSandboxDirectoryExists(sandboxId);
+        } catch (error) {
+            this.logger.warn({
+                message: `SandboxLeaseManager: failed to inspect local sandbox directory prKey="${prKey}"`,
+                context: SandboxLeaseManager.name,
+                error,
+                metadata: { prKey, sandboxId },
+            });
+            return true;
+        }
+    }
+
+    private async waitForDeletingLeaseAndRollback(
+        prKey: string,
+        leaseId: string,
+        sandboxId?: string,
+    ): Promise<void> {
+        const noActiveLeases = await this.rollbackAcquire(prKey, leaseId);
+
+        const deadline = Date.now() + MAX_POLL_WAIT_MS;
+        while (Date.now() < deadline) {
+            const doc = await this.leaseRepo.findByPrKey(prKey);
+            if (!doc || doc.state !== 'DELETING') {
+                return;
+            }
+            if (
+                noActiveLeases &&
+                doc.sandboxId &&
+                isLocalSandboxPath(doc.sandboxId) &&
+                !(await this.localSandboxExists(prKey, doc.sandboxId))
+            ) {
+                const deleted =
+                    await this.leaseRepo.deleteDeletingWithSandboxId(
+                        prKey,
+                        doc.sandboxId,
+                    );
+                if (deleted) {
+                    return;
+                }
+            }
+            await sleep(POLL_INTERVAL_MS);
+        }
+
+        throw new SandboxDeletingInProgressError(prKey, sandboxId);
+    }
+
     /**
      * Build a minimal SandboxInstance wrapping an existing connected E2B sandbox.
      * This is used by the joiner path when connecting to an already-READY sandbox.
      */
-    private buildSandboxInstance(e2bSandbox: Sandbox, prKey: string, leaseId: string): SandboxInstance {
+    private buildSandboxInstance(
+        e2bSandbox: Sandbox,
+        prKey: string,
+        leaseId: string,
+    ): SandboxInstance {
         return {
             remoteCommands: {
                 grep: async (pattern: string, path: string, glob?: string) => {
@@ -607,8 +1178,14 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                     return result.stdout || '';
                 },
                 exec: async (command: string) => {
-                    const result = await e2bSandbox.commands.run(command, { timeoutMs: 30_000 });
-                    return { stdout: result.stdout || '', exitCode: result.exitCode };
+                    const result = await e2bSandbox.commands.run(command, {
+                        timeoutMs: 30_000,
+                    });
+                    return {
+                        stdout: result.stdout || '',
+                        stderr: result.stderr || '',
+                        exitCode: result.exitCode,
+                    };
                 },
             },
             cleanup: async () => {
@@ -642,7 +1219,10 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
      * Build a null sandbox with a release-bound cleanup function.
      * Used when E2B is not configured or when connect is not needed.
      */
-    private buildNullSandboxWithRelease(prKey: string, leaseId: string): SandboxInstance {
+    private buildNullSandboxWithRelease(
+        prKey: string,
+        leaseId: string,
+    ): SandboxInstance {
         return {
             ...NULL_SANDBOX_INSTANCE,
             cleanup: async () => {

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
@@ -23,12 +23,16 @@
 import { Sandbox } from 'e2b';
 import { SandboxLeaseManager } from './sandbox-lease-manager.service';
 import { SandboxLeaseReaperService } from './sandbox-lease-reaper.service';
+import { localSandboxDirectoryExists } from './local-sandbox-cleanup';
 import { SandboxLeaseRepository } from '../repositories/sandbox-lease.repository';
 import {
     ISandboxProvider,
     SandboxInstance,
 } from '@libs/sandbox/domain/contracts/sandbox.provider';
 import { ConfigService } from '@nestjs/config';
+import { mkdtemp, rm } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 // ─── Shared test helpers ─────────────────────────────────────────────────────
 
@@ -37,17 +41,30 @@ function makeMockLeaseRepo(): jest.Mocked<SandboxLeaseRepository> {
         upsertAcquire: jest.fn(),
         decrementLease: jest.fn(),
         updateReady: jest.fn().mockResolvedValue(undefined),
-        markInvalidated: jest.fn().mockResolvedValue(undefined),
+        markInvalidated: jest.fn().mockResolvedValue(true),
+        markInvalidatedIfCreating: jest.fn().mockResolvedValue(true),
         findByPrKey: jest.fn().mockResolvedValue(null),
         findExpired: jest.fn().mockResolvedValue([]),
         delete: jest.fn().mockResolvedValue(undefined),
-        setKillAt: jest.fn().mockResolvedValue(undefined),
+        deleteIfNoActiveLeases: jest.fn().mockResolvedValue(true),
+        deleteDeletingWithSandboxId: jest.fn().mockResolvedValue(true),
+        markDeletingIfNoActiveLeases: jest.fn().mockResolvedValue(true),
+        markDeletingIfExpired: jest.fn().mockResolvedValue(true),
+        markDeletingIfReadyToKill: jest.fn().mockResolvedValue(true),
+        setKillAt: jest.fn().mockResolvedValue(true),
+        scheduleCleanupRetry: jest.fn().mockResolvedValue(true),
+        markDeletingWithSandboxId: jest.fn().mockResolvedValue(true),
+        markDeletingWithSandboxIdIfNoActiveLeases: jest
+            .fn()
+            .mockResolvedValue(true),
         clearKillAt: jest.fn().mockResolvedValue(undefined),
         findReadyToKill: jest.fn().mockResolvedValue([]),
     } as unknown as jest.Mocked<SandboxLeaseRepository>;
 }
 
-function makeMockSandboxProvider(available = true): jest.Mocked<ISandboxProvider> {
+function makeMockSandboxProvider(
+    available = true,
+): jest.Mocked<ISandboxProvider> {
     const mockSandboxInstance: SandboxInstance = {
         remoteCommands: {
             grep: jest.fn().mockResolvedValue(''),
@@ -59,7 +76,9 @@ function makeMockSandboxProvider(available = true): jest.Mocked<ISandboxProvider
         type: 'e2b',
         sandboxId: 'mock-sandbox-id',
         repoDir: '/home/user/repo',
-        run: jest.fn().mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 }),
+        run: jest
+            .fn()
+            .mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 }),
         readFile: jest.fn().mockResolvedValue(''),
         writeFile: jest.fn().mockResolvedValue(undefined),
     };
@@ -67,10 +86,35 @@ function makeMockSandboxProvider(available = true): jest.Mocked<ISandboxProvider
     return {
         isAvailable: jest.fn().mockReturnValue(available),
         createSandboxWithRepo: jest.fn().mockResolvedValue(mockSandboxInstance),
+        connectToExistingSandbox: jest.fn(),
     } as jest.Mocked<ISandboxProvider>;
 }
 
-function makeMockConfigService(e2bKey: string | undefined = 'test-e2b-key'): jest.Mocked<ConfigService> {
+function makeLocalSandboxInstance(tempDir: string): SandboxInstance {
+    return {
+        remoteCommands: {
+            grep: jest.fn().mockResolvedValue(''),
+            read: jest.fn().mockResolvedValue(''),
+            listDir: jest.fn().mockResolvedValue(''),
+            exec: jest.fn().mockResolvedValue({ stdout: '', exitCode: 0 }),
+        },
+        cleanup: jest.fn(async () => {
+            await rm(tempDir, { recursive: true, force: true });
+        }),
+        type: 'local',
+        sandboxId: tempDir,
+        repoDir: tempDir,
+        run: jest
+            .fn()
+            .mockResolvedValue({ stdout: '', stderr: '', exitCode: 0 }),
+        readFile: jest.fn().mockResolvedValue(''),
+        writeFile: jest.fn().mockResolvedValue(undefined),
+    };
+}
+
+function makeMockConfigService(
+    e2bKey: string | undefined = 'test-e2b-key',
+): jest.Mocked<ConfigService> {
     return {
         get: jest.fn().mockReturnValue(e2bKey),
     } as unknown as jest.Mocked<ConfigService>;
@@ -138,7 +182,10 @@ describe('SandboxLeaseManager', () => {
         expect(result.sandbox).toBeDefined();
 
         // updateReady called with prKey
-        expect(leaseRepo.updateReady).toHaveBeenCalledWith(prKey, expect.any(String));
+        expect(leaseRepo.updateReady).toHaveBeenCalledWith(
+            prKey,
+            expect.any(String),
+        );
 
         // Release: decrement lease
         leaseRepo.decrementLease.mockResolvedValue({
@@ -161,6 +208,148 @@ describe('SandboxLeaseManager', () => {
 
         // kill is NEVER called on release
         expect(Sandbox.kill).not.toHaveBeenCalled();
+    });
+
+    it('release removes a local sandbox directory when the last lease is released', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:203';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'CREATING',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'READY',
+            sandboxId: '',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        const result = await manager.acquire(prKey, 'review');
+
+        leaseRepo.decrementLease.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        try {
+            await manager.release(result.leaseId, { idleMs: 30_000 });
+
+            await expect(localSandboxDirectoryExists(tempDir)).resolves.toBe(
+                false,
+            );
+            expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledWith(
+                prKey,
+                tempDir,
+            );
+            expect(leaseRepo.deleteDeletingWithSandboxId).toHaveBeenCalledWith(
+                prKey,
+                tempDir,
+            );
+            expect(leaseRepo.setKillAt).not.toHaveBeenCalled();
+            expect(Sandbox.setTimeout).not.toHaveBeenCalled();
+            expect(Sandbox.kill).not.toHaveBeenCalled();
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('release deletes the local lease when the directory is already missing', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:204';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        await rm(tempDir, { recursive: true, force: true });
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'CREATING',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'READY',
+            sandboxId: '',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        const result = await manager.acquire(prKey, 'review');
+
+        leaseRepo.decrementLease.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        await manager.release(result.leaseId, { idleMs: 30_000 });
+
+        expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledWith(
+            prKey,
+            tempDir,
+        );
+        expect(leaseRepo.deleteDeletingWithSandboxId).toHaveBeenCalledWith(
+            prKey,
+            tempDir,
+        );
+        expect(leaseRepo.setKillAt).not.toHaveBeenCalled();
+        expect(Sandbox.setTimeout).not.toHaveBeenCalled();
+    });
+
+    it('release skips local cleanup when the lease was re-acquired before marking deleting', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:205';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'CREATING',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'READY',
+            sandboxId: '',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        const result = await manager.acquire(prKey, 'review');
+
+        leaseRepo.decrementLease.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.markDeletingIfNoActiveLeases.mockResolvedValue(false);
+
+        try {
+            await manager.release(result.leaseId, { idleMs: 30_000 });
+
+            await expect(localSandboxDirectoryExists(tempDir)).resolves.toBe(
+                true,
+            );
+            expect(leaseRepo.deleteIfNoActiveLeases).not.toHaveBeenCalled();
+            expect(leaseRepo.setKillAt).not.toHaveBeenCalled();
+            expect(Sandbox.setTimeout).not.toHaveBeenCalled();
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
     });
 
     // ─── Test 2: concurrent acquire — exactly one createSandboxWithRepo ───
@@ -238,10 +427,9 @@ describe('SandboxLeaseManager', () => {
 
         // Joiner (second acquire) connected to existing sandbox via Sandbox.connect
         // (creator path — without cloneParams — uses null sandbox for initial CREATING→READY)
-        expect(Sandbox.connect).toHaveBeenCalledWith(
-            'e2b-poll-sandbox',
-            { apiKey: 'test-e2b-key' },
-        );
+        expect(Sandbox.connect).toHaveBeenCalledWith('e2b-poll-sandbox', {
+            apiKey: 'test-e2b-key',
+        });
 
         // Key invariant: createSandboxWithRepo NOT called without cloneParams
         // (manager falls back to null sandbox when no clone params supplied).
@@ -277,6 +465,249 @@ describe('SandboxLeaseManager', () => {
         expect(leaseRepo.delete).toHaveBeenCalledWith(prKey);
 
         // kill is NOT called synchronously (soft-drain, not immediate kill)
+        expect(Sandbox.kill).not.toHaveBeenCalled();
+    });
+
+    it('invalidate preserves a remote lease when the invalidation claim loses to DELETING cleanup', async () => {
+        const prKey = 'org:repo:82';
+
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'READY',
+            sandboxId: 'e2b-deleting-race',
+            killAt: new Date(Date.now() - 1000),
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.markInvalidated.mockResolvedValueOnce(false);
+
+        await manager.invalidate(prKey);
+
+        expect(leaseRepo.markInvalidated).toHaveBeenCalledWith(prKey);
+        expect(leaseRepo.clearKillAt).not.toHaveBeenCalledWith(prKey);
+        expect(Sandbox.setTimeout).not.toHaveBeenCalled();
+        expect(leaseRepo.delete).not.toHaveBeenCalledWith(prKey);
+    });
+
+    it('invalidate re-reads and soft-drains when a CREATING lease becomes READY before the invalidation claim', async () => {
+        const prKey = 'org:repo:83';
+
+        leaseRepo.findByPrKey
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'CREATING',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any)
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'READY',
+                sandboxId: 'e2b-ready-race',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+        leaseRepo.markInvalidatedIfCreating.mockResolvedValueOnce(false);
+        leaseRepo.markInvalidated.mockResolvedValueOnce(true);
+
+        await manager.invalidate(prKey);
+
+        expect(leaseRepo.markInvalidatedIfCreating).toHaveBeenCalledWith(prKey);
+        expect(leaseRepo.markInvalidated).toHaveBeenCalledWith(prKey);
+        expect(Sandbox.setTimeout).toHaveBeenCalledWith(
+            'e2b-ready-race',
+            60_000,
+            { apiKey: 'test-e2b-key' },
+        );
+        expect(leaseRepo.delete).toHaveBeenCalledWith(prKey);
+    });
+
+    it('invalidate removes a local sandbox directory before deleting an inactive lease', async () => {
+        const prKey = 'org:repo:78';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        try {
+            await manager.invalidate(prKey);
+
+            await expect(localSandboxDirectoryExists(tempDir)).resolves.toBe(
+                false,
+            );
+            expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledWith(
+                prKey,
+                tempDir,
+            );
+            expect(leaseRepo.deleteDeletingWithSandboxId).toHaveBeenCalledWith(
+                prKey,
+                tempDir,
+            );
+            expect(leaseRepo.delete).not.toHaveBeenCalledWith(prKey);
+            expect(Sandbox.setTimeout).not.toHaveBeenCalled();
+            expect(Sandbox.kill).not.toHaveBeenCalled();
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('invalidate marks an active local sandbox invalidated without deleting the active directory', async () => {
+        const prKey = 'org:repo:80';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.markDeletingIfNoActiveLeases.mockResolvedValueOnce(false);
+
+        try {
+            await manager.invalidate(prKey);
+
+            expect(leaseRepo.markInvalidated).toHaveBeenCalledWith(prKey);
+            expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledWith(
+                prKey,
+                tempDir,
+            );
+            await expect(localSandboxDirectoryExists(tempDir)).resolves.toBe(
+                true,
+            );
+            expect(leaseRepo.deleteIfNoActiveLeases).not.toHaveBeenCalled();
+            expect(leaseRepo.delete).not.toHaveBeenCalledWith(prKey);
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('cleanupInactiveLocalSandbox schedules a near-term retry when local cleanup fails after the DELETING claim', async () => {
+        const prKey = 'org:repo:84';
+        const sandboxId = 'not-a-local-sandbox-path';
+
+        const before = Date.now();
+        await (manager as any).cleanupInactiveLocalSandbox(
+            prKey,
+            sandboxId,
+            'test',
+        );
+
+        expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledWith(
+            prKey,
+            sandboxId,
+        );
+        expect(leaseRepo.scheduleCleanupRetry).toHaveBeenCalledTimes(1);
+        const [calledPrKey, retryAt] = (
+            leaseRepo.scheduleCleanupRetry as jest.Mock
+        ).mock.calls[0];
+        expect(calledPrKey).toBe(prKey);
+        expect(retryAt.getTime()).toBeGreaterThanOrEqual(before);
+        expect(retryAt.getTime()).toBeLessThanOrEqual(
+            Date.now() + 2 * 60 * 1000,
+        );
+        expect(leaseRepo.deleteIfNoActiveLeases).not.toHaveBeenCalled();
+        expect(leaseRepo.delete).not.toHaveBeenCalledWith(prKey);
+    });
+
+    it('cleanupInactiveLocalSandbox retries an inactive INVALIDATED local lease when the first DELETING claim loses to a transient join', async () => {
+        const prKey = 'org:repo:85';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        leaseRepo.markDeletingIfNoActiveLeases.mockResolvedValueOnce(false);
+        leaseRepo.findByPrKey.mockResolvedValueOnce({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'INVALIDATED',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        const before = Date.now();
+        try {
+            await (manager as any).cleanupInactiveLocalSandbox(
+                prKey,
+                tempDir,
+                'invalidation',
+            );
+
+            expect(
+                leaseRepo.markDeletingWithSandboxIdIfNoActiveLeases,
+            ).toHaveBeenCalledTimes(1);
+            const [calledPrKey, calledSandboxId, retryAt] = (
+                leaseRepo.markDeletingWithSandboxIdIfNoActiveLeases as jest.Mock
+            ).mock.calls[0];
+            expect(calledPrKey).toBe(prKey);
+            expect(calledSandboxId).toBe(tempDir);
+            expect(retryAt.getTime()).toBeGreaterThanOrEqual(before);
+            expect(retryAt.getTime()).toBeLessThanOrEqual(
+                Date.now() + 2 * 60 * 1000,
+            );
+            await expect(localSandboxDirectoryExists(tempDir)).resolves.toBe(
+                true,
+            );
+            expect(leaseRepo.deleteIfNoActiveLeases).not.toHaveBeenCalled();
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('invalidate deletes a local lease when the directory is already missing', async () => {
+        const prKey = 'org:repo:79';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        await rm(tempDir, { recursive: true, force: true });
+
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        await manager.invalidate(prKey);
+
+        expect(leaseRepo.markDeletingIfNoActiveLeases).toHaveBeenCalledWith(
+            prKey,
+            tempDir,
+        );
+        expect(leaseRepo.deleteDeletingWithSandboxId).toHaveBeenCalledWith(
+            prKey,
+            tempDir,
+        );
+        expect(leaseRepo.delete).not.toHaveBeenCalledWith(prKey);
+        expect(Sandbox.setTimeout).not.toHaveBeenCalled();
+    });
+
+    it('invalidate preserves a DELETING lease and its idle retry cursor', async () => {
+        const prKey = 'org:repo:81';
+        const killAt = new Date(Date.now() - 1000);
+
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'DELETING',
+            sandboxId: 'e2b-deleting-retry',
+            killAt,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        await manager.invalidate(prKey);
+
+        expect(leaseRepo.clearKillAt).not.toHaveBeenCalledWith(prKey);
+        expect(leaseRepo.delete).not.toHaveBeenCalledWith(prKey);
+        expect(Sandbox.setTimeout).not.toHaveBeenCalled();
         expect(Sandbox.kill).not.toHaveBeenCalled();
     });
 
@@ -326,20 +757,34 @@ describe('SandboxLeaseManager', () => {
         ['only one segment', 'foo'],
         ['two segments', 'foo:bar'],
         ['five segments', 'a:b:c:d:e'],
-        ['UUID v4-shape but invalid hex', 'gggggggg-aaaa-aaaa-aaaa-aaaaaaaaaaaa:r:1'],
-    ])('rejects malformed prKey (%s) before any side-effect', async (_label, badKey) => {
-        const leaseRepo = makeMockLeaseRepo();
-        const configService = makeMockConfigService('test-e2b-key');
-        const sandboxProvider = makeMockSandboxProvider(true);
-        const manager = makeLeaseManager(leaseRepo, sandboxProvider, configService);
+        [
+            'UUID v4-shape but invalid hex',
+            'gggggggg-aaaa-aaaa-aaaa-aaaaaaaaaaaa:r:1',
+        ],
+    ])(
+        'rejects malformed prKey (%s) before any side-effect',
+        async (_label, badKey) => {
+            const leaseRepo = makeMockLeaseRepo();
+            const configService = makeMockConfigService('test-e2b-key');
+            const sandboxProvider = makeMockSandboxProvider(true);
+            const manager = makeLeaseManager(
+                leaseRepo,
+                sandboxProvider,
+                configService,
+            );
 
-        await expect(manager.acquire(badKey, 'review')).rejects.toThrow(/Invalid prKey/);
+            await expect(manager.acquire(badKey, 'review')).rejects.toThrow(
+                /Invalid prKey/,
+            );
 
-        // CRITICAL: NO Mongo write happened, NO sandbox was created.
-        // A malformed key MUST NOT pollute the lease collection.
-        expect(leaseRepo.upsertAcquire).not.toHaveBeenCalled();
-        expect(sandboxProvider.createSandboxWithRepo).not.toHaveBeenCalled();
-    });
+            // CRITICAL: NO Mongo write happened, NO sandbox was created.
+            // A malformed key MUST NOT pollute the lease collection.
+            expect(leaseRepo.upsertAcquire).not.toHaveBeenCalled();
+            expect(
+                sandboxProvider.createSandboxWithRepo,
+            ).not.toHaveBeenCalled();
+        },
+    );
 
     // ─── Test 6: orphan kill when post-create Mongo step fails ────────────
 
@@ -378,7 +823,9 @@ describe('SandboxLeaseManager', () => {
         } as any);
 
         // updateReady fails AFTER the sandbox was created
-        leaseRepo.updateReady.mockRejectedValue(new Error('Mongo connection lost'));
+        leaseRepo.updateReady.mockRejectedValue(
+            new Error('Mongo connection lost'),
+        );
 
         await expect(
             manager.acquire(prKey, 'review', undefined, cloneParams),
@@ -390,6 +837,224 @@ describe('SandboxLeaseManager', () => {
         });
         // And the lease doc was cleaned up so other callers don't poll forever
         expect(leaseRepo.delete).toHaveBeenCalledWith(prKey);
+    });
+
+    it('cleans and deletes the lease when creator-path local cleanup succeeds after updateReady fails', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:206';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 206,
+            platform: 'GITHUB' as any,
+        };
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'CREATING',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        sandboxProvider.createSandboxWithRepo.mockResolvedValue(
+            makeLocalSandboxInstance(tempDir),
+        );
+        leaseRepo.updateReady.mockRejectedValueOnce(
+            new Error('Mongo connection lost'),
+        );
+
+        try {
+            await expect(
+                manager.acquire(prKey, 'review', undefined, cloneParams),
+            ).rejects.toThrow(/Mongo connection lost/);
+
+            await expect(localSandboxDirectoryExists(tempDir)).resolves.toBe(
+                false,
+            );
+            expect(leaseRepo.delete).toHaveBeenCalledWith(prKey);
+            expect(Sandbox.kill).not.toHaveBeenCalled();
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('persists the local sandbox path for retry when creator-path cleanup fails after updateReady fails', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:214';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 214,
+            platform: 'GITHUB' as any,
+        };
+        const cleanupSpy = jest
+            .spyOn(manager as any, 'cleanupLocalSandbox')
+            .mockResolvedValueOnce(false);
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'CREATING',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        sandboxProvider.createSandboxWithRepo.mockResolvedValue(
+            makeLocalSandboxInstance(tempDir),
+        );
+        leaseRepo.updateReady.mockRejectedValueOnce(
+            new Error('Mongo connection lost'),
+        );
+
+        const before = Date.now();
+        try {
+            await expect(
+                manager.acquire(prKey, 'review', undefined, cloneParams),
+            ).rejects.toThrow(/Mongo connection lost/);
+
+            expect(leaseRepo.markDeletingWithSandboxId).toHaveBeenCalledTimes(
+                1,
+            );
+            const [calledPrKey, calledSandboxId, retryAt] = (
+                leaseRepo.markDeletingWithSandboxId as jest.Mock
+            ).mock.calls[0];
+            expect(calledPrKey).toBe(prKey);
+            expect(calledSandboxId).toBe(tempDir);
+            expect(retryAt.getTime()).toBeGreaterThanOrEqual(before);
+            expect(retryAt.getTime()).toBeLessThanOrEqual(
+                Date.now() + 2 * 60 * 1000,
+            );
+            expect(leaseRepo.delete).not.toHaveBeenCalledWith(prKey);
+        } finally {
+            cleanupSpy.mockRestore();
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('logs possible local sandbox orphaning when creator-path cleanup retry cannot be persisted', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:215';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 215,
+            platform: 'GITHUB' as any,
+        };
+        const cleanupSpy = jest
+            .spyOn(manager as any, 'cleanupLocalSandbox')
+            .mockResolvedValueOnce(false);
+        const errorSpy = jest
+            .spyOn((manager as any).logger, 'error')
+            .mockImplementation(() => undefined);
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'CREATING',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        sandboxProvider.createSandboxWithRepo.mockResolvedValue(
+            makeLocalSandboxInstance(tempDir),
+        );
+        leaseRepo.updateReady.mockRejectedValueOnce(
+            new Error('Mongo connection lost'),
+        );
+        leaseRepo.markDeletingWithSandboxId.mockResolvedValueOnce(false);
+
+        try {
+            await expect(
+                manager.acquire(prKey, 'review', undefined, cloneParams),
+            ).rejects.toThrow(/Mongo connection lost/);
+
+            expect(errorSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    message: expect.stringContaining(
+                        'local sandbox directory may be orphaned',
+                    ),
+                    metadata: { prKey, sandboxId: tempDir },
+                }),
+            );
+        } finally {
+            cleanupSpy.mockRestore();
+            errorSpy.mockRestore();
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('deletes the lease when creator-path local cleanup finds the directory already missing', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:207';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        await rm(tempDir, { recursive: true, force: true });
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 207,
+            platform: 'GITHUB' as any,
+        };
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'CREATING',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        sandboxProvider.createSandboxWithRepo.mockResolvedValue(
+            makeLocalSandboxInstance(tempDir),
+        );
+        leaseRepo.updateReady.mockRejectedValueOnce(
+            new Error('Mongo connection lost'),
+        );
+
+        await expect(
+            manager.acquire(prKey, 'review', undefined, cloneParams),
+        ).rejects.toThrow(/Mongo connection lost/);
+
+        expect(leaseRepo.delete).toHaveBeenCalledWith(prKey);
+        expect(Sandbox.kill).not.toHaveBeenCalled();
+    });
+
+    it('deletes the lease when local cleanup after mid-create invalidation finds the directory already missing', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:213';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        await rm(tempDir, { recursive: true, force: true });
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 213,
+            platform: 'GITHUB' as any,
+        };
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'CREATING',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        sandboxProvider.createSandboxWithRepo.mockResolvedValue(
+            makeLocalSandboxInstance(tempDir),
+        );
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'INVALIDATED',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+
+        await expect(
+            manager.acquire(prKey, 'review', undefined, cloneParams),
+        ).rejects.toThrow(/invalidated mid-create/);
+
+        expect(leaseRepo.delete).toHaveBeenCalledWith(prKey);
+        expect(Sandbox.kill).not.toHaveBeenCalled();
     });
 
     // ─── Test 7: retry succeeds on 2nd attempt ────────────────────────────
@@ -435,7 +1100,12 @@ describe('SandboxLeaseManager', () => {
             } as any);
 
         jest.useFakeTimers();
-        const acquirePromise = manager.acquire(prKey, 'review', undefined, cloneParams);
+        const acquirePromise = manager.acquire(
+            prKey,
+            'review',
+            undefined,
+            cloneParams,
+        );
 
         // Fast-forward through the 60s backoff between attempt 1 and 2
         await jest.runAllTimersAsync();
@@ -534,9 +1204,8 @@ describe('SandboxLeaseManager', () => {
         // killAt scheduled in Mongo — the killIdleSandboxes cron will sweep it.
         // No in-memory timer involved, so any worker can pick up the kill.
         expect(leaseRepo.setKillAt).toHaveBeenCalledTimes(1);
-        const [calledPrKey, calledKillAt] = (
-            leaseRepo.setKillAt as jest.Mock
-        ).mock.calls[0];
+        const [calledPrKey, calledKillAt] = (leaseRepo.setKillAt as jest.Mock)
+            .mock.calls[0];
         expect(calledPrKey).toBe(prKey);
         expect(calledKillAt).toBeInstanceOf(Date);
         const expectedAt = before + 30_000;
@@ -651,9 +1320,393 @@ describe('SandboxLeaseManager', () => {
         // Stale lease was deleted before cold-start
         expect(leaseRepo.delete).toHaveBeenCalledWith(prKey);
         // Cold-start succeeded — fresh sandbox created
-        expect(sandboxProvider.createSandboxWithRepo).toHaveBeenCalledWith(cloneParams);
+        expect(sandboxProvider.createSandboxWithRepo).toHaveBeenCalledWith(
+            cloneParams,
+        );
         expect(result.sandboxId).toBe('fresh-sandbox-id');
         expect(result.wasCreated).toBe(true);
+    });
+
+    it('local reconnect uses the provider and does not call E2B connect even when API_E2B_KEY exists', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:208';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        sandboxProvider.connectToExistingSandbox.mockResolvedValue(
+            makeLocalSandboxInstance(tempDir),
+        );
+
+        try {
+            const result = await manager.acquire(prKey, 'conversation');
+
+            expect(result.sandboxId).toBe(tempDir);
+            expect(result.wasCreated).toBe(false);
+            expect(
+                sandboxProvider.connectToExistingSandbox,
+            ).toHaveBeenCalledWith(tempDir);
+            expect(Sandbox.connect).not.toHaveBeenCalled();
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('local reconnect missing directory cold-starts after rollback leaves no active leases', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:209';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        await rm(tempDir, { recursive: true, force: true });
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 209,
+            platform: 'GITHUB' as any,
+        };
+
+        leaseRepo.upsertAcquire
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'READY',
+                sandboxId: tempDir,
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any)
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'CREATING',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+        leaseRepo.decrementLease.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'READY',
+            sandboxId: 'fresh-after-local-stale',
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        sandboxProvider.connectToExistingSandbox.mockRejectedValueOnce(
+            new Error('local sandbox missing'),
+        );
+        sandboxProvider.createSandboxWithRepo.mockResolvedValue({
+            type: 'e2b',
+            sandboxId: 'fresh-after-local-stale',
+            cleanup: jest.fn(),
+            remoteCommands: {} as any,
+            run: jest.fn(),
+            readFile: jest.fn(),
+            writeFile: jest.fn(),
+            repoDir: '/home/user/repo',
+        } as any);
+
+        const result = await manager.acquire(
+            prKey,
+            'conversation',
+            undefined,
+            cloneParams,
+        );
+
+        expect(leaseRepo.decrementLease).toHaveBeenCalledWith(prKey);
+        expect(leaseRepo.deleteIfNoActiveLeases).toHaveBeenCalledWith(
+            prKey,
+            tempDir,
+        );
+        expect(leaseRepo.upsertAcquire).toHaveBeenCalledTimes(2);
+        expect(result.sandboxId).toBe('fresh-after-local-stale');
+        expect(result.wasCreated).toBe(true);
+    });
+
+    it('local reconnect missing directory does not cold-start when stale lease delete loses the race', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:212';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        await rm(tempDir, { recursive: true, force: true });
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 212,
+            platform: 'GITHUB' as any,
+        };
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.decrementLease.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.deleteIfNoActiveLeases.mockResolvedValueOnce(false);
+        sandboxProvider.connectToExistingSandbox.mockRejectedValueOnce(
+            new Error('local sandbox missing'),
+        );
+
+        await expect(
+            manager.acquire(prKey, 'conversation', undefined, cloneParams),
+        ).rejects.toThrow(/local sandbox missing/);
+
+        expect(leaseRepo.deleteIfNoActiveLeases).toHaveBeenCalledWith(
+            prKey,
+            tempDir,
+        );
+        expect(leaseRepo.upsertAcquire).toHaveBeenCalledTimes(1);
+        expect(sandboxProvider.createSandboxWithRepo).not.toHaveBeenCalled();
+    });
+
+    it('local reconnect failure with an existing directory preserves the lease and rethrows', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:210';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 210,
+            platform: 'GITHUB' as any,
+        };
+
+        leaseRepo.upsertAcquire.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 1,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.decrementLease.mockResolvedValue({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'READY',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        sandboxProvider.connectToExistingSandbox.mockRejectedValueOnce(
+            new Error('local provider failed'),
+        );
+
+        try {
+            await expect(
+                manager.acquire(prKey, 'conversation', undefined, cloneParams),
+            ).rejects.toThrow(/local provider failed/);
+
+            expect(leaseRepo.decrementLease).toHaveBeenCalledWith(prKey);
+            expect(leaseRepo.deleteIfNoActiveLeases).not.toHaveBeenCalled();
+            expect(leaseRepo.upsertAcquire).toHaveBeenCalledTimes(1);
+            expect(
+                sandboxProvider.createSandboxWithRepo,
+            ).not.toHaveBeenCalled();
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('joiner retries after a DELETING lease disappears', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:211';
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 211,
+            platform: 'GITHUB' as any,
+        };
+
+        leaseRepo.upsertAcquire
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'DELETING',
+                sandboxId: '/tmp/kodus-sandbox-old',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any)
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'CREATING',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+        leaseRepo.findByPrKey
+            .mockResolvedValueOnce(null)
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'READY',
+                sandboxId: 'fresh-after-deleting',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+        sandboxProvider.createSandboxWithRepo.mockResolvedValue({
+            type: 'e2b',
+            sandboxId: 'fresh-after-deleting',
+            cleanup: jest.fn(),
+            remoteCommands: {} as any,
+            run: jest.fn(),
+            readFile: jest.fn(),
+            writeFile: jest.fn(),
+            repoDir: '/home/user/repo',
+        } as any);
+
+        const result = await manager.acquire(
+            prKey,
+            'conversation',
+            undefined,
+            cloneParams,
+        );
+
+        expect(leaseRepo.decrementLease).toHaveBeenCalledWith(prKey);
+        expect(leaseRepo.clearKillAt).toHaveBeenCalledTimes(1);
+        expect(leaseRepo.upsertAcquire).toHaveBeenCalledTimes(2);
+        expect(result.sandboxId).toBe('fresh-after-deleting');
+        expect(result.wasCreated).toBe(true);
+    });
+
+    it('joiner finalizes a DELETING local lease when cleanup already removed the directory', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:215';
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        await rm(tempDir, { recursive: true, force: true });
+        const cloneParams = {
+            cloneUrl: 'https://github.com/org/repo.git',
+            authToken: 'token',
+            branch: 'feature',
+            prNumber: 215,
+            platform: 'GITHUB' as any,
+        };
+
+        leaseRepo.upsertAcquire
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'DELETING',
+                sandboxId: tempDir,
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any)
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'CREATING',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+        leaseRepo.decrementLease.mockResolvedValueOnce({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'DELETING',
+            sandboxId: tempDir,
+            createdAt: new Date(),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        } as any);
+        leaseRepo.findByPrKey
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 0,
+                state: 'DELETING',
+                sandboxId: tempDir,
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any)
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'READY',
+                sandboxId: 'fresh-after-finalized-deleting',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+        sandboxProvider.createSandboxWithRepo.mockResolvedValue({
+            type: 'e2b',
+            sandboxId: 'fresh-after-finalized-deleting',
+            cleanup: jest.fn(),
+            remoteCommands: {} as any,
+            run: jest.fn(),
+            readFile: jest.fn(),
+            writeFile: jest.fn(),
+            repoDir: '/home/user/repo',
+        } as any);
+
+        const result = await manager.acquire(
+            prKey,
+            'conversation',
+            undefined,
+            cloneParams,
+        );
+
+        expect(leaseRepo.deleteDeletingWithSandboxId).toHaveBeenCalledWith(
+            prKey,
+            tempDir,
+        );
+        expect(leaseRepo.upsertAcquire).toHaveBeenCalledTimes(2);
+        expect(result.sandboxId).toBe('fresh-after-finalized-deleting');
+        expect(result.wasCreated).toBe(true);
+    });
+
+    it('joiner does not recursively cold-start when a remote DELETING lease is still waiting for reaper retry', async () => {
+        const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:216';
+        const dateNowSpy = jest
+            .spyOn(Date, 'now')
+            .mockReturnValueOnce(0)
+            .mockReturnValue(31_000);
+
+        leaseRepo.upsertAcquire
+            .mockResolvedValueOnce({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'DELETING',
+                sandboxId: 'e2b-deleting-retry',
+                killAt: new Date('2026-01-01T00:00:00.000Z'),
+                createdAt: new Date('2026-01-01T00:00:00.000Z'),
+                expiresAt: new Date('2026-01-01T00:30:00.000Z'),
+            } as any)
+            .mockRejectedValueOnce(
+                new Error('recursive acquire should not run'),
+            );
+        leaseRepo.decrementLease.mockResolvedValueOnce({
+            _id: prKey,
+            leaseCount: 0,
+            state: 'DELETING',
+            sandboxId: 'e2b-deleting-retry',
+            killAt: new Date('2026-01-01T00:00:00.000Z'),
+            createdAt: new Date('2026-01-01T00:00:00.000Z'),
+            expiresAt: new Date('2026-01-01T00:30:00.000Z'),
+        } as any);
+
+        try {
+            await expect(
+                manager.acquire(prKey, 'conversation'),
+            ).rejects.toThrow(/deleting cleanup still in progress/);
+
+            expect(leaseRepo.upsertAcquire).toHaveBeenCalledTimes(1);
+            expect(
+                sandboxProvider.createSandboxWithRepo,
+            ).not.toHaveBeenCalled();
+        } finally {
+            dateNowSpy.mockRestore();
+        }
     });
 
     // ─── Test 9a: release accepts custom idleMs (review uses 30s) ────────
@@ -792,11 +1845,309 @@ describe('SandboxLeaseReaperService', () => {
 
         await reaper.reapExpiredLeases();
 
+        expect(leaseRepo.findExpired).toHaveBeenCalledWith(
+            expect.any(Date),
+            expect.any(Number),
+        );
         // Sandbox.kill called with the expired sandbox ID
-        expect(Sandbox.kill).toHaveBeenCalledWith('e2b-123', { apiKey: 'test-e2b-key' });
+        expect(Sandbox.kill).toHaveBeenCalledWith('e2b-123', {
+            apiKey: 'test-e2b-key',
+        });
 
-        // Mongo doc deleted
-        expect(leaseRepo.delete).toHaveBeenCalledWith('org:repo:1');
+        // Mongo doc deleted only if it is still the claimed lease
+        expect(leaseRepo.deleteDeletingWithSandboxId).toHaveBeenCalledWith(
+            'org:repo:1',
+            'e2b-123',
+        );
+    });
+
+    it('reaper removes expired local sandbox directories before deleting the lease', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+
+        leaseRepo.findExpired.mockResolvedValue([
+            {
+                _id: 'org:repo:local-expired',
+                sandboxId: tempDir,
+                leaseCount: 1,
+                state: 'READY',
+                createdAt: new Date(Date.now() - 60 * 60 * 1000),
+                expiresAt: new Date(Date.now() - 10 * 60 * 1000),
+            } as any,
+        ]);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        await reaper.reapExpiredLeases();
+
+        await expect(localSandboxDirectoryExists(tempDir)).resolves.toBe(false);
+        expect(Sandbox.kill).not.toHaveBeenCalled();
+        expect(leaseRepo.deleteDeletingWithSandboxId).toHaveBeenCalledWith(
+            'org:repo:local-expired',
+            tempDir,
+        );
+    });
+
+    it('reaper deletes an expired local lease when the directory is already missing', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        await rm(tempDir, { recursive: true, force: true });
+
+        leaseRepo.findExpired.mockResolvedValue([
+            {
+                _id: 'org:repo:local-missing',
+                sandboxId: tempDir,
+                leaseCount: 1,
+                state: 'READY',
+                createdAt: new Date(Date.now() - 60 * 60 * 1000),
+                expiresAt: new Date(Date.now() - 10 * 60 * 1000),
+            } as any,
+        ]);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        await reaper.reapExpiredLeases();
+
+        expect(Sandbox.kill).not.toHaveBeenCalled();
+        expect(leaseRepo.deleteDeletingWithSandboxId).toHaveBeenCalledWith(
+            'org:repo:local-missing',
+            tempDir,
+        );
+    });
+
+    it('reaper schedules a cleanup retry when an expired E2B lease cannot be killed without an API key', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('');
+        const expiresAt = new Date(Date.now() - 10 * 60 * 1000);
+
+        leaseRepo.findExpired.mockResolvedValue([
+            {
+                _id: 'org:repo:e2b-no-api-key-expired',
+                sandboxId: 'e2b-no-api-key-expired',
+                leaseCount: 1,
+                state: 'READY',
+                createdAt: new Date(Date.now() - 60 * 60 * 1000),
+                expiresAt,
+            } as any,
+        ]);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        const before = Date.now();
+        await reaper.reapExpiredLeases();
+
+        expect(leaseRepo.markDeletingIfExpired).toHaveBeenCalledWith(
+            'org:repo:e2b-no-api-key-expired',
+            expiresAt,
+        );
+        expect(leaseRepo.scheduleCleanupRetry).toHaveBeenCalledTimes(1);
+        const [calledPrKey, retryAt] = (
+            leaseRepo.scheduleCleanupRetry as jest.Mock
+        ).mock.calls[0];
+        expect(calledPrKey).toBe('org:repo:e2b-no-api-key-expired');
+        expect(retryAt.getTime()).toBeGreaterThanOrEqual(before);
+        expect(retryAt.getTime()).toBeLessThanOrEqual(
+            Date.now() + 2 * 60 * 1000,
+        );
+        expect(Sandbox.kill).not.toHaveBeenCalled();
+        expect(leaseRepo.delete).not.toHaveBeenCalledWith(
+            'org:repo:e2b-no-api-key-expired',
+        );
+    });
+
+    it('reaper skips a stale expired local result when the atomic claim loses the race', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        const expiresAt = new Date(Date.now() - 10 * 60 * 1000);
+
+        leaseRepo.findExpired.mockResolvedValue([
+            {
+                _id: 'org:repo:local-expired-race',
+                sandboxId: tempDir,
+                leaseCount: 1,
+                state: 'READY',
+                createdAt: new Date(Date.now() - 60 * 60 * 1000),
+                expiresAt,
+            } as any,
+        ]);
+        leaseRepo.markDeletingIfExpired.mockResolvedValueOnce(false);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        try {
+            await reaper.reapExpiredLeases();
+
+            expect(leaseRepo.markDeletingIfExpired).toHaveBeenCalledWith(
+                'org:repo:local-expired-race',
+                expiresAt,
+            );
+            await expect(localSandboxDirectoryExists(tempDir)).resolves.toBe(
+                true,
+            );
+            expect(leaseRepo.delete).not.toHaveBeenCalledWith(
+                'org:repo:local-expired-race',
+            );
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('reaper skips a stale expired E2B result when the atomic claim loses the race', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+        const expiresAt = new Date(Date.now() - 10 * 60 * 1000);
+
+        leaseRepo.findExpired.mockResolvedValue([
+            {
+                _id: 'org:repo:e2b-expired-race',
+                sandboxId: 'e2b-expired-race',
+                leaseCount: 1,
+                state: 'READY',
+                createdAt: new Date(Date.now() - 60 * 60 * 1000),
+                expiresAt,
+            } as any,
+        ]);
+        leaseRepo.markDeletingIfExpired.mockResolvedValueOnce(false);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        await reaper.reapExpiredLeases();
+
+        expect(leaseRepo.markDeletingIfExpired).toHaveBeenCalledWith(
+            'org:repo:e2b-expired-race',
+            expiresAt,
+        );
+        expect(Sandbox.kill).not.toHaveBeenCalledWith('e2b-expired-race', {
+            apiKey: 'test-e2b-key',
+        });
+        expect(leaseRepo.delete).not.toHaveBeenCalledWith(
+            'org:repo:e2b-expired-race',
+        );
+    });
+
+    it('reaper kills an expired INVALIDATED E2B lease that still has a sandboxId', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+        const expiresAt = new Date(Date.now() - 10 * 60 * 1000);
+
+        leaseRepo.findExpired.mockResolvedValue([
+            {
+                _id: 'org:repo:invalidated-e2b',
+                sandboxId: 'e2b-invalidated',
+                leaseCount: 0,
+                state: 'INVALIDATED',
+                createdAt: new Date(Date.now() - 60 * 60 * 1000),
+                expiresAt,
+            } as any,
+        ]);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        await reaper.reapExpiredLeases();
+
+        expect(Sandbox.kill).toHaveBeenCalledWith('e2b-invalidated', {
+            apiKey: 'test-e2b-key',
+        });
+        expect(leaseRepo.deleteDeletingWithSandboxId).toHaveBeenCalledWith(
+            'org:repo:invalidated-e2b',
+            'e2b-invalidated',
+        );
+    });
+
+    it('reaper skips a stale expired sandboxless result when the atomic claim loses the race', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+        const expiresAt = new Date(Date.now() - 10 * 60 * 1000);
+
+        leaseRepo.findExpired.mockResolvedValue([
+            {
+                _id: 'org:repo:sandboxless-expired-race',
+                sandboxId: undefined,
+                leaseCount: 1,
+                state: 'CREATING',
+                createdAt: new Date(Date.now() - 60 * 60 * 1000),
+                expiresAt,
+            } as any,
+        ]);
+        leaseRepo.markDeletingIfExpired.mockResolvedValueOnce(false);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        await reaper.reapExpiredLeases();
+
+        expect(leaseRepo.markDeletingIfExpired).toHaveBeenCalledWith(
+            'org:repo:sandboxless-expired-race',
+            expiresAt,
+        );
+        expect(leaseRepo.delete).not.toHaveBeenCalledWith(
+            'org:repo:sandboxless-expired-race',
+        );
     });
 
     // ─── Idle-kill cron tests ────────────────────────────────────────────
@@ -844,11 +2195,75 @@ describe('SandboxLeaseReaperService', () => {
             'CRON:SANDBOX:IDLE_KILL',
             { ttl: 25_000 },
         );
-        expect(Sandbox.kill).toHaveBeenCalledWith('e2b-idle-1', { apiKey: 'test-e2b-key' });
-        expect(Sandbox.kill).toHaveBeenCalledWith('e2b-idle-2', { apiKey: 'test-e2b-key' });
-        expect(leaseRepo.delete).toHaveBeenCalledWith('org-uuid:repo:1');
-        expect(leaseRepo.delete).toHaveBeenCalledWith('org-uuid:repo:2');
+        expect(leaseRepo.findReadyToKill).toHaveBeenCalledWith(
+            expect.any(Date),
+            expect.any(Number),
+        );
+        expect(Sandbox.kill).toHaveBeenCalledWith('e2b-idle-1', {
+            apiKey: 'test-e2b-key',
+        });
+        expect(Sandbox.kill).toHaveBeenCalledWith('e2b-idle-2', {
+            apiKey: 'test-e2b-key',
+        });
+        expect(leaseRepo.deleteDeletingWithSandboxId).toHaveBeenCalledWith(
+            'org-uuid:repo:1',
+            'e2b-idle-1',
+        );
+        expect(leaseRepo.deleteDeletingWithSandboxId).toHaveBeenCalledWith(
+            'org-uuid:repo:2',
+            'e2b-idle-2',
+        );
         expect(mockLock.release).toHaveBeenCalledTimes(1);
+    });
+
+    it('killIdleSandboxes: bounds local cleanup concurrency', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+        const killAt = new Date(Date.now() - 1000);
+        const leases = Array.from({ length: 12 }, (_, index) => ({
+            _id: `org-uuid:repo:local-${index}`,
+            sandboxId: join(tmpdir(), `kodus-sandbox-local-${index}`),
+            leaseCount: 0,
+            state: 'READY',
+            killAt,
+            createdAt: new Date(Date.now() - 60 * 1000),
+            expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+        }));
+
+        leaseRepo.findReadyToKill.mockResolvedValue(leases as any);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+        let inFlight = 0;
+        let maxInFlight = 0;
+        const cleanupSpy = jest
+            .spyOn(reaper as any, 'cleanupLocalExpiredSandbox')
+            .mockImplementation(async () => {
+                inFlight += 1;
+                maxInFlight = Math.max(maxInFlight, inFlight);
+                await new Promise((resolve) => setTimeout(resolve, 5));
+                inFlight -= 1;
+                return true;
+            });
+
+        try {
+            await reaper.killIdleSandboxes();
+
+            expect(maxInFlight).toBeLessThanOrEqual(5);
+            expect(leaseRepo.deleteDeletingWithSandboxId).toHaveBeenCalledTimes(
+                leases.length,
+            );
+        } finally {
+            cleanupSpy.mockRestore();
+        }
     });
 
     it('killIdleSandboxes: skips when another worker holds the lock', async () => {
@@ -874,7 +2289,96 @@ describe('SandboxLeaseReaperService', () => {
         expect(leaseRepo.delete).not.toHaveBeenCalled();
     });
 
-    it('killIdleSandboxes: continues deleting Mongo doc even when Sandbox.kill fails', async () => {
+    it('killIdleSandboxes: skips a stale local idle result when the atomic claim loses the race', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+        const tempDir = await mkdtemp(join(tmpdir(), 'kodus-sandbox-'));
+        const killAt = new Date(Date.now() - 1000);
+
+        leaseRepo.findReadyToKill.mockResolvedValue([
+            {
+                _id: 'org-uuid:repo:11',
+                sandboxId: tempDir,
+                leaseCount: 0,
+                state: 'READY',
+                killAt,
+                createdAt: new Date(Date.now() - 60 * 1000),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any,
+        ]);
+        leaseRepo.markDeletingIfReadyToKill.mockResolvedValueOnce(false);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        try {
+            await reaper.killIdleSandboxes();
+
+            expect(leaseRepo.markDeletingIfReadyToKill).toHaveBeenCalledWith(
+                'org-uuid:repo:11',
+                killAt,
+            );
+            await expect(localSandboxDirectoryExists(tempDir)).resolves.toBe(
+                true,
+            );
+            expect(leaseRepo.delete).not.toHaveBeenCalledWith(
+                'org-uuid:repo:11',
+            );
+        } finally {
+            await rm(tempDir, { recursive: true, force: true });
+        }
+    });
+
+    it('killIdleSandboxes: skips a stale E2B idle result when the atomic claim loses the race', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+        const killAt = new Date(Date.now() - 1000);
+
+        leaseRepo.findReadyToKill.mockResolvedValue([
+            {
+                _id: 'org-uuid:repo:12',
+                sandboxId: 'e2b-race',
+                leaseCount: 0,
+                state: 'READY',
+                killAt,
+                createdAt: new Date(Date.now() - 60 * 1000),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any,
+        ]);
+        leaseRepo.markDeletingIfReadyToKill.mockResolvedValueOnce(false);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        await reaper.killIdleSandboxes();
+
+        expect(leaseRepo.markDeletingIfReadyToKill).toHaveBeenCalledWith(
+            'org-uuid:repo:12',
+            killAt,
+        );
+        expect(Sandbox.kill).not.toHaveBeenCalledWith('e2b-race', {
+            apiKey: 'test-e2b-key',
+        });
+        expect(leaseRepo.delete).not.toHaveBeenCalledWith('org-uuid:repo:12');
+    });
+
+    it('killIdleSandboxes: keeps Mongo doc when Sandbox.kill fails so the next cron can retry', async () => {
         const leaseRepo = makeMockLeaseRepo();
         const configService = makeMockConfigService('test-e2b-key');
 
@@ -890,7 +2394,45 @@ describe('SandboxLeaseReaperService', () => {
             } as any,
         ]);
 
-        // E2B already removed the sandbox (race with reaper, external kill, etc.)
+        (Sandbox.kill as jest.Mock).mockRejectedValueOnce(
+            new Error('temporary e2b outage'),
+        );
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        await reaper.killIdleSandboxes();
+
+        expect(leaseRepo.delete).not.toHaveBeenCalledWith('org-uuid:repo:9');
+        expect(leaseRepo.scheduleCleanupRetry).toHaveBeenCalledTimes(1);
+        expect(mockLock.release).toHaveBeenCalledTimes(1);
+    });
+
+    it('killIdleSandboxes: deletes the lease when E2B says the sandbox is already gone', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+        const killAt = new Date(Date.now() - 1000);
+
+        leaseRepo.findReadyToKill.mockResolvedValue([
+            {
+                _id: 'org-uuid:repo:11',
+                sandboxId: 'e2b-already-gone',
+                leaseCount: 0,
+                state: 'READY',
+                killAt,
+                createdAt: new Date(Date.now() - 60 * 1000),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any,
+        ]);
+
         (Sandbox.kill as jest.Mock).mockRejectedValueOnce(
             new Error('sandbox not found'),
         );
@@ -908,9 +2450,50 @@ describe('SandboxLeaseReaperService', () => {
 
         await reaper.killIdleSandboxes();
 
-        // Doc deleted regardless — lease can't linger waiting for a sandbox
-        // that's already gone
-        expect(leaseRepo.delete).toHaveBeenCalledWith('org-uuid:repo:9');
+        expect(leaseRepo.markDeletingIfReadyToKill).toHaveBeenCalledWith(
+            'org-uuid:repo:11',
+            killAt,
+        );
+        expect(leaseRepo.deleteDeletingWithSandboxId).toHaveBeenCalledWith(
+            'org-uuid:repo:11',
+            'e2b-already-gone',
+        );
+        expect(leaseRepo.scheduleCleanupRetry).not.toHaveBeenCalled();
+        expect(mockLock.release).toHaveBeenCalledTimes(1);
+    });
+
+    it('killIdleSandboxes: keeps E2B lease when API key is missing', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('');
+
+        leaseRepo.findReadyToKill.mockResolvedValue([
+            {
+                _id: 'org-uuid:repo:10',
+                sandboxId: 'e2b-no-api-key',
+                leaseCount: 0,
+                state: 'READY',
+                killAt: new Date(Date.now() - 1000),
+                createdAt: new Date(Date.now() - 60 * 1000),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any,
+        ]);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        await reaper.killIdleSandboxes();
+
+        expect(Sandbox.kill).not.toHaveBeenCalled();
+        expect(leaseRepo.scheduleCleanupRetry).toHaveBeenCalledTimes(1);
+        expect(leaseRepo.delete).not.toHaveBeenCalledWith('org-uuid:repo:10');
         expect(mockLock.release).toHaveBeenCalledTimes(1);
     });
 });

--- a/libs/sandbox/infrastructure/services/sandbox-lease-reaper.service.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-reaper.service.ts
@@ -8,6 +8,15 @@ import {
     DistributedLockService,
 } from '@libs/core/workflow/infrastructure/distributed-lock.service';
 import { SandboxLeaseRepository } from '@libs/sandbox/infrastructure/repositories/sandbox-lease.repository';
+import {
+    cleanupLocalSandboxDirectory,
+    isLocalSandboxPath,
+    localSandboxDirectoryExists,
+} from './local-sandbox-cleanup';
+
+const SANDBOX_REAPER_BATCH_LIMIT = 100;
+const CLEANUP_CONCURRENCY = 5;
+const CLEANUP_RETRY_DELAY_MS = 60_000;
 
 @Injectable()
 export class SandboxLeaseReaperService {
@@ -28,34 +37,104 @@ export class SandboxLeaseReaperService {
         if (!lock) return;
 
         try {
-            const expired = await this.leaseRepository.findExpired(new Date());
+            const expired = await this.leaseRepository.findExpired(
+                new Date(),
+                SANDBOX_REAPER_BATCH_LIMIT,
+            );
             if (expired.length === 0) return;
 
             const apiKey = this.configService.get<string>('API_E2B_KEY');
 
-            await Promise.allSettled(
-                expired.map(async (lease) => {
-                    if (
-                        lease.sandboxId &&
-                        lease.state !== 'INVALIDATED' &&
-                        apiKey
-                    ) {
-                        await Sandbox.kill(lease.sandboxId, { apiKey }).catch(
-                            (err) => {
-                                this.logger.warn({
-                                    message:
-                                        '[SANDBOX-REAPER] Failed to kill sandbox — continuing',
-                                    context: SandboxLeaseReaperService.name,
-                                    metadata: {
-                                        sandboxId: lease.sandboxId,
-                                        error: String(err),
-                                    },
-                                });
-                            },
+            await this.mapWithConcurrency(
+                expired,
+                CLEANUP_CONCURRENCY,
+                async (lease) => {
+                    const claimed =
+                        await this.leaseRepository.markDeletingIfExpired(
+                            lease._id,
+                            lease.expiresAt,
                         );
+                    if (!claimed) {
+                        this.logger.log({
+                            message:
+                                '[SANDBOX-REAPER] Skipped stale expired candidate because lease was refreshed',
+                            context: SandboxLeaseReaperService.name,
+                            metadata: {
+                                prKey: lease._id,
+                                sandboxId: lease.sandboxId,
+                                expiresAt: lease.expiresAt,
+                            },
+                        });
+                        return;
                     }
 
-                    await this.leaseRepository.delete(lease._id);
+                    if (
+                        lease.sandboxId &&
+                        isLocalSandboxPath(lease.sandboxId)
+                    ) {
+                        const cleaned = await this.cleanupLocalExpiredSandbox(
+                            lease._id,
+                            lease.sandboxId,
+                        );
+                        if (!cleaned) {
+                            await this.scheduleCleanupRetry(
+                                lease._id,
+                                lease.sandboxId,
+                                '[SANDBOX-REAPER]',
+                            );
+                            return;
+                        }
+
+                        await this.leaseRepository.deleteDeletingWithSandboxId(
+                            lease._id,
+                            lease.sandboxId,
+                        );
+                        this.logger.log({
+                            message:
+                                '[SANDBOX-REAPER] Reaped expired local lease',
+                            context: SandboxLeaseReaperService.name,
+                            metadata: {
+                                prKey: lease._id,
+                                sandboxId: lease.sandboxId,
+                                state: lease.state,
+                            },
+                        });
+                        return;
+                    }
+
+                    if (lease.sandboxId) {
+                        if (!apiKey) {
+                            this.logMissingE2BApiKey(
+                                lease._id,
+                                lease.sandboxId,
+                            );
+                            await this.scheduleCleanupRetry(
+                                lease._id,
+                                lease.sandboxId,
+                                '[SANDBOX-REAPER]',
+                            );
+                            return;
+                        }
+
+                        const killed = await this.killE2BSandbox(
+                            lease.sandboxId,
+                            apiKey,
+                            '[SANDBOX-REAPER]',
+                        );
+                        if (!killed) {
+                            await this.scheduleCleanupRetry(
+                                lease._id,
+                                lease.sandboxId,
+                                '[SANDBOX-REAPER]',
+                            );
+                            return;
+                        }
+                    }
+
+                    await this.leaseRepository.deleteDeletingWithSandboxId(
+                        lease._id,
+                        lease.sandboxId,
+                    );
 
                     this.logger.log({
                         message: '[SANDBOX-REAPER] Reaped expired lease',
@@ -66,7 +145,7 @@ export class SandboxLeaseReaperService {
                             state: lease.state,
                         },
                     });
-                }),
+                },
             );
         } finally {
             await this.releaseCronLock(
@@ -96,30 +175,93 @@ export class SandboxLeaseReaperService {
         if (!lock) return;
 
         try {
-            const ready = await this.leaseRepository.findReadyToKill(new Date());
+            const ready = await this.leaseRepository.findReadyToKill(
+                new Date(),
+                SANDBOX_REAPER_BATCH_LIMIT,
+            );
             if (ready.length === 0) return;
 
             const apiKey = this.configService.get<string>('API_E2B_KEY');
 
-            await Promise.allSettled(
-                ready.map(async (lease) => {
-                    if (lease.sandboxId && apiKey) {
-                        await Sandbox.kill(lease.sandboxId, { apiKey }).catch(
-                            (err) => {
-                                this.logger.warn({
-                                    message:
-                                        '[SANDBOX-IDLE-KILL] Failed to kill sandbox — Mongo doc still deleted; reaper will retry if E2B still has it',
-                                    context: SandboxLeaseReaperService.name,
-                                    metadata: {
-                                        sandboxId: lease.sandboxId,
-                                        error: String(err),
-                                    },
-                                });
-                            },
-                        );
+            await this.mapWithConcurrency(
+                ready,
+                CLEANUP_CONCURRENCY,
+                async (lease) => {
+                    if (!lease.killAt) {
+                        return;
                     }
 
-                    await this.leaseRepository.delete(lease._id);
+                    const claimed =
+                        await this.leaseRepository.markDeletingIfReadyToKill(
+                            lease._id,
+                            lease.killAt,
+                        );
+                    if (!claimed) {
+                        this.logger.log({
+                            message:
+                                '[SANDBOX-IDLE-KILL] Skipped stale idle candidate because lease was re-acquired',
+                            context: SandboxLeaseReaperService.name,
+                            metadata: {
+                                prKey: lease._id,
+                                sandboxId: lease.sandboxId,
+                                killAt: lease.killAt,
+                            },
+                        });
+                        return;
+                    }
+
+                    if (
+                        lease.sandboxId &&
+                        isLocalSandboxPath(lease.sandboxId)
+                    ) {
+                        const cleaned = await this.cleanupLocalExpiredSandbox(
+                            lease._id,
+                            lease.sandboxId,
+                        );
+                        if (!cleaned) {
+                            await this.scheduleCleanupRetry(
+                                lease._id,
+                                lease.sandboxId,
+                                '[SANDBOX-IDLE-KILL]',
+                            );
+                            return;
+                        }
+
+                        await this.leaseRepository.deleteDeletingWithSandboxId(
+                            lease._id,
+                            lease.sandboxId,
+                        );
+                        return;
+                    }
+
+                    if (lease.sandboxId && apiKey) {
+                        const killed = await this.killE2BSandbox(
+                            lease.sandboxId,
+                            apiKey,
+                            '[SANDBOX-IDLE-KILL]',
+                        );
+                        if (!killed) {
+                            await this.scheduleCleanupRetry(
+                                lease._id,
+                                lease.sandboxId,
+                                '[SANDBOX-IDLE-KILL]',
+                            );
+                            return;
+                        }
+                    } else if (lease.sandboxId) {
+                        this.logMissingE2BApiKey(lease._id, lease.sandboxId);
+                        await this.scheduleCleanupRetry(
+                            lease._id,
+                            lease.sandboxId,
+                            '[SANDBOX-IDLE-KILL]',
+                        );
+                        return;
+                    }
+
+                    await this.leaseRepository.deleteDeletingWithSandboxId(
+                        lease._id,
+                        lease.sandboxId,
+                    );
 
                     this.logger.log({
                         message: '[SANDBOX-IDLE-KILL] Killed idle sandbox',
@@ -130,7 +272,7 @@ export class SandboxLeaseReaperService {
                             killAt: lease.killAt,
                         },
                     });
-                }),
+                },
             );
         } finally {
             await this.releaseCronLock(
@@ -154,6 +296,141 @@ export class SandboxLeaseReaperService {
             });
             return null;
         }
+    }
+
+    private async mapWithConcurrency<T>(
+        items: T[],
+        concurrency: number,
+        worker: (item: T) => Promise<void>,
+    ): Promise<void> {
+        let nextIndex = 0;
+        const workerCount = Math.min(concurrency, items.length);
+
+        await Promise.all(
+            Array.from({ length: workerCount }, async () => {
+                while (nextIndex < items.length) {
+                    const currentIndex = nextIndex++;
+
+                    try {
+                        await worker(items[currentIndex]);
+                    } catch (error) {
+                        this.logger.error({
+                            message:
+                                '[SANDBOX-REAPER] Unexpected cleanup worker failure',
+                            context: SandboxLeaseReaperService.name,
+                            error,
+                        });
+                    }
+                }
+            }),
+        );
+    }
+
+    private async cleanupLocalExpiredSandbox(
+        prKey: string,
+        sandboxId: string,
+    ): Promise<boolean> {
+        try {
+            const exists = await localSandboxDirectoryExists(sandboxId);
+            if (!exists) {
+                return true;
+            }
+
+            const cleaned = await cleanupLocalSandboxDirectory(sandboxId);
+            if (!cleaned) {
+                this.logger.warn({
+                    message:
+                        '[SANDBOX-REAPER] Local sandbox cleanup returned false',
+                    context: SandboxLeaseReaperService.name,
+                    metadata: { prKey, sandboxId },
+                });
+            }
+            return cleaned;
+        } catch (error) {
+            this.logger.warn({
+                message: '[SANDBOX-REAPER] Failed to clean local sandbox',
+                context: SandboxLeaseReaperService.name,
+                error,
+                metadata: { prKey, sandboxId },
+            });
+            return false;
+        }
+    }
+
+    private async killE2BSandbox(
+        sandboxId: string,
+        apiKey: string,
+        logPrefix: string,
+    ): Promise<boolean> {
+        try {
+            await Sandbox.kill(sandboxId, { apiKey });
+            return true;
+        } catch (err) {
+            if (this.isSandboxAlreadyGoneError(err)) {
+                this.logger.log({
+                    message: `${logPrefix} Sandbox already gone — deleting stale lease`,
+                    context: SandboxLeaseReaperService.name,
+                    metadata: {
+                        sandboxId,
+                        error: String(err),
+                    },
+                });
+                return true;
+            }
+
+            this.logger.warn({
+                message: `${logPrefix} Failed to kill sandbox — keeping lease for retry`,
+                context: SandboxLeaseReaperService.name,
+                metadata: {
+                    sandboxId,
+                    error: String(err),
+                },
+            });
+            return false;
+        }
+    }
+
+    private isSandboxAlreadyGoneError(error: unknown): boolean {
+        const message =
+            error instanceof Error ? error.message : String(error ?? '');
+
+        return /\b(404|not found|does not exist)\b/i.test(message);
+    }
+
+    private logMissingE2BApiKey(prKey: string, sandboxId: string): void {
+        this.logger.warn({
+            message:
+                '[SANDBOX-REAPER] Missing API_E2B_KEY — keeping lease for retry',
+            context: SandboxLeaseReaperService.name,
+            metadata: { prKey, sandboxId },
+        });
+    }
+
+    private async scheduleCleanupRetry(
+        prKey: string,
+        sandboxId: string,
+        logPrefix: string,
+    ): Promise<void> {
+        const retryAt = new Date(Date.now() + CLEANUP_RETRY_DELAY_MS);
+        const scheduled = await this.leaseRepository.scheduleCleanupRetry(
+            prKey,
+            retryAt,
+        );
+
+        if (!scheduled) {
+            this.logger.log({
+                message: `${logPrefix} Skipped cleanup retry schedule because lease state changed`,
+                context: SandboxLeaseReaperService.name,
+                metadata: { prKey, sandboxId, retryAt },
+            });
+            return;
+        }
+
+        this.logger.warn({
+            message: `${logPrefix} Scheduled cleanup retry`,
+            context: SandboxLeaseReaperService.name,
+            metadata: { prKey, sandboxId, retryAt },
+        });
     }
 
     private async releaseCronLock(


### PR DESCRIPTION
## Summary
- add safe cleanup for self-hosted local sandbox directories under the OS temp dir
- persist local sandbox paths as lease sandbox IDs so release, invalidation, creator failures, and reapers can remove or retry cleanup
- harden sandbox lease state transitions with atomic DELETING/INVALIDATED claims, retry cursors, guarded final deletes, and expiry preservation for non-reusable leases

## Why
Self-hosted workers can leave `/tmp/kodus-sandbox-*` directories behind when local sandboxes are released, invalidated, or abandoned by crashed workers. The cleanup path also needs to avoid deleting or extending the wrong lease under concurrent acquire, reaper, and invalidation races.

## Validation
- `pnpm test -- --runTestsByPath libs/sandbox/infrastructure/services/local-sandbox-cleanup.spec.ts libs/sandbox/infrastructure/repositories/sandbox-lease.repository.spec.ts libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts libs/sandbox/infrastructure/providers/local-sandbox.exec-streams.spec.ts libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts test/unit/code-review/pipeline/stages/create-sandbox.stage.spec.ts --no-coverage --runInBand`
- `pnpm exec prettier --check` on changed files
- `pnpm exec eslint` on changed files
- `pnpm run typecheck:libs-gate`
- `git diff --check`

Note: local full `pnpm run test` / pre-push still fails on existing environment-dependent repo-wide tests: missing local Postgres and missing `libs/ee/configs/environment/environment`. The focused sandbox tests above pass.