### PR TITLE
fix(kody-rules): stop resurrecting stale soft-deleted rules on re-import

### DIFF
--- a/libs/kodyRules/infrastructure/adapters/services/kodyRulesSync.service.ts
+++ b/libs/kodyRules/infrastructure/adapters/services/kodyRulesSync.service.ts
@@ -236,11 +236,34 @@ export class KodyRulesSyncService {
             const existing = await this.kodyRulesService.findByOrganizationId(
                 organizationAndTeamData.organizationId,
             );
-            const found = existing?.rules?.find(
-                (r) =>
-                    r?.repositoryId === repositoryId &&
-                    r?.sourcePath === sourcePath,
+            const matches =
+                existing?.rules?.filter(
+                    (r) =>
+                        r?.repositoryId === repositoryId &&
+                        r?.sourcePath === sourcePath,
+                ) ?? [];
+
+            if (!matches.length) return null;
+
+            // Prefer the NEWEST non-deleted record. The old `Array.find`
+            // returned the first (i.e. oldest) match regardless of status,
+            // so when a sourcePath had both a stale soft-DELETED record and
+            // a newer live one, re-imports kept resurrecting/updating the
+            // stale record (customer-reported: "old rule persisted; toggle
+            // off removed it, toggle on re-added it"). Falling back to a
+            // deleted match is intentional — if the source file still
+            // exists in the repo, reviving that record (with refreshed
+            // content) beats accumulating duplicates.
+            const newestFirst = [...matches].sort(
+                (a, b) =>
+                    new Date((b as any)?.createdAt ?? 0).getTime() -
+                    new Date((a as any)?.createdAt ?? 0).getTime(),
             );
+            const found =
+                newestFirst.find(
+                    (r) => r?.status !== KodyRulesStatus.DELETED,
+                ) ?? newestFirst[0];
+
             return found ? { uuid: found.uuid } : null;
         } catch (error) {
             this.logger.error({

--- a/test/unit/kodyRules/services/kody-rules-sync.service.spec.ts
+++ b/test/unit/kodyRules/services/kody-rules-sync.service.spec.ts
@@ -1318,3 +1318,111 @@ describe('KodyRulesSyncService.resolveSyncDefaultStatus (IDE-sync knowledge-appr
         expect(status).toBe(KodyRulesStatus.ACTIVE);
     });
 });
+
+describe('KodyRulesSyncService.findRuleBySourcePath — stale-record precedence', () => {
+    const organizationAndTeamData = {
+        organizationId: 'org-1',
+        teamId: 'team-1',
+    };
+
+    function createService(rules: any[]) {
+        const kodyRulesService = {
+            findByOrganizationId: jest.fn().mockResolvedValue({ rules }),
+        };
+        const service = new KodyRulesSyncService(
+            kodyRulesService as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+        );
+        return service;
+    }
+
+    const lookup = (service: KodyRulesSyncService) =>
+        (service as any).findRuleBySourcePath({
+            organizationAndTeamData,
+            repositoryId: 'repo-1',
+            sourcePath: '.kody/rules/naming.md',
+        });
+
+    it('prefers the newest non-deleted record over an older soft-deleted one', async () => {
+        // Customer-reported: "old rule persisted; toggle off removed it,
+        // toggle on re-added it". Array.find picked the OLDEST record for
+        // the sourcePath regardless of status, resurrecting the stale one.
+        const service = createService([
+            {
+                uuid: 'stale-deleted',
+                repositoryId: 'repo-1',
+                sourcePath: '.kody/rules/naming.md',
+                status: KodyRulesStatus.DELETED,
+                createdAt: '2026-01-01T00:00:00.000Z',
+            },
+            {
+                uuid: 'live-newer',
+                repositoryId: 'repo-1',
+                sourcePath: '.kody/rules/naming.md',
+                status: KodyRulesStatus.ACTIVE,
+                createdAt: '2026-06-01T00:00:00.000Z',
+            },
+        ]);
+
+        await expect(lookup(service)).resolves.toEqual({ uuid: 'live-newer' });
+    });
+
+    it('prefers a non-deleted record even when it is older', async () => {
+        const service = createService([
+            {
+                uuid: 'deleted-newer',
+                repositoryId: 'repo-1',
+                sourcePath: '.kody/rules/naming.md',
+                status: KodyRulesStatus.DELETED,
+                createdAt: '2026-06-01T00:00:00.000Z',
+            },
+            {
+                uuid: 'live-older',
+                repositoryId: 'repo-1',
+                sourcePath: '.kody/rules/naming.md',
+                status: KodyRulesStatus.ACTIVE,
+                createdAt: '2026-01-01T00:00:00.000Z',
+            },
+        ]);
+
+        await expect(lookup(service)).resolves.toEqual({ uuid: 'live-older' });
+    });
+
+    it('falls back to the deleted record when it is the only match (intentional revive)', async () => {
+        const service = createService([
+            {
+                uuid: 'only-deleted',
+                repositoryId: 'repo-1',
+                sourcePath: '.kody/rules/naming.md',
+                status: KodyRulesStatus.DELETED,
+                createdAt: '2026-01-01T00:00:00.000Z',
+            },
+        ]);
+
+        await expect(lookup(service)).resolves.toEqual({
+            uuid: 'only-deleted',
+        });
+    });
+
+    it('returns null when nothing matches repo + sourcePath', async () => {
+        const service = createService([
+            {
+                uuid: 'other-repo',
+                repositoryId: 'repo-2',
+                sourcePath: '.kody/rules/naming.md',
+                status: KodyRulesStatus.ACTIVE,
+            },
+        ]);
+
+        await expect(lookup(service)).resolves.toBeNull();
+    });
+});


### PR DESCRIPTION
## Problem

Customer-reported (first report, item 5): an old rule persisted; toggling sync off auto-removed it, toggling on re-added it on the next run.

Root cause: toggle-off "delete" is a soft-delete (status → DELETED, record stays in the rules array), and `findRuleBySourcePath` matched with `Array.find` over ALL rules — soft-deleted included — returning the **first (oldest)** record for a sourcePath. When a stale deleted record coexisted with a newer live one, every re-import matched the stale uuid, and `createOrUpdate` merged the fresh content into it and flipped it back to ACTIVE — a resurrection of the oldest record, not an update of the current one.

## Fix

`findRuleBySourcePath` now prefers the **newest non-deleted** match. Falling back to a deleted record when it's the only match is kept intentionally: if the source file still exists in the repo, reviving that record (with content refreshed from the file) beats accumulating duplicates.

## Tests

4 new tests covering: newest-live wins over older-deleted, live wins even when older, sole-deleted fallback (revive), and no-match. Full kody sweep green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)