### PR TITLE
fix(kody-rules): match comma-joined multi-glob rule paths at review time

### DIFF
--- a/libs/ee/kodyRules/service/kody-rules-validation.service.ts
+++ b/libs/ee/kodyRules/service/kody-rules-validation.service.ts
@@ -418,6 +418,41 @@ export class KodyRulesValidationService {
     }
 
     /**
+     * Splits a rule's `path` into its individual glob patterns.
+     *
+     * Kody Rules support OR-joined globs in a single `path` string — the
+     * IDE-rule importer comma-joins declared globs (e.g. a frontmatter
+     * `path: ["app/**", "lib/**"]` is persisted as "app/**,lib/**") and
+     * `pathMatchesIdeRuleDir` has always split on commas. The review-time
+     * matchers below, however, used to pass the whole string to picomatch
+     * as ONE pattern, where a comma is a literal character — so any
+     * multi-glob rule silently matched zero files.
+     *
+     * Commas inside braces are NOT separators: "{app,lib}/**" is a single
+     * valid picomatch alternation and must stay intact.
+     */
+    private splitRulePathGlobs(rulePath: string): string[] {
+        const globs: string[] = [];
+        let current = '';
+        let braceDepth = 0;
+
+        for (const char of rulePath) {
+            if (char === '{') braceDepth++;
+            else if (char === '}' && braceDepth > 0) braceDepth--;
+
+            if (char === ',' && braceDepth === 0) {
+                if (current.trim()) globs.push(current.trim());
+                current = '';
+                continue;
+            }
+            current += char;
+        }
+        if (current.trim()) globs.push(current.trim());
+
+        return globs;
+    }
+
+    /**
      * Private helper to check if a rule's path matches a specific *file*.
      */
     private isFilePathMatch(
@@ -441,8 +476,12 @@ export class KodyRulesValidationService {
             return true;
         }
 
-        // Use glob matching to check if the file matches the rule's path pattern.
-        return isFileMatchingGlob(normalizedFilename, [rulePath]);
+        // Use glob matching to check if the file matches any of the rule's
+        // path patterns (comma-joined globs are OR-ed).
+        return isFileMatchingGlob(
+            normalizedFilename,
+            this.splitRulePathGlobs(rulePath),
+        );
     }
 
     /**
@@ -467,11 +506,19 @@ export class KodyRulesValidationService {
             return true;
         }
 
-        if (isFileMatchingGlob(normalizedFolder, [rulePath])) {
+        // Comma-joined globs are OR-ed: the folder matches if ANY of the
+        // individual patterns matches it.
+        return this.splitRulePathGlobs(rulePath).some((glob) =>
+            this.isFolderGlobMatch(glob, normalizedFolder),
+        );
+    }
+
+    private isFolderGlobMatch(glob: string, normalizedFolder: string): boolean {
+        if (isFileMatchingGlob(normalizedFolder, [glob])) {
             return true;
         }
 
-        const ruleBasePath = this.getGlobBasePath(rulePath);
+        const ruleBasePath = this.getGlobBasePath(glob);
 
         if (ruleBasePath === '') {
             return true;
@@ -486,7 +533,7 @@ export class KodyRulesValidationService {
         }
 
         if (
-            rulePath.startsWith('**') &&
+            glob.startsWith('**') &&
             normalizedFolder.endsWith('/' + ruleBasePath)
         ) {
             return true;

--- a/test/unit/ee/kodyRules/service/kody-rules-validation.service.spec.ts
+++ b/test/unit/ee/kodyRules/service/kody-rules-validation.service.spec.ts
@@ -629,4 +629,115 @@ describe('KodyRulesValidationService', () => {
             expect(result.map((rule) => rule.uuid)).toEqual(['included']);
         });
     });
+
+    describe('comma-joined multi-glob rule paths (#1483)', () => {
+        // The IDE-rule importer persists multi-glob paths comma-joined
+        // (e.g. frontmatter `path: ["app/**/*.rb", "lib/**/*.rb"]` becomes
+        // "app/**/*.rb,lib/**/*.rb"). picomatch treats a comma as a literal
+        // character, so before the split these rules matched ZERO files and
+        // were silently never enforced.
+        const filters = { repositoryId: 'repo-1' };
+
+        it('matches a file against ANY of the comma-joined globs', () => {
+            const rule = createRule({
+                uuid: 'multi',
+                path: 'app/**/*.rb,lib/**/*.rb',
+            });
+
+            for (const file of ['app/models/user.rb', 'lib/tasks/foo.rb']) {
+                const result = service.getKodyRulesForFile(
+                    file,
+                    [rule],
+                    filters,
+                );
+                expect(result.map((r) => r.uuid)).toEqual(['multi']);
+            }
+        });
+
+        it('does not match files outside every glob', () => {
+            const rule = createRule({
+                uuid: 'multi',
+                path: 'app/services/**/*.rb,app/interactors/**/*.rb',
+            });
+
+            const result = service.getKodyRulesForFile(
+                'app/models/user.rb',
+                [rule],
+                filters,
+            );
+
+            expect(result).toEqual([]);
+        });
+
+        it('tolerates whitespace around the commas', () => {
+            const rule = createRule({
+                uuid: 'spaced',
+                path: 'app/**/*.rb, lib/**/*.rb',
+            });
+
+            const result = service.getKodyRulesForFile(
+                'lib/foo.rb',
+                [rule],
+                filters,
+            );
+
+            expect(result.map((r) => r.uuid)).toEqual(['spaced']);
+        });
+
+        it('keeps brace alternations intact (comma inside {} is not a separator)', () => {
+            const rule = createRule({
+                uuid: 'braced',
+                path: '{app,lib}/**/*.rb,config/**/*.yml',
+            });
+
+            for (const file of [
+                'app/models/user.rb',
+                'lib/foo.rb',
+                'config/settings.yml',
+            ]) {
+                const result = service.getKodyRulesForFile(
+                    file,
+                    [rule],
+                    filters,
+                );
+                expect(result.map((r) => r.uuid)).toEqual(['braced']);
+            }
+        });
+
+        it('still matches single-glob paths as before', () => {
+            const rule = createRule({
+                uuid: 'single',
+                path: 'app/jobs/**/*.rb',
+            });
+
+            expect(
+                service
+                    .getKodyRulesForFile('app/jobs/sync_job.rb', [rule], filters)
+                    .map((r) => r.uuid),
+            ).toEqual(['single']);
+            expect(
+                service.getKodyRulesForFile('app/models/user.rb', [rule], filters),
+            ).toEqual([]);
+        });
+
+        it('matches folders against ANY of the comma-joined globs', () => {
+            const rule = createRule({
+                uuid: 'folder-multi',
+                path: 'app/services/**,lib/tasks/**',
+            });
+
+            for (const folder of ['app/services', 'lib/tasks']) {
+                const result = service.getKodyRulesForFolder(
+                    folder,
+                    [rule],
+                    filters,
+                );
+                expect(result.map((r) => r.uuid)).toEqual(['folder-multi']);
+            }
+
+            expect(
+                service.getKodyRulesForFolder('app/models', [rule], filters),
+            ).toEqual([]);
+        });
+    });
 });


