### PR TITLE
fix(healthchecks): use correct queue names for rabbitmq healtcheck

### DIFF
--- a/apps/api/src/controllers/webhook-health.controller.ts
+++ b/apps/api/src/controllers/webhook-health.controller.ts
@@ -85,7 +85,7 @@ export class WebhookHealthController {
             }
 
             // Try to check a queue (non-blocking if it doesn't exist yet)
-            await channel.checkQueue('workflow.webhooks.queue').catch(() => {
+            await channel.checkQueue('workflow.jobs.webhook.queue').catch(() => {
                 // Queue may not exist yet, but the connection is OK
             });
 

--- a/apps/webhooks/src/controllers/webhook-health.controller.ts
+++ b/apps/webhooks/src/controllers/webhook-health.controller.ts
@@ -122,7 +122,7 @@ export class WebhookHealthController {
             }
 
             // Try to verify a queue (non-blocking if it doesn't exist)
-            await channel.checkQueue('workflow.webhooks.queue').catch(() => {
+            await channel.checkQueue('workflow.jobs.webhook.queue').catch(() => {
                 // Queue might not exist yet, but connection is OK
             });
 


### PR DESCRIPTION
<!--
  Thanks for sending a PR! The PR title MUST follow Conventional Commits, e.g.
    feat(code-review): add agent-first reviewer
    fix(web): block app.kodus.io from search-engine indexing
    chore(deps): bump posthog-node to 4.x
  CI will fail otherwise.
-->

The webhook health check was looking for a queue that doesn't exist. It used `workflow.webhooks.queue`, but the app actually publishes to `workflow.jobs.webhook.queue`.