### PR TITLE
fix(gitlab): respect work_in_progress for draft MRs

### DIFF
--- a/libs/common/utils/webhooks/gitlab-draft.utils.spec.ts
+++ b/libs/common/utils/webhooks/gitlab-draft.utils.spec.ts
@@ -1,0 +1,112 @@
+import {
+    isGitlabDraftToReadyChange,
+    resolveGitlabDraftStatus,
+} from './gitlab-draft.utils';
+
+describe('resolveGitlabDraftStatus', () => {
+    it('returns true when draft is true and work_in_progress is false', () => {
+        expect(
+            resolveGitlabDraftStatus({ draft: true, work_in_progress: false }),
+        ).toBe(true);
+    });
+
+    it('returns false when draft is false even if work_in_progress is true', () => {
+        expect(
+            resolveGitlabDraftStatus({ draft: false, work_in_progress: true }),
+        ).toBe(false);
+    });
+
+    it('falls back to work_in_progress when draft is null', () => {
+        expect(
+            resolveGitlabDraftStatus({ draft: null, work_in_progress: true }),
+        ).toBe(true);
+    });
+
+    it('falls back to work_in_progress when draft is missing', () => {
+        expect(resolveGitlabDraftStatus({ work_in_progress: true })).toBe(true);
+    });
+
+    it('returns false when both fields are missing', () => {
+        expect(resolveGitlabDraftStatus({})).toBe(false);
+    });
+});
+
+describe('isGitlabDraftToReadyChange', () => {
+    it('detects draft true to false', () => {
+        expect(
+            isGitlabDraftToReadyChange({
+                draft: { previous: true, current: false },
+            }),
+        ).toBe(true);
+    });
+
+    it('detects work_in_progress true to false', () => {
+        expect(
+            isGitlabDraftToReadyChange({
+                work_in_progress: { previous: true, current: false },
+            }),
+        ).toBe(true);
+    });
+
+    it('falls back to work_in_progress when draft change values are null', () => {
+        expect(
+            isGitlabDraftToReadyChange({
+                draft: { previous: null, current: null },
+                work_in_progress: { previous: true, current: false },
+            }),
+        ).toBe(true);
+    });
+
+    it('does not let work_in_progress override explicit draft change values', () => {
+        expect(
+            isGitlabDraftToReadyChange({
+                draft: { previous: false, current: false },
+                work_in_progress: { previous: true, current: false },
+            }),
+        ).toBe(false);
+    });
+
+    it('does not mix draft previous true with work_in_progress current false', () => {
+        expect(
+            isGitlabDraftToReadyChange({
+                draft: { previous: true, current: null },
+                work_in_progress: { previous: false, current: false },
+            }),
+        ).toBe(false);
+    });
+
+    it('does not mix work_in_progress previous true with draft current false', () => {
+        expect(
+            isGitlabDraftToReadyChange({
+                draft: { previous: null, current: false },
+                work_in_progress: { previous: true, current: true },
+            }),
+        ).toBe(false);
+    });
+
+    it('falls back to work_in_progress when draft previous is null and current is false', () => {
+        expect(
+            isGitlabDraftToReadyChange({
+                draft: { previous: null, current: false },
+                work_in_progress: { previous: true, current: false },
+            }),
+        ).toBe(true);
+    });
+
+    it('falls back to work_in_progress when draft previous is true and current is null', () => {
+        expect(
+            isGitlabDraftToReadyChange({
+                draft: { previous: true, current: null },
+                work_in_progress: { previous: true, current: false },
+            }),
+        ).toBe(true);
+    });
+
+    it('returns false for work_in_progress false to true', () => {
+        expect(
+            isGitlabDraftToReadyChange({
+                work_in_progress: { previous: false, current: true },
+            }),
+        ).toBe(false);
+    });
+});

--- a/libs/common/utils/webhooks/gitlab-draft.utils.ts
+++ b/libs/common/utils/webhooks/gitlab-draft.utils.ts
@@ -1,0 +1,43 @@
+export type GitlabDraftLike = {
+    readonly draft?: boolean | null;
+    readonly work_in_progress?: boolean | null;
+};
+
+export type GitlabDraftChangeLike = {
+    readonly previous?: boolean | null;
+    readonly current?: boolean | null;
+};
+
+export type GitlabDraftChangesLike = {
+    readonly draft?: GitlabDraftChangeLike;
+    readonly work_in_progress?: GitlabDraftChangeLike;
+};
+
+export const resolveGitlabDraftStatus = (
+    mergeRequest?: GitlabDraftLike | null,
+): boolean =>
+    mergeRequest?.draft ?? mergeRequest?.work_in_progress ?? false;
+
+export const isGitlabDraftToReadyChange = (
+    changes?: GitlabDraftChangesLike | null,
+): boolean => {
+    const draftChange = changes?.draft;
+
+    if (draftChange?.previous === true && draftChange?.current === false) {
+        return true;
+    }
+
+    const hasCompleteDraftChange =
+        typeof draftChange?.previous === 'boolean' &&
+        typeof draftChange?.current === 'boolean';
+
+    if (hasCompleteDraftChange) {
+        return false;
+    }
+
+    const workInProgressChange = changes?.work_in_progress;
+    return (
+        workInProgressChange?.previous === true &&
+        workInProgressChange?.current === false
+    );
+};

