### PR TITLE
fix(llm): centrally convert zod schemas to OpenAI-strict wire schemas

### DIFF
--- a/libs/llm/strict-wire-schema.spec.ts
+++ b/libs/llm/strict-wire-schema.spec.ts
@@ -1,0 +1,93 @@
+import { z } from 'zod';
+import { zodToStrictWireSchema } from '@libs/llm/strict-wire-schema';
+import { kodyRulesIDEGeneratorSchema } from '@libs/common/utils/langchainCommon/prompts/kodyRules';
+import { kodyMemoryResolutionSchema } from '@libs/common/utils/langchainCommon/prompts/kodyMemoryResolution';
+import { compilerOutputSchema } from '@libs/code-review/infrastructure/agents/collaborators/kody-rules-detector.compiler';
+
+// Every property of every object node must be in `required` — OpenAI strict
+// structured outputs 400 otherwise ("'required' is required to be supplied
+// and to be an array including every key in properties"). Checked recursively
+// because the live failures were on NESTED nodes (rules.items, violations.items).
+function assertStrictRequired(node: any, path = '$'): void {
+    if (!node || typeof node !== 'object') return;
+    if (Array.isArray(node)) {
+        node.forEach((n, i) => assertStrictRequired(n, `${path}[${i}]`));
+        return;
+    }
+    if (node.type === 'object' && node.properties) {
+        expect({ path, required: [...(node.required ?? [])].sort() }).toEqual({
+            path,
+            required: Object.keys(node.properties).sort(),
+        });
+    }
+    for (const key of Object.keys(node)) {
+        assertStrictRequired(node[key], `${path}.${key}`);
+    }
+}
+
+describe('zodToStrictWireSchema', () => {
+    // The two schemas that failed LIVE in QA for BYOK-OpenAI orgs, plus the
+    // other .optional()-carrying callers of runStructuredReviewCall.
+    const realSchemas: Array<[string, z.ZodType]> = [
+        ['kodyRulesIDEGeneratorSchema (guidance-file extraction)', kodyRulesIDEGeneratorSchema],
+        ['kodyMemoryResolutionSchema', kodyMemoryResolutionSchema],
+        ['compilerOutputSchema (detector compiler)', compilerOutputSchema],
+    ];
+
+    it.each(realSchemas)(
+        '%s → wire schema is OpenAI-strict compatible',
+        (_name, schema) => {
+            const wire = (zodToStrictWireSchema(schema) as any).jsonSchema;
+            assertStrictRequired(wire);
+        },
+    );
+
+    it('previously-optional fields become nullable on the wire', () => {
+        const wire = (zodToStrictWireSchema(compilerOutputSchema) as any)
+            .jsonSchema;
+        // pattern was .optional() — must now be required AND accept null
+        expect(wire.required).toContain('pattern');
+        expect(JSON.stringify(wire.properties.pattern)).toContain('"null"');
+        // mechanical was already required — left untouched
+        expect(JSON.stringify(wire.properties.mechanical)).not.toContain(
+            '"null"',
+        );
+    });
+
+    it('validate(): strict-provider null fills round-trip to absent', () => {
+        const result = (zodToStrictWireSchema(compilerOutputSchema) as any)
+            .validate({
+                mechanical: false,
+                pattern: null,
+                flags: null,
+                reason: null,
+            });
+        expect(result.success).toBe(true);
+        expect(result.value.pattern).toBeUndefined();
+        expect(result.value.mechanical).toBe(false);
+    });
+
+    it('validate(): lenient providers that omit optional keys still parse', () => {
+        const result = (zodToStrictWireSchema(kodyRulesIDEGeneratorSchema) as any)
+            .validate({
+                rules: [
+                    {
+                        title: 't',
+                        rule: 'r',
+                        path: '**/*.rb',
+                        sourcePath: 'CLAUDE.md',
+                        severity: 'high',
+                        examples: [{ snippet: 's', isCorrect: true }],
+                    },
+                ],
+            });
+        expect(result.success).toBe(true);
+        expect(result.value.rules).toHaveLength(1);
+    });
+
+    it('validate(): real type errors still fail parse', () => {
+        const result = (zodToStrictWireSchema(compilerOutputSchema) as any)
+            .validate({ mechanical: 'yes' });
+        expect(result.success).toBe(false);
+    });
+});

