### PR TITLE
feat(sandbox): add self-hosted local sandbox cleanup

### DIFF
--- a/libs/sandbox/infrastructure/repositories/sandbox-lease.repository.ts
+++ b/libs/sandbox/infrastructure/repositories/sandbox-lease.repository.ts
@@ -2,6 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 
+import { SANDBOX_LEASE_CLEANUP_STATUS } from './schemas/sandbox-lease.model';
 import { SandboxLeaseModel } from './schemas/sandbox-lease.model';
 
 /**
@@ -218,5 +219,83 @@ export class SandboxLeaseRepository {
             })
             .select('_id sandboxId killAt')
             .lean();
+    }
+
+    /**
+     * Atomically claim a local cleanup. Returns the doc only when prKey and
+     * sandboxId match and cleanup is not already in_progress or completed.
+     */
+    async claimCleanup(
+        prKey: string,
+        expectedSandboxId: string,
+    ): Promise<SandboxLeaseModel | null> {
+        return this.leaseModel
+            .findOneAndUpdate(
+                {
+                    _id: prKey,
+                    sandboxId: expectedSandboxId,
+                    cleanupStatus: {
+                        $nin: [
+                            SANDBOX_LEASE_CLEANUP_STATUS.IN_PROGRESS,
+                            SANDBOX_LEASE_CLEANUP_STATUS.COMPLETED,
+                        ],
+                    },
+                },
+                {
+                    $set: {
+                        cleanupStatus: SANDBOX_LEASE_CLEANUP_STATUS.IN_PROGRESS,
+                        cleanupRetryAt: null,
+                    },
+                    $inc: { cleanupAttempts: 1 },
+                },
+                { new: true },
+            )
+            .exec();
+    }
+
+    /**
+     * Complete a local cleanup by deleting the lease doc.
+     * Only deletes when prKey, sandboxId, and cleanupStatus=IN_PROGRESS match.
+     */
+    async completeCleanup(
+        prKey: string,
+        expectedSandboxId: string,
+    ): Promise<boolean> {
+        const result = await this.leaseModel
+            .deleteOne({
+                _id: prKey,
+                sandboxId: expectedSandboxId,
+                cleanupStatus: SANDBOX_LEASE_CLEANUP_STATUS.IN_PROGRESS,
+            })
+            .exec();
+        return result.deletedCount === 1;
+    }
+
+    /**
+     * Mark a local cleanup as failed. Sets a retry marker.
+     * Only updates when prKey, sandboxId, and cleanupStatus=IN_PROGRESS match.
+     */
+    async failCleanup(
+        prKey: string,
+        expectedSandboxId: string,
+        error: string,
+    ): Promise<boolean> {
+        const result = await this.leaseModel
+            .updateOne(
+                {
+                    _id: prKey,
+                    sandboxId: expectedSandboxId,
+                    cleanupStatus: SANDBOX_LEASE_CLEANUP_STATUS.IN_PROGRESS,
+                },
+                {
+                    $set: {
+                        cleanupStatus: SANDBOX_LEASE_CLEANUP_STATUS.FAILED,
+                        cleanupRetryAt: new Date(Date.now() + 60_000),
+                        cleanupError: error.slice(0, 500),
+                    },
+                },
+            )
+            .exec();
+        return result.modifiedCount === 1;
     }
 }

--- a/libs/sandbox/infrastructure/repositories/sandbox-lease.repository.ts
+++ b/libs/sandbox/infrastructure/repositories/sandbox-lease.repository.ts
@@ -128,12 +128,17 @@ export class SandboxLeaseRepository {
     }
 
     /**
-     * Mark a CREATING lease as INVALIDATED (mid-create race handling).
-     * The create path will check for this state after completing and kill the sandbox.
+     * Mark a CREATING or READY lease as INVALIDATED.
+     *
+     * CREATING: mid-create race handling — the create path detects this
+     * after completing and kills the sandbox.
+     * READY: called by invalidate() when a local READY lease has active
+     * consumers (leaseCount > 0). The state change prevents new acquires
+     * from attaching to the stale sandbox.
      */
     async markInvalidated(prKey: string): Promise<void> {
         await this.leaseModel.updateOne(
-            { _id: prKey, state: 'CREATING' },
+            { _id: prKey, state: { $in: ['CREATING', 'READY'] } },
             { $set: { state: 'INVALIDATED' } },
         );
     }
@@ -224,27 +229,40 @@ export class SandboxLeaseRepository {
     /**
      * Atomically claim a local cleanup. Returns the doc only when prKey and
      * sandboxId match and cleanup is not already in_progress or completed.
+     *
+     * @param requireLeaseCountZero When true, also requires leaseCount <= 0.
+     *   Used by release/invalidate to prevent deleting a local sandbox
+     *   directory while a concurrent acquire has re-incremented the lease
+     *   count (race between decrementLease and claimCleanup). The reaper
+     *   path passes false (default) because it force-reclaims regardless
+     *   of active leases (expired TTL = all leases are dead).
      */
     async claimCleanup(
         prKey: string,
         expectedSandboxId: string,
+        requireLeaseCountZero = false,
     ): Promise<SandboxLeaseModel | null> {
+        const filter: Record<string, unknown> = {
+            _id: prKey,
+            sandboxId: expectedSandboxId,
+            cleanupStatus: {
+                $nin: [
+                    SANDBOX_LEASE_CLEANUP_STATUS.IN_PROGRESS,
+                    SANDBOX_LEASE_CLEANUP_STATUS.COMPLETED,
+                ],
+            },
+        };
+        if (requireLeaseCountZero) {
+            filter.leaseCount = { $lte: 0 };
+        }
         return this.leaseModel
             .findOneAndUpdate(
-                {
-                    _id: prKey,
-                    sandboxId: expectedSandboxId,
-                    cleanupStatus: {
-                        $nin: [
-                            SANDBOX_LEASE_CLEANUP_STATUS.IN_PROGRESS,
-                            SANDBOX_LEASE_CLEANUP_STATUS.COMPLETED,
-                        ],
-                    },
-                },
+                filter,
                 {
                     $set: {
                         cleanupStatus: SANDBOX_LEASE_CLEANUP_STATUS.IN_PROGRESS,
                         cleanupRetryAt: null,
+                        cleanupStartedAt: new Date(),
                     },
                     $inc: { cleanupAttempts: 1 },
                 },
@@ -297,5 +315,35 @@ export class SandboxLeaseRepository {
             )
             .exec();
         return result.modifiedCount === 1;
+    }
+
+    /**
+     * Reset stale in_progress cleanup claims left behind by a crashed worker.
+     * When a worker crashes after claiming cleanup (cleanupStatus=IN_PROGRESS)
+     * but before completing it, the lease gets stuck forever — claimCleanup
+     * rejects IN_PROGRESS docs. This method detects stale claims by checking
+     * cleanupStartedAt against a threshold (typically 5 minutes) and resets
+     * them to FAILED so the reaper can retry on the next tick.
+     */
+    async resetStaleCleanup(
+        prKey: string,
+        staleThreshold: Date,
+    ): Promise<void> {
+        await this.leaseModel
+            .updateOne(
+                {
+                    _id: prKey,
+                    cleanupStatus: SANDBOX_LEASE_CLEANUP_STATUS.IN_PROGRESS,
+                    cleanupStartedAt: { $lt: staleThreshold },
+                },
+                {
+                    $set: {
+                        cleanupStatus: SANDBOX_LEASE_CLEANUP_STATUS.FAILED,
+                        cleanupError:
+                            'Worker crash recovery — stale in_progress reset',
+                    },
+                },
+            )
+            .exec();
     }
 }

--- a/libs/sandbox/infrastructure/repositories/schemas/sandbox-lease.model.ts
+++ b/libs/sandbox/infrastructure/repositories/schemas/sandbox-lease.model.ts
@@ -8,6 +8,20 @@ const PR_KEY_REGEX: RegExp =
     /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}:[^:]+:[^:]+(:[^:]+)?$/i;
 
 /**
+ * Cleanup status for local sandbox directories.
+ * Tracks the lifecycle of filesystem cleanup after a lease is released.
+ */
+export const SANDBOX_LEASE_CLEANUP_STATUS = {
+    PENDING: 'pending',
+    IN_PROGRESS: 'in_progress',
+    COMPLETED: 'completed',
+    FAILED: 'failed',
+} as const;
+
+export type SandboxLeaseCleanupStatus =
+    (typeof SANDBOX_LEASE_CLEANUP_STATUS)[keyof typeof SANDBOX_LEASE_CLEANUP_STATUS];
+
+/**
  * Mongoose schema for the sandbox_leases collection.
  *
  * Each document represents a coordination lease for a single PR (keyed by prKey).
@@ -84,6 +98,22 @@ export class SandboxLeaseModel extends CoreDocument {
      */
     @Prop({ type: Date, required: false })
     killAt?: Date;
+
+    @Prop({
+        type: String,
+        required: false,
+        enum: Object.values(SANDBOX_LEASE_CLEANUP_STATUS),
+    })
+    cleanupStatus?: SandboxLeaseCleanupStatus;
+
+    @Prop({ type: Number, required: false, default: 0 })
+    cleanupAttempts?: number;
+
+    @Prop({ type: Date, required: false })
+    cleanupRetryAt?: Date;
+
+    @Prop({ type: String, required: false })
+    cleanupError?: string;
 }
 
 // Explicit type annotation: with the killAt field added the inferred type

--- a/libs/sandbox/infrastructure/repositories/schemas/sandbox-lease.model.ts
+++ b/libs/sandbox/infrastructure/repositories/schemas/sandbox-lease.model.ts
@@ -114,6 +114,15 @@ export class SandboxLeaseModel extends CoreDocument {
 
     @Prop({ type: String, required: false })
     cleanupError?: string;
+
+    /**
+     * Timestamp when cleanup was claimed (set by claimCleanup).
+     * Used by the reaper to detect stale in_progress claims left behind
+     * by a crashed worker. After a timeout (e.g. 5 minutes), the reaper
+     * resets the status to FAILED so the next tick can retry.
+     */
+    @Prop({ type: Date, required: false })
+    cleanupStartedAt?: Date;
 }
 
 // Explicit type annotation: with the killAt field added the inferred type

--- a/libs/sandbox/infrastructure/services/local-sandbox-cleanup.service.ts
+++ b/libs/sandbox/infrastructure/services/local-sandbox-cleanup.service.ts
@@ -1,0 +1,46 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+
+const SANDBOX_PREFIX = 'kodus-sandbox-';
+
+/**
+ * Check if a sandboxId refers to a local sandbox directory.
+ * Returns true only for direct children of os.tmpdir() whose basename
+ * starts with 'kodus-sandbox-'.
+ */
+export function isLocalSandboxPath(
+    sandboxId: string | null | undefined,
+): boolean {
+    if (!sandboxId || typeof sandboxId !== 'string') return false;
+
+    const tmpDir = os.tmpdir();
+    const basename = path.basename(sandboxId);
+    const resolved = path.resolve(tmpDir, basename);
+
+    // Must be a direct child of tmpdir
+    if (path.dirname(resolved) !== tmpDir) return false;
+    // Must match the original path (prevents traversal)
+    if (resolved !== sandboxId) return false;
+    // Must have the right prefix
+    return basename.startsWith(SANDBOX_PREFIX);
+}
+
+/**
+ * Delete a local sandbox directory. Validates the path first.
+ * Treats missing directories as success.
+ */
+export async function deleteLocalSandbox(sandboxId: string): Promise<void> {
+    if (!isLocalSandboxPath(sandboxId)) {
+        throw new Error(`Invalid local sandbox path: ${sandboxId}`);
+    }
+
+    try {
+        await fs.access(sandboxId);
+    } catch {
+        // Directory already gone — success
+        return;
+    }
+
+    await fs.rm(sandboxId, { recursive: true, force: true });
+}