--- a/libs/common/utils/webhooks/gitlab.ts
+++ b/libs/common/utils/webhooks/gitlab.ts
@@ -11,6 +11,7 @@ import {
     IWebhookGitlabCommentEvent,
 } from '@libs/platform/domain/platformIntegrations/types/webhooks/webhooks-gitlab.type';
 
+import { resolveGitlabDraftStatus } from './gitlab-draft.utils';
 import { extractRepoFullName } from './webhooks.utils';
 
 export class GitlabMappedPlatform implements IMappedPlatform {
@@ -73,10 +74,7 @@ export class GitlabMappedPlatform implements IMappedPlatform {
                 },
                 ref: mergeRequest?.target_branch,
             },
-            isDraft:
-                'draft' in mergeRequest
-                    ? (mergeRequest?.draft ?? false)
-                    : false,
+            isDraft: resolveGitlabDraftStatus(mergeRequest),
             tags: mergeRequest?.labels?.map((label) => label.title) ?? [],
         };
     }

--- a/libs/platform/domain/platformIntegrations/types/webhooks/webhooks-gitlab.type.ts
+++ b/libs/platform/domain/platformIntegrations/types/webhooks/webhooks-gitlab.type.ts
@@ -74,7 +74,8 @@ interface IWebhookGitlabChanges {
     milestone_id: Compare<number | null>;
     updated_by_id: Compare<number | null>;
     updated_at: Compare<string>;
-    draft: Compare<boolean>;
+    draft?: Compare<boolean | null>;
+    work_in_progress?: Compare<boolean | null>;
     labels: Compare<IWebhookGitlabLabel[]>;
     last_edited_at: Compare<string | null>;
     last_edited_by_id: Compare<number | null>;
@@ -107,7 +108,8 @@ interface IWebhookGitlabMergeRequest {
     source: IWebhookGitlabProject;
     target: IWebhookGitlabProject;
     last_commit: IWebhookGitlabCommit;
-    work_in_progress: boolean;
+    work_in_progress?: boolean | null;
+    draft?: boolean | null;
     assignee: IWebhookGitlabUser;
     approved_by_ids?: number[];
     approver_ids?: number[];
@@ -189,8 +191,8 @@ interface IWebhookGitlabMergeRequestAttributes {
     state_id: number;
     state: WebhookGitlabMergeRequestState;
     blocking_discussions_resolved: boolean;
-    work_in_progress: boolean;
-    draft: boolean;
+    work_in_progress?: boolean | null;
+    draft?: boolean | null;
     first_contribution: boolean;
     target_project_id: number;
     description: string;
@@ -231,6 +233,7 @@ interface IWebhookGitlabCommentAttributes {
 export interface IWebhookGitlabMergeRequestEvent {
     object_kind: 'merge_request';
     event_type: 'merge_request';
+    action?: string;
     user: IWebhookGitlabUser;
     project: IWebhookGitlabProject;
     repository: IWebhookGitlabRepository;

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.spec.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.spec.ts
@@ -120,4 +120,65 @@ describe('GitlabService', () => {
             token: 'oauth-token',
         });
     });
+
+    describe('getPullRequest draft detection', () => {
+        const repository = {
+            id: 'repo-1',
+            name: 'repo',
+            default_branch: 'main',
+        };
+
+        const getPullRequest = async (mergeRequest: object) => {
+            Object.defineProperty(service, 'getAuthDetails', {
+                value: jest.fn().mockResolvedValue({
+                    accessToken: 'oauth-token',
+                    authMode: AuthMode.OAUTH,
+                }),
+            });
+
+            mockedGitlab.mockReturnValue({
+                MergeRequests: {
+                    show: jest.fn().mockResolvedValue(mergeRequest),
+                },
+            });
+
+            return service.getPullRequest({
+                organizationAndTeamData,
+                repository,
+                prNumber: 1,
+            });
+        };
+
+        it('maps draft null and work_in_progress true to draft', async () => {
+            const result = await getPullRequest({
+                id: 1,
+                iid: 1,
+                draft: null,
+                work_in_progress: true,
+            });
+
+            expect(result?.isDraft).toBe(true);
+        });
+
+        it('maps omitted draft and work_in_progress true to draft', async () => {
+            const result = await getPullRequest({
+                id: 1,
+                iid: 1,
+                work_in_progress: true,
+            });
+
+            expect(result?.isDraft).toBe(true);
+        });
+
+        it('prefers explicit draft false over work_in_progress true', async () => {
+            const result = await getPullRequest({
+                id: 1,
+                iid: 1,
+                draft: false,
+                work_in_progress: true,
+            });
+
+            expect(result?.isDraft).toBe(false);
+        });
+    });
 });

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -14,6 +14,7 @@ import { Reaction } from '@libs/code-review/domain/codeReviewFeedback/enums/code
 import { decrypt, encrypt } from '@libs/common/utils/crypto';
 import { fitPRDescription } from '@libs/code-review/utils/fit-pr-description';
 import { IntegrationServiceDecorator } from '@libs/common/utils/decorators/integration-service.decorator';
+import { resolveGitlabDraftStatus } from '@libs/common/utils/webhooks/gitlab-draft.utils';
 import { CacheService } from '@libs/core/cache/cache.service';
 import {
     CreateAuthIntegrationStatus,
@@ -4828,7 +4829,7 @@ export class GitlabService implements Omit<
                 name: mergeRequest?.author?.name ?? '',
                 id: mergeRequest?.author?.id?.toString() ?? '',
             },
-            isDraft: mergeRequest?.draft ?? false,
+            isDraft: resolveGitlabDraftStatus(mergeRequest),
         };
     }
 