--- a/libs/llm/strict-wire-schema.spec.ts
+++ b/libs/llm/strict-wire-schema.spec.ts
@@ -85,6 +85,15 @@ describe('zodToStrictWireSchema', () => {
         expect(result.value.rules).toHaveLength(1);
     });
 
+    it('validate(): a literal __proto__ key in LLM output cannot touch prototypes', () => {
+        const schema = z.object({ a: z.string().optional() });
+        const payload = JSON.parse('{"a":"x","__proto__":{"polluted":true}}');
+        const result = (zodToStrictWireSchema(schema) as any).validate(payload);
+        expect(result.success).toBe(true);
+        expect(({} as any).polluted).toBeUndefined();
+        expect((result.value as any).polluted).toBeUndefined();
+    });
+
     it('validate(): real type errors still fail parse', () => {
         const result = (zodToStrictWireSchema(compilerOutputSchema) as any)
             .validate({ mechanical: 'yes' });

--- a/libs/llm/strict-wire-schema.ts
+++ b/libs/llm/strict-wire-schema.ts
@@ -1,0 +1,117 @@
+/**
+ * OpenAI structured outputs (strict `json_schema`) reject any schema whose
+ * `required` array doesn't list EVERY key in `properties`. Zod schemas with
+ * `.optional()` fields therefore 400 instantly on `openai.responses` — this
+ * silently killed every kody-rules shard AND every guidance-file rule
+ * extraction for BYOK-OpenAI orgs (found live in QA; two call sites, same
+ * class, and any future `.optional()` schema would reintroduce it).
+ *
+ * `zodToStrictWireSchema` converts a zod schema into an AI-SDK `Schema` whose
+ * WIRE format is strict-compatible while the PARSE stays lenient:
+ *
+ *  - wire: OUTPUT-side JSON schema, then every object property is forced into
+ *    `required` — previously-optional ones become nullable (`anyOf [T, null]`)
+ *    so a strict provider has a way to express "absent".
+ *  - validate: `null` object properties are stripped back to ABSENT, then the
+ *    original zod schema parses. Lenient providers that omit keys entirely
+ *    parse unchanged; strict providers' `null` fills round-trip to undefined.
+ *
+ * Constraint: fields that MUST be `null` as a meaningful value are not
+ * supported (null is normalized to absent). All review-pipeline schemas use
+ * `.optional()`, not `.nullable()`, so this holds — assert it stays that way
+ * in the schema, not here.
+ *
+ * NOTE deliberately NOT using the AI SDK's `zodSchema()`: it derives the JSON
+ * schema from the zod INPUT side, where `.optional()`/preprocess fields accept
+ * `undefined`, so it drops them from `required` — that exact gap shipped one
+ * broken fix already (#1525).
+ */
+import { jsonSchema, type Schema } from 'ai';
+import { z } from 'zod';
+
+const NULL_TYPE = { type: 'null' };
+
+function allowsNull(node: any): boolean {
+    if (!node || typeof node !== 'object') return false;
+    if (node.type === 'null') return true;
+    if (Array.isArray(node.type) && node.type.includes('null')) return true;
+    return ['anyOf', 'oneOf'].some(
+        (k) => Array.isArray(node[k]) && node[k].some(allowsNull),
+    );
+}
+
+/** Recursively force strict-mode required semantics onto a JSON schema. */
+function makeStrictRequired(node: any): void {
+    if (!node || typeof node !== 'object') return;
+
+    if (Array.isArray(node)) {
+        node.forEach(makeStrictRequired);
+        return;
+    }
+
+    if (node.type === 'object' && node.properties) {
+        const required = new Set<string>(node.required ?? []);
+        for (const key of Object.keys(node.properties)) {
+            if (!required.has(key)) {
+                const prop = node.properties[key];
+                if (!allowsNull(prop)) {
+                    node.properties[key] = { anyOf: [prop, NULL_TYPE] };
+                }
+            }
+        }
+        node.required = Object.keys(node.properties);
+    }
+
+    for (const key of [
+        'properties',
+        'items',
+        'anyOf',
+        'oneOf',
+        'allOf',
+        '$defs',
+        'definitions',
+        'additionalProperties',
+    ]) {
+        const child = node[key];
+        if (child && typeof child === 'object') {
+            if (key === 'properties' || key === '$defs' || key === 'definitions') {
+                Object.values(child).forEach(makeStrictRequired);
+            } else {
+                makeStrictRequired(child);
+            }
+        }
+    }
+}
+
+/** Strip null-valued object properties so lenient zod parse sees them as absent. */
+function stripNullProps(value: unknown): unknown {
+    if (Array.isArray(value)) return value.map(stripNullProps);
+    if (value && typeof value === 'object') {
+        const out: Record<string, unknown> = {};
+        for (const [k, v] of Object.entries(value)) {
+            if (v === null) continue;
+            out[k] = stripNullProps(v);
+        }
+        return out;
+    }
+    return value;
+}
+
+export function zodToStrictWireSchema<T extends z.ZodType>(
+    schema: T,
+): Schema<z.infer<T>> {
+    const wire = z.toJSONSchema(schema, {
+        target: 'draft-7',
+        io: 'output',
+    }) as any;
+    makeStrictRequired(wire);
+
+    return jsonSchema(wire, {
+        validate: (value) => {
+            const result = schema.safeParse(stripNullProps(value));
+            return result.success
+                ? { success: true, value: result.data }
+                : { success: false, error: result.error };
+        },
+    });
+}

--- a/libs/llm/strict-wire-schema.ts
+++ b/libs/llm/strict-wire-schema.ts
@@ -87,7 +87,10 @@ function makeStrictRequired(node: any): void {
 function stripNullProps(value: unknown): unknown {
     if (Array.isArray(value)) return value.map(stripNullProps);
     if (value && typeof value === 'object') {
-        const out: Record<string, unknown> = {};
+        // Null-prototype target: the keys come from raw LLM output, so a
+        // literal "__proto__" key on a plain {} would hit the prototype
+        // setter instead of creating an own property.
+        const out: Record<string, unknown> = Object.create(null);
         for (const [k, v] of Object.entries(value)) {
             if (v === null) continue;
             out[k] = stripNullProps(v);

--- a/libs/llm/structured-review-call.ts
+++ b/libs/llm/structured-review-call.ts
@@ -27,6 +27,7 @@ import {
     LLM_CALL_TIMEOUT_MS,
 } from '@libs/llm/llm-call';
 import { buildLangfuseTelemetry } from '@libs/core/log/langfuse';
+import { zodToStrictWireSchema } from '@libs/llm/strict-wire-schema';
 import { ObservabilityService } from '@libs/core/log/observability.service';
 
 /** Managed trial-only fallback: Groq `openai/gpt-oss-120b`. Null if unconfigured. */
@@ -78,6 +79,24 @@ export async function runStructuredReviewCall<S extends z.ZodType | Schema>(
 
     const hasByok = !!byokConfig?.main;
 
+    // A raw zod schema would go through the AI SDK's zodSchema(), whose
+    // INPUT-side conversion drops `.optional()` fields from `required` —
+    // OpenAI strict structured outputs 400 on that, which silently killed
+    // kody-rules shards and guidance-file extraction for BYOK-OpenAI orgs.
+    // Convert centrally so every caller (present and future) sends a
+    // strict-compatible wire schema; AI-SDK Schema objects pass through
+    // untouched (the caller already controls its wire format).
+    let wireSchema: unknown = schema;
+    if (schema instanceof z.ZodType) {
+        try {
+            wireSchema = zodToStrictWireSchema(schema);
+        } catch {
+            // Unconvertible zod shape — fall back to the SDK's own
+            // conversion rather than failing the call outright.
+            wireSchema = schema;
+        }
+    }
+
     const mainModel = wrapByokModel(
         byokToVercelModel(byokConfig, 'main', { structuredOutputs: true }),
         { byokConfig, organizationId, role: 'main' },
@@ -111,7 +130,7 @@ export async function runStructuredReviewCall<S extends z.ZodType | Schema>(
                         model: model as any,
                         system,
                         prompt: user,
-                        output: Output.object({ schema: schema as any }),
+                        output: Output.object({ schema: wireSchema as any }),
                         // Cap hung provider calls at LLM_CALL_TIMEOUT_MS (10min)
                         // instead of the 30min agent-level fallback — these run
                         // in parallel shards, so a stuck call must not hold a

--- a/libs/llm/structured-review-call.ts
+++ b/libs/llm/structured-review-call.ts
@@ -27,8 +27,11 @@ import {
     LLM_CALL_TIMEOUT_MS,
 } from '@libs/llm/llm-call';
 import { buildLangfuseTelemetry } from '@libs/core/log/langfuse';
+import { createLogger } from '@libs/core/log/logger';
 import { zodToStrictWireSchema } from '@libs/llm/strict-wire-schema';
 import { ObservabilityService } from '@libs/core/log/observability.service';
+
+const logger = createLogger('StructuredReviewCall');
 
 /** Managed trial-only fallback: Groq `openai/gpt-oss-120b`. Null if unconfigured. */
 function buildTrialGroqFallback(): LanguageModel | null {
@@ -90,9 +93,17 @@ export async function runStructuredReviewCall<S extends z.ZodType | Schema>(
     if (schema instanceof z.ZodType) {
         try {
             wireSchema = zodToStrictWireSchema(schema);
-        } catch {
+        } catch (err) {
             // Unconvertible zod shape — fall back to the SDK's own
-            // conversion rather than failing the call outright.
+            // conversion rather than failing the call outright. That
+            // fallback still 400s on OpenAI strict when the schema has
+            // optional fields, so make the degradation loud: this is the
+            // exact silence that hid the shard/extraction failures.
+            logger.warn({
+                message: `[strict-wire-schema] conversion failed for ${runName}; falling back to raw zod schema (OpenAI-strict callers may reject it): ${err instanceof Error ? err.message : String(err)}`,
+                context: 'runStructuredReviewCall',
+                metadata: { runName, organizationId, err },
+            });
             wireSchema = schema;
         }
     }


### PR DESCRIPTION
Third head of the same hydra — and the last, because this one is central.

## What

#1525 fixed the kody-rules SHARD schema, but validating in QA revealed the same failure in a second call site: guidance-file rule extraction (`kodyRulesFileToRules`) 400s on OpenAI strict for BYOK-OpenAI orgs, so AGENTS.md/CLAUDE.md imports were skipped with `no rule extracted (… LLM returned none)`:

```
Invalid schema for response_format 'response': In context=('properties','rules','items'),
'required' is required to be supplied ... Missing 'pathSource'.
```

Sweep found 4 of 5 `runStructuredReviewCall` callers pass zod schemas with `.optional()` fields (extraction, detector compiler, memory resolution, IDE generator) — all broken the same way for BYOK-OpenAI orgs.

## Fix

Central conversion in `runStructuredReviewCall`: any zod schema goes through `zodToStrictWireSchema` —
- wire: OUTPUT-side JSON schema, every object property forced into `required`, previously-optional ones become `anyOf [T, null]`
- validate: null props stripped back to absent, then the original zod parse (lenient providers unchanged)
- AI-SDK `Schema` objects pass through untouched (the shard wire schema from #1525 keeps its custom coercion)

Future `.optional()` schemas are covered by construction instead of per-site whack-a-mole.

## Tests

367 green across strict-wire-schema / structured-review-call / kody-rules sweeps. The new spec pins the three real production schemas (recursive strict-required assertion on nested nodes — the live failures were on `rules.items`/`violations.items`), null round-trip, lenient omission, and type-error rejection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)