### PR TITLE
fix(kody-rules): detect root AGENTS.md and discover nested rule files

### DIFF
--- a/libs/common/utils/kody-rules/file-patterns.ts
+++ b/libs/common/utils/kody-rules/file-patterns.ts
@@ -12,6 +12,7 @@ export const RULE_FILE_PATTERNS = [
     '.github/instructions/**/*.instructions.md',
 
     // Agentic
+    'AGENTS.md',
     '.agents.md',
     '.agent.md',
 
@@ -41,6 +42,23 @@ export const RULE_FILE_PATTERNS = [
 export type RuleFilePattern = (typeof RULE_FILE_PATTERNS)[number];
 
 /**
+ * Patterns used to DISCOVER rule files anywhere in a repository: every
+ * base pattern plus its `**\/`-prefixed variant, so root-level names like
+ * `CLAUDE.md` or `AGENTS.md` are also found in subdirectories (the
+ * common monorepo convention of per-directory guidance files).
+ *
+ * Discovery and recognition (`isIdeRuleSource`) intentionally share this
+ * list — a file the sync imports must always be recognised as IDE-synced
+ * afterwards. Nested sources are scoped to their subdirectory by
+ * `extractRepoSubdirFromIdeSource`, so a `services/foo/CLAUDE.md` rule
+ * applies to `services/foo/**`, not repo-wide.
+ */
+export const RULE_FILE_DISCOVERY_PATTERNS: ReadonlyArray<string> = [
+    ...RULE_FILE_PATTERNS,
+    ...RULE_FILE_PATTERNS.map((p) => `**/${p}`),
+];
+
+/**
  * Whether `sourcePath` came from an IDE rule file recognised by the auto-sync
  * importer (i.e. it matches one of `RULE_FILE_PATTERNS`, anywhere in the repo).
  *
@@ -60,11 +78,7 @@ export function isIdeRuleSource(
     sourcePath: string | null | undefined,
 ): boolean {
     if (!sourcePath) return false;
-    const patterns: string[] = [
-        ...RULE_FILE_PATTERNS,
-        ...RULE_FILE_PATTERNS.map((p) => `**/${p}`),
-    ];
-    return isFileMatchingGlob(sourcePath, patterns);
+    return isFileMatchingGlob(sourcePath, [...RULE_FILE_DISCOVERY_PATTERNS]);
 }
 
 /**

--- a/libs/kodyRules/infrastructure/adapters/services/kodyRulesSync.service.ts
+++ b/libs/kodyRules/infrastructure/adapters/services/kodyRulesSync.service.ts
@@ -22,10 +22,11 @@ import {
 import { ParametersKey } from '@libs/core/domain/enums';
 import {
     RULE_FILE_PATTERNS,
+    RULE_FILE_DISCOVERY_PATTERNS,
     isIdeRuleSource,
     validateAndScopeIdeRulePath,
 } from '@libs/common/utils/kody-rules/file-patterns';
-import { isFileMatchingGlob } from '@libs/common/utils/glob-utils';
+import { isFileMatchingGlobCaseInsensitive } from '@libs/common/utils/glob-utils';
 import {
     CreateKodyRuleDto,
     KodyRuleSeverity,
@@ -386,9 +387,12 @@ export class KodyRulesSyncService {
                     organizationAndTeamData,
                     repository.id,
                 );
-                const patterns = [...RULE_FILE_PATTERNS, ...directoryPatterns];
+                const patterns = [
+                    ...RULE_FILE_DISCOVERY_PATTERNS,
+                    ...directoryPatterns,
+                ];
                 const isRuleFile = (fp?: string) =>
-                    !!fp && isFileMatchingGlob(fp, patterns);
+                    !!fp && isFileMatchingGlobCaseInsensitive(fp, patterns);
 
                 const ruleChanges = files.filter(
                     (f) =>
@@ -494,9 +498,12 @@ export class KodyRulesSyncService {
                 repository.id,
             );
 
-            const patterns = [...RULE_FILE_PATTERNS, ...directoryPatterns];
+            const patterns = [
+                ...RULE_FILE_DISCOVERY_PATTERNS,
+                ...directoryPatterns,
+            ];
             const isRuleFile = (fp?: string) =>
-                !!fp && isFileMatchingGlob(fp, patterns);
+                !!fp && isFileMatchingGlobCaseInsensitive(fp, patterns);
 
             let ruleChanges = files.filter(
                 (f) =>
@@ -533,19 +540,22 @@ export class KodyRulesSyncService {
                 // Reuse cached content from the @kody-sync scan when
                 // available to avoid a duplicate API call for the same
                 // file (the scan already fetched it moments ago).
-                let decoded: string | null = contentCache.get(f.filename) ?? null;
+                let decoded: string | null =
+                    contentCache.get(f.filename) ?? null;
 
                 if (!decoded) {
                     const contentResp =
-                        await this.codeManagementService.getRepositoryContentFile({
-                            organizationAndTeamData,
-                            repository: {
-                                id: repository.id,
-                                name: repository.name,
+                        await this.codeManagementService.getRepositoryContentFile(
+                            {
+                                organizationAndTeamData,
+                                repository: {
+                                    id: repository.id,
+                                    name: repository.name,
+                                },
+                                file: { filename: f.filename },
+                                pullRequest: pullRequestParam,
                             },
-                            file: { filename: f.filename },
-                            pullRequest: pullRequestParam,
-                        });
+                        );
                     // Fallbacks if the source branch was deleted on merge (e.g., GitLab):
                     // 1) Try with base as head
                     // 2) Try with default branch as head
@@ -563,7 +573,9 @@ export class KodyRulesSyncService {
                                                 name: repository.name,
                                             },
                                             file: { filename: f.filename },
-                                            pullRequest: { head: { ref: baseRef } },
+                                            pullRequest: {
+                                                head: { ref: baseRef },
+                                            },
                                         },
                                     );
                                 if (baseAsHead?.data?.content) {
@@ -577,13 +589,15 @@ export class KodyRulesSyncService {
                     if (!effectiveContent?.data?.content) {
                         try {
                             const defaultBranch =
-                                await this.codeManagementService.getDefaultBranch({
-                                    organizationAndTeamData,
-                                    repository: {
-                                        id: repository.id,
-                                        name: repository.name,
+                                await this.codeManagementService.getDefaultBranch(
+                                    {
+                                        organizationAndTeamData,
+                                        repository: {
+                                            id: repository.id,
+                                            name: repository.name,
+                                        },
                                     },
-                                });
+                                );
                             if (defaultBranch) {
                                 const defAsHead =
                                     await this.codeManagementService.getRepositoryContentFile(
@@ -615,7 +629,9 @@ export class KodyRulesSyncService {
 
                     decoded =
                         effectiveContent?.data?.encoding === 'base64'
-                            ? Buffer.from(rawContent, 'base64').toString('utf-8')
+                            ? Buffer.from(rawContent, 'base64').toString(
+                                  'utf-8',
+                              )
                             : rawContent;
                 }
 
@@ -798,7 +814,10 @@ export class KodyRulesSyncService {
                 repository.id,
             );
 
-            const patterns = [...RULE_FILE_PATTERNS, ...directoryPatterns];
+            const patterns = [
+                ...RULE_FILE_DISCOVERY_PATTERNS,
+                ...directoryPatterns,
+            ];
 
             if (requestedPath) {
                 const normalizedRequestedPath = requestedPath
@@ -806,7 +825,12 @@ export class KodyRulesSyncService {
                     .replace(/^\.\/+/, '')
                     .replace(/^\/+/, '');
 
-                if (!isFileMatchingGlob(normalizedRequestedPath, patterns)) {
+                if (
+                    !isFileMatchingGlobCaseInsensitive(
+                        normalizedRequestedPath,
+                        patterns,
+                    )
+                ) {
                     this.logger.log({
                         message:
                             'Requested file path is not a supported IDE rule file',
@@ -888,9 +912,7 @@ export class KodyRulesSyncService {
                 //     marker dropped → depin (no-op if already not pinned).
                 //   - sourcePath in `forceSyncFiles` → will be re-synced
                 //     below, which writes `pinnedSync: true` again.
-                const allFilePaths = new Set(
-                    allFiles.map((f: any) => f.path),
-                );
+                const allFilePaths = new Set(allFiles.map((f: any) => f.path));
                 const forceSyncFilePaths = new Set(forceSyncFiles);
                 const existing =
                     await this.kodyRulesService.findByOrganizationId(
@@ -1346,7 +1368,10 @@ export class KodyRulesSyncService {
                 organizationAndTeamData,
                 repository.id,
             );
-            const patterns = [...RULE_FILE_PATTERNS, ...directoryPatterns];
+            const patterns = [
+                ...RULE_FILE_DISCOVERY_PATTERNS,
+                ...directoryPatterns,
+            ];
 
             const allFiles =
                 await this.codeManagementService.getRepositoryAllFiles({

--- a/test/unit/common/kody-rules-file-patterns.spec.ts
+++ b/test/unit/common/kody-rules-file-patterns.spec.ts
@@ -1,11 +1,13 @@
 import {
     IDE_RULE_DIR_MARKERS,
     RULE_FILE_PATTERNS,
+    RULE_FILE_DISCOVERY_PATTERNS,
     extractRepoSubdirFromIdeSource,
     isIdeRuleSource,
     pathMatchesIdeRuleDir,
     validateAndScopeIdeRulePath,
 } from '../../../libs/common/utils/kody-rules/file-patterns';
+import { isFileMatchingGlobCaseInsensitive } from '../../../libs/common/utils/glob-utils';
 
 describe('IDE_RULE_DIR_MARKERS', () => {
     it('is derived from RULE_FILE_PATTERNS — every pattern with a directory part contributes a marker', () => {
@@ -157,6 +159,66 @@ describe('isIdeRuleSource — sanity check', () => {
         expect(isIdeRuleSource(undefined)).toBe(false);
         expect(isIdeRuleSource('')).toBe(false);
     });
+
+    it('recognises AGENTS.md at root and under subdirs (#1484)', () => {
+        expect(isIdeRuleSource('AGENTS.md')).toBe(true);
+        expect(isIdeRuleSource('apps/web/AGENTS.md')).toBe(true);
+    });
+});
+
+describe('RULE_FILE_DISCOVERY_PATTERNS (#1484/#1485)', () => {
+    // The sync service discovers rule files with these patterns matched
+    // case-insensitively (same matcher the provider services use for
+    // repo-tree listings). Pins the customer-reported gaps: root AGENTS.md
+    // was never fetched, and nested CLAUDE.md files were only discovered
+    // under directories explicitly configured in code review settings.
+    const discovers = (filePath: string) =>
+        isFileMatchingGlobCaseInsensitive(filePath, [
+            ...RULE_FILE_DISCOVERY_PATTERNS,
+        ]);
+
+    it('discovers root AGENTS.md (uppercase, no leading dot)', () => {
+        expect(discovers('AGENTS.md')).toBe(true);
+    });
+
+    it('discovers nested guidance files (monorepo convention)', () => {
+        expect(discovers('apps/api/CLAUDE.md')).toBe(true);
+        expect(discovers('services/billing/AGENTS.md')).toBe(true);
+        expect(discovers('packages/ui/.kody/rules/naming.md')).toBe(true);
+    });
+
+    it('matches case-insensitively (claude.md == CLAUDE.md)', () => {
+        expect(discovers('claude.md')).toBe(true);
+        expect(discovers('agents.md')).toBe(true);
+    });
+
+    it('still ignores unrelated files', () => {
+        expect(discovers('README.md')).toBe(false);
+        expect(discovers('src/agents/index.ts')).toBe(false);
+        expect(discovers('docs/AGENTS-guide.md')).toBe(false);
+    });
+
+    it('every base pattern has its **/ variant', () => {
+        expect(RULE_FILE_DISCOVERY_PATTERNS).toHaveLength(
+            RULE_FILE_PATTERNS.length * 2,
+        );
+    });
+});
+
+describe('extractRepoSubdirFromIdeSource — nested guidance files', () => {
+    it('scopes nested CLAUDE.md/AGENTS.md to their subdirectory', () => {
+        expect(extractRepoSubdirFromIdeSource('apps/api/CLAUDE.md')).toBe(
+            'apps/api',
+        );
+        expect(extractRepoSubdirFromIdeSource('services/x/AGENTS.md')).toBe(
+            'services/x',
+        );
+    });
+
+    it('keeps root-level files repo-wide', () => {
+        expect(extractRepoSubdirFromIdeSource('AGENTS.md')).toBeNull();
+        expect(extractRepoSubdirFromIdeSource('CLAUDE.md')).toBeNull();
+    });
 });
 
 describe('pathMatchesIdeRuleDir', () => {
@@ -192,9 +254,9 @@ describe('pathMatchesIdeRuleDir', () => {
     it('flags any glob in a comma-separated list that hits an IDE dir', () => {
         // Defensive: even if the LLM slips an IDE glob into a list of
         // otherwise legit globs, we want to catch it.
-        expect(
-            pathMatchesIdeRuleDir('src/**/*.ts,.cursor/rules/**/*'),
-        ).toBe(true);
+        expect(pathMatchesIdeRuleDir('src/**/*.ts,.cursor/rules/**/*')).toBe(
+            true,
+        );
     });
 
     it('returns false for empty / nullish input', () => {


### PR DESCRIPTION
## Problem

Two customer-reported gaps in IDE rule-file detection (#1484, #1485):

1. The de-facto standard `AGENTS.md` (uppercase, repo root, no leading dot) never matched — `RULE_FILE_PATTERNS` only listed the `.agents.md`/`.agent.md` dotfiles — so repos following the agents.md convention were never synced.
2. Root-level patterns (`CLAUDE.md`, `AGENTS.md`, etc.) were matched against the full path, so per-directory guidance files (the common monorepo convention) were only discovered if each directory was explicitly configured in code review settings.

Bonus inconsistency: PR-driven sync matched rule files case-sensitively while full-repo listings matched case-insensitively, so a lowercase `claude.md` synced on full sync but was ignored on PR merge.

## Fix

- Add `AGENTS.md` to `RULE_FILE_PATTERNS`.
- New `RULE_FILE_DISCOVERY_PATTERNS` (every base pattern + its `**/` variant) used by all four discovery/filter sites in `KodyRulesSyncService`. This is the same list `isIdeRuleSource` already recognised, so anything the sync imports is guaranteed to be recognised as IDE-synced afterwards (toggle-off purge, orphan chip, etc.).
- Nested sources keep being scoped to their subdirectory by the existing `extractRepoSubdirFromIdeSource` — a `services/foo/CLAUDE.md` rule applies to `services/foo/**`, not repo-wide.
- Both sync paths now match with `isFileMatchingGlobCaseInsensitive`, aligning with the provider-side repo listings.

## Behavior change note

Existing installs will start discovering nested guidance files on the next sync. Rules stay scoped per subdirectory, and the onboarding fast-sync caps (maxFiles/maxBytes) still apply.

## Tests

9 new tests in `kody-rules-file-patterns.spec.ts` (root AGENTS.md, nested discovery, case-insensitivity, discovery-list invariant, subdir scoping). Full `file-patterns|kody-rules|kodyRules` sweep: 42 suites / 396 tests green.

Fixes #1484
Fixes #1485

🤖 Generated with [Claude Code](https://claude.com/claude-code)