--- a/libs/platform/infrastructure/webhooks/gitlab/gitlabPullRequest.handler.spec.ts
+++ b/libs/platform/infrastructure/webhooks/gitlab/gitlabPullRequest.handler.spec.ts
@@ -1,4 +1,14 @@
-import { extractGitlabHost } from './gitlabPullRequest.handler';
+jest.mock(
+    '@libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case',
+    () => ({
+        ChatWithKodyFromGitUseCase: jest.fn(),
+    }),
+);
+
+import {
+    extractGitlabHost,
+    shouldTriggerGitlabCodeReview,
+} from './gitlabPullRequest.handler';
 
 describe('extractGitlabHost', () => {
     it('extracts host from project.git_http_url (real Ikatec payload shape)', () => {
@@ -140,5 +150,62 @@ describe('extractGitlabHost', () => {
         // URL.hostname does not include the port — covers the case where a
         // self-hosted GitLab listens on a non-standard port.
         expect(extractGitlabHost(payload)).toBe('gitlab.example.com');
+    });
+});
+
+describe('shouldTriggerGitlabCodeReview', () => {
+    it('triggers on draft true to false', () => {
+        expect(
+            shouldTriggerGitlabCodeReview({
+                object_attributes: { action: 'update' },
+                changes: { draft: { previous: true, current: false } },
+            }),
+        ).toBe(true);
+    });
+
+    it('triggers on work_in_progress true to false', () => {
+        expect(
+            shouldTriggerGitlabCodeReview({
+                object_attributes: { action: 'update' },
+                changes: {
+                    work_in_progress: { previous: true, current: false },
+                },
+            }),
+        ).toBe(true);
+    });
+
+    it('triggers when draft null change accompanies work_in_progress true to false', () => {
+        expect(
+            shouldTriggerGitlabCodeReview({
+                object_attributes: { action: 'update' },
+                changes: {
+                    draft: { previous: null, current: null },
+                    work_in_progress: { previous: true, current: false },
+                },
+            }),
+        ).toBe(true);
+    });
+
+    it('triggers before skipping a simultaneous description update', () => {
+        expect(
+            shouldTriggerGitlabCodeReview({
+                object_attributes: { action: 'update' },
+                changes: {
+                    description: { previous: 'old', current: 'new' },
+                    work_in_progress: { previous: true, current: false },
+                },
+            }),
+        ).toBe(true);
+    });
+
+    it('does not trigger on work_in_progress false to true', () => {
+        expect(
+            shouldTriggerGitlabCodeReview({
+                object_attributes: { action: 'update' },
+                changes: {
+                    work_in_progress: { previous: false, current: true },
+                },
+            }),
+        ).toBe(false);
     });
 });

--- a/libs/platform/infrastructure/webhooks/gitlab/gitlabPullRequest.handler.ts
+++ b/libs/platform/infrastructure/webhooks/gitlab/gitlabPullRequest.handler.ts
@@ -19,6 +19,10 @@ import {
     isReviewCommand,
     parseReviewDirective,
 } from '@libs/common/utils/codeManagement/codeCommentMarkers';
+import {
+    isGitlabDraftToReadyChange,
+    type GitlabDraftChangesLike,
+} from '@libs/common/utils/webhooks/gitlab-draft.utils';
 import { getMappedPlatform } from '@libs/common/utils/webhooks';
 import { PlatformType } from '@libs/core/domain/enums/platform-type.enum';
 import { PullRequestClosedEvent } from '@libs/core/domain/events/pull-request-closed.event';
@@ -32,6 +36,69 @@ import {
 } from '@libs/platform/domain/platformIntegrations/interfaces/webhook-event-handler.interface';
 import { SavePullRequestUseCase } from '@libs/platformData/application/use-cases/pullRequests/save.use-case';
 import { CodeManagementService } from '../../adapters/services/codeManagement.service';
+
+type GitlabCodeReviewTriggerPayload = {
+    readonly object_attributes?: {
+        readonly action?: string;
+        readonly state?: string;
+        readonly last_commit?: { readonly id?: string | null } | null;
+        readonly oldrev?: string | null;
+    } | null;
+    readonly changes?: (GitlabDraftChangesLike & {
+        readonly description?: unknown;
+    }) | null;
+};
+
+export const shouldTriggerGitlabCodeReview = (
+    params: GitlabCodeReviewTriggerPayload,
+): boolean => {
+    const objectAttributes = params?.object_attributes || {};
+    const changes = params?.changes || {};
+
+    // Verify if it's a new MR
+    if (objectAttributes.action === 'open') {
+        return true;
+    }
+
+    // Verify if it's a new commit
+    const lastCommitId = objectAttributes.last_commit?.id;
+    const oldRev = objectAttributes.oldrev;
+
+    if (lastCommitId && oldRev && lastCommitId !== oldRev) {
+        return true;
+    }
+
+    // Verify if it's a merge
+    if (
+        objectAttributes.state === 'merged' ||
+        objectAttributes.action === 'merge'
+    ) {
+        return true;
+    }
+
+    // Verify if the PR is closed.
+    if (
+        objectAttributes.state === 'closed' ||
+        objectAttributes.action === 'close'
+    ) {
+        return true;
+    }
+
+    if (
+        objectAttributes.action === 'update' &&
+        isGitlabDraftToReadyChange(changes)
+    ) {
+        return true;
+    }
+
+    // Ignore if it's an update to the description
+    if (objectAttributes.action === 'update' && changes.description) {
+        return false;
+    }
+
+    // For all other cases, return false
+    return false;
+};
 
 /**
  * Handler for GitLab webhook events.
@@ -539,55 +606,10 @@ export class GitLabMergeRequestHandler implements IWebhookEventHandler {
         }
     }
 
-    private shouldTriggerCodeReviewForGitLab(params: any): boolean {
-        const objectAttributes = params?.object_attributes || {};
-        const changes = params?.changes || {};
-
-        // Verify if it's a new MR
-        if (objectAttributes.action === 'open') {
-            return true;
-        }
-
-        // Verify if it's a new commit
-        const lastCommitId = objectAttributes.last_commit?.id;
-        const oldRev = objectAttributes.oldrev;
-
-        if (lastCommitId && oldRev && lastCommitId !== oldRev) {
-            return true;
-        }
-
-        // Verify if it's a merge
-        if (
-            objectAttributes.state === 'merged' ||
-            objectAttributes.action === 'merge'
-        ) {
-            return true;
-        }
-
-        // Verify if the PR is closed.
-        if (
-            objectAttributes.state === 'closed' ||
-            objectAttributes.action === 'close'
-        ) {
-            return true;
-        }
-
-        // Ignore if it's an update to the description
-        if (objectAttributes.action === 'update' && changes.description) {
-            return false;
-        }
-
-        if (
-            objectAttributes.action === 'update' &&
-            changes?.draft &&
-            changes.draft.previous === true &&
-            changes.draft.current === false
-        ) {
-            return true;
-        }
-
-        // For all other cases, return false
-        return false;
+    private shouldTriggerCodeReviewForGitLab(
+        params: GitlabCodeReviewTriggerPayload,
+    ): boolean {
+        return shouldTriggerGitlabCodeReview(params);
     }
 
     private isNewCommitUpdate(payload: any): boolean {

--- a/test/unit/webhooks/mappers/gitlab-mapped-platform.spec.ts
+++ b/test/unit/webhooks/mappers/gitlab-mapped-platform.spec.ts
@@ -1,0 +1,88 @@
+import { GitlabMappedPlatform } from '../../../../libs/common/utils/webhooks/gitlab';
+import { IMappedPlatform } from '../../../../libs/platform/domain/platformIntegrations/types/webhooks/webhooks-common.type';
+
+describe('GitlabMappedPlatform.mapPullRequest', () => {
+    const platform: IMappedPlatform = new GitlabMappedPlatform();
+
+    const buildMergeRequestPayload = (objectAttributes: object) => ({
+        object_kind: 'merge_request',
+        event_type: 'merge_request',
+        object_attributes: {
+            iid: 1,
+            title: 'Test MR',
+            description: 'description',
+            source_branch: 'feature',
+            target_branch: 'main',
+            source: { path_with_namespace: 'org/repo' },
+            target: {
+                path_with_namespace: 'org/repo',
+                default_branch: 'main',
+            },
+            labels: [],
+            ...objectAttributes,
+        },
+        repository: { name: 'repo' },
+        project: { id: 1, name: 'repo', path_with_namespace: 'org/repo' },
+        user: { id: 1, username: 'user' },
+    });
+
+    it('maps draft null and work_in_progress true to draft', () => {
+        const result = platform.mapPullRequest({
+            payload: buildMergeRequestPayload({
+                draft: null,
+                work_in_progress: true,
+            }),
+        });
+
+        expect(result?.isDraft).toBe(true);
+    });
+
+    it('maps omitted draft and work_in_progress true to draft', () => {
+        const result = platform.mapPullRequest({
+            payload: buildMergeRequestPayload({ work_in_progress: true }),
+        });
+
+        expect(result?.isDraft).toBe(true);
+    });
+
+    it('prefers explicit draft false over work_in_progress true', () => {
+        const result = platform.mapPullRequest({
+            payload: buildMergeRequestPayload({
+                draft: false,
+                work_in_progress: true,
+            }),
+        });
+
+        expect(result?.isDraft).toBe(false);
+    });
+
+    it('maps note merge_request draft null and work_in_progress true to draft', () => {
+        const result = platform.mapPullRequest({
+            payload: {
+                object_kind: 'note',
+                event_type: 'note',
+                object_attributes: { note: 'comment' },
+                merge_request: {
+                    iid: 2,
+                    title: 'Comment MR',
+                    description: 'desc',
+                    draft: null,
+                    work_in_progress: true,
+                    source_branch: 'feature',
+                    target_branch: 'main',
+                    source: { path_with_namespace: 'org/repo' },
+                    target: {
+                        path_with_namespace: 'org/repo',
+                        default_branch: 'main',
+                    },
+                    labels: [],
+                },
+                repository: { name: 'repo' },
+                project: { id: 1, name: 'repo', path_with_namespace: 'org/repo' },
+                user: { id: 1, username: 'user' },
+            },
+        });
+
+        expect(result?.isDraft).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary

Fixes #1514.

GitLab Draft MR detection now falls back to `work_in_progress` when `draft` is `null` or omitted. This covers older/self-managed GitLab versions, including the confirmed GitLab 13.x shape where a Draft MR can be returned as `draft: null` and `work_in_progress: true`.

## What changed

- Added a shared GitLab draft compatibility helper.
- Updated GitLab webhook MR mapping to use `draft ?? work_in_progress ?? false`.
- Updated GitLab REST API PR transformation to use the same draft compatibility rule.
- Updated Draft -> Ready detection to support old GitLab `changes.work_in_progress: true -> false` payloads.
- Kept explicit `draft` booleans canonical when present.
- Added regressions for partial/null `draft` changes and non-mixing behavior.

## Validation

Passed:

- `pnpm run test --testPathPatterns=gitlab-draft.utils.spec.ts --runInBand` — 14 tests
- `pnpm run test --testPathPatterns=gitlabPullRequest.handler.spec.ts --runInBand` — 18 tests
- `pnpm run test --testPathPatterns=gitlab --runInBand` — 10 suites / 85 tests
- `pnpm exec eslint libs/common/utils/webhooks/gitlab-draft.utils.ts libs/common/utils/webhooks/gitlab-draft.utils.spec.ts --max-warnings=0`
- `git diff --check`

Push note:

- The repository pre-push hook runs the full Jest suite. It failed on unrelated existing local environment/dependency issues, including `@ai-sdk/... createProviderToolFactoryWithOutputSchema is not a function`, missing web packages such as `class-variance-authority` / `@radix-ui/react-avatar`, and local Postgres integration tests being unreachable. The GitLab-focused suite above passes.