### PR TITLE
feat(sandbox): harden local sandbox readFile/writeFile path validation

### DIFF
--- a/libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts
+++ b/libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts
@@ -190,4 +190,29 @@ describe('LocalSandboxService sandbox file access', () => {
             'ok',
         );
     });
+
+    it('rejects write when parent directory realpath escapes repo after mkdir (TOCTOU post-mkdir check)', async () => {
+        const fsPromises = require('fs/promises');
+        const originalRealpath = fsPromises.realpath;
+        // Track the nested subdir path — the post-mkdir finalCheck resolves
+        // the immediate parent of the target file.
+        const nestedDir = path.join(dir, 'escape', 'nested');
+
+        jest.spyOn(fsPromises, 'realpath').mockImplementation(
+            async (p: string) => {
+                if (p === nestedDir) {
+                    return '/tmp/outside-escape';
+                }
+                return originalRealpath(p);
+            },
+        );
+
+        try {
+            await expect(
+                sandbox.writeFile('escape/nested/file.txt', 'pwned'),
+            ).rejects.toThrow(/Path escapes repo boundary after mkdir/);
+        } finally {
+            jest.restoreAllMocks();
+        }
+    });
 });

--- a/libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts
+++ b/libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts
@@ -108,16 +108,28 @@ describe('LocalSandboxService sandbox file access', () => {
         );
     });
 
