### PR TITLE
docs: translate README to pt-BR, es, ja, zh-CN, and fr

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,0 +1,289 @@
+<p align="center">
+  <img alt="logotipo de kodus" src="https://kodus.io/wp-content/uploads/2026/06/kodus-thumb-git-scaled.png">
+</p>
+
+<p align="center">
+   <a href="http://makeapullrequest.com">
+      <img alt="PRs bienvenidos" src="https://img.shields.io/badge/PRs-welcome-darkgreen.svg?style=shields" />
+   </a>
+   <a href="https://github.com/kodustech/kodus-ai" target="_blank">
+      <img src="https://img.shields.io/github/stars/kodustech/kodus-ai" alt="Estrellas de Github" />
+   </a>
+   <a href="./license.md">
+      <img src="https://img.shields.io/badge/license-AGPLv3-red" alt="Licencia" />
+   </a>
+</p>
+
+---
+
+<p align="center">
+   <a href="https://kodus.io">Sitio web</a> ·
+   <a href="https://discord.gg/6WbWrRbsH7">Comunidad</a> ·
+   <a href="https://docs.kodus.io">Docs</a> ·
+   <a href="https://docs.kodus.io/how_to_use/en/cli/overview">Docs del CLI</a> ·
+   <strong><a href="https://app.kodus.io">Prueba Kodus Cloud </a></strong> ·
+   <strong><a href="https://docs.kodus.io/how_to_deploy/en/deploy_kodus/generic_vm">Guía de Self-Host</a></strong>
+</p>
+
+<p align="center">
+   🌐
+   <a href="./README.md">English</a> ·
+   <a href="./README.pt-BR.md">Português (BR)</a> ·
+   <a href="./README.es.md">Español</a> ·
+   <a href="./README.ja.md">日本語</a> ·
+   <a href="./README.zh-CN.md">简体中文</a> ·
+   <a href="./README.fr.md">Français</a>
+</p>
+
+## Por qué los equipos eligen Kodus
+
+- **Agnóstico de modelos**: Usa Claude, GPT-5, Gemini, Llama, GLM, Kimi o cualquier endpoint compatible con OpenAI.
+- **Sin recargo en los costos de LLM**: Pagas directamente a los proveedores de modelos. Sin multiplicadores ocultos.
+- **Aprende de tu contexto**: Kody se adapta a tu arquitectura, estándares y flujo de trabajo.
+- **Tú estableces las reglas**: Define reglas de revisión personalizadas en lenguaje natural.
+- **Privacidad y seguridad**: El código fuente no se usa para entrenar modelos, los datos se cifran en tránsito y en reposo, y se admiten runners self-hosted. Las instancias self-hosted envían un heartbeat anónimo por día (solo contadores agregados — sin código, nombres ni identificadores); desactívalo con `KODUS_TELEMETRY_DISABLED=true`. Consulta [Telemetría anónima](https://docs.kodus.io/how_to_deploy/en/deploy_kodus/telemetry).
+- **Flujo de Git nativo**: Funciona directamente en PRs con GitHub, GitLab, Bitbucket y Azure Repos.
+- **Listo para CLI + CI/CD**: Ejecuta revisiones localmente y en pipelines.
+- **Impacto operativo**: Haz seguimiento de la deuda técnica y métricas de entrega manteniendo alta la calidad de revisión.
+
+## Características destacadas del producto
+
+<details>
+  <summary><strong>🔑 Trae Tu Propia Clave (BYOK)</strong></summary>
+<br />
+Conecta tus propias credenciales de proveedor y elige los modelos detrás de las revisiones de Kodus: OpenAI, Anthropic, Google Gemini, Vertex AI, Novita o cualquier endpoint compatible con OpenAI. Mantén la facturación y el uso bajo tu propia cuenta de proveedor, sin recargos ocultos de LLM.
+
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/byok-scaled.png" alt="Configuración de proveedor de modelos Kodus BYOK" width="900">
+</p>
+
+</details>
+
+<br />
+
+<details>
+  <summary><strong>📈 Uso de Tokens</strong></summary>
+<br />
+Haz seguimiento del consumo de tokens en las revisiones de código con IA, comprende los factores de costo y mantén el gasto de modelos predecible a medida que crece la adopción.
+
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/token-usage-scaled.png" alt="Dashboard de uso de tokens de Kodus" width="900">
+</p>
+
+</details>
+
+<br />
+
+<details>
+  <summary><strong>⚙️ Kody Rules</strong></summary>
+<br />
+Kody Rules permite a los equipos definir instrucciones de revisión en lenguaje natural y aplicarlas en organizaciones, repositorios, rutas o ámbitos de revisión específicos. Kody usa esas reglas como contexto al revisar pull requests, ayudando a aplicar decisiones de arquitectura, expectativas de seguridad, prácticas de testing y convenciones específicas del repositorio sin depender de que los revisores repitan manualmente los mismos comentarios.
+
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/rules-scaled.png" alt="Reglas de Kody" width="900">
+</p>
+</details>
+<br />
+<details>
+  <summary><strong>📊 Cockpit</strong></summary>
+<br />
+Cockpit ayuda a los equipos a medir la efectividad de las revisiones de Kodus, la salud de las Kody Rules, la salud de los repositorios y las métricas de entrega en todo el flujo de trabajo de ingeniería.
+
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/cockpit-kodus-scaled.png" alt="Cockpit de Kodus mostrando la salud del pipeline de revisión de código con IA" width="900">
+</p>
+
+</details>
+
+<br />
+
+<details>
+  <summary><strong>🧩 Kody Issues</strong></summary>
+<br />
+Haz seguimiento automático de las sugerencias no implementadas de pull requests cerrados, gestiónalas por estado, severidad, categoría y repositorio, y deja que Kody las resuelva cuando la corrección aparezca en un PR futuro.
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/issues-scaled.png" alt="Dashboard de Kody Issues" width="900">
+</p>
+
+</details>
+
+<br />
+<details>
+  <summary><strong>🔎 Mira a Kody revisando un pull request real</strong></summary>
+<br />
+Kody hace más que resumir diffs. Revisa código con contexto, marca riesgos por severidad y sugiere correcciones concretas directamente en el pull request.
+
+<br />
+<br />
+
+<p align="center">
+  <img
+    src="https://kodus.io/wp-content/uploads/2025/12/review-kody-.png"
+    alt="Kody detectando un problema crítico de seguridad IDOR en una revisión de pull request"
+    width="700"
+  />
+</p>
+
+En este ejemplo, Kody detecta un riesgo crítico de IDOR donde un parámetro de consulta `organizationId` podría evadir la protección de tenant al pasarse como un array, y luego sugiere una validación explícita en tiempo de ejecución antes de que el código se fusione.
+
+</details>
+
+## Comienza
+
+Elige el flujo de trabajo que coincida con cómo quieres usar Kodus.
+
+<table>
+  <tr>
+    <td width="50%">
+      <strong>Prueba Kodus Cloud</strong>
+      <br />
+      Comienza a revisar pull requests sin gestionar infraestructura.
+      <br />
+      <br />
+      <a href="https://app.kodus.io/signup">Crea una cuenta gratuita</a>
+      ·
+      <a href="https://kodus.io/pricing">Ver precios</a>
+    </td>
+    <td width="50%">
+      <strong>Self-host Kodus</strong>
+      <br />
+      Despliega Kodus en tu propia infraestructura con control sobre los datos,
+      los modelos y la configuración de ejecución.
+      <br />
+      <br />
+      <a href="https://docs.kodus.io/how_to_deploy/en/deploy_kodus/generic_vm">Guía de instalación</a>
+    </td>
+  </tr>
+  <tr>
+    <td width="50%">
+      <strong>Usa el CLI</strong>
+      <br />
+      Ejecuta revisiones de código con IA desde tu terminal sobre un árbol de
+      trabajo, diff staged, rama o commit.
+      <br />
+      <br />
+      <code>kodus review</code>
+      <br />
+      <code>kodus review --staged</code>
+      <br />
+      <code>kodus review --prompt-only</code>
+      <br />
+      <br />
+      <a href="https://docs.kodus.io/how_to_use/en/cli/introduction">Visión general del CLI</a>
+      ·
+      <a href="https://docs.kodus.io/how_to_use/en/cli/commands">Referencia de comandos</a>
+      ·
+      <a href="https://docs.kodus.io/how_to_use/en/cli/ci_cd">CI/CD</a>
+    </td>
+    <td width="50%">
+      <strong>Contribuye localmente</strong>
+      <br />
+      Ejecuta el monorepo de Kodus localmente para desarrollo en la API, worker,
+      servicio de webhooks, aplicación web e infraestructura local.
+      <br />
+      <br />
+      <code>git clone https://github.com/kodustech/kodus-ai.git</code>
+      <br />
+      <code>cd kodus-ai</code>
+      <br />
+      <code>yarn setup</code>
+      <br />
+      <br />
+      <a href="https://docs.kodus.io/how_to_deploy/en/local_quickstart/orchestrator">Quickstart local</a>
+    </td>
+  </tr>
+</table>
+
+## Estructura del Monorepo
+
+Kodus es un monorepo con múltiples aplicaciones, librerías de dominio compartidas y paquetes publicados.
+
+```txt
+kodus-ai/
+├── apps/
+│   ├── api/          # API NestJS
+│   ├── web/          # Dashboard Next.js
+│   ├── worker/       # Ejecución de revisiones y consumidores de cola
+│   └── webhooks/     # Ingestión de webhooks de proveedores Git
+├── libs/             # Módulos de dominio NestJS compartidos
+├── packages/
+│   ├── kodus-flow/   # SDK de orquestación de agentes IA
+│   └── kodus-common/ # Paquete de abstracción de LLM
+└── scripts/          # Scripts de dev, deploy, benchmark y automatización
+```
+
+| Ruta | Propósito |
+| --- | --- |
+| `apps/api` | API NestJS principal para autenticación, organizaciones, equipos, Kody Rules, integraciones, permisos y orquestación de revisiones de código. |
+| `apps/web` | Aplicación web Next.js para el dashboard de Kodus. |
+| `apps/worker` | Servicio en segundo plano para la ejecución de revisiones de código, procesamiento de colas, verificación de sugerencias, jobs de automatización y tareas de monitoreo. |
+| `apps/webhooks` | Servicio de ingestión de webhooks para eventos de GitHub, GitLab, Azure Repos, Bitbucket y Forgejo. |
+| `libs` | Módulos de dominio NestJS compartidos usados en todas las aplicaciones de Kodus. |
+| `packages/kodus-flow` | SDK para orquestación de agentes IA. |
+| `packages/kodus-common` | Paquete de abstracción de LLM compartido para proveedores de modelos. |
+
+Para instrucciones completas de configuración, sigue el [Quickstart local](https://docs.kodus.io/how_to_deploy/en/local_quickstart/orchestrator).
+
+## Open Source vs. Teams vs. Enterprise
+
+| Característica | <img src="https://kodus.io/wp-content/uploads/2026/06/kody-community2-scaled.webp" alt="Kody Community" width="110" /><br>Community | <img src="https://kodus.io/wp-content/uploads/2026/06/kody-team-scaled.webp" alt="Kody Teams" width="110" /><br>Teams | <img src="https://kodus.io/wp-content/uploads/2026/06/kody-enterprise-scaled.webp" alt="Kody Enterprise" width="110" /><br>Enterprise |
+| :--- | :---: | :---: | :---: |
+| Precio | Gratis | $10/dev mensual o $8/dev anual (+ tokens/dev) | Personalizado |
+| Hosting | Self-hosted **o** alojado por Kodus | Alojado por Kodus | Self-hosted **o** alojado por Kodus |
+| Trae Tu Propia Clave (BYOK) | ✅ | ✅ | ✅ |
+| Uso de PR | PRs ilimitados usando tu propia API key | PRs ilimitados usando tu propia API key | PRs ilimitados usando la API key de Kodus AI Tokens |
+| Usuarios | Ilimitados | Ilimitados | Ilimitados |
+| Kody Rules | Hasta 10 | Ilimitadas | Ilimitadas |
+| Plugins activos | Hasta 3 | Ilimitados | Ilimitados |
+| Kody Learnings y Memory | ✅ | ✅ | ✅ |
+| Issues del Quality Radar | Ilimitados | Ilimitados | Ilimitados |
+| Cola prioritaria para Kody Agents | ❌ | ✅ | ✅ |
+| Métricas de ingeniería / Cockpit | ❌ | ✅ | ✅ |
+| SSO | ❌ | ❌ | ✅ |
+| RBAC + logs de auditoría + analítica | ❌ | ❌ | ✅ |
+| Cumplimiento | ❌ | ❌ | SOC 2 |
+| Soporte | Soporte de la comunidad en Discord | Comunidad en Discord + Soporte por Email | Discord privado + Email + hasta 5h/mes de onboarding/soporte dedicado |
+
+[Compara todos los planes →](https://kodus.io/pricing)
+
+## Recursos
+
+| Recurso | Descripción |
+| --- | --- |
+| [Sitio web](https://kodus.io) | Conoce más sobre Kodus, las capacidades del producto y los precios. |
+| [Documentación](https://docs.kodus.io) | Guías de configuración, docs del producto, uso del CLI e instrucciones de self-hosting. |
+| [Kodus Cloud](https://app.kodus.io) | Comienza a usar Kodus sin gestionar infraestructura. |
+| [Guía de Self-Host](https://docs.kodus.io/how_to_deploy/en/deploy_kodus/generic_vm) | Despliega Kodus en tu propio entorno. |
+| [Docs del CLI](https://docs.kodus.io/how_to_use/en/cli/overview) | Ejecuta revisiones de código con IA localmente, en CI/CD o dentro de agentes de codificación. |
+| [Comunidad de Discord](https://discord.gg/6WbWrRbsH7) | Haz preguntas, obtén ayuda de configuración y habla con el equipo de Kodus. |
+| [Precios](https://kodus.io/pricing) | Compara las ediciones Community, Teams y Enterprise. |
+| [Agenda una llamada](https://cal.com/gabrielmalinosqui/30min) | Habla con el equipo de Kodus sobre configuración, self-hosting o necesidades enterprise. |
+
+
+
+## Contribuir
+
+<p align="left">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/kody-contributing-scaled.png" alt="Kody contribuyendo" width="230" />
+</p>
+
+Agradecemos contribuciones de todos los tamaños 🧡
+
+Corrige un typo, mejora los docs, reporta un bug, sugiere una feature o abre un pull request para algo que crees que debería existir.
+
+¿No sabes por dónde empezar? Abre un issue o únete a la comunidad. Estamos felices de ayudar.

--- a/README.fr.md
+++ b/README.fr.md
@@ -1,0 +1,289 @@
+<p align="center">
+  <img alt="logo kodus" src="https://kodus.io/wp-content/uploads/2026/06/kodus-thumb-git-scaled.png">
+</p>
+
+<p align="center">
+   <a href="http://makeapullrequest.com">
+      <img alt="PRs bienvenues" src="https://img.shields.io/badge/PRs-welcome-darkgreen.svg?style=shields" />
+   </a>
+   <a href="https://github.com/kodustech/kodus-ai" target="_blank">
+      <img src="https://img.shields.io/github/stars/kodustech/kodus-ai" alt="Étoiles Github" />
+   </a>
+   <a href="./license.md">
+      <img src="https://img.shields.io/badge/license-AGPLv3-red" alt="Licence" />
+   </a>
+</p>
+
+---
+
+<p align="center">
+   <a href="https://kodus.io">Site web</a> ·
+   <a href="https://discord.gg/6WbWrRbsH7">Communauté</a> ·
+   <a href="https://docs.kodus.io">Docs</a> ·
+   <a href="https://docs.kodus.io/how_to_use/en/cli/overview">Docs CLI</a> ·
+   <strong><a href="https://app.kodus.io">Essayer Kodus Cloud </a></strong> ·
+   <strong><a href="https://docs.kodus.io/how_to_deploy/en/deploy_kodus/generic_vm">Guide d'auto-hébergement</a></strong>
+</p>
+
+<p align="center">
+   🌐
+   <a href="./README.md">English</a> ·
+   <a href="./README.pt-BR.md">Português (BR)</a> ·
+   <a href="./README.es.md">Español</a> ·
+   <a href="./README.ja.md">日本語</a> ·
+   <a href="./README.zh-CN.md">简体中文</a> ·
+   <a href="./README.fr.md">Français</a>
+</p>
+
+## Pourquoi les équipes choisissent Kodus
+
+- **Agnostique au modèle** : Utilisez Claude, GPT-5, Gemini, Llama, GLM, Kimi ou tout endpoint compatible OpenAI.
+- **Aucune majoration sur les coûts LLM** : Vous payez directement les fournisseurs de modèles. Aucun multiplicateur caché.
+- **Apprend de votre contexte** : Kody s'adapte à votre architecture, vos standards et votre workflow.
+- **Vous définissez les règles** : Créez des règles de revue personnalisées en langage naturel.
+- **Confidentialité et sécurité** : Le code source n'est pas utilisé pour entraîner les modèles, les données sont chiffrées en transit et au repos, et les runners auto-hébergés sont pris en charge. Les instances auto-hébergées envoient un heartbeat anonyme par jour (compteurs agrégés uniquement — aucun code, nom ou identifiant) ; désactivez-le avec `KODUS_TELEMETRY_DISABLED=true`. Voir [Télémétrie anonyme](https://docs.kodus.io/how_to_deploy/en/deploy_kodus/telemetry).
+- **Workflow Git natif** : Fonctionne directement dans les PR avec GitHub, GitLab, Bitbucket et Azure Repos.
+- **CLI + CI/CD prêt** : Lancez des revues localement et dans vos pipelines.
+- **Impact opérationnel** : Suivez la dette technique et les métriques de livraison tout en maintenant une haute qualité de revue.
+
+## Points forts du produit
+
+<details>
+  <summary><strong>🔑 Apportez Votre Propre Clé (BYOK)</strong></summary>
+<br />
+Connectez vos propres identifiants de fournisseur et choisissez les modèles derrière les revues Kodus : OpenAI, Anthropic, Google Gemini, Vertex AI, Novita, ou tout endpoint compatible OpenAI. Gardez la facturation et l'utilisation sous votre propre compte fournisseurs, sans majoration LLM cachée.
+
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/byok-scaled.png" alt="Configuration du fournisseur de modèle Kodus BYOK" width="900">
+</p>
+
+</details>
+
+<br />
+
+<details>
+  <summary><strong>📈 Utilisation des tokens</strong></summary>
+<br />
+Suivez la consommation de tokens across les revues de code IA, comprenez les facteurs de coût, et gardez les dépenses de modèle prévisibles à mesure que l'adoption augmente.
+
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/token-usage-scaled.png" alt="Dashboard d'utilisation des tokens Kodus" width="900">
+</p>
+
+</details>
+
+<br />
+
+<details>
+  <summary><strong>⚙️ Kody Rules</strong></summary>
+<br />
+Kody Rules permet aux équipes de définir des instructions de revue en langage naturel et de les appliquer au niveau des organisations, dépôts, chemins ou portées de revue spécifiques. Kody utilise ces règles comme contexte lors de la revue des pull requests, aidant à faire respecter les décisions d'architecture, les attentes de sécurité, les pratiques de test et les conventions spécifiques au dépôt sans dépendre des relecteurs pour répéter manuellement le même feedback.
+
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/rules-scaled.png" alt="Règles Kody" width="900">
+</p>
+</details>
+<br />
+<details>
+  <summary><strong>📊 Cockpit</strong></summary>
+<br />
+Cockpit aide les équipes à mesurer l'efficacité des revues Kodus, la santé des Kody Rules, la santé des dépôts et les métriques de livraison à travers le workflow d'ingénierie.
+
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/cockpit-kodus-scaled.png" alt="Cockpit Kodus montrant la santé du pipeline de revue de code IA" width="900">
+</p>
+
+</details>
+
+<br />
+
+<details>
+  <summary><strong>🧩 Kody Issues</strong></summary>
+<br />
+Suivez automatiquement les suggestions non implémentées issues des pull requests fermées, gérez-les par statut, sévérité, catégorie et dépôt, et laissez Kody les résoudre lorsque le correctif apparaît dans une future PR.
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/issues-scaled.png" alt="Dashboard Kody Issues" width="900">
+</p>
+
+</details>
+
+<br />
+<details>
+  <summary><strong>🔎 Voir Kody reviewer une vraie pull request</strong></summary>
+<br />
+Kody fait bien plus que résumer les diffs. Il examine le code avec contexte, signale les risques par sévérité, et suggère des correctifs concrets directement dans la pull request.
+
+<br />
+<br />
+
+<p align="center">
+  <img
+    src="https://kodus.io/wp-content/uploads/2025/12/review-kody-.png"
+    alt="Kody détectant un problème de sécurité IDOR critique dans une revue de pull request"
+    width="700"
+  />
+</p>
+
+Dans cet exemple, Kody intercepte un risque IDOR critique où un paramètre de requête `organizationId` pourrait contourner la protection tenant lorsqu'il est passé sous forme de tableau, puis suggère une validation explicite à l'exécution avant que le code ne soit mergé.
+
+</details>
+
+## Pour commencer
+
+Choisissez le workflow qui correspond à la façon dont vous souhaitez utiliser Kodus.
+
+<table>
+  <tr>
+    <td width="50%">
+      <strong>Essayer Kodus Cloud</strong>
+      <br />
+      Commencez à reviewer des pull requests sans gérer d'infrastructure.
+      <br />
+      <br />
+      <a href="https://app.kodus.io/signup">Créer un compte gratuit</a>
+      ·
+      <a href="https://kodus.io/pricing">Voir les tarifs</a>
+    </td>
+    <td width="50%">
+      <strong>Auto-héberger Kodus</strong>
+      <br />
+      Déployez Kodus sur votre propre infrastructure avec le contrôle des données, des modèles,
+      et de la configuration d'exécution.
+      <br />
+      <br />
+      <a href="https://docs.kodus.io/how_to_deploy/en/deploy_kodus/generic_vm">Guide d'installation</a>
+    </td>
+  </tr>
+  <tr>
+    <td width="50%">
+      <strong>Utiliser la CLI</strong>
+      <br />
+      Lancez des revues de code IA depuis votre terminal sur un working tree, un diff staged,
+      une branche ou un commit.
+      <br />
+      <br />
+      <code>kodus review</code>
+      <br />
+      <code>kodus review --staged</code>
+      <br />
+      <code>kodus review --prompt-only</code>
+      <br />
+      <br />
+      <a href="https://docs.kodus.io/how_to_use/en/cli/introduction">Aperçu de la CLI</a>
+      ·
+      <a href="https://docs.kodus.io/how_to_use/en/cli/commands">Référence des commandes</a>
+      ·
+      <a href="https://docs.kodus.io/how_to_use/en/cli/ci_cd">CI/CD</a>
+    </td>
+    <td width="50%">
+      <strong>Contribuer localement</strong>
+      <br />
+      Exécutez le monorepo Kodus localement pour le développement sur l'API, le worker,
+      le service webhooks, l'application web et l'infrastructure locale.
+      <br />
+      <br />
+      <code>git clone https://github.com/kodustech/kodus-ai.git</code>
+      <br />
+      <code>cd kodus-ai</code>
+      <br />
+      <code>yarn setup</code>
+      <br />
+      <br />
+      <a href="https://docs.kodus.io/how_to_deploy/en/local_quickstart/orchestrator">Démarrage rapide local</a>
+    </td>
+  </tr>
+</table>
+
+## Structure du monorepo
+
+Kodus est un monorepo avec plusieurs applications, des bibliothèques de domaine partagées et des packages publiés.
+
+```txt
+kodus-ai/
+├── apps/
+│   ├── api/          # API NestJS
+│   ├── web/          # Dashboard Next.js
+│   ├── worker/       # Exécution des revues et consommateurs de queue
+│   └── webhooks/     # Ingestion des webhooks des fournisseurs Git
+├── libs/             # Modules de domaine NestJS partagés
+├── packages/
+│   ├── kodus-flow/   # SDK d'orchestration d'agents IA
+│   └── kodus-common/ # Package d'abstraction LLM
+└── scripts/          # Scripts de dev, deploy, benchmark et automatisation
+```
+
+| Chemin | Objectif |
+| --- | --- |
+| `apps/api` | API NestJS principale pour l'authentification, les organisations, les équipes, les Kody Rules, les intégrations, les permissions et l'orchestration des revues de code. |
+| `apps/web` | Application web Next.js pour le dashboard Kodus. |
+| `apps/worker` | Service en arrière-plan pour l'exécution des revues de code, le traitement des queues, les vérifications de suggestions, les jobs d'automatisation et les tâches de monitoring. |
+| `apps/webhooks` | Service d'ingestion de webhooks pour les événements GitHub, GitLab, Azure Repos, Bitbucket et Forgejo. |
+| `libs` | Modules de domaine NestJS partagés utilisés à travers les applications Kodus. |
+| `packages/kodus-flow` | SDK pour l'orchestration d'agents IA. |
+| `packages/kodus-common` | Package d'abstraction LLM partagé pour les fournisseurs de modèles. |
+
+Pour des instructions d'installation complètes, suivez le [Démarrage rapide local](https://docs.kodus.io/how_to_deploy/en/local_quickstart/orchestrator).
+
+## Open Source vs. Teams vs. Enterprise
+
+| Fonctionnalité | <img src="https://kodus.io/wp-content/uploads/2026/06/kody-community2-scaled.webp" alt="Kody Community" width="110" /><br>Community | <img src="https://kodus.io/wp-content/uploads/2026/06/kody-team-scaled.webp" alt="Kody Teams" width="110" /><br>Teams | <img src="https://kodus.io/wp-content/uploads/2026/06/kody-enterprise-scaled.webp" alt="Kody Enterprise" width="110" /><br>Enterprise |
+| :--- | :---: | :---: | :---: |
+| Prix | Gratuit | 10 $/dev mensuel ou 8 $/dev annuel (+ tokens/dev) | Sur mesure |
+| Hébergement | Auto-hébergé **ou** hébergé par Kodus | Hébergé par Kodus | Auto-hébergé **ou** hébergé par Kodus |
+| Apportez Votre Propre Clé (BYOK) | ✅ | ✅ | ✅ |
+| Utilisation de PR | PR illimitées avec votre propre clé API | PR illimitées avec votre propre clé API | PR illimitées avec la clé API Kodus AI Tokens |
+| Utilisateurs | Illimités | Illimités | Illimités |
+| Kody Rules | Jusqu'à 10 | Illimitées | Illimitées |
+| Plugins actifs | Jusqu'à 3 | Illimités | Illimités |
+| Kody Learnings et mémoire | ✅ | ✅ | ✅ |
+| Issues Quality Radar | Illimités | Illimités | Illimités |
+| File prioritaire pour les Kody Agents | ❌ | ✅ | ✅ |
+| Métriques d'ingénierie / Cockpit | ❌ | ✅ | ✅ |
+| SSO | ❌ | ❌ | ✅ |
+| RBAC + logs d'audit + analytics | ❌ | ❌ | ✅ |
+| Conformité | ❌ | ❌ | SOC 2 |
+| Support | Support Communauté Discord | Support Communauté + Email Discord | Discord privé + Email + jusqu'à 5 h/mois d'onboarding/support dédié |
+
+[Comparer tous les plans →](https://kodus.io/pricing)
+
+## Ressources
+
+| Ressource | Description |
+| --- | --- |
+| [Site web](https://kodus.io) | En savoir plus sur Kodus, les capacités produit et les tarifs. |
+| [Documentation](https://docs.kodus.io) | Guides d'installation, docs produit, utilisation CLI et instructions d'auto-hébergement. |
+| [Kodus Cloud](https://app.kodus.io) | Commencez à utiliser Kodus sans gérer d'infrastructure. |
+| [Guide d'auto-hébergement](https://docs.kodus.io/how_to_deploy/en/deploy_kodus/generic_vm) | Déployez Kodus dans votre propre environnement. |
+| [Docs CLI](https://docs.kodus.io/how_to_use/en/cli/overview) | Lancez des revues de code IA localement, en CI/CD, ou dans des agents de codage. |
+| [Communauté Discord](https://discord.gg/6WbWrRbsH7) | Posez des questions, obtenez de l'aide à l'installation et échangez avec l'équipe Kodus. |
+| [Tarifs](https://kodus.io/pricing) | Comparez les éditions Community, Teams et Enterprise. |
+| [Planifier un appel](https://cal.com/gabrielmalinosqui/30min) | Discutez avec l'équipe Kodus de l'installation, de l'auto-hébergement ou des besoins enterprise. |
+
+
+
+## Contribuer
+
+<p align="left">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/kody-contributing-scaled.png" alt="Kody contribuant" width="230" />
+</p>
+
+Nous accueillons les contributions de toutes tailles 🧡
+
+Corrigez une faute de frappe, améliorez la documentation, signalez un bug, suggérez une fonctionnalité, ou ouvrez une pull request pour quelque chose qui devrait selon vous exister.
+
+Vous ne savez pas par où commencer ? Ouvrez une issue ou rejoignez la communauté. Nous sommes ravis de vous aider.

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,289 @@
+<p align="center">
+  <img alt="kodusロゴ" src="https://kodus.io/wp-content/uploads/2026/06/kodus-thumb-git-scaled.png">
+</p>
+
+<p align="center">
+   <a href="http://makeapullrequest.com">
+      <img alt="PRを歓迎します" src="https://img.shields.io/badge/PRs-welcome-darkgreen.svg?style=shields" />
+   </a>
+   <a href="https://github.com/kodustech/kodus-ai" target="_blank">
+      <img src="https://img.shields.io/github/stars/kodustech/kodus-ai" alt="Githubのスター" />
+   </a>
+   <a href="./license.md">
+      <img src="https://img.shields.io/badge/license-AGPLv3-red" alt="ライセンス" />
+   </a>
+</p>
+
+---
+
+<p align="center">
+   <a href="https://kodus.io">ウェブサイト</a> ·
+   <a href="https://discord.gg/6WbWrRbsH7">コミュニティ</a> ·
+   <a href="https://docs.kodus.io">ドキュメント</a> ·
+   <a href="https://docs.kodus.io/how_to_use/en/cli/overview">CLIドキュメント</a> ·
+   <strong><a href="https://app.kodus.io">Kodus Cloudを試す </a></strong> ·
+   <strong><a href="https://docs.kodus.io/how_to_deploy/en/deploy_kodus/generic_vm">セルフホストガイド</a></strong>
+</p>
+
+<p align="center">
+   🌐
+   <a href="./README.md">English</a> ·
+   <a href="./README.pt-BR.md">Português (BR)</a> ·
+   <a href="./README.es.md">Español</a> ·
+   <a href="./README.ja.md">日本語</a> ·
+   <a href="./README.zh-CN.md">简体中文</a> ·
+   <a href="./README.fr.md">Français</a>
+</p>
+
+## チームがKodusを選ぶ理由
+
+- **モデル非依存**: Claude、GPT-5、Gemini、Llama、GLM、Kimi、または任意のOpenAI互換エンドポイントを利用可能。
+- **LLMコストの上乗せなし**: モデルプロバイダーに直接支払い。隠れた倍率はありません。
+- **コンテキストから学習**: Kodyはあなたのアーキテクチャ、標準、ワークフローに適応します。
+- **ルールはあなたが決める**: 自然言語でカスタムレビュールールを定義。
+- **プライバシーとセキュリティ**: ソースコードはモデルのトレーニングに使用されず、データは転送時および保存時に暗号化され、セルフホストランナーもサポート。セルフホストインスタンスは1日に1回の匿名ハートビートを送信します（集計カウンターのみ — コード、名前、識別子は含まれません）。`KODUS_TELEMETRY_DISABLED=true`でオプトアウト可能。[匿名テレメトリー](https://docs.kodus.io/how_to_deploy/en/deploy_kodus/telemetry)を参照。
+- **ネイティブなGitワークフロー**: GitHub、GitLab、Bitbucket、Azure ReposでPR内に直接機能。
+- **CLI + CI/CD対応**: ローカルおよびパイプラインでレビューを実行。
+- **運用への影響**: レビュー品質を高く保ちながら、技術的負債とデリバリーメトリクスを追跡。
+
+## 製品のハイライト
+
+<details>
+  <summary><strong>🔑 独自キーの持ち込み (BYOK)</strong></summary>
+<br />
+独自のプロバイダー認証情報を接続し、Kodusレビューの背後にあるモデルを選択: OpenAI、Anthropic、Google Gemini、Vertex AI、Novita、または任意のOpenAI互換エンドポイント。隠れたLLM上乗せなしで、課金と使用量は独自のプロバイダーアカウントで管理。
+
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/byok-scaled.png" alt="Kodus BYOKモデルプロバイダー設定" width="900">
+</p>
+
+</details>
+
+<br />
+
+<details>
+  <summary><strong>📈 トークン使用量</strong></summary>
+<br />
+AIコードレビュー全体のトークン消費を追跡し、コスト要因を把握し、導入が拡大してもモデル支出を予測可能に保ちます。
+
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/token-usage-scaled.png" alt="Kodusトークン使用量ダッシュボード" width="900">
+</p>
+
+</details>
+
+<br />
+
+<details>
+  <summary><strong>⚙️ Kody Rules</strong></summary>
+<br />
+Kody Rulesにより、チームは自然言語でレビュー指示を定義し、組織、リポジトリ、パス、または特定のレビュースコープ全体に適用できます。Kodyはプルリクエストをレビューする際、これらのルールをコンテキストとして使用し、レビュー担当者が同じフィードバックを手動で繰り返すことなく、アーキテクチャの決定、セキュリティ要件、テストプラクティス、リポジトリ固有の規約を強制するのに役立ちます。
+
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/rules-scaled.png" alt="Kodyルール" width="900">
+</p>
+</details>
+<br />
+<details>
+  <summary><strong>📊 Cockpit</strong></summary>
+<br />
+Cockpitは、エンジニアリングワークフロー全体でKodusのレビュー効果、Kody Ruleの健全性、リポジトリの健全性、デリバリーメトリクスを測定するのに役立ちます。
+
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/cockpit-kodus-scaled.png" alt="AIコードレビューパイプラインの健全性を示すKodus Cockpit" width="900">
+</p>
+
+</details>
+
+<br />
+
+<details>
+  <summary><strong>🧩 Kody Issues</strong></summary>
+<br />
+クローズされたプルリクエストの未実装サジェスションを自動的に追跡し、ステータス、重要度、カテゴリ、リポジトリごとに管理。将来のPRで修正が現れた際にKodyがそれらを解決。
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/issues-scaled.png" alt="Kodus Issuesダッシュボード" width="900">
+</p>
+
+</details>
+
+<br />
+<details>
+  <summary><strong>🔎 実際のプルリクエストをレビューするKodyを見る</strong></summary>
+<br />
+Kodyは差分を要約するだけではありません。コンテキストを伴ってコードをレビューし、重要度ごとにリスクをフラグし、プルリクエストに直接具体的な修正案を提案します。
+
+<br />
+<br />
+
+<p align="center">
+  <img
+    src="https://kodus.io/wp-content/uploads/2025/12/review-kody-.png"
+    alt="プルリクエストレビューで重大なIDORセキュリティ問題を検出するKody"
+    width="700"
+  />
+</p>
+
+この例では、Kodyは`organizationId`クエリパラメータが配列として渡されるとテナント保護をバイパスする可能性がある重大なIDORリスクを検出し、コードがマージされる前に明示的なランタイムバリデーションを提案します。
+
+</details>
+
+## はじめに
+
+Kodusをどのように利用したいかに合わせたワークフローを選択してください。
+
+<table>
+  <tr>
+    <td width="50%">
+      <strong>Kodus Cloudを試す</strong>
+      <br />
+      インフラを管理せずにプルリクエストのレビューを開始。
+      <br />
+      <br />
+      <a href="https://app.kodus.io/signup">無料アカウントを作成</a>
+      ·
+      <a href="https://kodus.io/pricing">料金を見る</a>
+    </td>
+    <td width="50%">
+      <strong>Kodusをセルフホスト</strong>
+      <br />
+      データ、モデル、ランタイム設定を制御しながら、独自のインフラにKodusを
+      デプロイ。
+      <br />
+      <br />
+      <a href="https://docs.kodus.io/how_to_deploy/en/deploy_kodus/generic_vm">インストールガイド</a>
+    </td>
+  </tr>
+  <tr>
+    <td width="50%">
+      <strong>CLIを使用</strong>
+      <br />
+      ターミナルから、ワーキングツリー、ステージ済み差分、
+      ブランチ、コミットに対してAIコードレビューを実行。
+      <br />
+      <br />
+      <code>kodus review</code>
+      <br />
+      <code>kodus review --staged</code>
+      <br />
+      <code>kodus review --prompt-only</code>
+      <br />
+      <br />
+      <a href="https://docs.kodus.io/how_to_use/en/cli/introduction">CLIの概要</a>
+      ·
+      <a href="https://docs.kodus.io/how_to_use/en/cli/commands">コマンドリファレンス</a>
+      ·
+      <a href="https://docs.kodus.io/how_to_use/en/cli/ci_cd">CI/CD</a>
+    </td>
+    <td width="50%">
+      <strong>ローカルで貢献</strong>
+      <br />
+      API、worker、webhooksサービス、Webアプリ、ローカルインフラ全体にわたる
+      開発のためにKodusモノレポをローカルで実行。
+      <br />
+      <br />
+      <code>git clone https://github.com/kodustech/kodus-ai.git</code>
+      <br />
+      <code>cd kodus-ai</code>
+      <br />
+      <code>yarn setup</code>
+      <br />
+      <br />
+      <a href="https://docs.kodus.io/how_to_deploy/en/local_quickstart/orchestrator">ローカルクイックスタート</a>
+    </td>
+  </tr>
+</table>
+
+## モノレポ構造
+
+Kodusは複数のアプリケーション、共有ドメインライブラリ、公開パッケージを含むモノレポです。
+
+```txt
+kodus-ai/
+├── apps/
+│   ├── api/          # NestJS API
+│   ├── web/          # Next.jsダッシュボード
+│   ├── worker/       # レビュー実行とキューのコンシューマー
+│   └── webhooks/     # Gitプロバイダーのwebhook取り込み
+├── libs/             # 共有NestJSドメインモジュール
+├── packages/
+│   ├── kodus-flow/   # AIエージェントオーケストレーションSDK
+│   └── kodus-common/ # LLM抽象化パッケージ
+└── scripts/          # 開発、デプロイ、ベンチマーク、自動化スクリプト
+```
+
+| パス | 目的 |
+| --- | --- |
+| `apps/api` | 認証、組織、チーム、Kody Rules、インテグレーション、権限、コードレビューオーケストレーションを担うメインのNestJS API。 |
+| `apps/web` | KodusダッシュボードのNext.js Webアプリケーション。 |
+| `apps/worker` | コードレビュー実行、キュー処理、サジェスションチェック、自動化ジョブ、監視タスクを行うバックグラウンドサービス。 |
+| `apps/webhooks` | GitHub、GitLab、Azure Repos、Bitbucket、Forgejoイベントのwebhook取り込みサービス。 |
+| `libs` | Kodusアプリケーション全体で使用される共有NestJSドメインモジュール。 |
+| `packages/kodus-flow` | AIエージェントオーケストレーション用SDK。 |
+| `packages/kodus-common` | モデルプロバイダー向けの共有LLM抽象化パッケージ。 |
+
+完全なセットアップ手順については、[ローカルクイックスタート](https://docs.kodus.io/how_to_deploy/en/local_quickstart/orchestrator)に従ってください。
+
+## オープンソース vs. Teams vs. Enterprise
+
+| 機能 | <img src="https://kodus.io/wp-content/uploads/2026/06/kody-community2-scaled.webp" alt="Kody Community" width="110" /><br>Community | <img src="https://kodus.io/wp-content/uploads/2026/06/kody-team-scaled.webp" alt="Kody Teams" width="110" /><br>Teams | <img src="https://kodus.io/wp-content/uploads/2026/06/kody-enterprise-scaled.webp" alt="Kody Enterprise" width="110" /><br>Enterprise |
+| :--- | :---: | :---: | :---: |
+| 価格 | 無料 | $10/開発者 月額 または $8/開発者 年額 (+ tokens/開発者) | カスタム |
+| ホスティング | セルフホスト **または** Kodusがホスト | Kodusがホスト | セルフホスト **または** Kodusがホスト |
+| 独自キーの持ち込み (BYOK) | ✅ | ✅ | ✅ |
+| PR使用量 | 独自のAPIキーで無制限のPR | 独自のAPIキーで無制限のPR | Kodus AI Tokens APIキーで無制限のPR |
+| ユーザー | 無制限 | 無制限 | 無制限 |
+| Kody Rules | 最大10 | 無制限 | 無制限 |
+| アクティブなプラグイン | 最大3 | 無制限 | 無制限 |
+| Kody Learningsとメモリ | ✅ | ✅ | ✅ |
+| Quality Radarのイシュー | 無制限 | 無制限 | 無制限 |
+| Kody Agentsの優先キュー | ❌ | ✅ | ✅ |
+| エンジニアリングメトリクス / Cockpit | ❌ | ✅ | ✅ |
+| SSO | ❌ | ❌ | ✅ |
+| RBAC + 監査ログ + 分析 | ❌ | ❌ | ✅ |
+| コンプライアンス | ❌ | ❌ | SOC 2 |
+| サポート | Discordコミュニティサポート | Discordコミュニティ + メールサポート | プライベートDiscord + メール + 最大5時間/月の専用オンボーディング/サポート |
+
+[すべてのプランを比較 →](https://kodus.io/pricing)
+
+## リソース
+
+| リソース | 説明 |
+| --- | --- |
+| [ウェブサイト](https://kodus.io) | Kodus、製品機能、価格について詳しく。 |
+| [ドキュメント](https://docs.kodus.io) | セットアップガイド、製品ドキュメント、CLIの使用法、セルフホスト手順。 |
+| [Kodus Cloud](https://app.kodus.io) | インフラを管理せずにKodusを使い始める。 |
+| [セルフホストガイド](https://docs.kodus.io/how_to_deploy/en/deploy_kodus/generic_vm) | 独自の環境にKodusをデプロイ。 |
+| [CLIドキュメント](https://docs.kodus.io/how_to_use/en/cli/overview) | ローカル、CI/CD、コーディングエージェント内でAIコードレビューを実行。 |
+| [Discordコミュニティ](https://discord.gg/6WbWrRbsH7) | 質問、セットアップのサポート、Kodusチームとの対話。 |
+| [料金](https://kodus.io/pricing) | Community、Teams、Enterpriseエディションを比較。 |
+| [通話をスケジュール](https://cal.com/gabrielmalinosqui/30min) | セットアップ、セルフホスト、エンタープライズのニーズについてKodusチームと相談。 |
+
+
+
+## コントリビュート
+
+<p align="left">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/kody-contributing-scaled.png" alt="Kodyのコントリビュート" width="230" />
+</p>
+
+あらゆる規模のコントリビューションを歓迎します 🧡
+
+誤字の修正、ドキュメントの改善、バグの報告、機能の提案、またはあるべきだと思うもののプルリクエストをオープンしてください。
+
+どこから始めればよいか迷ったら、イシューをオープンするかコミュニティに参加してください。喜んでお手伝いします。

--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@
    <strong><a href="https://docs.kodus.io/how_to_deploy/en/deploy_kodus/generic_vm">Self-Host Guide</a></strong>
 </p>
 
+<p align="center">
+   🌐
+   <a href="./README.md">English</a> ·
+   <a href="./README.pt-BR.md">Português (BR)</a> ·
+   <a href="./README.es.md">Español</a> ·
+   <a href="./README.ja.md">日本語</a> ·
+   <a href="./README.zh-CN.md">简体中文</a> ·
+   <a href="./README.fr.md">Français</a>
+</p>
+
 ## Why Teams Choose Kodus
 
 - **Model Agnostic**: Use Claude, GPT-5, Gemini, Llama, GLM, Kimi or any OpenAI-compatible endpoint.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,0 +1,289 @@
+<p align="center">
+  <img alt="logotipo do kodus" src="https://kodus.io/wp-content/uploads/2026/06/kodus-thumb-git-scaled.png">
+</p>
+
+<p align="center">
+   <a href="http://makeapullrequest.com">
+      <img alt="PRs bem-vindos" src="https://img.shields.io/badge/PRs-welcome-darkgreen.svg?style=shields" />
+   </a>
+   <a href="https://github.com/kodustech/kodus-ai" target="_blank">
+      <img src="https://img.shields.io/github/stars/kodustech/kodus-ai" alt="Estrelas no Github" />
+   </a>
+   <a href="./license.md">
+      <img src="https://img.shields.io/badge/license-AGPLv3-red" alt="Licença" />
+   </a>
+</p>
+
+---
+
+<p align="center">
+   <a href="https://kodus.io">Website</a> ·
+   <a href="https://discord.gg/6WbWrRbsH7">Comunidade</a> ·
+   <a href="https://docs.kodus.io">Docs</a> ·
+   <a href="https://docs.kodus.io/how_to_use/en/cli/overview">Docs da CLI</a> ·
+   <strong><a href="https://app.kodus.io">Experimente o Kodus Cloud </a></strong> ·
+   <strong><a href="https://docs.kodus.io/how_to_deploy/en/deploy_kodus/generic_vm">Guia de Self-Host</a></strong>
+</p>
+
+<p align="center">
+   🌐
+   <a href="./README.md">English</a> ·
+   <a href="./README.pt-BR.md">Português (BR)</a> ·
+   <a href="./README.es.md">Español</a> ·
+   <a href="./README.ja.md">日本語</a> ·
+   <a href="./README.zh-CN.md">简体中文</a> ·
+   <a href="./README.fr.md">Français</a>
+</p>
+
+## Por Que as Equipes Escolhem o Kodus
+
+- **Agnóstico de Modelo**: Use Claude, GPT-5, Gemini, Llama, GLM, Kimi ou qualquer endpoint compatível com OpenAI.
+- **Sem Markup no Custo de LLM**: Você paga diretamente aos provedores de modelo. Sem multiplicadores ocultos.
+- **Aprende com Seu Contexto**: Kody se adapta à sua arquitetura, padrões e fluxo de trabalho.
+- **Você Define as Regras**: Defina regras de revisão personalizadas em linguagem natural.
+- **Privacidade e Segurança**: O código-fonte não é usado para treinar modelos, os dados são criptografados em trânsito e em repouso, e runners self-hosted são suportados. Instâncias self-hosted enviam um heartbeat anônimo por dia (apenas contadores agregados — sem código, nomes ou identificadores); desative com `KODUS_TELEMETRY_DISABLED=true`. Veja [Telemetria Anônima](https://docs.kodus.io/how_to_deploy/en/deploy_kodus/telemetry).
+- **Fluxo Git Nativo**: Funciona diretamente em PRs com GitHub, GitLab, Bitbucket e Azure Repos.
+- **CLI + CI/CD Pronto**: Execute revisões localmente e em pipelines.
+- **Impacto Operacional**: Acompanhe dívida técnica e métricas de entrega mantendo a qualidade da revisão alta.
+
+## Destaques do Produto
+
+<details>
+  <summary><strong>🔑 Traga Sua Própria Chave (BYOK)</strong></summary>
+<br />
+Conecte suas próprias credenciais de provedor e escolha os modelos por trás das revisões do Kodus: OpenAI, Anthropic, Google Gemini, Vertex AI, Novita ou qualquer endpoint compatível com OpenAI. Mantenha o faturamento e o uso na sua própria conta do provedor, sem markups ocultos de LLM.
+
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/byok-scaled.png" alt="Configuração de provedor de modelo BYOK do Kodus" width="900">
+</p>
+
+</details>
+
+<br />
+
+<details>
+  <summary><strong>📈 Uso de Tokens</strong></summary>
+<br />
+Acompanhe o consumo de tokens nas revisões de código com IA, entenda os geradores de custo e mantenha o gasto com modelos previsível conforme a adoção cresce.
+
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/token-usage-scaled.png" alt="Dashboard de uso de tokens do Kodus" width="900">
+</p>
+
+</details>
+
+<br />
+
+<details>
+  <summary><strong>⚙️ Kody Rules</strong></summary>
+<br />
+Kody Rules permitem que as equipes definam instruções de revisão em linguagem natural e as apliquem em organizações, repositórios, paths ou escopos específicos de revisão. Kody usa essas regras como contexto ao revisar pull requests, ajudando a garantir decisões de arquitetura, expectativas de segurança, práticas de teste e convenções específicas de repositório sem depender de revisores para repetir o mesmo feedback manualmente.
+
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/rules-scaled.png" alt="Regras do Kody" width="900">
+</p>
+</details>
+<br />
+<details>
+  <summary><strong>📊 Cockpit</strong></summary>
+<br />
+Cockpit ajuda as equipes a medir a eficácia das revisões do Kodus, a saúde das Kody Rules, a saúde dos repositórios e as métricas de entrega em todo o fluxo de trabalho de engenharia.
+
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/cockpit-kodus-scaled.png" alt="Cockpit do Kodus mostrando a saúde do pipeline de revisão de código com IA" width="900">
+</p>
+
+</details>
+
+<br />
+
+<details>
+  <summary><strong>🧩 Kody Issues</strong></summary>
+<br />
+Acompanhe automaticamente sugestões não implementadas de PRs fechados, gerencie-as por status, severidade, categoria e repositório, e deixe Kody resolvê-las quando a correção aparecer em um PR futuro.
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/issues-scaled.png" alt="Dashboard do Kodus Issues" width="900">
+</p>
+
+</details>
+
+<br />
+<details>
+  <summary><strong>🔎 Veja o Kody revisando um pull request real</strong></summary>
+<br />
+Kody faz mais do que resumir diffs. Ele revisa código com contexto, sinaliza riscos por severidade e sugere correções concretas diretamente no pull request.
+
+<br />
+<br />
+
+<p align="center">
+  <img
+    src="https://kodus.io/wp-content/uploads/2025/12/review-kody-.png"
+    alt="Kody detectando um problema crítico de segurança IDOR em uma revisão de pull request"
+    width="700"
+  />
+</p>
+
+Neste exemplo, Kody captura um risco crítico de IDOR onde um parâmetro de consulta `organizationId` poderia contornar a proteção de tenant quando passado como um array, e então sugere uma validação explícita em runtime antes que o código seja merged.
+
+</details>
+
+## Comece Agora
+
+Escolha o fluxo de trabalho que corresponde a como você quer usar o Kodus.
+
+<table>
+  <tr>
+    <td width="50%">
+      <strong>Experimente o Kodus Cloud</strong>
+      <br />
+      Comece a revisar pull requests sem gerenciar infraestrutura.
+      <br />
+      <br />
+      <a href="https://app.kodus.io/signup">Crie uma conta gratuita</a>
+      ·
+      <a href="https://kodus.io/pricing">Veja os preços</a>
+    </td>
+    <td width="50%">
+      <strong>Faça self-host do Kodus</strong>
+      <br />
+      Faça deploy do Kodus na sua própria infraestrutura com controle sobre dados, modelos
+      e configuração de runtime.
+      <br />
+      <br />
+      <a href="https://docs.kodus.io/how_to_deploy/en/deploy_kodus/generic_vm">Guia de instalação</a>
+    </td>
+  </tr>
+  <tr>
+    <td width="50%">
+      <strong>Use a CLI</strong>
+      <br />
+      Execute revisões de código com IA pelo seu terminal em uma árvore de trabalho, diff staged,
+      branch ou commit.
+      <br />
+      <br />
+      <code>kodus review</code>
+      <br />
+      <code>kodus review --staged</code>
+      <br />
+      <code>kodus review --prompt-only</code>
+      <br />
+      <br />
+      <a href="https://docs.kodus.io/how_to_use/en/cli/introduction">Visão geral da CLI</a>
+      ·
+      <a href="https://docs.kodus.io/how_to_use/en/cli/commands">Referência de comandos</a>
+      ·
+      <a href="https://docs.kodus.io/how_to_use/en/cli/ci_cd">CI/CD</a>
+    </td>
+    <td width="50%">
+      <strong>Contribua Localmente</strong>
+      <br />
+      Rode o monorepo do Kodus localmente para desenvolvimento na API, worker,
+      serviço de webhooks, app web e infraestrutura local.
+      <br />
+      <br />
+      <code>git clone https://github.com/kodustech/kodus-ai.git</code>
+      <br />
+      <code>cd kodus-ai</code>
+      <br />
+      <code>yarn setup</code>
+      <br />
+      <br />
+      <a href="https://docs.kodus.io/how_to_deploy/en/local_quickstart/orchestrator">Quickstart local</a>
+    </td>
+  </tr>
+</table>
+
+## Estrutura do Monorepo
+
+Kodus é um monorepo com múltiplas aplicações, bibliotecas de domínio compartilhadas e pacotes publicados.
+
+```txt
+kodus-ai/
+├── apps/
+│   ├── api/          # API NestJS
+│   ├── web/          # Dashboard Next.js
+│   ├── worker/       # Execução de revisões e consumidores de fila
+│   └── webhooks/     # Ingestão de webhooks de provedores Git
+├── libs/             # Módulos de domínio NestJS compartilhados
+├── packages/
+│   ├── kodus-flow/   # SDK de orquestração de agentes de IA
+│   └── kodus-common/ # Pacote de abstração de LLM
+└── scripts/          # Scripts de dev, deploy, benchmark e automação
+```
+
+| Path | Finalidade |
+| --- | --- |
+| `apps/api` | API NestJS principal para autenticação, organizações, equipes, Kody Rules, integrações, permissões e orquestração de revisão de código. |
+| `apps/web` | Aplicação web Next.js para o dashboard do Kodus. |
+| `apps/worker` | Serviço em background para execução de revisão de código, processamento de fila, verificação de sugestões, jobs de automação e tarefas de monitoramento. |
+| `apps/webhooks` | Serviço de ingestão de webhooks para eventos do GitHub, GitLab, Azure Repos, Bitbucket e Forgejo. |
+| `libs` | Módulos de domínio NestJS compartilhados usados nas aplicações do Kodus. |
+| `packages/kodus-flow` | SDK para orquestração de agentes de IA. |
+| `packages/kodus-common` | Pacote compartilhado de abstração de LLM para provedores de modelo. |
+
+Para instruções completas de configuração, siga o [Quickstart Local](https://docs.kodus.io/how_to_deploy/en/local_quickstart/orchestrator).
+
+## Open Source vs. Teams vs. Enterprise
+
+| Recurso | <img src="https://kodus.io/wp-content/uploads/2026/06/kody-community2-scaled.webp" alt="Kody Community" width="110" /><br>Community | <img src="https://kodus.io/wp-content/uploads/2026/06/kody-team-scaled.webp" alt="Kody Teams" width="110" /><br>Teams | <img src="https://kodus.io/wp-content/uploads/2026/06/kody-enterprise-scaled.webp" alt="Kody Enterprise" width="110" /><br>Enterprise |
+| :--- | :---: | :---: | :---: |
+| Preço | Grátis | $10/dev mensal ou $8/dev anual (+ tokens/dev) | Personalizado |
+| Hosting | Self-hosted **ou** hospedado pelo Kodus | Hospedado pelo Kodus | Self-hosted **ou** hospedado pelo Kodus |
+| Traga Sua Própria Chave (BYOK) | ✅ | ✅ | ✅ |
+| Uso de PR | PRs ilimitados usando sua própria API key | PRs ilimitados usando sua própria API key | PRs ilimitados usando a API key de Tokens do Kodus AI |
+| Usuários | Ilimitados | Ilimitados | Ilimitados |
+| Kody Rules | Até 10 | Ilimitadas | Ilimitadas |
+| Plugins ativos | Até 3 | Ilimitados | Ilimitados |
+| Kody Learnings e Memória | ✅ | ✅ | ✅ |
+| Issues do Quality Radar | Ilimitadas | Ilimitadas | Ilimitadas |
+| Fila prioritária para Kody Agents | ❌ | ✅ | ✅ |
+| Métricas de Engenharia / Cockpit | ❌ | ✅ | ✅ |
+| SSO | ❌ | ❌ | ✅ |
+| RBAC + logs de auditoria + analytics | ❌ | ❌ | ✅ |
+| Conformidade | ❌ | ❌ | SOC 2 |
+| Suporte | Suporte da Comunidade no Discord | Comunidade no Discord + Suporte por Email | Discord Privado + Email + até 5h/mês de onboarding/suporte dedicado |
+
+[Comparar todos os planos →](https://kodus.io/pricing)
+
+## Recursos
+
+| Recurso | Descrição |
+| --- | --- |
+| [Website](https://kodus.io) | Saiba mais sobre o Kodus, capacidades do produto e preços. |
+| [Documentação](https://docs.kodus.io) | Guias de configuração, docs de produto, uso da CLI e instruções de self-host. |
+| [Kodus Cloud](https://app.kodus.io) | Comece a usar o Kodus sem gerenciar infraestrutura. |
+| [Guia de Self-Host](https://docs.kodus.io/how_to_deploy/en/deploy_kodus/generic_vm) | Faça deploy do Kodus no seu próprio ambiente. |
+| [Docs da CLI](https://docs.kodus.io/how_to_use/en/cli/overview) | Execute revisões de código com IA localmente, em CI/CD ou dentro de agentes de codificação. |
+| [Comunidade no Discord](https://discord.gg/6WbWrRbsH7) | Faça perguntas, obtenha ajuda de configuração e converse com a equipe do Kodus. |
+| [Preços](https://kodus.io/pricing) | Compare as edições Community, Teams e Enterprise. |
+| [Agende uma Chamada](https://cal.com/gabrielmalinosqui/30min) | Converse com a equipe do Kodus sobre configuração, self-host ou necessidades enterprise. |
+
+
+
+## Contribuindo
+
+<p align="left">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/kody-contributing-scaled.png" alt="Kody contribuindo" width="230" />
+</p>
+
+Recebemos contribuições de todos os tamanhos 🧡
+
+Corrija um erro de digitação, melhore as docs, reporte um bug, sugira uma funcionalidade ou abra um pull request para algo que você acha que deveria existir.
+
+Não sabe por onde começar? Abra uma issue ou entre na comunidade. Ficaremos felizes em ajudar.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,0 +1,289 @@
+<p align="center">
+  <img alt="koduslogo" src="https://kodus.io/wp-content/uploads/2026/06/kodus-thumb-git-scaled.png">
+</p>
+
+<p align="center">
+   <a href="http://makeapullrequest.com">
+      <img alt="欢迎 PRs" src="https://img.shields.io/badge/PRs-welcome-darkgreen.svg?style=shields" />
+   </a>
+   <a href="https://github.com/kodustech/kodus-ai" target="_blank">
+      <img src="https://img.shields.io/github/stars/kodustech/kodus-ai" alt="Github Stars" />
+   </a>
+   <a href="./license.md">
+      <img src="https://img.shields.io/badge/license-AGPLv3-red" alt="许可证" />
+   </a>
+</p>
+
+---
+
+<p align="center">
+   <a href="https://kodus.io">官网</a> ·
+   <a href="https://discord.gg/6WbWrRbsH7">社区</a> ·
+   <a href="https://docs.kodus.io">文档</a> ·
+   <a href="https://docs.kodus.io/how_to_use/en/cli/overview">CLI 文档</a> ·
+   <strong><a href="https://app.kodus.io">试用 Kodus Cloud </a></strong> ·
+   <strong><a href="https://docs.kodus.io/how_to_deploy/en/deploy_kodus/generic_vm">自托管指南</a></strong>
+</p>
+
+<p align="center">
+   🌐
+   <a href="./README.md">English</a> ·
+   <a href="./README.pt-BR.md">Português (BR)</a> ·
+   <a href="./README.es.md">Español</a> ·
+   <a href="./README.ja.md">日本語</a> ·
+   <a href="./README.zh-CN.md">简体中文</a> ·
+   <a href="./README.fr.md">Français</a>
+</p>
+
+## 为什么团队选择 Kodus
+
+- **模型无关**：使用 Claude、GPT-5、Gemini、Llama、GLM、Kimi 或任何 OpenAI 兼容的 endpoint。
+- **LLM 成本零加价**：你直接向模型 provider 付费。没有隐藏的倍数加价。
+- **从你的上下文中学习**：Kody 适应你的架构、标准和工作流。
+- **你来制定规则**：用自然语言定义自定义 review 规则。
+- **隐私与安全**：源代码不会用于训练模型，数据在传输和静态存储时均加密，并支持自托管 runners。自托管实例每天发送一次匿名 heartbeat（仅聚合计数器 — 不含代码、名称或标识符）；可通过 `KODUS_TELEMETRY_DISABLED=true` 关闭。参见[匿名遥测](https://docs.kodus.io/how_to_deploy/en/deploy_kodus/telemetry)。
+- **原生 Git 工作流**：直接在 GitHub、GitLab、Bitbucket 和 Azure Repos 的 PR 中工作。
+- **CLI + CI/CD 就绪**：在本地和 pipelines 中运行 review。
+- **运营影响**：跟踪技术债务和交付指标，同时保持高 review 质量。
+
+## 产品亮点
+
+<details>
+  <summary><strong>🔑 自带密钥 (BYOK)</strong></summary>
+<br />
+连接你自己的 provider 凭证，并选择 Kodus review 背后使用的模型：OpenAI、Anthropic、Google Gemini、Vertex AI、Novita，或任何 OpenAI 兼容的 endpoint。在你的 provider 账户下管理计费和用量，没有隐藏的 LLM 加价。
+
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/byok-scaled.png" alt="Kodus BYOK 模型 provider 配置" width="900">
+</p>
+
+</details>
+
+<br />
+
+<details>
+  <summary><strong>📈 Token 用量</strong></summary>
+<br />
+跟踪 AI 代码 review 中的 token 消耗，了解成本驱动因素，并随着采用规模增长保持模型支出可预测。
+
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/token-usage-scaled.png" alt="Kodus token 用量 dashboard" width="900">
+</p>
+
+</details>
+
+<br />
+
+<details>
+  <summary><strong>⚙️ Kody Rules</strong></summary>
+<br />
+Kody Rules 让团队用自然语言定义 review 指令，并将其应用到组织、仓库、路径或特定 review 范围。Kody 在 review PR 时将这些规则作为上下文，帮助执行架构决策、安全要求、测试实践和仓库特定约定，无需 reviewer 手动重复相同的反馈。
+
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/rules-scaled.png" alt="Kody rules" width="900">
+</p>
+</details>
+<br />
+<details>
+  <summary><strong>📊 Cockpit</strong></summary>
+<br />
+Cockpit 帮助团队衡量 Kodus review 有效性、Kody Rule 健康度、仓库健康度以及贯穿工程工作流的交付指标。
+
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/cockpit-kodus-scaled.png" alt="Kodus Cockpit 展示 AI 代码 review pipeline 健康状况" width="900">
+</p>
+
+</details>
+
+<br />
+
+<details>
+  <summary><strong>🧩 Kody Issues</strong></summary>
+<br />
+自动跟踪已关闭 PR 中未实现的建议，按状态、严重程度、类别和仓库进行管理，并在修复出现在未来的 PR 中时让 Kody 解决它们。
+<br />
+<br />
+
+<p align="center">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/issues-scaled.png" alt="Kodus Issues dashboard" width="900">
+</p>
+
+</details>
+
+<br />
+<details>
+  <summary><strong>🔎 查看 Kody review 真实 PR 的过程</strong></summary>
+<br />
+Kody 不仅仅是总结 diff。它会结合上下文 review 代码，按严重程度标记风险，并直接在 PR 中建议具体的修复方案。
+
+<br />
+<br />
+
+<p align="center">
+  <img
+    src="https://kodus.io/wp-content/uploads/2025/12/review-kody-.png"
+    alt="Kody 在 PR review 中检测到关键 IDOR 安全问题"
+    width="700"
+  />
+</p>
+
+在这个示例中，Kody 捕获了一个关键的 IDOR 风险：当 `organizationId` 查询参数以数组形式传入时可能绕过 tenant 保护，随后它在代码合并前建议了明确的运行时校验。
+
+</details>
+
+## 快速开始
+
+选择符合你使用 Kodus 方式的工作流。
+
+<table>
+  <tr>
+    <td width="50%">
+      <strong>试用 Kodus Cloud</strong>
+      <br />
+      无需管理基础设施即可开始 review PR。
+      <br />
+      <br />
+      <a href="https://app.kodus.io/signup">创建免费账户</a>
+      ·
+      <a href="https://kodus.io/pricing">查看定价</a>
+    </td>
+    <td width="50%">
+      <strong>自托管 Kodus</strong>
+      <br />
+      在你自己的基础设施上部署 Kodus，掌控数据、模型
+      和运行时配置。
+      <br />
+      <br />
+      <a href="https://docs.kodus.io/how_to_deploy/en/deploy_kodus/generic_vm">安装指南</a>
+    </td>
+  </tr>
+  <tr>
+    <td width="50%">
+      <strong>使用 CLI</strong>
+      <br />
+      在终端中针对工作树、暂存 diff、
+      分支或 commit 运行 AI 代码 review。
+      <br />
+      <br />
+      <code>kodus review</code>
+      <br />
+      <code>kodus review --staged</code>
+      <br />
+      <code>kodus review --prompt-only</code>
+      <br />
+      <br />
+      <a href="https://docs.kodus.io/how_to_use/en/cli/introduction">CLI 概览</a>
+      ·
+      <a href="https://docs.kodus.io/how_to_use/en/cli/commands">命令参考</a>
+      ·
+      <a href="https://docs.kodus.io/how_to_use/en/cli/ci_cd">CI/CD</a>
+    </td>
+    <td width="50%">
+      <strong>本地贡献</strong>
+      <br />
+      在本地运行 Kodus monorepo，进行 API、worker、
+      webhooks 服务、web 应用和本地基础设施的开发。
+      <br />
+      <br />
+      <code>git clone https://github.com/kodustech/kodus-ai.git</code>
+      <br />
+      <code>cd kodus-ai</code>
+      <br />
+      <code>yarn setup</code>
+      <br />
+      <br />
+      <a href="https://docs.kodus.io/how_to_deploy/en/local_quickstart/orchestrator">本地快速开始</a>
+    </td>
+  </tr>
+</table>
+
+## Monorepo 结构
+
+Kodus 是一个 monorepo，包含多个应用、共享 domain 库和已发布的 package。
+
+```txt
+kodus-ai/
+├── apps/
+│   ├── api/          # NestJS API
+│   ├── web/          # Next.js dashboard
+│   ├── worker/       # review 执行与队列消费者
+│   └── webhooks/     # Git provider webhook 接入
+├── libs/             # 共享 NestJS domain 模块
+├── packages/
+│   ├── kodus-flow/   # AI agent 编排 SDK
+│   └── kodus-common/ # LLM 抽象 package
+└── scripts/          # 开发、deploy、benchmark 与自动化脚本
+```
+
+| 路径 | 用途 |
+| --- | --- |
+| `apps/api` | 主 NestJS API，用于认证、组织、团队、Kody Rules、集成、权限和代码 review 编排。 |
+| `apps/web` | Kodus dashboard 的 Next.js web 应用。 |
+| `apps/worker` | 后台服务，用于代码 review 执行、队列处理、建议检查、自动化任务和监控任务。 |
+| `apps/webhooks` | 用于 GitHub、GitLab、Azure Repos、Bitbucket 和 Forgejo 事件的 webhook 接入服务。 |
+| `libs` | Kodus 各应用共享的 NestJS domain 模块。 |
+| `packages/kodus-flow` | AI agent 编排 SDK。 |
+| `packages/kodus-common` | 面向模型 provider 的共享 LLM 抽象 package。 |
+
+如需完整的安装说明，请参考[本地快速开始](https://docs.kodus.io/how_to_deploy/en/local_quickstart/orchestrator)。
+
+## 开源版 vs. Teams vs. Enterprise
+
+| 功能 | <img src="https://kodus.io/wp-content/uploads/2026/06/kody-community2-scaled.webp" alt="Kody Community" width="110" /><br>Community | <img src="https://kodus.io/wp-content/uploads/2026/06/kody-team-scaled.webp" alt="Kody Teams" width="110" /><br>Teams | <img src="https://kodus.io/wp-content/uploads/2026/06/kody-enterprise-scaled.webp" alt="Kody Enterprise" width="110" /><br>Enterprise |
+| :--- | :---: | :---: | :---: |
+| 价格 | 免费 | $10/开发者/月 或 $8/开发者/年（+ tokens/开发者） | 定制 |
+| 托管方式 | 自托管 **或** 由 Kodus 托管 | 由 Kodus 托管 | 自托管 **或** 由 Kodus 托管 |
+| 自带密钥 (BYOK) | ✅ | ✅ | ✅ |
+| PR 用量 | 使用你自己的 API key，PR 无限制 | 使用你自己的 API key，PR 无限制 | 使用 Kodus AI Tokens API key，PR 无限制 |
+| 用户 | 无限制 | 无限制 | 无限制 |
+| Kody Rules | 最多 10 条 | 无限制 | 无限制 |
+| 活跃插件 | 最多 3 个 | 无限制 | 无限制 |
+| Kody Learnings 与 Memory | ✅ | ✅ | ✅ |
+| Quality Radar issues | 无限制 | 无限制 | 无限制 |
+| Kody Agents 优先队列 | ❌ | ✅ | ✅ |
+| Engineering Metrics / Cockpit | ❌ | ✅ | ✅ |
+| SSO | ❌ | ❌ | ✅ |
+| RBAC + 审计日志 + analytics | ❌ | ❌ | ✅ |
+| 合规 | ❌ | ❌ | SOC 2 |
+| 支持 | Discord 社区支持 | Discord 社区 + 邮件支持 | 私密 Discord + 邮件 + 每月最多 5 小时专属 onboarding/支持 |
+
+[对比所有方案 →](https://kodus.io/pricing)
+
+## 资源
+
+| 资源 | 描述 |
+| --- | --- |
+| [官网](https://kodus.io) | 了解更多关于 Kodus、产品能力和定价的信息。 |
+| [文档](https://docs.kodus.io) | 安装指南、产品文档、CLI 用法和自托管说明。 |
+| [Kodus Cloud](https://app.kodus.io) | 无需管理基础设施即可开始使用 Kodus。 |
+| [自托管指南](https://docs.kodus.io/how_to_deploy/en/deploy_kodus/generic_vm) | 在你自己的环境中部署 Kodus。 |
+| [CLI 文档](https://docs.kodus.io/how_to_use/en/cli/overview) | 在本地、CI/CD 中或 coding agents 内运行 AI 代码 review。 |
+| [Discord 社区](https://discord.gg/6WbWrRbsH7) | 提问、获取安装帮助，与 Kodus 团队交流。 |
+| [定价](https://kodus.io/pricing) | 对比 Community、Teams 和 Enterprise 版本。 |
+| [预约通话](https://cal.com/gabrielmalinosqui/30min) | 与 Kodus 团队沟通安装、自托管或企业需求。 |
+
+
+
+## 贡献
+
+<p align="left">
+  <img src="https://kodus.io/wp-content/uploads/2026/06/kody-contributing-scaled.png" alt="Kody 贡献" width="230" />
+</p>
+
+我们欢迎各种规模的贡献 🧡
+
+修复拼写错误、改进文档、报告 bug、建议功能，或者为你认为应该存在的功能提交一个 PR。
+
+不知道从哪里开始？提一个 issue 或加入社区。我们很乐意帮忙。


### PR DESCRIPTION
## Summary

Adds localized versions of the project README so the Kodus community can read the docs in their native language.

## Changes

- Added a 🌐 language selector to the top of the original English `README.md`
- Created localized READMEs:

| File | Language |
| --- | --- |
| `README.pt-BR.md` | Portuguese (Brazil) |
| `README.es.md` | Spanish |
| `README.ja.md` | Japanese |
| `README.zh-CN.md` | Simplified Chinese |
| `README.fr.md` | French |

## Translation guidelines followed

- HTML/Markdown structure, URLs, image links, code blocks, and inline code preserved identically
- Brand/product names kept untranslated (Kodus, Kody, Kody Rules, Cockpit, Kody Issues, GitHub, NestJS, OpenAI, Anthropic, etc.)
- Section headings, prose, table content, and image alt text translated to each language
- Technical terms kept in English where natural for devs (deploy, webhook, dashboard, pipelines, tokens, endpoints, runners, heartbeat, tenant, IDOR, PR)

## Checklist

- [x] All 6 files share the same structure (289 lines, 7 `##` headings)
- [x] Language selector present in every file
- [x] No URLs or code blocks modified