### PR TITLE
feat(kody-rules): import .kody/rules template files verbatim (no LLM)

### DIFF
--- a/libs/common/utils/kody-rules/kody-rule-file-parser.ts
+++ b/libs/common/utils/kody-rules/kody-rule-file-parser.ts
@@ -1,0 +1,191 @@
+import * as yaml from 'js-yaml';
+
+/**
+ * Deterministic parser for `.kody/rules/**` markdown files (the structured
+ * template documented in "Repository Rules").
+ *
+ * These files are authored against OUR OWN template (YAML frontmatter +
+ * `## Instructions` + Bad/Good examples), so they must be imported
+ * verbatim — no LLM conversion. The LLM path (see
+ * `KodyRulesSyncService.convertFileToKodyRules`) remains the fallback for
+ * free-form sources (CLAUDE.md, .cursorrules, ...) and for `.kody` files
+ * that don't parse as the template.
+ *
+ * Returns `null` when the content doesn't look like the template
+ * (no/invalid frontmatter or no title), so callers can fall back to the
+ * LLM importer instead of failing the sync.
+ */
+
+export interface ParsedKodyRuleFile {
+    uuid?: string;
+    title: string;
+    /** Full markdown body after the frontmatter, verbatim. */
+    rule: string;
+    /** Comma-joined globs (the storage form the matchers consume). */
+    path: string;
+    severity: 'low' | 'medium' | 'high' | 'critical';
+    scope: 'file' | 'pull-request';
+    /** `enabled: false` in the frontmatter — caller decides how to persist. */
+    enabled: boolean;
+    examples: Array<{ snippet: string; isCorrect: boolean }>;
+}
+
+const FRONTMATTER_RE = /^﻿?---\r?\n([\s\S]*?)\r?\n---\r?\n?/;
+
+const VALID_SEVERITIES = ['low', 'medium', 'high', 'critical'] as const;
+
+function normalizeSeverity(
+    value: unknown,
+): ParsedKodyRuleFile['severity'] | null {
+    if (typeof value !== 'string') return null;
+    const lowered = value.trim().toLowerCase();
+    return (VALID_SEVERITIES as readonly string[]).includes(lowered)
+        ? (lowered as ParsedKodyRuleFile['severity'])
+        : null;
+}
+
+function normalizePath(value: unknown): string | null {
+    if (Array.isArray(value)) {
+        const globs = value
+            .filter((g): g is string => typeof g === 'string')
+            .map((g) => g.trim())
+            .filter(Boolean);
+        return globs.length ? globs.join(',') : null;
+    }
+    if (typeof value === 'string' && value.trim()) {
+        return value.trim();
+    }
+    return null;
+}
+
+/**
+ * Extracts Bad/Good examples from the markdown body.
+ *
+ * Recognises headings (any level) whose text contains "bad" or "good"
+ * ("### Bad example", "## Good:", "#### bad") and captures every fenced
+ * code block until the next heading of the same-or-higher level. Text in
+ * between is ignored — only the fenced snippets become examples.
+ */
+export function extractExamplesFromBody(
+    body: string,
+): ParsedKodyRuleFile['examples'] {
+    const examples: ParsedKodyRuleFile['examples'] = [];
+    const lines = body.split(/\r?\n/);
+
+    let currentKind: boolean | null = null; // isCorrect, null = outside
+    let inFence = false;
+    let fenceMarker = '';
+    let snippetLines: string[] = [];
+
+    const flushSnippet = () => {
+        if (currentKind !== null && snippetLines.length) {
+            examples.push({
+                snippet: snippetLines.join('\n'),
+                isCorrect: currentKind,
+            });
+        }
+        snippetLines = [];
+    };
+
+    for (const line of lines) {
+        if (inFence) {
+            if (line.trim().startsWith(fenceMarker)) {
+                inFence = false;
+                flushSnippet();
+            } else {
+                snippetLines.push(line);
+            }
+            continue;
+        }
+
+        const heading = /^(#{1,6})\s+(.*)$/.exec(line);
+        if (heading) {
+            const text = heading[2].toLowerCase();
+            if (/\bbad\b|\bincorrect\b|\bwrong\b/.test(text)) {
+                currentKind = false;
+            } else if (/\bgood\b|\bcorrect\b/.test(text)) {
+                currentKind = true;
+            } else {
+                currentKind = null;
+            }
+            continue;
+        }
+
+        const fence = /^\s*(```+|~~~+)/.exec(line);
+        if (fence && currentKind !== null) {
+            inFence = true;
+            fenceMarker = fence[1];
+            snippetLines = [];
+        }
+    }
+
+    // Unterminated fence at EOF: keep what we captured.
+    if (inFence) flushSnippet();
+
+    return examples;
+}
+
+export function parseKodyRuleFile(content: string): ParsedKodyRuleFile | null {
+    if (!content) return null;
+
+    const match = FRONTMATTER_RE.exec(content);
+    if (!match) return null;
+
+    let frontmatter: Record<string, unknown>;
+    try {
+        const parsed = yaml.load(match[1]);
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+            return null;
+        }
+        frontmatter = parsed as Record<string, unknown>;
+    } catch {
+        return null;
+    }
+
+    const title =
+        typeof frontmatter.title === 'string' ? frontmatter.title.trim() : '';
+    if (!title) return null;
+
+    const body = content.slice(match[0].length).trim();
+    if (!body) return null;
+
+    // The documented field is `severity_min`; accept `severity` too since
+    // it's a natural authoring mistake and the intent is unambiguous.
+    const severity =
+        normalizeSeverity(frontmatter.severity_min) ??
+        normalizeSeverity(frontmatter.severity) ??
+        'medium';
+
+    const scope =
+        frontmatter.scope === 'pull-request' ? 'pull-request' : 'file';
+
+    const path = normalizePath(frontmatter.path) ?? '**/*';
+
+    const uuid =
+        typeof frontmatter.uuid === 'string' && frontmatter.uuid.trim()
+            ? frontmatter.uuid.trim()
+            : undefined;
+
+    return {
+        uuid,
+        title,
+        rule: body,
+        path,
+        severity,
+        scope,
+        enabled: frontmatter.enabled !== false,
+        examples: extractExamplesFromBody(body),
+    };
+}
+
+/**
+ * Whether `filePath` is a structured Kody rule template file (the only
+ * sources parsed verbatim). Matches `.kody/rules/**` at the repo root or
+ * under any subdirectory.
+ */
+export function isKodyRuleTemplateFile(
+    filePath: string | null | undefined,
+): boolean {
+    if (!filePath) return false;
+    return /(?:^|\/)\.kody\/rules\/.+/i.test(filePath.replace(/\\/g, '/'));
+}

--- a/libs/kodyRules/infrastructure/adapters/services/kodyRulesSync.service.ts
+++ b/libs/kodyRules/infrastructure/adapters/services/kodyRulesSync.service.ts
@@ -25,6 +25,10 @@ import {
     isIdeRuleSource,
     validateAndScopeIdeRulePath,
 } from '@libs/common/utils/kody-rules/file-patterns';
+import {
+    isKodyRuleTemplateFile,
+    parseKodyRuleFile,
+} from '@libs/common/utils/kody-rules/kody-rule-file-parser';
 import { isFileMatchingGlob } from '@libs/common/utils/glob-utils';
 import {
     CreateKodyRuleDto,
@@ -533,19 +537,22 @@ export class KodyRulesSyncService {
                 // Reuse cached content from the @kody-sync scan when
                 // available to avoid a duplicate API call for the same
                 // file (the scan already fetched it moments ago).
-                let decoded: string | null = contentCache.get(f.filename) ?? null;
+                let decoded: string | null =
+                    contentCache.get(f.filename) ?? null;
 
                 if (!decoded) {
                     const contentResp =
-                        await this.codeManagementService.getRepositoryContentFile({
-                            organizationAndTeamData,
-                            repository: {
-                                id: repository.id,
-                                name: repository.name,
+                        await this.codeManagementService.getRepositoryContentFile(
+                            {
+                                organizationAndTeamData,
+                                repository: {
+                                    id: repository.id,
+                                    name: repository.name,
+                                },
+                                file: { filename: f.filename },
+                                pullRequest: pullRequestParam,
                             },
-                            file: { filename: f.filename },
-                            pullRequest: pullRequestParam,
-                        });
+                        );
                     // Fallbacks if the source branch was deleted on merge (e.g., GitLab):
                     // 1) Try with base as head
                     // 2) Try with default branch as head
@@ -563,7 +570,9 @@ export class KodyRulesSyncService {
                                                 name: repository.name,
                                             },
                                             file: { filename: f.filename },
-                                            pullRequest: { head: { ref: baseRef } },
+                                            pullRequest: {
+                                                head: { ref: baseRef },
+                                            },
                                         },
                                     );
                                 if (baseAsHead?.data?.content) {
@@ -577,13 +586,15 @@ export class KodyRulesSyncService {
                     if (!effectiveContent?.data?.content) {
                         try {
                             const defaultBranch =
-                                await this.codeManagementService.getDefaultBranch({
-                                    organizationAndTeamData,
-                                    repository: {
-                                        id: repository.id,
-                                        name: repository.name,
+                                await this.codeManagementService.getDefaultBranch(
+                                    {
+                                        organizationAndTeamData,
+                                        repository: {
+                                            id: repository.id,
+                                            name: repository.name,
+                                        },
                                     },
-                                });
+                                );
                             if (defaultBranch) {
                                 const defAsHead =
                                     await this.codeManagementService.getRepositoryContentFile(
@@ -615,7 +626,9 @@ export class KodyRulesSyncService {
 
                     decoded =
                         effectiveContent?.data?.encoding === 'base64'
-                            ? Buffer.from(rawContent, 'base64').toString('utf-8')
+                            ? Buffer.from(rawContent, 'base64').toString(
+                                  'utf-8',
+                              )
                             : rawContent;
                 }
 
@@ -888,9 +901,7 @@ export class KodyRulesSyncService {
                 //     marker dropped → depin (no-op if already not pinned).
                 //   - sourcePath in `forceSyncFiles` → will be re-synced
                 //     below, which writes `pinnedSync: true` again.
-                const allFilePaths = new Set(
-                    allFiles.map((f: any) => f.path),
-                );
+                const allFilePaths = new Set(allFiles.map((f: any) => f.path));
                 const forceSyncFilePaths = new Set(forceSyncFiles);
                 const existing =
                     await this.kodyRulesService.findByOrganizationId(
@@ -1546,17 +1557,52 @@ export class KodyRulesSyncService {
                 return response;
             }
 
-            const rules = manifestMode
-                ? await this.convertManifestsToKodyRulesFastBatch({
-                      files: candidates,
-                      repositoryId: repository.id,
-                      organizationAndTeamData,
-                  })
-                : await this.convertFilesToKodyRulesFastBatch({
-                      files: candidates,
-                      repositoryId: repository.id,
-                      organizationAndTeamData,
-                  });
+            // Structured `.kody/rules/**` templates never go through the
+            // batch LLM — parse them verbatim and only send the free-form
+            // remainder to the model (same policy as the main sync path).
+            const templateRules: Array<Partial<CreateKodyRuleDto>> = [];
+            const llmCandidates: typeof candidates = [];
+            for (const candidate of candidates) {
+                const parsed = isKodyRuleTemplateFile(candidate.path)
+                    ? parseKodyRuleFile(candidate.content)
+                    : null;
+                if (parsed) {
+                    if (!parsed.enabled) continue;
+                    templateRules.push({
+                        title: parsed.title,
+                        rule: parsed.rule,
+                        path: parsed.path,
+                        sourcePath: candidate.path,
+                        severity: parsed.severity as KodyRuleSeverity,
+                        scope: parsed.scope as KodyRulesScope,
+                        examples: parsed.examples,
+                        // Template paths are author-declared; the loop below
+                        // must not re-scope them.
+                        pathSource: 'declared',
+                    } as any);
+                } else {
+                    llmCandidates.push(candidate);
+                }
+            }
+
+            const llmRules = !llmCandidates.length
+                ? []
+                : manifestMode
+                  ? await this.convertManifestsToKodyRulesFastBatch({
+                        files: llmCandidates,
+                        repositoryId: repository.id,
+                        organizationAndTeamData,
+                    })
+                  : await this.convertFilesToKodyRulesFastBatch({
+                        files: llmCandidates,
+                        repositoryId: repository.id,
+                        organizationAndTeamData,
+                    });
+
+            const rules = [
+                ...templateRules,
+                ...(Array.isArray(llmRules) ? llmRules : []),
+            ];
 
             if (Array.isArray(rules)) {
                 for (const rule of rules) {
@@ -1790,6 +1836,65 @@ export class KodyRulesSyncService {
                 params.organizationAndTeamData,
                 params.repositoryId,
             ));
+
+        // Structured `.kody/rules/**` templates are imported VERBATIM —
+        // the user authored the exact shape we document, so LLM conversion
+        // would only lose content (trimmed examples, rewritten wording,
+        // stripped identifiers). Non-template `.kody` files (no/invalid
+        // frontmatter) fall through to the LLM path below.
+        if (isKodyRuleTemplateFile(params.filePath)) {
+            const parsed = parseKodyRuleFile(params.content);
+            if (parsed) {
+                if (!parsed.enabled) {
+                    this.logger.log({
+                        message:
+                            '[kody-rules-sync] template file disabled via frontmatter, skipping import',
+                        context: KodyRulesSyncService.name,
+                        metadata: {
+                            filePath: params.filePath,
+                            repositoryId: params.repositoryId,
+                        },
+                    });
+                    return [];
+                }
+
+                // Keep the same path guard the LLM path uses so a template
+                // can't scope a rule against the rule sources themselves.
+                const validated = validateAndScopeIdeRulePath({
+                    llmPath: parsed.path,
+                    sourceFilePath: params.filePath,
+                    pathSource: 'declared',
+                });
+
+                this.logger.log({
+                    message:
+                        '[kody-rules-sync] imported .kody/rules template verbatim (no LLM)',
+                    context: KodyRulesSyncService.name,
+                    metadata: {
+                        filePath: params.filePath,
+                        repositoryId: params.repositoryId,
+                        examplesCount: parsed.examples.length,
+                        pathValidation: validated.reason,
+                    },
+                });
+
+                return [
+                    {
+                        ...(parsed.uuid ? { uuid: parsed.uuid } : {}),
+                        title: parsed.title,
+                        rule: parsed.rule,
+                        path: validated.path,
+                        sourcePath: params.filePath,
+                        severity: parsed.severity as KodyRuleSeverity,
+                        scope: parsed.scope as KodyRulesScope,
+                        repositoryId: params.repositoryId,
+                        origin: KodyRulesOrigin.REPO_FILE_SYNC,
+                        status: effectiveDefaultStatus,
+                        examples: parsed.examples,
+                    },
+                ];
+            }
+        }
 
         const mainProvider =
             options?.mainProvider ?? LLMModelProvider.GEMINI_2_5_FLASH;

--- a/test/unit/common/kody-rule-file-parser.spec.ts
+++ b/test/unit/common/kody-rule-file-parser.spec.ts
@@ -1,0 +1,183 @@
+import {
+    extractExamplesFromBody,
+    isKodyRuleTemplateFile,
+    parseKodyRuleFile,
+} from '../../../libs/common/utils/kody-rules/kody-rule-file-parser';
+
+// Mirrors the real-world template from the "Repository Rules" docs page —
+// the exact shape a customer authored when they hit the lossy LLM import
+// (#1487): trimmed examples, rewritten wording, stripped identifiers.
+const TEMPLATE = `---
+title: "No exceptions for control flow"
+scope: "file"
+path: ["app/**/*.rb", "lib/**/*.rb"]
+severity_min: "medium"
+languages: ["ruby"]
+buckets: ["error-handling"]
+enabled: true
+---
+
+## Instructions
+- **CF1** No exceptions for control flow — anywhere in the codebase.
+- **CF2** \`raise\` is reserved for genuinely unexpected conditions.
+
+## Examples
+
+### Bad example
+\`\`\`ruby
+def publish(post)
+  raise NotReady unless post.ready?
+end
+\`\`\`
+
+### Good example
+\`\`\`ruby
+def publish(post)
+  return false unless post.ready?
+  true
+end
+\`\`\`
+`;
+
+describe('parseKodyRuleFile', () => {
+    it('parses the documented template verbatim', () => {
+        const parsed = parseKodyRuleFile(TEMPLATE);
+
+        expect(parsed).not.toBeNull();
+        expect(parsed!.title).toBe('No exceptions for control flow');
+        expect(parsed!.scope).toBe('file');
+        expect(parsed!.severity).toBe('medium');
+        expect(parsed!.enabled).toBe(true);
+        // Multi-glob frontmatter arrays become the comma-joined storage
+        // form the review matchers consume.
+        expect(parsed!.path).toBe('app/**/*.rb,lib/**/*.rb');
+        // Body is verbatim — identifiers like **CF1** must survive.
+        expect(parsed!.rule).toContain('**CF1**');
+        expect(parsed!.rule).toContain('**CF2**');
+        expect(parsed!.rule).toContain('## Instructions');
+    });
+
+    it('extracts Bad/Good examples structurally', () => {
+        const parsed = parseKodyRuleFile(TEMPLATE)!;
+
+        expect(parsed.examples).toHaveLength(2);
+        expect(parsed.examples[0]).toEqual({
+            snippet: expect.stringContaining('raise NotReady'),
+            isCorrect: false,
+        });
+        expect(parsed.examples[1]).toEqual({
+            snippet: expect.stringContaining('return false'),
+            isCorrect: true,
+        });
+    });
+
+    it('accepts a plain-string path and `severity` as an alias', () => {
+        const parsed = parseKodyRuleFile(
+            [
+                '---',
+                'title: T',
+                'path: "src/**"',
+                'severity: HIGH',
+                '---',
+                'Body.',
+            ].join('\n'),
+        )!;
+        expect(parsed.path).toBe('src/**');
+        expect(parsed.severity).toBe('high');
+    });
+
+    it('defaults: severity medium, scope file, path repo-wide', () => {
+        const parsed = parseKodyRuleFile(
+            ['---', 'title: T', '---', 'Body.'].join('\n'),
+        )!;
+        expect(parsed.severity).toBe('medium');
+        expect(parsed.scope).toBe('file');
+        expect(parsed.path).toBe('**/*');
+    });
+
+    it('reports enabled=false so callers can skip the import', () => {
+        const parsed = parseKodyRuleFile(
+            ['---', 'title: T', 'enabled: false', '---', 'Body.'].join('\n'),
+        )!;
+        expect(parsed.enabled).toBe(false);
+    });
+
+    it('passes uuid through when declared', () => {
+        const parsed = parseKodyRuleFile(
+            [
+                '---',
+                'title: T',
+                'uuid: 2f9d8c1e-1111-2222-3333-444455556666',
+                '---',
+                'Body.',
+            ].join('\n'),
+        )!;
+        expect(parsed.uuid).toBe('2f9d8c1e-1111-2222-3333-444455556666');
+    });
+
+    it.each([
+        ['no frontmatter', '# Just markdown\nSome rule text.'],
+        ['invalid yaml', '---\ntitle: [unclosed\n---\nBody.'],
+        ['missing title', '---\nscope: file\n---\nBody.'],
+        ['empty body', '---\ntitle: T\n---\n'],
+        ['empty content', ''],
+    ])('returns null for %s (caller falls back to LLM)', (_name, content) => {
+        expect(parseKodyRuleFile(content)).toBeNull();
+    });
+});
+
+describe('extractExamplesFromBody', () => {
+    it('captures multiple fenced blocks under one heading', () => {
+        const body = [
+            '### Bad example',
+            '```js',
+            'a()',
+            '```',
+            'prose in between',
+            '```js',
+            'b()',
+            '```',
+            '### Good example',
+            '```js',
+            'c()',
+            '```',
+        ].join('\n');
+
+        expect(extractExamplesFromBody(body)).toEqual([
+            { snippet: 'a()', isCorrect: false },
+            { snippet: 'b()', isCorrect: false },
+            { snippet: 'c()', isCorrect: true },
+        ]);
+    });
+
+    it('ignores fences outside bad/good sections', () => {
+        const body = [
+            '## Instructions',
+            '```js',
+            'setup()',
+            '```',
+            '### Good example',
+            '```js',
+            'ok()',
+            '```',
+        ].join('\n');
+
+        expect(extractExamplesFromBody(body)).toEqual([
+            { snippet: 'ok()', isCorrect: true },
+        ]);
+    });
+});
+
+describe('isKodyRuleTemplateFile', () => {
+    it.each([
+        ['.kody/rules/security.md', true],
+        ['.kody/rules/architecture/layering.md', true],
+        ['apps/api/.kody/rules/naming.md', true],
+        ['.kody/other/file.md', false],
+        ['CLAUDE.md', false],
+        ['docs/coding-standards/style.md', false],
+        [null, false],
+    ])('%s → %s', (filePath, expected) => {
+        expect(isKodyRuleTemplateFile(filePath as any)).toBe(expected);
+    });
+});


### PR DESCRIPTION
## Problem

`.kody/rules/**` files follow our own documented structured template, but the importer ran them through the same LLM conversion used for free-form sources (CLAUDE.md, .cursorrules). The conversion merges everything into one condensed rule: Bad/Good examples were trimmed, wording rewritten, and rule identifiers (e.g. `**NAME1**`) stripped — reported by a self-hosted customer who authored 9 rule files exactly per the docs and found the imported content mangled.

## Fix

New deterministic parser `libs/common/utils/kody-rules/kody-rule-file-parser.ts`:

- Frontmatter: `title` (required), `path` (string or array → comma-joined, the storage form the review matchers consume), `severity_min` (documented) or `severity` (alias), `scope`, `uuid` passthrough, `enabled: false` → skip import.
- Body after the frontmatter becomes the rule text **verbatim**.
- Bad/Good examples extracted structurally (headings containing bad/incorrect/wrong vs good/correct; all fenced blocks under each).
- Returns `null` for anything that doesn't parse as the template → caller falls back to the LLM importer, so free-form `.kody` files keep working.

Wired into both import paths: `convertFileToKodyRules` (main/PR-driven sync) and the onboarding fast batch (templates are parsed locally, only free-form files go to the batch LLM). Declared template paths keep the `validateAndScopeIdeRulePath` guard so a template can't scope a rule against the rule sources themselves.

## Tests

19 new tests (`kody-rule-file-parser.spec.ts`) including the customer's exact template shape (multi-glob path array, `**CF1**` identifiers surviving, Bad/Good extraction) and fallback cases. Full kody sweep: 460 tests green.

Note: multi-glob comma-joined paths depend on the matcher fix in #1494.

Closes #1487

🤖 Generated with [Claude Code](https://claude.com/claude-code)