--- a/libs/sandbox/infrastructure/services/local-sandbox-cleanup.spec.ts
+++ b/libs/sandbox/infrastructure/services/local-sandbox-cleanup.spec.ts
@@ -1,0 +1,83 @@
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import {
+    isLocalSandboxPath,
+    deleteLocalSandbox,
+} from './local-sandbox-cleanup.service';
+
+describe('isLocalSandboxPath', () => {
+    it('accepts a valid local sandbox path', () => {
+        const tmpDir = os.tmpdir();
+        expect(
+            isLocalSandboxPath(path.join(tmpDir, 'kodus-sandbox-abc123')),
+        ).toBe(true);
+    });
+
+    it('rejects null/undefined', () => {
+        expect(isLocalSandboxPath(null)).toBe(false);
+        expect(isLocalSandboxPath(undefined)).toBe(false);
+    });
+
+    it('rejects empty string', () => {
+        expect(isLocalSandboxPath('')).toBe(false);
+    });
+
+    it('rejects path outside tmpdir', () => {
+        expect(isLocalSandboxPath('/var/kodus-sandbox-abc')).toBe(false);
+    });
+
+    it('rejects path traversal', () => {
+        const tmpDir = os.tmpdir();
+        expect(
+            isLocalSandboxPath(
+                path.join(tmpDir, 'kodus-sandbox-abc', '..', '..', 'etc'),
+            ),
+        ).toBe(false);
+    });
+
+    it('rejects wrong prefix', () => {
+        const tmpDir = os.tmpdir();
+        expect(isLocalSandboxPath(path.join(tmpDir, 'other-dir'))).toBe(false);
+    });
+
+    it('rejects nested path', () => {
+        const tmpDir = os.tmpdir();
+        expect(
+            isLocalSandboxPath(
+                path.join(tmpDir, 'kodus-sandbox-abc', 'subdir'),
+            ),
+        ).toBe(false);
+    });
+});
+
+describe('deleteLocalSandbox', () => {
+    let tmpDir: string;
+
+    beforeEach(async () => {
+        tmpDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'kodus-sandbox-test-'),
+        );
+    });
+
+    afterEach(async () => {
+        await fs.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
+    });
+
+    it('deletes an existing sandbox directory', async () => {
+        await expect(fs.access(tmpDir)).resolves.toBeUndefined();
+        await deleteLocalSandbox(tmpDir);
+        await expect(fs.access(tmpDir)).rejects.toThrow();
+    });
+
+    it('succeeds when directory is already gone', async () => {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+        await expect(deleteLocalSandbox(tmpDir)).resolves.toBeUndefined();
+    });
+
+    it('rejects invalid path', async () => {
+        await expect(deleteLocalSandbox('/etc/passwd')).rejects.toThrow(
+            /Invalid local sandbox path/,
+        );
+    });
+});

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
@@ -17,9 +17,7 @@ import { randomUUID } from 'crypto';
 
 import { calculateBackoffInterval } from '@libs/common/utils/polling';
 import { SandboxLeaseRepository } from '../repositories/sandbox-lease.repository';
-import {
-    SANDBOX_LEASE_CLEANUP_STATUS,
-} from '../repositories/schemas/sandbox-lease.model';
+import { SANDBOX_LEASE_CLEANUP_STATUS } from '../repositories/schemas/sandbox-lease.model';
 import { NULL_SANDBOX_INSTANCE } from '../providers/null-sandbox.service';
 import { buildE2BRemoteCommands } from '../providers/e2b-sandbox.service';
 import {
@@ -171,10 +169,7 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
         // Finding 1 fix: if cleanup is in progress, wait for it to complete
         // (doc will be deleted), then retry acquire from scratch. Prevents
         // attaching to a doc that's being cleaned up.
-        if (
-            doc.cleanupStatus ===
-            SANDBOX_LEASE_CLEANUP_STATUS.IN_PROGRESS
-        ) {
+        if (doc.cleanupStatus === SANDBOX_LEASE_CLEANUP_STATUS.IN_PROGRESS) {
             this.logger.log({
                 message: `SandboxLeaseManager: cleanup in progress, waiting for completion prKey="${prKey}"`,
                 context: SandboxLeaseManager.name,
@@ -187,6 +182,22 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                 if (!check) break; // Doc deleted — cleanup complete
             }
             // Retry acquire from scratch
+            return this.acquire(prKey, consumer, leaseTtlMs, cloneParams);
+        }
+
+        // Acquire-vs-invalidated race: upsertAcquire() already incremented
+        // leaseCount, but the doc is INVALIDATED. If we proceed to
+        // handleJoinerPath it will throw without decrementing, leaking the
+        // count. Undo the increment, delete the stale doc, and retry so
+        // the next acquire creates a fresh lease.
+        if (doc.state === 'INVALIDATED') {
+            await this.leaseRepo.decrementLease(prKey);
+            await this.leaseRepo.delete(prKey);
+            this.logger.log({
+                message: `SandboxLeaseManager: acquired INVALIDATED doc, cleaned up stale lease prKey="${prKey}"`,
+                context: SandboxLeaseManager.name,
+                metadata: { prKey },
+            });
             return this.acquire(prKey, consumer, leaseTtlMs, cloneParams);
         }
 

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
@@ -540,6 +540,7 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                             // retry the cleanup.
                             throw new Error(
                                 `SandboxLeaseManager: sandbox invalidated mid-create for prKey="${prKey}"`,
+                                { cause: localErr },
                             );
                         }
                     } else {

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
@@ -17,6 +17,9 @@ import { randomUUID } from 'crypto';
 
 import { calculateBackoffInterval } from '@libs/common/utils/polling';
 import { SandboxLeaseRepository } from '../repositories/sandbox-lease.repository';
+import {
+    SANDBOX_LEASE_CLEANUP_STATUS,
+} from '../repositories/schemas/sandbox-lease.model';
 import { NULL_SANDBOX_INSTANCE } from '../providers/null-sandbox.service';
 import { buildE2BRemoteCommands } from '../providers/e2b-sandbox.service';
 import {
@@ -164,6 +167,29 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
             leaseTtlMs,
             consumer,
         );
+
+        // Finding 1 fix: if cleanup is in progress, wait for it to complete
+        // (doc will be deleted), then retry acquire from scratch. Prevents
+        // attaching to a doc that's being cleaned up.
+        if (
+            doc.cleanupStatus ===
+            SANDBOX_LEASE_CLEANUP_STATUS.IN_PROGRESS
+        ) {
+            this.logger.log({
+                message: `SandboxLeaseManager: cleanup in progress, waiting for completion prKey="${prKey}"`,
+                context: SandboxLeaseManager.name,
+                metadata: { prKey },
+            });
+            const deadline = Date.now() + MAX_POLL_WAIT_MS;
+            while (Date.now() < deadline) {
+                await sleep(POLL_INTERVAL_MS);
+                const check = await this.leaseRepo.findByPrKey(prKey);
+                if (!check) break; // Doc deleted — cleanup complete
+            }
+            // Retry acquire from scratch
+            return this.acquire(prKey, consumer, leaseTtlMs, cloneParams);
+        }
+
         const leaseId = randomUUID();
 
         // A new acquire arrived — atomically clear any pending idle-kill so
@@ -496,6 +522,12 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                                 context: SandboxLeaseManager.name,
                                 error: localErr as Error,
                             });
+                            // Finding 4 fix: don't delete the lease doc when
+                            // local cleanup fails — keep it so the reaper can
+                            // retry the cleanup.
+                            throw new Error(
+                                `SandboxLeaseManager: sandbox invalidated mid-create for prKey="${prKey}"`,
+                            );
                         }
                     } else {
                         const apiKey =
@@ -507,7 +539,6 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                         }
                     }
                 }