### PR DESCRIPTION
## Problem

A Kody Rule whose `path` contains multiple comma-joined globs (e.g. `app/**/*.rb,lib/**/*.rb`) was silently never applied to any file during review. The IDE-rule importer explicitly comma-joins declared globs, but `isFilePathMatch`/`isFolderPathMatch` passed the whole string to picomatch as a single pattern — where a comma is a literal character — so the pattern matched zero files. Single-glob rules worked, which produced a confusing all-or-nothing failure pattern per rule file (reported by a self-hosted customer with controlled planted-violation experiments).

`pathMatchesIdeRuleDir` already splits on commas ("KodyRules supports OR-joined globs"); the review-time matchers never got that support.

## Fix

- New `splitRulePathGlobs`: splits the rule path on commas, ignoring commas inside brace alternations (`{app,lib}/**` stays intact), trimming whitespace.
- `isFilePathMatch` ORs the resulting globs via `isFileMatchingGlob` (already array-aware).
- `isFolderPathMatch` runs its existing base-path logic per glob (`isFolderGlobMatch`).

Fixing on the read path repairs all already-persisted multi-glob rules with no migration.

## Tests

6 new tests in `kody-rules-validation.service.spec.ts`: multi-glob file match (both sides), non-match outside all globs, whitespace tolerance, brace alternation preservation, single-glob regression, folder matching. Full `kodyRules|kody-rules` suite: 42 suites / 394 tests green.

Fixes #1483

🤖 Generated with [Claude Code](https://claude.com/claude-code)