### PR TITLE
fix(kody-rules): send hand-authored wire schema — zodSchema() re-dropped required keys

### DIFF
--- a/libs/code-review/infrastructure/agents/collaborators/kody-rules-sharded.judge.spec.ts
+++ b/libs/code-review/infrastructure/agents/collaborators/kody-rules-sharded.judge.spec.ts
@@ -1,7 +1,7 @@
-import { z } from 'zod';
 import {
     judgeKodyRulesSharded,
     shardViolationsSchema,
+    shardViolationsWireSchema,
     RunJudge,
     RawShardViolation,
 } from './kody-rules-sharded.judge';
@@ -66,18 +66,28 @@ describe('shardViolationsSchema — model JSON parsing', () => {
     });
 
     // OpenAI structured outputs (strict json_schema) reject any schema whose
-    // `required` array doesn't list EVERY key in `properties`. The AI SDK
-    // derives the wire schema from this zod object, so `.optional()` fields
-    // made the API 400 instantly ("Missing 'relevantLinesStart'") and every
-    // shard silently errored for BYOK-OpenAI orgs (found live in QA).
-    it('emits an OpenAI-strict-compatible JSON schema: every property is required', () => {
-        const jsonSchema = z.toJSONSchema(shardViolationsSchema, {
-            target: 'draft-7',
-        }) as any;
-        const items = jsonSchema.properties.violations.items;
+    // `required` array doesn't list EVERY key in `properties` — every shard
+    // silently errored for BYOK-OpenAI orgs (found live in QA). This pins the
+    // ACTUAL wire schema the provider sends (shardViolationsWireSchema), not
+    // a local re-derivation: the first fix attempt passed the zod object and
+    // the AI SDK's input-side conversion silently re-dropped the preprocess
+    // fields from `required`, recreating the 400 in production.
+    it('wire schema is OpenAI-strict compatible: every property is required', () => {
+        const wire = (shardViolationsWireSchema as any).jsonSchema;
+        const items = wire.properties.violations.items;
         expect([...(items.required ?? [])].sort()).toEqual(
             Object.keys(items.properties).sort(),
         );
+        // and the array itself is required at the top level
+        expect(wire.required).toContain('violations');
+    });
+
+    it('wire schema validate() applies the lenient zod parse (missing keys → null)', () => {
+        const result = (shardViolationsWireSchema as any).validate({
+            violations: [{ ruleId: 1, suggestionContent: 'x' }],
+        });
+        expect(result.success).toBe(true);
+        expect(result.value.violations[0].relevantLinesStart).toBeNull();
     });
 
     it('accepts strict-provider output where inapplicable keys are null', () => {

--- a/libs/code-review/infrastructure/agents/collaborators/kody-rules-sharded.judge.ts
+++ b/libs/code-review/infrastructure/agents/collaborators/kody-rules-sharded.judge.ts
@@ -19,6 +19,7 @@
  * Out of scope here (later phases): the T0 regex compiler, T2 reference-file
  * inlining, hybrid regex+judge, compound-rule decomposition.
  */
+import { jsonSchema, type Schema } from 'ai';
 import { z } from 'zod';
 import { recoverRuleUuid } from './finding-mapper';
 import { fileMatchesRulePath } from '@libs/common/utils/kody-rules/file-patterns';
@@ -94,6 +95,34 @@ export const shardViolationsSchema = z.object({
         )
         .default([]),
 });
+
+/**
+ * WIRE schema for the shard call — what the provider actually sends as
+ * `response_format`. This CANNOT be the zod object above passed directly:
+ * the AI SDK's `zodSchema()` derives the JSON schema from the zod INPUT
+ * side, and the preprocess fields accept `undefined` there, so the SDK
+ * drops them from `required` — recreating the exact OpenAI-strict 400
+ * ("Missing 'relevantLinesStart'") this schema exists to prevent (observed
+ * live on the first fix attempt). Hand the SDK the OUTPUT-side JSON schema
+ * (every key required, nullable via anyOf) and keep the lenient zod parse
+ * as the validate step.
+ */
+export const shardViolationsWireSchema: Schema<
+    z.infer<typeof shardViolationsSchema>
+> = jsonSchema(
+    z.toJSONSchema(shardViolationsSchema, {
+        target: 'draft-7',
+        io: 'output',
+    }) as any,
+    {
+        validate: (value) => {
+            const r = shardViolationsSchema.safeParse(value);
+            return r.success
+                ? { success: true, value: r.data }
+                : { success: false, error: r.error };
+        },
+    },
+);
 
 /**
  * A violation exactly as the model emits it (pre-resolution): the rule is a

--- a/libs/code-review/infrastructure/agents/providers/kody-rules-agent.provider.ts
+++ b/libs/code-review/infrastructure/agents/providers/kody-rules-agent.provider.ts
@@ -13,7 +13,7 @@ import { mapAgentFindings } from '@libs/code-review/infrastructure/agents/collab
 import {
     judgeKodyRulesSharded,
     inlineRuleReferences,
-    shardViolationsSchema,
+    shardViolationsWireSchema,
     type RunJudge,
     type RawShardViolation,
     type ShardViolation,
@@ -174,7 +174,11 @@ export class KodyRulesAgentProvider extends BaseCodeReviewAgentProvider {
             const runJudge: RunJudge = async ({ system, user, filename }) => {
                 const parsed = await runStructuredReviewCall({
                     byokConfig: byokConfig ?? undefined,
-                    schema: shardViolationsSchema,
+                    // Wire schema, NOT the zod object: zodSchema() would
+                    // re-derive `required` from the zod input side and
+                    // reintroduce the OpenAI-strict 400. See the
+                    // shardViolationsWireSchema doc.
+                    schema: shardViolationsWireSchema,
                     system,
                     user,
                     runName: 'kodus-rules-review-agent.shard',

--- a/libs/llm/structured-review-call.ts
+++ b/libs/llm/structured-review-call.ts
@@ -15,7 +15,7 @@
  * Groq provider used (`API_GROQ_API_KEY` / `API_GROQ_BASE_URL`), so there is no
  * decrypt path and no synthetic BYOK config.
  */
-import { Output, type LanguageModel } from 'ai';
+import { Output, type LanguageModel, type Schema } from 'ai';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import type { BYOKConfig } from '@kodus/kodus-common/llm';
 import { z } from 'zod';
@@ -42,8 +42,11 @@ function buildTrialGroqFallback(): LanguageModel | null {
     })('openai/gpt-oss-120b') as unknown as LanguageModel;
 }
 
-export interface StructuredReviewCallParams<S extends z.ZodType> {
+export interface StructuredReviewCallParams<S extends z.ZodType | Schema> {
     byokConfig?: BYOKConfig;
+    /** A zod schema, or an AI-SDK `jsonSchema()` Schema when the caller
+     *  needs the wire JSON schema to differ from the parse validation
+     *  (e.g. OpenAI-strict `required` semantics vs lenient providers). */
     schema: S;
     system: string;
     user: string;
@@ -59,9 +62,9 @@ export interface StructuredReviewCallParams<S extends z.ZodType> {
  * back to the org's own fallback / the trial Groq model per the policy above.
  * Returns the parsed object validated against `schema`.
  */
-export async function runStructuredReviewCall<S extends z.ZodType>(
+export async function runStructuredReviewCall<S extends z.ZodType | Schema>(
     params: StructuredReviewCallParams<S>,
-): Promise<z.infer<S>> {
+): Promise<S extends z.ZodType ? z.infer<S> : S extends Schema<infer T> ? T : never> {
     const {
         byokConfig,
         schema,
@@ -96,7 +99,7 @@ export async function runStructuredReviewCall<S extends z.ZodType>(
         model: LanguageModel,
         modelName: string,
         isFallback: boolean,
-    ): Promise<z.infer<S>> =>
+    ): Promise<any> =>
         observabilityService
             .runAiSdkLLMInSpan<any>({
                 spanName: runName,
@@ -122,7 +125,7 @@ export async function runStructuredReviewCall<S extends z.ZodType>(
             })
             .then(
                 (r: any) =>
-                    (r.experimental_output ?? r.output) as z.infer<S>,
+                    (r.experimental_output ?? r.output) as any,
             );
 
     try {


### PR DESCRIPTION
Follow-up to #1523 — the shard fix didn't hold in QA.

## What happened

#1523 made the ZOD schema OpenAI-strict compatible and validated the JSON schema locally via `z.toJSONSchema` (output side). But the AI SDK's `zodSchema()` derives the wire schema from the zod **input** side, where the preprocess fields accept `undefined` — so it silently dropped them from `required` again, and BYOK-OpenAI shards kept 400ing with the same error:

```
Invalid schema for response_format 'response': ... Missing 'relevantLinesStart'.
```

The shard-error logging added in #1523 worked as intended: the failure was visible in the worker logs within minutes of the deploy (previously it was a bare `N errored` counter).

## Fix

Decouple wire format from parse validation explicitly:

- `shardViolationsWireSchema` = AI-SDK `jsonSchema()` built from the OUTPUT-side JSON schema (every key in `required`, nullable via `anyOf [T, null]`) with the lenient zod parse as its `validate` step (missing key → null, numeric-string lines coerced, garbage rejected).
- Provider sends the wire schema; `runStructuredReviewCall` now accepts zod or an AI-SDK `Schema`.
- The contract test pins the **actual exported wire schema**, not a local re-derivation — that gap is exactly what let the first fix pass its tests and still fail live.

## Tests

69 green across kody-rules-sharded / kody-rules-agent / structured-review-call; tsc clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)