-                // Clean up the invalidated doc
                 await this.leaseRepo.delete(prKey);
                 throw new Error(
                     `SandboxLeaseManager: sandbox invalidated mid-create for prKey="${prKey}"`,
@@ -624,18 +655,9 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
         sandboxId?: string,
     ): Promise<AcquireResult> {
         if (state === 'INVALIDATED') {
-            // Clean up local sandbox directory if applicable
-            if (sandboxId && isLocalSandboxPath(sandboxId)) {
-                try {
-                    await deleteLocalSandbox(sandboxId);
-                } catch (err) {
-                    this.logger.warn({
-                        message: `SandboxLeaseManager: failed to clean local sandbox on INVALIDATED prKey="${prKey}" sandboxId="${sandboxId}"`,
-                        context: SandboxLeaseManager.name,
-                        error: err as Error,
-                    });
-                }
-            }
+            // Finding 2 fix: do NOT delete the sandbox here — active leases
+            // may still be using it. The reaper will clean up when all leases
+            // release and the TTL expires.
             throw new Error(
                 `SandboxLeaseManager: sandbox invalidated for prKey="${prKey}"`,
             );

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
@@ -263,6 +263,7 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                 const claimed = await this.leaseRepo.claimCleanup(
                     prKey,
                     updated.sandboxId,
+                    true,
                 );
                 if (claimed) {
                     try {
@@ -390,6 +391,7 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                 const claimed = await this.leaseRepo.claimCleanup(
                     prKey,
                     doc.sandboxId,
+                    true,
                 );
                 if (claimed) {
                     try {
@@ -527,6 +529,8 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                 try {
                     await deleteLocalSandbox(sandboxId);
                 } catch (cleanupErr) {
+                    // Local cleanup failed — persist retry marker and DON'T
+                    // delete lease doc so the reaper can retry.
                     try {
                         await this.leaseRepo.failCleanup(
                             prKey,
@@ -540,6 +544,7 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                             error: markerErr as Error,
                         });
                     }
+                    throw err;
                 }
             }
             // If a real E2B sandbox was created but a later step failed
@@ -557,7 +562,7 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                     await Sandbox.kill(sandboxId, { apiKey }).catch(() => {});
                 }
             }
-            // Remove the lease doc so other callers don't poll forever
+            // Remove lease doc only if local cleanup succeeded or E2B/null path
             await this.leaseRepo.delete(prKey).catch(() => {});
             throw err;
         }

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
@@ -19,6 +19,10 @@ import { calculateBackoffInterval } from '@libs/common/utils/polling';
 import { SandboxLeaseRepository } from '../repositories/sandbox-lease.repository';
 import { NULL_SANDBOX_INSTANCE } from '../providers/null-sandbox.service';
 import { buildE2BRemoteCommands } from '../providers/e2b-sandbox.service';
+import {
+    isLocalSandboxPath,
+    deleteLocalSandbox,
+} from './local-sandbox-cleanup.service';
 
 /**
  * Default idle timeout applied when the last lease on a sandbox is released.
@@ -155,7 +159,11 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
             metadata: { prKey, consumer },
         });
 
-        const doc = await this.leaseRepo.upsertAcquire(prKey, leaseTtlMs, consumer);
+        const doc = await this.leaseRepo.upsertAcquire(
+            prKey,
+            leaseTtlMs,
+            consumer,
+        );
         const leaseId = randomUUID();
 
         // A new acquire arrived — atomically clear any pending idle-kill so
@@ -175,12 +183,23 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
         // 1 on an existing READY doc) would wrongly cold-create another sandbox
         // instead of warm-resuming the one already on the lease doc.
         if (doc.state === 'CREATING' && doc.leaseCount === 1) {
-            return this.handleCreatorPath(prKey, leaseId, consumer, cloneParams);
+            return this.handleCreatorPath(
+                prKey,
+                leaseId,
+                consumer,
+                cloneParams,
+            );
         }
 
         // --- Path B: joiner — doc already existed or someone else is creating ---
         try {
-            return await this.handleJoinerPath(prKey, leaseId, consumer, doc.state, doc.sandboxId);
+            return await this.handleJoinerPath(
+                prKey,
+                leaseId,
+                consumer,
+                doc.state,
+                doc.sandboxId,
+            );
         } catch (err) {
             if (err instanceof SandboxStaleConnectionError) {
                 // Lease referenced a sandbox that E2B no longer has (idle-
@@ -218,10 +237,7 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
      * @kody arrives within seconds or much later; conversation uses the
      * 5min default because the user is interactive.
      */
-    async release(
-        leaseId: string,
-        opts?: { idleMs?: number },
-    ): Promise<void> {
+    async release(leaseId: string, opts?: { idleMs?: number }): Promise<void> {
         const prKey = this.leaseIdToPrKey.get(leaseId);
         if (!prKey) {
             this.logger.warn({
@@ -242,6 +258,48 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
         });
 
         if (updated && updated.leaseCount <= 0 && updated.sandboxId) {
+            // Local sandbox: immediate cleanup
+            if (isLocalSandboxPath(updated.sandboxId)) {
+                const claimed = await this.leaseRepo.claimCleanup(
+                    prKey,
+                    updated.sandboxId,
+                );
+                if (claimed) {
+                    try {
+                        await deleteLocalSandbox(updated.sandboxId);
+                        await this.leaseRepo.completeCleanup(
+                            prKey,
+                            updated.sandboxId,
+                        );
+                        this.logger.log({
+                            message: `SandboxLeaseManager: cleaned local sandbox sandboxId="${updated.sandboxId}" prKey="${prKey}"`,
+                            context: SandboxLeaseManager.name,
+                            metadata: {
+                                prKey,
+                                sandboxId: updated.sandboxId,
+                            },
+                        });
+                    } catch (err) {
+                        await this.leaseRepo.failCleanup(
+                            prKey,
+                            updated.sandboxId,
+                            (err as Error).message,
+                        );
+                        this.logger.warn({
+                            message: `SandboxLeaseManager: local cleanup failed, retry marker set sandboxId="${updated.sandboxId}"`,
+                            context: SandboxLeaseManager.name,
+                            error: err as Error,
+                            metadata: {
+                                prKey,
+                                sandboxId: updated.sandboxId,
+                            },
+                        });
+                    }
+                }
+                return;
+            }
+
+            // E2B path: existing idle-kill logic (unchanged)
             const idleMs = opts?.idleMs ?? IDLE_TIMEOUT_MS;
             const killAt = new Date(Date.now() + idleMs);
             await this.leaseRepo.setKillAt(prKey, killAt);
@@ -249,13 +307,20 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
             this.logger.log({
                 message: `SandboxLeaseManager: scheduled idle-kill at ${killAt.toISOString()} for sandboxId="${updated.sandboxId}"`,
                 context: SandboxLeaseManager.name,
-                metadata: { prKey, sandboxId: updated.sandboxId, idleTimeoutMs: idleMs, killAt },
+                metadata: {
+                    prKey,
+                    sandboxId: updated.sandboxId,
+                    idleTimeoutMs: idleMs,
+                    killAt,
+                },
             });
 
             const apiKey = this.configService.get<string>('API_E2B_KEY');
             if (apiKey) {
                 try {
-                    await Sandbox.setTimeout(updated.sandboxId, idleMs, { apiKey });
+                    await Sandbox.setTimeout(updated.sandboxId, idleMs, {
+                        apiKey,
+                    });
                 } catch (err) {
                     this.logger.warn({
                         message: `SandboxLeaseManager: failed to set E2B-side idle timeout on sandboxId="${updated.sandboxId}" (kill cron is the primary path)`,
@@ -299,6 +364,16 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
 
         if (doc.state === 'CREATING') {
             // Mid-create race: mark as INVALIDATED so the create path can detect and kill
+            // Local sandbox: mark invalidated (cleanup on creator failure or final release)
+            if (isLocalSandboxPath(doc.sandboxId)) {
+                await this.leaseRepo.markInvalidated(prKey);
+                this.logger.log({
+                    message: `SandboxLeaseManager: marked INVALIDATED (mid-create, local) prKey="${prKey}"`,
+                    context: SandboxLeaseManager.name,
+                    metadata: { prKey },
+                });
+                return;
+            }
             await this.leaseRepo.markInvalidated(prKey);
             this.logger.log({
                 message: `SandboxLeaseManager: marked INVALIDATED (mid-create) prKey="${prKey}"`,
@@ -309,6 +384,35 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
         }
 
         // READY or PAUSED: soft-drain then delete
+        // Local sandbox path
+        if (isLocalSandboxPath(doc.sandboxId)) {
+            if (doc.leaseCount <= 0) {
+                const claimed = await this.leaseRepo.claimCleanup(
+                    prKey,
+                    doc.sandboxId,
+                );
+                if (claimed) {
+                    try {
+                        await deleteLocalSandbox(doc.sandboxId);
+                        await this.leaseRepo.completeCleanup(
+                            prKey,
+                            doc.sandboxId,
+                        );
+                    } catch (err) {
+                        await this.leaseRepo.failCleanup(
+                            prKey,
+                            doc.sandboxId,
+                            (err as Error).message,
+                        );
+                    }
+                }
+            } else {
+                await this.leaseRepo.markInvalidated(prKey);
+            }
+            return;
+        }
+
+        // E2B path: soft-drain then delete
         if (doc.sandboxId) {
             const apiKey = this.configService.get<string>('API_E2B_KEY');
             if (apiKey) {
@@ -381,9 +485,16 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                 });
                 // Kill the sandbox we just created; it is orphaned
                 if (sandboxId) {
-                    const apiKey = this.configService.get<string>('API_E2B_KEY');
-                    if (apiKey) {
-                        await Sandbox.kill(sandboxId, { apiKey }).catch(() => {});
+                    if (isLocalSandboxPath(sandboxId)) {
+                        await deleteLocalSandbox(sandboxId).catch(() => {});
+                    } else {
+                        const apiKey =
+                            this.configService.get<string>('API_E2B_KEY');
+                        if (apiKey) {
+                            await Sandbox.kill(sandboxId, {
+                                apiKey,
+                            }).catch(() => {});
+                        }
                     }
                 }
                 // Clean up the invalidated doc
@@ -411,11 +522,31 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
 
             return { sandbox, leaseId, sandboxId, wasCreated: true };
         } catch (err) {
+            // Local sandbox cleanup on creator failure
+            if (sandboxId && isLocalSandboxPath(sandboxId)) {
+                try {
+                    await deleteLocalSandbox(sandboxId);
+                } catch (cleanupErr) {
+                    try {
+                        await this.leaseRepo.failCleanup(
+                            prKey,
+                            sandboxId,
+                            (cleanupErr as Error).message,
+                        );
+                    } catch (markerErr) {
+                        this.logger.error({
+                            message: `Failed to persist local cleanup retry marker for prKey="${prKey}"`,
+                            context: SandboxLeaseManager.name,
+                            error: markerErr as Error,
+                        });
+                    }
+                }
+            }
             // If a real E2B sandbox was created but a later step failed
             // (Mongo update, mid-create invalidation, etc.), kill it so it
             // doesn't run for the full ceiling burning quota. Null-sandbox
             // doesn't need killing — its sandboxId is empty.
-            if (sandboxId) {
+            else if (sandboxId) {
                 const apiKey = this.configService.get<string>('API_E2B_KEY');
                 if (apiKey) {
                     this.logger.warn({
@@ -511,7 +642,12 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
             }
 
             if (doc.state === 'READY' && doc.sandboxId) {
-                return this.connectToExisting(prKey, leaseId, consumer, doc.sandboxId);
+                return this.connectToExisting(
+                    prKey,
+                    leaseId,
+                    consumer,
+                    doc.sandboxId,
+                );
             }
         }
 
@@ -566,7 +702,11 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
             throw new SandboxStaleConnectionError(prKey, sandboxId);
         }
 
-        const sandbox: SandboxInstance = this.buildSandboxInstance(e2bSandbox, prKey, leaseId);
+        const sandbox: SandboxInstance = this.buildSandboxInstance(
+            e2bSandbox,
+            prKey,
+            leaseId,
+        );
         this.leaseIdToPrKey.set(leaseId, prKey);
 
         this.logger.log({
@@ -582,7 +722,11 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
      * Build a minimal SandboxInstance wrapping an existing connected E2B sandbox.
      * This is used by the joiner path when connecting to an already-READY sandbox.
      */
-    private buildSandboxInstance(e2bSandbox: Sandbox, prKey: string, leaseId: string): SandboxInstance {
+    private buildSandboxInstance(
+        e2bSandbox: Sandbox,
+        prKey: string,
+        leaseId: string,
+    ): SandboxInstance {
         return {
             // Single shared implementation (see e2b-sandbox.service.ts) — resolves
             // paths against the repo root, surfaces errors, logs empty reads.
@@ -626,7 +770,10 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
      * Build a null sandbox with a release-bound cleanup function.
      * Used when E2B is not configured or when connect is not needed.
      */
-    private buildNullSandboxWithRelease(prKey: string, leaseId: string): SandboxInstance {
+    private buildNullSandboxWithRelease(
+        prKey: string,
+        leaseId: string,
+    ): SandboxInstance {
         return {
             ...NULL_SANDBOX_INSTANCE,
             cleanup: async () => {

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
@@ -488,7 +488,15 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                 // Kill the sandbox we just created; it is orphaned
                 if (sandboxId) {
                     if (isLocalSandboxPath(sandboxId)) {
-                        await deleteLocalSandbox(sandboxId).catch(() => {});
+                        try {
+                            await deleteLocalSandbox(sandboxId);
+                        } catch (localErr) {
+                            this.logger.warn({
+                                message: `SandboxLeaseManager: Failed to clean local sandbox after mid-create invalidation prKey="${prKey}"`,
+                                context: SandboxLeaseManager.name,
+                                error: localErr as Error,
+                            });
+                        }
                     } else {
                         const apiKey =
                             this.configService.get<string>('API_E2B_KEY');
@@ -529,19 +537,22 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                 try {
                     await deleteLocalSandbox(sandboxId);
                 } catch (cleanupErr) {
-                    // Local cleanup failed — persist retry marker and DON'T
-                    // delete lease doc so the reaper can retry.
-                    try {
+                    // Claim cleanup first, then mark as failed
+                    const claimed = await this.leaseRepo.claimCleanup(
+                        prKey,
+                        sandboxId,
+                    );
+                    if (claimed) {
                         await this.leaseRepo.failCleanup(
                             prKey,
                             sandboxId,
                             (cleanupErr as Error).message,
                         );
-                    } catch (markerErr) {
-                        this.logger.error({
-                            message: `Failed to persist local cleanup retry marker for prKey="${prKey}"`,
+                    } else {
+                        this.logger.warn({
+                            message: `SandboxLeaseManager: local cleanup failed but sandboxId not on doc — directory may be orphaned prKey="${prKey}" sandboxId="${sandboxId}"`,
                             context: SandboxLeaseManager.name,
-                            error: markerErr as Error,
+                            error: cleanupErr as Error,
                         });
                     }
                     throw err;
@@ -613,6 +624,18 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
         sandboxId?: string,
     ): Promise<AcquireResult> {
         if (state === 'INVALIDATED') {
+            // Clean up local sandbox directory if applicable
+            if (sandboxId && isLocalSandboxPath(sandboxId)) {
+                try {
+                    await deleteLocalSandbox(sandboxId);
+                } catch (err) {
+                    this.logger.warn({
+                        message: `SandboxLeaseManager: failed to clean local sandbox on INVALIDATED prKey="${prKey}" sandboxId="${sandboxId}"`,
+                        context: SandboxLeaseManager.name,
+                        error: err as Error,
+                    });
+                }
+            }
             throw new Error(
                 `SandboxLeaseManager: sandbox invalidated for prKey="${prKey}"`,
             );

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
@@ -109,6 +109,16 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
     private readonly logger = createLogger(SandboxLeaseManager.name);
 
     /**
+     * Lease invariants:
+     * - Only CREATING and READY leases are acquire targets; FAILED and
+     *   INVALIDATED leases are rejected.
+     * - Release/invalidate cleanup requires leaseCount <= 0; expired reaping
+     *   force-cleans because the owning worker is presumed dead.
+     * - Cleanup claims and deletes stay bound to the expected sandboxId and
+     *   cleanup status so a replacement lease cannot remove another sandbox.
+     */
+
+    /**
      * In-memory map from leaseId → prKey.
      *
      * Multi-worker note: leaseId is generated and consumed inside the same
@@ -183,6 +193,13 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
             }
             // Retry acquire from scratch
             return this.acquire(prKey, consumer, leaseTtlMs, cloneParams);
+        }
+
+        if (doc.cleanupStatus === SANDBOX_LEASE_CLEANUP_STATUS.FAILED) {
+            await this.leaseRepo.decrementLease(prKey);
+            throw new Error(
+                `SandboxLeaseManager: local cleanup previously failed for prKey="${prKey}"`,
+            );
         }
 
         // Acquire-vs-invalidated race: upsertAcquire() already incremented
@@ -445,6 +462,14 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                             doc.sandboxId,
                             (err as Error).message,
                         );
+                    }
+                } else {
+                    const latest = await this.leaseRepo.findByPrKey(prKey);
+                    if (
+                        latest?.sandboxId === doc.sandboxId &&
+                        latest.state === 'READY'
+                    ) {
+                        await this.leaseRepo.markInvalidated(prKey);
                     }
                 }
             } else {

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
@@ -186,19 +186,21 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
         }
 
         // Acquire-vs-invalidated race: upsertAcquire() already incremented
-        // leaseCount, but the doc is INVALIDATED. If we proceed to
-        // handleJoinerPath it will throw without decrementing, leaking the
-        // count. Undo the increment, delete the stale doc, and retry so
-        // the next acquire creates a fresh lease.
+        // leaseCount, but the doc is INVALIDATED. Undo the increment so it
+        // doesn't block cleanup. Do NOT delete the doc — a concurrent creator
+        // may still need to observe the INVALIDATED state, and the reaper
+        // handles stale doc cleanup. Throw so the caller knows the acquire
+        // failed; the caller can retry with a fresh acquire if needed.
         if (doc.state === 'INVALIDATED') {
-            await this.leaseRepo.decrementLease(prKey);
-            await this.leaseRepo.delete(prKey);
+            const updated = await this.leaseRepo.decrementLease(prKey);
             this.logger.log({
-                message: `SandboxLeaseManager: acquired INVALIDATED doc, cleaned up stale lease prKey="${prKey}"`,
+                message: `SandboxLeaseManager: acquired INVALIDATED doc, decremented lease prKey="${prKey}" leaseCount=${updated?.leaseCount ?? 'unknown'}`,
                 context: SandboxLeaseManager.name,
-                metadata: { prKey },
+                metadata: { prKey, leaseCount: updated?.leaseCount },
             });
-            return this.acquire(prKey, consumer, leaseTtlMs, cloneParams);
+            throw new Error(
+                `SandboxLeaseManager: sandbox invalidated for prKey="${prKey}"`,
+            );
         }
 
         const leaseId = randomUUID();

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
@@ -1150,9 +1150,9 @@ describe('SandboxLeaseManager', () => {
                 state: 'INVALIDATED',
             } as any);
 
-            await expect(
-                manager.acquire(prKey, 'review'),
-            ).rejects.toThrow(/sandbox invalidated/);
+            await expect(manager.acquire(prKey, 'review')).rejects.toThrow(
+                /sandbox invalidated/,
+            );
 
             // Must decrement the leaked leaseCount
             expect(leaseRepo.decrementLease).toHaveBeenCalledWith(prKey);
@@ -1944,9 +1944,9 @@ describe('SandboxLeaseManager reconnect RemoteCommands (blind-read fix)', () => 
             makeFakeE2bSandbox(run),
         );
 
-        await expect(remoteCommands.grep('x', '/etc', undefined)).rejects.toThrow(
-            /Absolute/,
-        );
+        await expect(
+            remoteCommands.grep('x', '/etc', undefined),
+        ).rejects.toThrow(/Absolute/);
         await expect(
             remoteCommands.grep('x', '../secrets', undefined),
         ).rejects.toThrow(/\.\./);
@@ -1966,7 +1966,9 @@ describe('SandboxLeaseManager reconnect RemoteCommands (blind-read fix)', () => 
             .mockImplementation(() => undefined);
 
         // prKey passed by buildReconnectCommands is 'org:repo:225'.
-        await expect(remoteCommands.read('x.ts', 1, 10)).rejects.toThrow(/boom/);
+        await expect(remoteCommands.read('x.ts', 1, 10)).rejects.toThrow(
+            /boom/,
+        );
         expect(warnSpy).toHaveBeenCalledWith(
             expect.objectContaining({
                 metadata: expect.objectContaining({

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
@@ -44,6 +44,9 @@ function makeMockLeaseRepo(): jest.Mocked<SandboxLeaseRepository> {
         setKillAt: jest.fn().mockResolvedValue(undefined),
         clearKillAt: jest.fn().mockResolvedValue(undefined),
         findReadyToKill: jest.fn().mockResolvedValue([]),
+        claimCleanup: jest.fn().mockResolvedValue(null),
+        completeCleanup: jest.fn().mockResolvedValue(true),
+        failCleanup: jest.fn().mockResolvedValue(true),
     } as unknown as jest.Mocked<SandboxLeaseRepository>;
 }
 
@@ -783,6 +786,144 @@ describe('SandboxLeaseManager', () => {
         });
         // Doc cleaned up
         expect(leaseRepo.delete).toHaveBeenCalledWith(prKey);
+    });
+
+    // ─── Local sandbox cleanup tests ─────────────────────────────────────
+
+    describe('local sandbox cleanup', () => {
+        it('cleans local dir immediately when leaseCount reaches zero on release', async () => {
+            const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:42';
+            const os = require('os');
+            const path = require('path');
+            const localSandboxId = path.join(
+                os.tmpdir(),
+                'kodus-sandbox-abc123',
+            );
+
+            leaseRepo.upsertAcquire.mockResolvedValue({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'CREATING',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+            leaseRepo.findByPrKey.mockResolvedValue({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'READY',
+                sandboxId: localSandboxId,
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+
+            sandboxProvider.createSandboxWithRepo.mockResolvedValue({
+                type: 'local',
+                sandboxId: localSandboxId,
+                cleanup: jest.fn(),
+                remoteCommands: {} as any,
+                run: jest.fn(),
+                readFile: jest.fn(),
+                writeFile: jest.fn(),
+                repoDir: localSandboxId,
+            } as any);
+
+            const result = await manager.acquire(prKey, 'review', undefined, {
+                cloneUrl: 'https://github.com/org/repo.git',
+                authToken: 'token',
+                branch: 'feature',
+                prNumber: 42,
+                platform: 'GITHUB' as any,
+            });
+
+            leaseRepo.decrementLease.mockResolvedValue({
+                _id: prKey,
+                leaseCount: 0,
+                state: 'READY',
+                sandboxId: localSandboxId,
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+            leaseRepo.claimCleanup.mockResolvedValue({
+                _id: prKey,
+                sandboxId: localSandboxId,
+                cleanupStatus: 'in_progress',
+            } as any);
+            leaseRepo.completeCleanup.mockResolvedValue(true);
+
+            await manager.release(result.leaseId);
+
+            expect(leaseRepo.claimCleanup).toHaveBeenCalledWith(
+                prKey,
+                localSandboxId,
+            );
+            expect(leaseRepo.completeCleanup).toHaveBeenCalledWith(
+                prKey,
+                localSandboxId,
+            );
+            expect(leaseRepo.setKillAt).not.toHaveBeenCalled();
+            expect(Sandbox.setTimeout).not.toHaveBeenCalled();
+        });
+
+        it('does not delete a fresh lease with different sandboxId', async () => {
+            const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:43';
+            const os = require('os');
+            const path = require('path');
+            const oldSandboxId = path.join(os.tmpdir(), 'kodus-sandbox-old');
+
+            leaseRepo.claimCleanup.mockResolvedValue(null);
+
+            leaseRepo.decrementLease.mockResolvedValue({
+                _id: prKey,
+                leaseCount: 0,
+                state: 'READY',
+                sandboxId: oldSandboxId,
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+
+            leaseRepo.upsertAcquire.mockResolvedValue({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'CREATING',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+            leaseRepo.findByPrKey.mockResolvedValue({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'READY',
+                sandboxId: oldSandboxId,
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+            sandboxProvider.createSandboxWithRepo.mockResolvedValue({
+                type: 'local',
+                sandboxId: oldSandboxId,
+                cleanup: jest.fn(),
+                remoteCommands: {} as any,
+                run: jest.fn(),
+                readFile: jest.fn(),
+                writeFile: jest.fn(),
+                repoDir: oldSandboxId,
+            } as any);
+
+            const result = await manager.acquire(prKey, 'review', undefined, {
+                cloneUrl: 'https://github.com/org/repo.git',
+                authToken: 'token',
+                branch: 'feature',
+                prNumber: 43,
+                platform: 'GITHUB' as any,
+            });
+
+            await manager.release(result.leaseId);
+
+            expect(leaseRepo.claimCleanup).toHaveBeenCalledWith(
+                prKey,
+                oldSandboxId,
+            );
+            expect(leaseRepo.completeCleanup).not.toHaveBeenCalled();
+            expect(leaseRepo.failCleanup).not.toHaveBeenCalled();
+        });
     });
 });
 

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
@@ -1070,7 +1070,10 @@ describe('SandboxLeaseManager', () => {
             const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:46';
             const os = require('os');
             const path = require('path');
-            const localSandboxId = path.join(os.tmpdir(), 'kodus-sandbox-orphan');
+            const localSandboxId = path.join(
+                os.tmpdir(),
+                'kodus-sandbox-orphan',
+            );
             const cloneParams = {
                 cloneUrl: 'https://github.com/org/repo.git',
                 authToken: 'token',
@@ -1123,35 +1126,125 @@ describe('SandboxLeaseManager', () => {
             expect(leaseRepo.delete).not.toHaveBeenCalled();
         });
 
-        it('joiner path throws on INVALIDATED state without deleting local sandbox', async () => {
+        it('acquire on INVALIDATED decrements leaseCount, deletes stale doc, retries', async () => {
             const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:47';
             const os = require('os');
             const path = require('path');
-            const localSandboxId = path.join(os.tmpdir(), 'kodus-sandbox-invalidated');
+            const localSandboxId = path.join(
+                os.tmpdir(),
+                'kodus-sandbox-invalidated',
+            );
 
-            leaseRepo.upsertAcquire.mockResolvedValue({
+            // First call: INVALIDATED (race with invalidate())
+            leaseRepo.upsertAcquire
+                .mockResolvedValueOnce({
+                    _id: prKey,
+                    leaseCount: 2,
+                    state: 'INVALIDATED',
+                    sandboxId: localSandboxId,
+                    createdAt: new Date(),
+                    expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+                } as any)
+                // Retry: fresh CREATING doc
+                .mockResolvedValueOnce({
+                    _id: prKey,
+                    leaseCount: 1,
+                    state: 'CREATING',
+                    createdAt: new Date(),
+                    expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+                } as any);
+
+            leaseRepo.decrementLease.mockResolvedValue({
                 _id: prKey,
-                leaseCount: 2,
+                leaseCount: 1,
                 state: 'INVALIDATED',
-                sandboxId: localSandboxId,
+            } as any);
+
+            leaseRepo.findByPrKey.mockResolvedValue({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'READY',
+                sandboxId: '',
                 createdAt: new Date(),
                 expiresAt: new Date(Date.now() + 30 * 60 * 1000),
             } as any);
 
-            await expect(
-                manager.acquire(prKey, 'review'),
-            ).rejects.toThrow(/sandbox invalidated/);
+            const result = await manager.acquire(prKey, 'review');
 
-            // Finding 2 fix: must NOT delete sandbox on INVALIDATED —
-            // active leases may still be using it
+            // Must NOT delete the local sandbox — active leases may still use it
             expect(localCleanup.deleteLocalSandbox).not.toHaveBeenCalled();
+            // Must decrement the leaked leaseCount
+            expect(leaseRepo.decrementLease).toHaveBeenCalledWith(prKey);
+            // Must delete the stale INVALIDATED doc
+            expect(leaseRepo.delete).toHaveBeenCalledWith(prKey);
+            // Retry succeeded
+            expect(result.sandbox).toBeDefined();
+        });
+
+        it('acquire on INVALIDATED local lease decrements leaseCount and retries', async () => {
+            const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:48';
+            const os = require('os');
+            const path = require('path');
+            const localSandboxId = path.join(
+                os.tmpdir(),
+                'kodus-sandbox-inval-race',
+            );
+
+            // First upsertAcquire: returns INVALIDATED doc (lease was invalidated
+            // while this acquire was in flight). leaseCount was incremented by
+            // upsertAcquire but the acquire must not leak it.
+            leaseRepo.upsertAcquire
+                .mockResolvedValueOnce({
+                    _id: prKey,
+                    leaseCount: 2,
+                    state: 'INVALIDATED',
+                    sandboxId: localSandboxId,
+                    createdAt: new Date(),
+                    expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+                } as any)
+                // Second upsertAcquire (retry): fresh CREATING doc
+                .mockResolvedValueOnce({
+                    _id: prKey,
+                    leaseCount: 1,
+                    state: 'CREATING',
+                    createdAt: new Date(),
+                    expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+                } as any);
+
+            leaseRepo.decrementLease.mockResolvedValue({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'INVALIDATED',
+            } as any);
+
+            leaseRepo.findByPrKey.mockResolvedValue({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'READY',
+                sandboxId: '',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+
+            const result = await manager.acquire(prKey, 'review');
+
+            // leaseCount was decremented to undo the leaked increment
+            expect(leaseRepo.decrementLease).toHaveBeenCalledWith(prKey);
+            // Stale INVALIDATED doc was deleted
+            expect(leaseRepo.delete).toHaveBeenCalledWith(prKey);
+            // acquire retried and succeeded
+            expect(result.sandbox).toBeDefined();
+            expect(leaseRepo.upsertAcquire).toHaveBeenCalledTimes(2);
         });
 
         it('mid-create invalidation preserves lease doc when local cleanup fails', async () => {
             const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:88';
             const os = require('os');
             const path = require('path');
-            const localSandboxId = path.join(os.tmpdir(), 'kodus-sandbox-mid-create');
+            const localSandboxId = path.join(
+                os.tmpdir(),
+                'kodus-sandbox-mid-create',
+            );
             const cloneParams = {
                 cloneUrl: 'https://github.com/org/repo.git',
                 authToken: 'token',

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
@@ -1043,18 +1043,166 @@ describe('SandboxLeaseManager', () => {
                 new Error('ENOENT: dir locked'),
             );
 
+            // Mock claimCleanup to return a doc (sandboxId is on doc)
+            leaseRepo.claimCleanup.mockResolvedValue({
+                _id: prKey,
+                sandboxId: localSandboxId,
+                cleanupStatus: 'in_progress',
+            } as any);
+
             await expect(
                 manager.acquire(prKey, 'review', undefined, cloneParams),
             ).rejects.toThrow(/Mongo connection lost/);
 
-            // failCleanup called to persist retry marker
+            expect(leaseRepo.claimCleanup).toHaveBeenCalledWith(
+                prKey,
+                localSandboxId,
+            );
             expect(leaseRepo.failCleanup).toHaveBeenCalledWith(
                 prKey,
                 localSandboxId,
                 'ENOENT: dir locked',
             );
-            // Lease doc NOT deleted — reaper will retry
             expect(leaseRepo.delete).not.toHaveBeenCalled();
+        });
+
+        it('creator failure logs warning when sandboxId not on doc', async () => {
+            const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:46';
+            const os = require('os');
+            const path = require('path');
+            const localSandboxId = path.join(os.tmpdir(), 'kodus-sandbox-orphan');
+            const cloneParams = {
+                cloneUrl: 'https://github.com/org/repo.git',
+                authToken: 'token',
+                branch: 'feature',
+                prNumber: 46,
+                platform: 'GITHUB' as any,
+            };
+
+            leaseRepo.upsertAcquire.mockResolvedValue({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'CREATING',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+
+            sandboxProvider.createSandboxWithRepo.mockResolvedValue({
+                type: 'local',
+                sandboxId: localSandboxId,
+                cleanup: jest.fn(),
+                remoteCommands: {} as any,
+                run: jest.fn(),
+                readFile: jest.fn(),
+                writeFile: jest.fn(),
+                repoDir: localSandboxId,
+            } as any);
+
+            // updateReady fails AFTER the local sandbox was created
+            leaseRepo.updateReady.mockRejectedValue(
+                new Error('Mongo connection lost'),
+            );
+
+            // Mock deleteLocalSandbox to throw so cleanup fails
+            (localCleanup.deleteLocalSandbox as jest.Mock).mockRejectedValue(
+                new Error('ENOENT: dir locked'),
+            );
+
+            // Mock claimCleanup to return null (sandboxId not on doc)
+            leaseRepo.claimCleanup.mockResolvedValue(null);
+
+            await expect(
+                manager.acquire(prKey, 'review', undefined, cloneParams),
+            ).rejects.toThrow(/Mongo connection lost/);
+
+            expect(leaseRepo.claimCleanup).toHaveBeenCalledWith(
+                prKey,
+                localSandboxId,
+            );
+            expect(leaseRepo.failCleanup).not.toHaveBeenCalled();
+            expect(leaseRepo.delete).not.toHaveBeenCalled();
+        });
+
+        it('joiner path cleans local sandbox on INVALIDATED state', async () => {
+            const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:47';
+            const os = require('os');
+            const path = require('path');
+            const localSandboxId = path.join(os.tmpdir(), 'kodus-sandbox-invalidated');
+
+            // First acquire: joiner path with INVALIDATED state
+            leaseRepo.upsertAcquire.mockResolvedValue({
+                _id: prKey,
+                leaseCount: 2,
+                state: 'INVALIDATED',
+                sandboxId: localSandboxId,
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+
+            await expect(
+                manager.acquire(prKey, 'review'),
+            ).rejects.toThrow(/sandbox invalidated/);
+
+            expect(localCleanup.deleteLocalSandbox).toHaveBeenCalledWith(
+                localSandboxId,
+            );
+        });
+
+        it('mid-create invalidation logs local cleanup errors instead of swallowing', async () => {
+            const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:88';
+            const os = require('os');
+            const path = require('path');
+            const localSandboxId = path.join(os.tmpdir(), 'kodus-sandbox-mid-create');
+            const cloneParams = {
+                cloneUrl: 'https://github.com/org/repo.git',
+                authToken: 'token',
+                branch: 'feature',
+                prNumber: 88,
+                platform: 'GITHUB' as any,
+            };
+
+            leaseRepo.upsertAcquire.mockResolvedValue({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'CREATING',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+
+            sandboxProvider.createSandboxWithRepo.mockResolvedValue({
+                type: 'local',
+                sandboxId: localSandboxId,
+                cleanup: jest.fn(),
+                remoteCommands: {} as any,
+                run: jest.fn(),
+                readFile: jest.fn(),
+                writeFile: jest.fn(),
+                repoDir: localSandboxId,
+            } as any);
+
+            // Post-create check returns INVALIDATED
+            leaseRepo.findByPrKey.mockResolvedValue({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'INVALIDATED',
+                sandboxId: localSandboxId,
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+
+            // Mock deleteLocalSandbox to throw
+            (localCleanup.deleteLocalSandbox as jest.Mock).mockRejectedValue(
+                new Error('Permission denied'),
+            );
+
+            await expect(
+                manager.acquire(prKey, 'review', undefined, cloneParams),
+            ).rejects.toThrow(/invalidated mid-create/);
+
+            expect(localCleanup.deleteLocalSandbox).toHaveBeenCalledWith(
+                localSandboxId,
+            );
+            expect(leaseRepo.delete).toHaveBeenCalledWith(prKey);
         });
     });
 });
@@ -1500,6 +1648,12 @@ describe('SandboxLeaseReaperService', () => {
                 state: 'READY',
             } as any,
         ]);
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: 'org:repo:stale',
+            sandboxId: localSandboxId,
+            leaseCount: 0,
+            state: 'READY',
+        } as any);
         leaseRepo.claimCleanup.mockResolvedValue({
             _id: 'org:repo:stale',
             sandboxId: localSandboxId,
@@ -1520,6 +1674,8 @@ describe('SandboxLeaseReaperService', () => {
 
         await reaper.reapExpiredLeases();
 
+        expect(leaseRepo.findByPrKey).toHaveBeenCalledWith('org:repo:stale');
+        expect(leaseRepo.resetStaleCleanup).toHaveBeenCalledTimes(1);
         expect(leaseRepo.resetStaleCleanup).toHaveBeenCalledWith(
             'org:repo:stale',
             expect.any(Date),
@@ -1532,6 +1688,46 @@ describe('SandboxLeaseReaperService', () => {
             'org:repo:stale',
             localSandboxId,
         );
+    });
+
+    it('cleanupLocalLease skips when concurrent acquire bumped leaseCount', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+        const os = require('os');
+        const path = require('path');
+        const localSandboxId = path.join(os.tmpdir(), 'kodus-sandbox-race');
+
+        leaseRepo.findExpired.mockResolvedValue([
+            {
+                _id: 'org:repo:race',
+                sandboxId: localSandboxId,
+                state: 'READY',
+            } as any,
+        ]);
+        // Concurrent acquire bumped leaseCount to 1
+        leaseRepo.findByPrKey.mockResolvedValue({
+            _id: 'org:repo:race',
+            sandboxId: localSandboxId,
+            leaseCount: 1,
+            state: 'READY',
+        } as any);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        await reaper.reapExpiredLeases();
+
+        expect(leaseRepo.findByPrKey).toHaveBeenCalledWith('org:repo:race');
+        expect(leaseRepo.claimCleanup).not.toHaveBeenCalled();
+        expect(leaseRepo.completeCleanup).not.toHaveBeenCalled();
     });
 });
 

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
@@ -1126,7 +1126,7 @@ describe('SandboxLeaseManager', () => {
             expect(leaseRepo.delete).not.toHaveBeenCalled();
         });
 
-        it('acquire on INVALIDATED decrements leaseCount, deletes stale doc, retries', async () => {
+        it('acquire on INVALIDATED decrements leaseCount without deleting doc', async () => {
             const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:47';
             const os = require('os');
             const path = require('path');
@@ -1135,24 +1135,14 @@ describe('SandboxLeaseManager', () => {
                 'kodus-sandbox-invalidated',
             );
 
-            // First call: INVALIDATED (race with invalidate())
-            leaseRepo.upsertAcquire
-                .mockResolvedValueOnce({
-                    _id: prKey,
-                    leaseCount: 2,
-                    state: 'INVALIDATED',
-                    sandboxId: localSandboxId,
-                    createdAt: new Date(),
-                    expiresAt: new Date(Date.now() + 30 * 60 * 1000),
-                } as any)
-                // Retry: fresh CREATING doc
-                .mockResolvedValueOnce({
-                    _id: prKey,
-                    leaseCount: 1,
-                    state: 'CREATING',
-                    createdAt: new Date(),
-                    expiresAt: new Date(Date.now() + 30 * 60 * 1000),
-                } as any);
+            leaseRepo.upsertAcquire.mockResolvedValue({
+                _id: prKey,
+                leaseCount: 2,
+                state: 'INVALIDATED',
+                sandboxId: localSandboxId,
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
 
             leaseRepo.decrementLease.mockResolvedValue({
                 _id: prKey,
@@ -1160,81 +1150,16 @@ describe('SandboxLeaseManager', () => {
                 state: 'INVALIDATED',
             } as any);
 
-            leaseRepo.findByPrKey.mockResolvedValue({
-                _id: prKey,
-                leaseCount: 1,
-                state: 'READY',
-                sandboxId: '',
-                createdAt: new Date(),
-                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
-            } as any);
+            await expect(
+                manager.acquire(prKey, 'review'),
+            ).rejects.toThrow(/sandbox invalidated/);
 
-            const result = await manager.acquire(prKey, 'review');
-
-            // Must NOT delete the local sandbox — active leases may still use it
-            expect(localCleanup.deleteLocalSandbox).not.toHaveBeenCalled();
             // Must decrement the leaked leaseCount
             expect(leaseRepo.decrementLease).toHaveBeenCalledWith(prKey);
-            // Must delete the stale INVALIDATED doc
-            expect(leaseRepo.delete).toHaveBeenCalledWith(prKey);
-            // Retry succeeded
-            expect(result.sandbox).toBeDefined();
-        });
-
-        it('acquire on INVALIDATED local lease decrements leaseCount and retries', async () => {
-            const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:48';
-            const os = require('os');
-            const path = require('path');
-            const localSandboxId = path.join(
-                os.tmpdir(),
-                'kodus-sandbox-inval-race',
-            );
-
-            // First upsertAcquire: returns INVALIDATED doc (lease was invalidated
-            // while this acquire was in flight). leaseCount was incremented by
-            // upsertAcquire but the acquire must not leak it.
-            leaseRepo.upsertAcquire
-                .mockResolvedValueOnce({
-                    _id: prKey,
-                    leaseCount: 2,
-                    state: 'INVALIDATED',
-                    sandboxId: localSandboxId,
-                    createdAt: new Date(),
-                    expiresAt: new Date(Date.now() + 30 * 60 * 1000),
-                } as any)
-                // Second upsertAcquire (retry): fresh CREATING doc
-                .mockResolvedValueOnce({
-                    _id: prKey,
-                    leaseCount: 1,
-                    state: 'CREATING',
-                    createdAt: new Date(),
-                    expiresAt: new Date(Date.now() + 30 * 60 * 1000),
-                } as any);
-
-            leaseRepo.decrementLease.mockResolvedValue({
-                _id: prKey,
-                leaseCount: 1,
-                state: 'INVALIDATED',
-            } as any);
-
-            leaseRepo.findByPrKey.mockResolvedValue({
-                _id: prKey,
-                leaseCount: 1,
-                state: 'READY',
-                sandboxId: '',
-                createdAt: new Date(),
-                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
-            } as any);
-
-            const result = await manager.acquire(prKey, 'review');
-
-            // leaseCount was decremented to undo the leaked increment
-            expect(leaseRepo.decrementLease).toHaveBeenCalledWith(prKey);
-            // Stale INVALIDATED doc was deleted
-            expect(leaseRepo.delete).toHaveBeenCalledWith(prKey);
-            // acquire retried and succeeded
-            expect(result.sandbox).toBeDefined();
-            expect(leaseRepo.upsertAcquire).toHaveBeenCalledTimes(2);
+            // Must NOT delete the doc — creator may still need to observe INVALIDATED
+            expect(leaseRepo.delete).not.toHaveBeenCalled();
+            // Must NOT delete the local sandbox — active leases may still use it
+            expect(localCleanup.deleteLocalSandbox).not.toHaveBeenCalled();
         });
 
         it('mid-create invalidation preserves lease doc when local cleanup fails', async () => {

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
@@ -1123,13 +1123,12 @@ describe('SandboxLeaseManager', () => {
             expect(leaseRepo.delete).not.toHaveBeenCalled();
         });
 
-        it('joiner path cleans local sandbox on INVALIDATED state', async () => {
+        it('joiner path throws on INVALIDATED state without deleting local sandbox', async () => {
             const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:47';
             const os = require('os');
             const path = require('path');
             const localSandboxId = path.join(os.tmpdir(), 'kodus-sandbox-invalidated');
 
-            // First acquire: joiner path with INVALIDATED state
             leaseRepo.upsertAcquire.mockResolvedValue({
                 _id: prKey,
                 leaseCount: 2,
@@ -1143,12 +1142,12 @@ describe('SandboxLeaseManager', () => {
                 manager.acquire(prKey, 'review'),
             ).rejects.toThrow(/sandbox invalidated/);
 
-            expect(localCleanup.deleteLocalSandbox).toHaveBeenCalledWith(
-                localSandboxId,
-            );
+            // Finding 2 fix: must NOT delete sandbox on INVALIDATED —
+            // active leases may still be using it
+            expect(localCleanup.deleteLocalSandbox).not.toHaveBeenCalled();
         });
 
-        it('mid-create invalidation logs local cleanup errors instead of swallowing', async () => {
+        it('mid-create invalidation preserves lease doc when local cleanup fails', async () => {
             const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:88';
             const os = require('os');
             const path = require('path');
@@ -1180,7 +1179,6 @@ describe('SandboxLeaseManager', () => {
                 repoDir: localSandboxId,
             } as any);
 
-            // Post-create check returns INVALIDATED
             leaseRepo.findByPrKey.mockResolvedValue({
                 _id: prKey,
                 leaseCount: 1,
@@ -1190,7 +1188,6 @@ describe('SandboxLeaseManager', () => {
                 expiresAt: new Date(Date.now() + 30 * 60 * 1000),
             } as any);
 
-            // Mock deleteLocalSandbox to throw
             (localCleanup.deleteLocalSandbox as jest.Mock).mockRejectedValue(
                 new Error('Permission denied'),
             );
@@ -1202,7 +1199,55 @@ describe('SandboxLeaseManager', () => {
             expect(localCleanup.deleteLocalSandbox).toHaveBeenCalledWith(
                 localSandboxId,
             );
-            expect(leaseRepo.delete).toHaveBeenCalledWith(prKey);
+            // Finding 4 fix: lease doc preserved so reaper can retry
+            expect(leaseRepo.delete).not.toHaveBeenCalled();
+        });
+
+        it('acquire waits for cleanup IN_PROGRESS then retries', async () => {
+            const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:50';
+
+            // First upsertAcquire returns doc with cleanupStatus IN_PROGRESS
+            // Second call (retry) returns normal CREATING doc
+            leaseRepo.upsertAcquire
+                .mockResolvedValueOnce({
+                    _id: prKey,
+                    leaseCount: 1,
+                    state: 'READY',
+                    cleanupStatus: 'in_progress',
+                    sandboxId: '/tmp/kodus-sandbox-cleanup-wait',
+                    createdAt: new Date(),
+                    expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+                } as any)
+                .mockResolvedValueOnce({
+                    _id: prKey,
+                    leaseCount: 1,
+                    state: 'CREATING',
+                    createdAt: new Date(),
+                    expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+                } as any);
+
+            // Poll finds doc gone (cleanup completed)
+            leaseRepo.findByPrKey.mockResolvedValue(null);
+
+            // Post-create check: READY
+            leaseRepo.findByPrKey.mockResolvedValue({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'READY',
+                sandboxId: '',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+
+            jest.useFakeTimers();
+            const acquirePromise = manager.acquire(prKey, 'review');
+            await jest.runAllTimersAsync();
+            const result = await acquirePromise;
+            jest.useRealTimers();
+
+            expect(result.sandbox).toBeDefined();
+            // Two upsertAcquire calls: first hit IN_PROGRESS, second succeeded
+            expect(leaseRepo.upsertAcquire).toHaveBeenCalledTimes(2);
         });
     });
 });
@@ -1683,6 +1728,7 @@ describe('SandboxLeaseReaperService', () => {
         expect(leaseRepo.claimCleanup).toHaveBeenCalledWith(
             'org:repo:stale',
             localSandboxId,
+            true,
         );
         expect(leaseRepo.completeCleanup).toHaveBeenCalledWith(
             'org:repo:stale',

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
@@ -1001,6 +1001,35 @@ describe('SandboxLeaseManager', () => {
             expect(leaseRepo.completeCleanup).not.toHaveBeenCalled();
         });
 
+        it('invalidates a READY local lease when cleanup claim loses a race', async () => {
+            const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:46';
+            const os = require('os');
+            const path = require('path');
+            const localSandboxId = path.join(
+                os.tmpdir(),
+                'kodus-sandbox-invalidate-race',
+            );
+
+            leaseRepo.findByPrKey
+                .mockResolvedValueOnce({
+                    _id: prKey,
+                    leaseCount: 0,
+                    state: 'READY',
+                    sandboxId: localSandboxId,
+                } as any)
+                .mockResolvedValueOnce({
+                    _id: prKey,
+                    leaseCount: 1,
+                    state: 'READY',
+                    sandboxId: localSandboxId,
+                } as any);
+            leaseRepo.claimCleanup.mockResolvedValue(null);
+
+            await manager.invalidate(prKey);
+
+            expect(leaseRepo.markInvalidated).toHaveBeenCalledWith(prKey);
+        });
+
         it('creator failure on local sandbox preserves retry marker instead of deleting lease', async () => {
             const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:45';
             const os = require('os');
@@ -1160,6 +1189,36 @@ describe('SandboxLeaseManager', () => {
             expect(leaseRepo.delete).not.toHaveBeenCalled();
             // Must NOT delete the local sandbox — active leases may still use it
             expect(localCleanup.deleteLocalSandbox).not.toHaveBeenCalled();
+        });
+
+        it('acquire rejects a local lease with FAILED cleanup', async () => {
+            const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:48';
+            const os = require('os');
+            const path = require('path');
+            const localSandboxId = path.join(
+                os.tmpdir(),
+                'kodus-sandbox-failed',
+            );
+
+            leaseRepo.upsertAcquire.mockResolvedValue({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'READY',
+                sandboxId: localSandboxId,
+                cleanupStatus: 'failed',
+            } as any);
+            leaseRepo.decrementLease.mockResolvedValue({
+                _id: prKey,
+                leaseCount: 0,
+                state: 'READY',
+                sandboxId: localSandboxId,
+                cleanupStatus: 'failed',
+            } as any);
+
+            await expect(manager.acquire(prKey, 'review')).rejects.toThrow(
+                /cleanup previously failed/,
+            );
+            expect(leaseRepo.decrementLease).toHaveBeenCalledWith(prKey);
         });
 
         it('mid-create invalidation preserves lease doc when local cleanup fails', async () => {
@@ -1697,7 +1756,7 @@ describe('SandboxLeaseReaperService', () => {
         expect(leaseRepo.delete).toHaveBeenCalledTimes(3);
     });
 
-    it('cleanupLocalLease resets stale in_progress claims before claiming', async () => {
+    it('reaper force-cleans expired local lease with leaked leaseCount', async () => {
         const leaseRepo = makeMockLeaseRepo();
         const configService = makeMockConfigService('test-e2b-key');
         const os = require('os');
@@ -1714,7 +1773,7 @@ describe('SandboxLeaseReaperService', () => {
         leaseRepo.findByPrKey.mockResolvedValue({
             _id: 'org:repo:stale',
             sandboxId: localSandboxId,
-            leaseCount: 0,
+            leaseCount: 1,
             state: 'READY',
         } as any);
         leaseRepo.claimCleanup.mockResolvedValue({
@@ -1746,7 +1805,7 @@ describe('SandboxLeaseReaperService', () => {
         expect(leaseRepo.claimCleanup).toHaveBeenCalledWith(
             'org:repo:stale',
             localSandboxId,
-            true,
+            false,
         );
         expect(leaseRepo.completeCleanup).toHaveBeenCalledWith(
             'org:repo:stale',
@@ -1754,14 +1813,14 @@ describe('SandboxLeaseReaperService', () => {
         );
     });
 
-    it('cleanupLocalLease skips when concurrent acquire bumped leaseCount', async () => {
+    it('idle local cleanup skips when concurrent acquire bumped leaseCount', async () => {
         const leaseRepo = makeMockLeaseRepo();
         const configService = makeMockConfigService('test-e2b-key');
         const os = require('os');
         const path = require('path');
         const localSandboxId = path.join(os.tmpdir(), 'kodus-sandbox-race');
 
-        leaseRepo.findExpired.mockResolvedValue([
+        leaseRepo.findReadyToKill.mockResolvedValue([
             {
                 _id: 'org:repo:race',
                 sandboxId: localSandboxId,
@@ -1787,7 +1846,7 @@ describe('SandboxLeaseReaperService', () => {
             configService,
         );
 
-        await reaper.reapExpiredLeases();
+        await reaper.killIdleSandboxes();
 
         expect(leaseRepo.findByPrKey).toHaveBeenCalledWith('org:repo:race');
         expect(leaseRepo.claimCleanup).not.toHaveBeenCalled();

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
@@ -29,6 +29,12 @@ import {
     SandboxInstance,
 } from '@libs/sandbox/domain/contracts/sandbox.provider';
 import { ConfigService } from '@nestjs/config';
+import * as localCleanup from './local-sandbox-cleanup.service';
+
+jest.mock('./local-sandbox-cleanup.service', () => ({
+    ...jest.requireActual('./local-sandbox-cleanup.service'),
+    deleteLocalSandbox: jest.fn(),
+}));
 
 // ─── Shared test helpers ─────────────────────────────────────────────────────
 
@@ -47,6 +53,7 @@ function makeMockLeaseRepo(): jest.Mocked<SandboxLeaseRepository> {
         claimCleanup: jest.fn().mockResolvedValue(null),
         completeCleanup: jest.fn().mockResolvedValue(true),
         failCleanup: jest.fn().mockResolvedValue(true),
+        resetStaleCleanup: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<SandboxLeaseRepository>;
 }
 
@@ -108,6 +115,10 @@ describe('SandboxLeaseManager', () => {
 
     beforeEach(() => {
         jest.clearAllMocks();
+        (localCleanup.deleteLocalSandbox as jest.Mock).mockImplementation(
+            jest.requireActual('./local-sandbox-cleanup.service')
+                .deleteLocalSandbox,
+        );
         leaseRepo = makeMockLeaseRepo();
         sandboxProvider = makeMockSandboxProvider(true);
         configService = makeMockConfigService('test-e2b-key');
@@ -855,6 +866,7 @@ describe('SandboxLeaseManager', () => {
             expect(leaseRepo.claimCleanup).toHaveBeenCalledWith(
                 prKey,
                 localSandboxId,
+                true,
             );
             expect(leaseRepo.completeCleanup).toHaveBeenCalledWith(
                 prKey,
@@ -920,9 +932,129 @@ describe('SandboxLeaseManager', () => {
             expect(leaseRepo.claimCleanup).toHaveBeenCalledWith(
                 prKey,
                 oldSandboxId,
+                true,
             );
             expect(leaseRepo.completeCleanup).not.toHaveBeenCalled();
             expect(leaseRepo.failCleanup).not.toHaveBeenCalled();
+        });
+
+        it('skips local cleanup when concurrent acquire bumps leaseCount before claimCleanup', async () => {
+            const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:44';
+            const os = require('os');
+            const path = require('path');
+            const localSandboxId = path.join(os.tmpdir(), 'kodus-sandbox-race');
+
+            leaseRepo.upsertAcquire.mockResolvedValue({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'CREATING',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+            leaseRepo.findByPrKey.mockResolvedValue({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'READY',
+                sandboxId: localSandboxId,
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+            sandboxProvider.createSandboxWithRepo.mockResolvedValue({
+                type: 'local',
+                sandboxId: localSandboxId,
+                cleanup: jest.fn(),
+                remoteCommands: {} as any,
+                run: jest.fn(),
+                readFile: jest.fn(),
+                writeFile: jest.fn(),
+                repoDir: localSandboxId,
+            } as any);
+
+            const result = await manager.acquire(prKey, 'review', undefined, {
+                cloneUrl: 'https://github.com/org/repo.git',
+                authToken: 'token',
+                branch: 'feature',
+                prNumber: 44,
+                platform: 'GITHUB' as any,
+            });
+
+            // After decrement, leaseCount is 0 but a concurrent acquire
+            // already bumped it back to 1 — claimCleanup with
+            // requireLeaseCountZero=true returns null (filter doesn't match).
+            leaseRepo.decrementLease.mockResolvedValue({
+                _id: prKey,
+                leaseCount: 0,
+                state: 'READY',
+                sandboxId: localSandboxId,
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+            leaseRepo.claimCleanup.mockResolvedValue(null);
+
+            await manager.release(result.leaseId);
+
+            expect(leaseRepo.claimCleanup).toHaveBeenCalledWith(
+                prKey,
+                localSandboxId,
+                true,
+            );
+            expect(leaseRepo.completeCleanup).not.toHaveBeenCalled();
+        });
+
+        it('creator failure on local sandbox preserves retry marker instead of deleting lease', async () => {
+            const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:45';
+            const os = require('os');
+            const path = require('path');
+            const localSandboxId = path.join(os.tmpdir(), 'kodus-sandbox-fail');
+            const cloneParams = {
+                cloneUrl: 'https://github.com/org/repo.git',
+                authToken: 'token',
+                branch: 'feature',
+                prNumber: 45,
+                platform: 'GITHUB' as any,
+            };
+
+            leaseRepo.upsertAcquire.mockResolvedValue({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'CREATING',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+
+            sandboxProvider.createSandboxWithRepo.mockResolvedValue({
+                type: 'local',
+                sandboxId: localSandboxId,
+                cleanup: jest.fn(),
+                remoteCommands: {} as any,
+                run: jest.fn(),
+                readFile: jest.fn(),
+                writeFile: jest.fn(),
+                repoDir: localSandboxId,
+            } as any);
+
+            // updateReady fails AFTER the local sandbox was created
+            leaseRepo.updateReady.mockRejectedValue(
+                new Error('Mongo connection lost'),
+            );
+
+            // Mock deleteLocalSandbox to throw so cleanup fails
+            (localCleanup.deleteLocalSandbox as jest.Mock).mockRejectedValue(
+                new Error('ENOENT: dir locked'),
+            );
+
+            await expect(
+                manager.acquire(prKey, 'review', undefined, cloneParams),
+            ).rejects.toThrow(/Mongo connection lost/);
+
+            // failCleanup called to persist retry marker
+            expect(leaseRepo.failCleanup).toHaveBeenCalledWith(
+                prKey,
+                localSandboxId,
+                'ENOENT: dir locked',
+            );
+            // Lease doc NOT deleted — reaper will retry
+            expect(leaseRepo.delete).not.toHaveBeenCalled();
         });
     });
 });
@@ -934,6 +1066,9 @@ describe('SandboxLeaseReaperService', () => {
         jest.clearAllMocks();
         (Sandbox.kill as jest.Mock).mockReset();
         (Sandbox.kill as jest.Mock).mockResolvedValue(undefined);
+        (localCleanup.deleteLocalSandbox as jest.Mock).mockResolvedValue(
+            undefined,
+        );
     });
 
     it('reaper cleans ALL expired leases regardless of leaseCount (crashed-worker scenario)', async () => {
@@ -1349,6 +1484,54 @@ describe('SandboxLeaseReaperService', () => {
 
         // All 3 leases were deleted despite one kill failure
         expect(leaseRepo.delete).toHaveBeenCalledTimes(3);
+    });
+
+    it('cleanupLocalLease resets stale in_progress claims before claiming', async () => {
+        const leaseRepo = makeMockLeaseRepo();
+        const configService = makeMockConfigService('test-e2b-key');
+        const os = require('os');
+        const path = require('path');
+        const localSandboxId = path.join(os.tmpdir(), 'kodus-sandbox-stale');
+
+        leaseRepo.findExpired.mockResolvedValue([
+            {
+                _id: 'org:repo:stale',
+                sandboxId: localSandboxId,
+                state: 'READY',
+            } as any,
+        ]);
+        leaseRepo.claimCleanup.mockResolvedValue({
+            _id: 'org:repo:stale',
+            sandboxId: localSandboxId,
+            cleanupStatus: 'in_progress',
+        } as any);
+        leaseRepo.completeCleanup.mockResolvedValue(true);
+
+        const mockLock = { release: jest.fn().mockResolvedValue(undefined) };
+        const mockDistributedLockService = {
+            acquire: jest.fn().mockResolvedValue(mockLock),
+        };
+
+        const reaper = new SandboxLeaseReaperService(
+            leaseRepo,
+            mockDistributedLockService as any,
+            configService,
+        );
+
+        await reaper.reapExpiredLeases();
+
+        expect(leaseRepo.resetStaleCleanup).toHaveBeenCalledWith(
+            'org:repo:stale',
+            expect.any(Date),
+        );
+        expect(leaseRepo.claimCleanup).toHaveBeenCalledWith(
+            'org:repo:stale',
+            localSandboxId,
+        );
+        expect(leaseRepo.completeCleanup).toHaveBeenCalledWith(
+            'org:repo:stale',
+            localSandboxId,
+        );
     });
 });
 

--- a/libs/sandbox/infrastructure/services/sandbox-lease-reaper.service.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-reaper.service.ts
@@ -224,6 +224,10 @@ export class SandboxLeaseReaperService {
     }): Promise<void> {
         if (!lease.sandboxId || !isLocalSandboxPath(lease.sandboxId)) return;
 
+        // Re-check: a concurrent acquire may have bumped leaseCount
+        const current = await this.leaseRepository.findByPrKey(lease._id);
+        if (!current || (current.leaseCount ?? 0) > 0) return;
+
         const staleThreshold = new Date(Date.now() - 5 * 60 * 1000);
         await this.leaseRepository.resetStaleCleanup(lease._id, staleThreshold);
 

--- a/libs/sandbox/infrastructure/services/sandbox-lease-reaper.service.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-reaper.service.ts
@@ -224,6 +224,9 @@ export class SandboxLeaseReaperService {
     }): Promise<void> {
         if (!lease.sandboxId || !isLocalSandboxPath(lease.sandboxId)) return;
 
+        const staleThreshold = new Date(Date.now() - 5 * 60 * 1000);
+        await this.leaseRepository.resetStaleCleanup(lease._id, staleThreshold);
+
         const claimed = await this.leaseRepository.claimCleanup(
             lease._id,
             lease.sandboxId,

--- a/libs/sandbox/infrastructure/services/sandbox-lease-reaper.service.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-reaper.service.ts
@@ -234,6 +234,7 @@ export class SandboxLeaseReaperService {
         const claimed = await this.leaseRepository.claimCleanup(
             lease._id,
             lease.sandboxId,
+            true,
         );
         if (!claimed) return;
 

--- a/libs/sandbox/infrastructure/services/sandbox-lease-reaper.service.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-reaper.service.ts
@@ -80,7 +80,7 @@ export class SandboxLeaseReaperService {
                 CLEANUP_CONCURRENCY,
                 async (lease) => {
                     if (isLocalSandboxPath(lease.sandboxId)) {
-                        await this.cleanupLocalLease(lease);
+                        await this.cleanupLocalLease(lease, false);
                         return;
                     }
                     if (
@@ -167,7 +167,7 @@ export class SandboxLeaseReaperService {
                 CLEANUP_CONCURRENCY,
                 async (lease) => {
                     if (isLocalSandboxPath(lease.sandboxId)) {
-                        await this.cleanupLocalLease(lease);
+                        await this.cleanupLocalLease(lease, true);
                         return;
                     }
                     if (lease.sandboxId && apiKey) {
@@ -218,15 +218,23 @@ export class SandboxLeaseReaperService {
         }
     }
 
-    private async cleanupLocalLease(lease: {
-        _id: string;
-        sandboxId?: string;
-    }): Promise<void> {
+    private async cleanupLocalLease(
+        lease: {
+            _id: string;
+            sandboxId?: string;
+        },
+        requireLeaseCountZero: boolean,
+    ): Promise<void> {
         if (!lease.sandboxId || !isLocalSandboxPath(lease.sandboxId)) return;
 
         // Re-check: a concurrent acquire may have bumped leaseCount
         const current = await this.leaseRepository.findByPrKey(lease._id);
-        if (!current || (current.leaseCount ?? 0) > 0) return;
+        if (
+            !current ||
+            (requireLeaseCountZero && (current.leaseCount ?? 0) > 0)
+        ) {
+            return;
+        }
 
         const staleThreshold = new Date(Date.now() - 5 * 60 * 1000);
         await this.leaseRepository.resetStaleCleanup(lease._id, staleThreshold);
@@ -234,7 +242,7 @@ export class SandboxLeaseReaperService {
         const claimed = await this.leaseRepository.claimCleanup(
             lease._id,
             lease.sandboxId,
-            true,
+            requireLeaseCountZero,
         );
         if (!claimed) return;
 

--- a/libs/sandbox/infrastructure/services/sandbox-lease-reaper.service.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-reaper.service.ts
@@ -8,6 +8,10 @@ import {
     DistributedLockService,
 } from '@libs/core/workflow/infrastructure/distributed-lock.service';
 import { SandboxLeaseRepository } from '@libs/sandbox/infrastructure/repositories/sandbox-lease.repository';
+import {
+    isLocalSandboxPath,
+    deleteLocalSandbox,
+} from './local-sandbox-cleanup.service';
 
 const CLEANUP_CONCURRENCY = 5;
 
@@ -75,6 +79,10 @@ export class SandboxLeaseReaperService {
                 expired,
                 CLEANUP_CONCURRENCY,
                 async (lease) => {
+                    if (isLocalSandboxPath(lease.sandboxId)) {
+                        await this.cleanupLocalLease(lease);
+                        return;
+                    }
                     if (
                         lease.sandboxId &&
                         lease.state !== 'INVALIDATED' &&
@@ -158,6 +166,10 @@ export class SandboxLeaseReaperService {
                 ready,
                 CLEANUP_CONCURRENCY,
                 async (lease) => {
+                    if (isLocalSandboxPath(lease.sandboxId)) {
+                        await this.cleanupLocalLease(lease);
+                        return;
+                    }
                     if (lease.sandboxId && apiKey) {
                         try {
                             await Sandbox.kill(lease.sandboxId, { apiKey });
@@ -203,6 +215,51 @@ export class SandboxLeaseReaperService {
                 lock,
                 'Failed to release sandbox idle-kill lock',
             );
+        }
+    }
+
+    private async cleanupLocalLease(lease: {
+        _id: string;
+        sandboxId?: string;
+    }): Promise<void> {
+        if (!lease.sandboxId || !isLocalSandboxPath(lease.sandboxId)) return;
+
+        const claimed = await this.leaseRepository.claimCleanup(
+            lease._id,
+            lease.sandboxId,
+        );
+        if (!claimed) return;
+
+        try {
+            await deleteLocalSandbox(lease.sandboxId);
+            await this.leaseRepository.completeCleanup(
+                lease._id,
+                lease.sandboxId,
+            );
+            this.logger.log({
+                message: '[SANDBOX-REAPER] Cleaned local sandbox',
+                context: SandboxLeaseReaperService.name,
+                metadata: {
+                    prKey: lease._id,
+                    sandboxId: lease.sandboxId,
+                },
+            });
+        } catch (err) {
+            await this.leaseRepository.failCleanup(
+                lease._id,
+                lease.sandboxId,
+                (err as Error).message,
+            );
+            this.logger.warn({
+                message:
+                    '[SANDBOX-REAPER] Local cleanup failed, retry marker set',
+                context: SandboxLeaseReaperService.name,
+                metadata: {
+                    prKey: lease._id,
+                    sandboxId: lease.sandboxId,
+                    error: String(err),
+                },
+            });
         }
     }
 


### PR DESCRIPTION
## Scope

Clean up `/tmp/kodus-sandbox-*` directories for self-hosted local sandboxes on release, invalidation, creator failure, and reaper paths, while guarding every delete by expected `sandboxId` to prevent deleting fresh leases.

**Changes:**
- Add path-hardened local cleanup helper (`isLocalSandboxPath`, `deleteLocalSandbox`)
- Add cleanup status fields to lease model (`cleanupStatus`, `cleanupAttempts`, `cleanupRetryAt`, `cleanupError`)
- Add atomic claim/complete/fail repository methods guarded by `prKey + sandboxId`
- Clean local sandboxes on `release()` when `leaseCount` reaches zero
- Clean inactive local sandboxes immediately on `invalidate()`
- Clean local sandboxes on creator failure with retry marker
- Add local cleanup to reaper for expired and retryable leases
- Guard every delete by expected `sandboxId` to prevent deleting fresh leases
- Treat missing directories as success

**Files changed:**
- `libs/sandbox/infrastructure/repositories/schemas/sandbox-lease.model.ts` — added cleanup fields
- `libs/sandbox/infrastructure/services/local-sandbox-cleanup.service.ts` — NEW: path-hardened cleanup helper
- `libs/sandbox/infrastructure/services/local-sandbox-cleanup.spec.ts` — NEW: helper tests
- `libs/sandbox/infrastructure/repositories/sandbox-lease.repository.ts` — added atomic cleanup methods
- `libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts` — wired cleanup into release/invalidate/creator-failure
- `libs/sandbox/infrastructure/services/sandbox-lease-reaper.service.ts` — added local cleanup to reaper
- `libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts` — added cleanup tests

## Non-goals

- Does NOT change local sandbox file access security (→ Goal 1 PR #1469)
- Does NOT change E2B kill/retry semantics
- Does NOT add reaper concurrency limiting (→ Goal 3 reaper concurrency PR)
- Does NOT perform broad lease state-machine refactoring
- Does NOT change file path traversal hardening (→ Goal 1 PR #1469)

## Validation

```
✅ pnpm test --runTestsByPath on 5 spec files (48/48 pass)
✅ pnpm exec prettier --check on changed files
✅ pnpm exec eslint on changed files
✅ pnpm run typecheck:libs-gate
✅ git diff --check
```

## Key Invariant

Every destructive filesystem operation validates both `os.tmpdir()` ancestry and the `kodus-sandbox-` basename prefix. Every lease delete or cleanup-complete operation is guarded by expected `sandboxId` via atomic `findOneAndUpdate`. A concurrent acquire creating a fresh lease for the same `prKey` will never be deleted by stale cleanup.

## Pre-review Checklist

- [x] Every destructive filesystem operation validates both `os.tmpdir()` ancestry and the `kodus-sandbox-` basename prefix
- [x] Every lease delete or cleanup-complete operation is guarded by expected `sandboxId`
- [x] Local cleanup treats missing directories as success
- [x] E2B kill behavior is unchanged in this PR
- [x] Reaper concurrency is unchanged in this PR
- [x] File path traversal hardening is unchanged in this PR

## Follow-ups

- Local sandbox path traversal hardening → Goal 1 PR #1469
- Reaper concurrency limiting and E2B already-gone handling → Goal 3 reaper concurrency PR