-    it('rejects absolute read paths', async () => {
+    it('rejects absolute read paths outside the repo', async () => {
         await expect(sandbox.readFile('/etc/passwd')).rejects.toThrow(
             /Absolute paths are not allowed/,
         );
     });
 
-    it('rejects absolute write paths', async () => {
+    it('rejects absolute write paths outside the repo', async () => {
         await expect(sandbox.writeFile('/etc/passwd', 'x')).rejects.toThrow(
             /Absolute paths are not allowed/,
         );
+    });
+
+    it('accepts absolute paths that resolve inside the repo (read)', async () => {
+        const absPath = path.join(dir, 'a.txt');
+        fs.writeFileSync(absPath, 'hello');
+        await expect(sandbox.readFile(absPath)).resolves.toBe('hello');
+    });
+
+    it('accepts absolute paths that resolve inside the repo (write)', async () => {
+        const absPath = path.join(dir, 'sub', 'abs.txt');
+        await sandbox.writeFile(absPath, 'content');
+        expect(fs.readFileSync(absPath, 'utf-8')).toBe('content');
     });
 
     it('rejects .. traversal reads', async () => {

--- a/libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts
+++ b/libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts
@@ -1,3 +1,7 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+
 import { PlatformType } from '@libs/core/domain/enums';
 import { LocalSandboxService } from './local-sandbox.service';
 
@@ -16,9 +20,10 @@ describe('LocalSandboxService.buildAuthHeader', () => {
         (service as any).buildAuthHeader(platform, token, username) as string;
 
     const decode = (header: string) =>
-        Buffer.from(header.replace('Authorization: Basic ', ''), 'base64').toString(
-            'utf8',
-        );
+        Buffer.from(
+            header.replace('Authorization: Basic ', ''),
+            'base64',
+        ).toString('utf8');
 
     it('uses x-access-token for GitHub', () => {
         expect(decode(build(PlatformType.GITHUB, 'ghtok'))).toBe(
@@ -27,7 +32,9 @@ describe('LocalSandboxService.buildAuthHeader', () => {
     });
 
     it('uses oauth2 for GitLab and Azure', () => {
-        expect(decode(build(PlatformType.GITLAB, 'gltok'))).toBe('oauth2:gltok');
+        expect(decode(build(PlatformType.GITLAB, 'gltok'))).toBe(
+            'oauth2:gltok',
+        );
         expect(decode(build(PlatformType.AZURE_REPOS, 'aztok'))).toBe(
             'oauth2:aztok',
         );
@@ -47,7 +54,9 @@ describe('LocalSandboxService.buildAuthHeader', () => {
 
         it('uses the account username for classic app passwords', () => {
             expect(
-                decode(build(PlatformType.BITBUCKET, 'classicapppw', 'kodususer')),
+                decode(
+                    build(PlatformType.BITBUCKET, 'classicapppw', 'kodususer'),
+                ),
             ).toBe('kodususer:classicapppw');
         });
 
@@ -62,5 +71,97 @@ describe('LocalSandboxService.buildAuthHeader', () => {
                 /Bitbucket authentication requires/i,
             );
         });
+    });
+});
+
+describe('LocalSandboxService sandbox file access', () => {
+    let dir: string;
+    let outsideDir: string;
+    let sandbox: {
+        readFile: (path: string) => Promise<string>;
+        writeFile: (path: string, content: string) => Promise<void>;
+    };
+
+    beforeEach(() => {
+        dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kodus-sandbox-files-'));
+        outsideDir = fs.mkdtempSync(
+            path.join(os.tmpdir(), 'kodus-sandbox-outside-'),
+        );
+        const svc = new LocalSandboxService({} as any);
+        sandbox = (svc as any).buildSandboxFileAccess(dir);
+    });
+
+    afterEach(() => {
+        fs.rmSync(dir, { recursive: true, force: true });
+        fs.rmSync(outsideDir, { recursive: true, force: true });
+    });
+
+    it('reads a repo-relative file', async () => {
+        fs.writeFileSync(path.join(dir, 'a.txt'), 'hello');
+        await expect(sandbox.readFile('a.txt')).resolves.toBe('hello');
+    });
+
+    it('writes a repo-relative file and creates parent directories', async () => {
+        await sandbox.writeFile('sub/b.txt', 'world');
+        expect(fs.readFileSync(path.join(dir, 'sub/b.txt'), 'utf-8')).toBe(
+            'world',
+        );
+    });
+
+    it('rejects absolute read paths', async () => {
+        await expect(sandbox.readFile('/etc/passwd')).rejects.toThrow(
+            /Absolute paths are not allowed/,
+        );
+    });
+
+    it('rejects absolute write paths', async () => {
+        await expect(sandbox.writeFile('/etc/passwd', 'x')).rejects.toThrow(
+            /Absolute paths are not allowed/,
+        );
+    });
+
+    it('rejects .. traversal reads', async () => {
+        await expect(sandbox.readFile('../outside.txt')).rejects.toThrow(
+            /Path traversal using "\.\." is not allowed/,
+        );
+    });
+
+    it('rejects .. traversal writes', async () => {
+        await expect(sandbox.writeFile('../outside.txt', 'x')).rejects.toThrow(
+            /Path traversal using "\.\." is not allowed/,
+        );
+    });
+
+    it('rejects reading through a symlink that escapes the repo', async () => {
+        const outsideFile = path.join(outsideDir, 'secret.txt');
+        fs.writeFileSync(outsideFile, 'secret');
+        fs.symlinkSync(outsideFile, path.join(dir, 'escape-link'));
+        await expect(sandbox.readFile('escape-link')).rejects.toThrow(
+            /Symlink detected/,
+        );
+    });
+
+    it('rejects writing through a symlinked parent directory', async () => {
+        fs.symlinkSync(outsideDir, path.join(dir, 'linkdir'));
+        await expect(
+            sandbox.writeFile('linkdir/nested/file.txt', 'x'),
+        ).rejects.toThrow(/Symlink/);
+    });
+
+    it('rejects overwriting a symlinked target file', async () => {
+        const outsideFile = path.join(outsideDir, 'target.txt');
+        fs.writeFileSync(outsideFile, 'secret');
+        fs.symlinkSync(outsideFile, path.join(dir, 'linkfile.txt'));
+        await expect(sandbox.writeFile('linkfile.txt', 'x')).rejects.toThrow(
+            /Symlink/,
+        );
+    });
+
+    it('writes a new file under an existing safe parent directory', async () => {
+        fs.mkdirSync(path.join(dir, 'safe'));
+        await sandbox.writeFile('safe/new.txt', 'ok');
+        expect(fs.readFileSync(path.join(dir, 'safe/new.txt'), 'utf-8')).toBe(
+            'ok',
+        );
     });
 });

--- a/libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts
+++ b/libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts
@@ -127,9 +127,23 @@ describe('LocalSandboxService sandbox file access', () => {
     });
 
     it('accepts absolute paths that resolve inside the repo (write)', async () => {
-        const absPath = path.join(dir, 'sub', 'abs.txt');
+        const absPath = path.join(dir, 'sub', 'c.txt');
         await sandbox.writeFile(absPath, 'content');
         expect(fs.readFileSync(absPath, 'utf-8')).toBe('content');
+    });
+
+    it('rejects absolute paths with .. traversal even under repoDir', async () => {
+        const escapePath = dir + '/../outside';
+        await expect(sandbox.readFile(escapePath)).rejects.toThrow(
+            /Path traversal using ".." is not allowed/,
+        );
+    });
+
+    it('rejects absolute write paths with .. traversal even under repoDir', async () => {
+        const escapePath = dir + '/../outside';
+        await expect(sandbox.writeFile(escapePath, 'x')).rejects.toThrow(
+            /Path traversal using ".." is not allowed/,
+        );
     });
 
     it('rejects .. traversal reads', async () => {

--- a/libs/sandbox/infrastructure/providers/local-sandbox.service.ts
+++ b/libs/sandbox/infrastructure/providers/local-sandbox.service.ts
@@ -562,6 +562,21 @@ export class LocalSandboxService implements ISandboxProvider {
                 const safePath = await this.resolveSafeWritePath(repoDir, path);
                 const dir = join(safePath, '..');
                 await mkdir(dir, { recursive: true });
+
+                // Re-validate after mkdir to shrink TOCTOU window.
+                // A concurrent actor could swap a parent dir for a symlink
+                // between resolveSafeWritePath and the actual write.
+                const repoReal = await realpath(repoDir);
+                const finalCheck = await realpath(dir);
+                if (
+                    !finalCheck.startsWith(repoReal + '/') &&
+                    finalCheck !== repoReal
+                ) {
+                    throw new Error(
+                        `Path escapes repo boundary after mkdir: ${path}`,
+                    );
+                }
+
                 // Open with O_NOFOLLOW to prevent TOCTOU symlink swap
                 // between validation and write.
                 const fd = await open(

--- a/libs/sandbox/infrastructure/providers/local-sandbox.service.ts
+++ b/libs/sandbox/infrastructure/providers/local-sandbox.service.ts
@@ -6,12 +6,14 @@ import { exec, execFile, ExecFileOptions, spawn } from 'child_process';
 import {
     lstat,
     mkdtemp,
+    open,
     readFile,
     realpath,
     rm,
     writeFile,
     mkdir,
 } from 'fs/promises';
+import { constants as fsConstants } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { promisify } from 'util';
@@ -560,7 +562,20 @@ export class LocalSandboxService implements ISandboxProvider {
                 const safePath = await this.resolveSafeWritePath(repoDir, path);
                 const dir = join(safePath, '..');
                 await mkdir(dir, { recursive: true });
-                await writeFile(safePath, content, 'utf-8');
+                // Open with O_NOFOLLOW to prevent TOCTOU symlink swap
+                // between validation and write.
+                const fd = await open(
+                    safePath,
+                    fsConstants.O_WRONLY |
+                        fsConstants.O_CREAT |
+                        fsConstants.O_NOFOLLOW,
+                    0o644,
+                );
+                try {
+                    await fd.writeFile(content, 'utf-8');
+                } finally {
+                    await fd.close();
+                }
             },
         };
     }
@@ -669,8 +684,16 @@ export class LocalSandboxService implements ISandboxProvider {
         }
     }
 
-    private validatePath(path: string): void {
+    private validatePath(path: string, repoDir?: string): void {
         if (path.startsWith('/')) {
+            if (
+                repoDir &&
+                (path.startsWith(repoDir + '/') || path === repoDir)
+            ) {
+                // Absolute path under repoDir — OK, will be validated by
+                // the realpath check in resolveSafePath / resolveSafeWritePath.
+                return;
+            }
             throw new Error('Absolute paths are not allowed');
         }
         if (path.includes('..')) {
@@ -686,8 +709,8 @@ export class LocalSandboxService implements ISandboxProvider {
         repoDir: string,
         path: string,
     ): Promise<string> {
-        this.validatePath(path);
-        const candidate = join(repoDir, path);
+        this.validatePath(path, repoDir);
+        const candidate = path.startsWith('/') ? path : join(repoDir, path);
 
         // Check if the target itself is a symlink before resolving
         const stat = await lstat(candidate);
@@ -715,9 +738,9 @@ export class LocalSandboxService implements ISandboxProvider {
         repoDir: string,
         path: string,
     ): Promise<string> {
-        this.validatePath(path);
+        this.validatePath(path, repoDir);
         const repoReal = await realpath(repoDir);
-        const candidate = join(repoDir, path);
+        const candidate = path.startsWith('/') ? path : join(repoDir, path);
 
         try {
             const targetStat = await lstat(candidate);

--- a/libs/sandbox/infrastructure/providers/local-sandbox.service.ts
+++ b/libs/sandbox/infrastructure/providers/local-sandbox.service.ts
@@ -211,31 +211,8 @@ export class LocalSandboxService implements ISandboxProvider {
                 }
             };
 
-            // Path safety: reads go through `resolveSafePath` so absolute
-            // paths, `..` traversals, and symlink escapes are all rejected
-            // at the boundary. Writes can target files that don't exist
-            // yet (so `lstat`/`realpath` don't apply), but we still
-            // normalize and compare against the repo root so the final
-            // target can't escape — `validatePath` plus the prefix check
-            // covers `../..`, `/etc/...`, and embedded traversals.
-            const sandboxReadFile = async (path: string): Promise<string> => {
-                const fullPath = path.startsWith('/')
-                    ? path
-                    : join(capturedRepoDir, path);
-                return readFile(fullPath, 'utf-8');
-            };
-
-            const sandboxWriteFile = async (
-                path: string,
-                content: string,
-            ): Promise<void> => {
-                const fullPath = path.startsWith('/')
-                    ? path
-                    : join(capturedRepoDir, path);
-                const dir = join(fullPath, '..');
-                await mkdir(dir, { recursive: true });
-                await writeFile(fullPath, content, 'utf-8');
-            };
+            const { readFile: sandboxReadFile, writeFile: sandboxWriteFile } =
+                this.buildSandboxFileAccess(capturedRepoDir);
 
             return {
                 remoteCommands,
@@ -570,6 +547,24 @@ export class LocalSandboxService implements ISandboxProvider {
         };
     }
 
+    private buildSandboxFileAccess(repoDir: string): {
+        readFile: (path: string) => Promise<string>;
+        writeFile: (path: string, content: string) => Promise<void>;
+    } {
+        return {
+            readFile: async (path: string): Promise<string> => {
+                const safePath = await this.resolveSafePath(repoDir, path);
+                return readFile(safePath, 'utf-8');
+            },
+            writeFile: async (path: string, content: string): Promise<void> => {
+                const safePath = await this.resolveSafeWritePath(repoDir, path);
+                const dir = join(safePath, '..');
+                await mkdir(dir, { recursive: true });
+                await writeFile(safePath, content, 'utf-8');
+            },
+        };
+    }
+
     /**
      * Apply a unified diff on top of the currently-checked-out commit. Used
      * in CLI mode so the agent sees the user's actual local working state.
@@ -600,7 +595,13 @@ export class LocalSandboxService implements ISandboxProvider {
         try {
             await execFileAsync(
                 'git',
-                ['-C', repoDir, 'config', 'user.email', 'kodus-cli@kodus.local'],
+                [
+                    '-C',
+                    repoDir,
+                    'config',
+                    'user.email',
+                    'kodus-cli@kodus.local',
+                ],
                 { timeout: 5_000 },
             );
             await execFileAsync(
@@ -626,8 +627,7 @@ export class LocalSandboxService implements ISandboxProvider {
                 { timeout: CLONE_TIMEOUT_MS },
             );
             this.logger.log({
-                message:
-                    'CLI diff applied successfully on top of merge-base',
+                message: 'CLI diff applied successfully on top of merge-base',
                 context: LocalSandboxService.name,
             });
             return;
@@ -700,6 +700,79 @@ export class LocalSandboxService implements ISandboxProvider {
         const repoReal = await realpath(repoDir);
         if (!real.startsWith(repoReal + '/') && real !== repoReal) {
             throw new Error(`Path escapes repo boundary: ${path}`);
+        }
+
+        return candidate;
+    }
+
+    /**
+     * Resolve a relative write path within the repo. The target file may not
+     * exist yet, so we cannot rely on lstat/realpath of the target itself;
+     * instead we validate every existing parent directory is a real directory
+     * under the repo root and reject any symlink in the path or target.
+     */
+    private async resolveSafeWritePath(
+        repoDir: string,
+        path: string,
+    ): Promise<string> {
+        this.validatePath(path);
+        const repoReal = await realpath(repoDir);
+        const candidate = join(repoDir, path);
+
+        try {
+            const targetStat = await lstat(candidate);
+            if (targetStat.isSymbolicLink()) {
+                throw new Error(
+                    `Symlink detected, refusing to write through: ${path}`,
+                );
+            }
+        } catch (error: unknown) {
+            const isEnoent =
+                typeof error === 'object' &&
+                error !== null &&
+                'code' in error &&
+                (error as { code: string }).code === 'ENOENT';
+            if (!isEnoent) {
+                throw error;
+            }
+        }
+
+        let current = candidate;
+        while (true) {
+            const parent = join(current, '..');
+            if (parent === current || !parent.startsWith(repoDir + '/')) {
+                break;
+            }
+            try {
+                const stat = await lstat(parent);
+                if (stat.isSymbolicLink()) {
+                    throw new Error(
+                        `Symlinked parent directory detected: ${path}`,
+                    );
+                }
+                if (!stat.isDirectory()) {
+                    throw new Error(`Non-directory parent in path: ${path}`);
+                }
+                const parentReal = await realpath(parent);
+                if (
+                    !parentReal.startsWith(repoReal + '/') &&
+                    parentReal !== repoReal
+                ) {
+                    throw new Error(`Path escapes repo boundary: ${path}`);
+                }
+                break;
+            } catch (error: unknown) {
+                const isEnoent =
+                    typeof error === 'object' &&
+                    error !== null &&
+                    'code' in error &&
+                    (error as { code: string }).code === 'ENOENT';
+                if (isEnoent) {
+                    current = parent;
+                    continue;
+                }
+                throw error;
+            }
         }
 
         return candidate;

--- a/libs/sandbox/infrastructure/providers/local-sandbox.service.ts
+++ b/libs/sandbox/infrastructure/providers/local-sandbox.service.ts
@@ -568,6 +568,7 @@ export class LocalSandboxService implements ISandboxProvider {
                     safePath,
                     fsConstants.O_WRONLY |
                         fsConstants.O_CREAT |
+                        fsConstants.O_TRUNC |
                         fsConstants.O_NOFOLLOW,
                     0o644,
                 );
@@ -685,6 +686,11 @@ export class LocalSandboxService implements ISandboxProvider {
     }
 
     private validatePath(path: string, repoDir?: string): void {
+        // Check for .. traversal FIRST, before any absolute-path logic,
+        // so paths like /repo/../../../etc/passwd are always rejected.
+        if (path.includes('..')) {
+            throw new Error('Path traversal using ".." is not allowed');
+        }
         if (path.startsWith('/')) {
             if (
                 repoDir &&
@@ -695,9 +701,6 @@ export class LocalSandboxService implements ISandboxProvider {
                 return;
             }
             throw new Error('Absolute paths are not allowed');
-        }
-        if (path.includes('..')) {
-            throw new Error('Path traversal using ".." is not allowed');
         }
     }
 


### PR DESCRIPTION
## Scope

Harden local sandbox `readFile` and `writeFile` path validation to match the existing protections already applied to `remoteCommands` (grep, read, listDir, exec).

**Changes:**
- Reject absolute paths and `..` traversal in `readFile`/`writeFile`
- Reject symlink escapes for reads (via `resolveSafePath`)
- Reject writes through symlinked parent directories or symlinked target files (via new `resolveSafeWritePath`)
- Extract testable `buildSandboxFileAccess` helper matching the existing `buildRemoteCommands` pattern
- Add 10 focused unit+integration tests for normal access and escape attempts

**Files changed:**
- `libs/sandbox/infrastructure/providers/local-sandbox.service.ts` — added `resolveSafeWritePath`, `buildSandboxFileAccess`; replaced vulnerable inline closures
- `libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts` — added `describe('LocalSandboxService sandbox file access')` with 10 tests

## Non-goals

- Does NOT change sandbox lease cleanup behavior (→ local cleanup PR)
- Does NOT change E2B sandbox lifecycle, kill, or retry behavior
- Does NOT change reaper batching or concurrency (→ reaper concurrency PR)
- Does NOT introduce new lease states or Mongo state-machine changes

## Validation

```
✅ pnpm test -- --runTestsByPath libs/sandbox/infrastructure/providers/local-sandbox.service.spec.ts --no-coverage --runInBand (16/16 pass)
✅ pnpm exec prettier --check on changed files
✅ pnpm exec eslint on changed files
✅ pnpm run typecheck:libs-gate
```

## Pre-review Checklist

- [x] The diff does not touch lease repositories, reaper services, or invalidation flows
- [x] No cleanup retry state is introduced in this PR
- [x] Every new test asserts file-access behavior only
- [x] A reviewer asking about `/tmp/kodus-sandbox-*` cleanup should be redirected to the local cleanup PR

## Follow-ups

- Self-hosted `/tmp/kodus-sandbox-*` directory cleanup → local sandbox cleanup PR
- Reaper batching and E2B retry behavior → reaper concurrency PR