### PR TITLE
fix: change `@kody resume` to `@kody start-review` in cadence message

### DIFF
--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/custom-messages/_components/options.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/custom-messages/_components/options.tsx
@@ -41,7 +41,7 @@ const REVIEW_CADENCE_COPY: Record<
     [ReviewCadenceType.AUTO_PAUSE]: {
         label: "⏸️ Auto-Pause Mode",
         description:
-            "Kody reviews the first push automatically, then pauses if you make 3+ pushes in 15 minutes. Use @kody resume to continue.",
+            "Kody reviews the first push automatically, then pauses if you make 3+ pushes in 15 minutes. Use @kody start-review to continue.",
     },
     [ReviewCadenceType.MANUAL]: {
         label: "✋ Manual Review",

--- a/libs/code-review/infrastructure/adapters/services/messageTemplateProcessor.service.ts
+++ b/libs/code-review/infrastructure/adapters/services/messageTemplateProcessor.service.ts
@@ -296,7 +296,7 @@ ${reviewOptionsMarkdown}
                     translation.autoPauseDesc
                         ?.replace('{timeWindow}', String(timeWindow))
                         ?.replace('{pushes}', String(pushes)) ||
-                    `Kody reviews the first push automatically, then pauses if you make ${pushes}+ pushes in ${timeWindow} minutes. Use @kody resume to continue.`;
+                    `Kody reviews the first push automatically, then pauses if you make ${pushes}+ pushes in ${timeWindow} minutes. Use @kody start-review to continue.`;
                 break;
             }
 

--- a/libs/common/utils/translations/dictionaries/en-US.json
+++ b/libs/common/utils/translations/dictionaries/en-US.json
@@ -100,7 +100,7 @@
         "automaticTitle": "Automatic Review",
         "automaticDesc": "Kody reviews this PR automatically on every push.",
         "autoPauseTitle": "Auto-Pause Mode",
-        "autoPauseDesc": "Kody reviews automatically but pauses after rapid changes ({pushes}+ pushes in {timeWindow} minutes). Use @kody resume to continue.",
+        "autoPauseDesc": "Kody reviews automatically but pauses after rapid changes ({pushes}+ pushes in {timeWindow} minutes). Use @kody start-review to continue.",
         "manualTitle": "Manual Review",
         "manualDesc": "Kody reviews the first push automatically, then only when you request with @kody start-review."
     }

--- a/libs/common/utils/translations/dictionaries/pt-BR.json
+++ b/libs/common/utils/translations/dictionaries/pt-BR.json
@@ -100,7 +100,7 @@
         "automaticTitle": "Review Automático",
         "automaticDesc": "Kody revisa esta PR automaticamente em cada push.",
         "autoPauseTitle": "Modo Auto-Pause",
-        "autoPauseDesc": "Kody revisa automaticamente mas pausa após mudanças rápidas ({pushes}+ pushes em {timeWindow} minutos). Use @kody resume para continuar.",
+        "autoPauseDesc": "Kody revisa automaticamente mas pausa após mudanças rápidas ({pushes}+ pushes em {timeWindow} minutos). Use @kody start-review para continuar.",
         "manualTitle": "Review Manual",
         "manualDesc": "Kody revisa o primeiro push automaticamente, depois apenas quando você solicita com @kody start-review."
     }


### PR DESCRIPTION
<!--
  Thanks for sending a PR! The PR title MUST follow Conventional Commits, e.g.
    feat(code-review): add agent-first reviewer
    fix(web): block app.kodus.io from search-engine indexing
    chore(deps): bump posthog-node to 4.x
  CI will fail otherwise.
-->

## Summary

`@kody resume` is not a valid command. 
