### PR TITLE
fix(code-review): resolve CLI sandbox clone platform from connected integration

### DIFF
--- a/libs/cli-review/application/use-cases/__tests__/execute-cli-review.use-case.spec.ts
+++ b/libs/cli-review/application/use-cases/__tests__/execute-cli-review.use-case.spec.ts
@@ -67,7 +67,7 @@ function createMocks() {
     };
 
     const codeManagementService = {
-        getCodeManagementPlatforms: jest.fn().mockResolvedValue([]),
+        getTypeIntegration: jest.fn().mockResolvedValue(null),
     };
 
     const useCase = new ExecuteCliReviewUseCase(
@@ -132,15 +132,15 @@ describe('ExecuteCliReviewUseCase', () => {
 
             expect(result).toBe(PlatformType.GITHUB);
             expect(
-                codeManagementService.getCodeManagementPlatforms,
+                codeManagementService.getTypeIntegration,
             ).not.toHaveBeenCalled();
         });
 
-        it('falls back to the sole connected integration for a self-managed host', async () => {
+        it('falls back to the connected integration for a self-managed host', async () => {
             const { useCase, codeManagementService } = createMocks();
-            codeManagementService.getCodeManagementPlatforms.mockResolvedValue([
+            codeManagementService.getTypeIntegration.mockResolvedValue(
                 PlatformType.GITLAB,
-            ]);
+            );
 
             const result = await (useCase as any).resolveCliPlatform(
                 { organizationId: 'org-1', teamId: 'team-1' },
@@ -153,7 +153,7 @@ describe('ExecuteCliReviewUseCase', () => {
 
         it('never guesses GitHub when the organization has no integration', async () => {
             const { useCase, codeManagementService } = createMocks();
-            codeManagementService.getCodeManagementPlatforms.mockResolvedValue([]);
+            codeManagementService.getTypeIntegration.mockResolvedValue(null);
 
             const result = await (useCase as any).resolveCliPlatform(
                 { organizationId: 'org-1', teamId: 'team-1' },
@@ -161,24 +161,6 @@ describe('ExecuteCliReviewUseCase', () => {
                 false,
             );
 
-            expect(result).toBeUndefined();
-        });
-
-        it('stays undefined when several integrations could match', async () => {
-            const { useCase, codeManagementService } = createMocks();
-            codeManagementService.getCodeManagementPlatforms.mockResolvedValue([
-                PlatformType.GITHUB,
-                PlatformType.GITLAB,
-            ]);
-
-            const result = await (useCase as any).resolveCliPlatform(
-                { organizationId: 'org-1', teamId: 'team-1' },
-                { remote: 'https://gitlab.acme.com/group/repo.git' },
-                false,
-            );
-
-            // Only the remote's host could disambiguate, and the sandbox stage
-            // already does that properly. Guessing here would be worse.
             expect(result).toBeUndefined();
         });
 
@@ -193,13 +175,13 @@ describe('ExecuteCliReviewUseCase', () => {
 
             expect(result).toBeUndefined();
             expect(
-                codeManagementService.getCodeManagementPlatforms,
+                codeManagementService.getTypeIntegration,
             ).not.toHaveBeenCalled();
         });
 
         it('degrades to undefined when the lookup blows up', async () => {
             const { useCase, codeManagementService } = createMocks();
-            codeManagementService.getCodeManagementPlatforms.mockRejectedValue(
+            codeManagementService.getTypeIntegration.mockRejectedValue(
                 new Error('db down'),
             );
 

--- a/libs/cli-review/application/use-cases/__tests__/execute-cli-review.use-case.spec.ts
+++ b/libs/cli-review/application/use-cases/__tests__/execute-cli-review.use-case.spec.ts
@@ -1,5 +1,6 @@
 import { ExecuteCliReviewUseCase } from '../execute-cli-review.use-case';
 import { KodyRulesStatus } from '@libs/kodyRules/domain/interfaces/kodyRules.interface';
+import { PlatformType } from '@libs/core/domain/enums/platform-type.enum';
 
 /**
  * We test the private helpers via the public execute() path and
@@ -65,9 +66,14 @@ function createMocks() {
         onStageSkipped: jest.fn().mockResolvedValue(undefined),
     };
 
+    const codeManagementService = {
+        getCodeManagementPlatforms: jest.fn().mockResolvedValue([]),
+    };
+
     const useCase = new ExecuteCliReviewUseCase(
         converter as any,
         pipelineStrategy as any,
+        codeManagementService as any,
         parametersService as any,
         automationExecutionService as any,
         teamAutomationService as any,
@@ -78,6 +84,7 @@ function createMocks() {
 
     return {
         useCase,
+        codeManagementService,
         converter,
         pipelineStrategy,
         parametersService,
@@ -106,6 +113,106 @@ function makeRule(overrides: Record<string, any> = {}) {
 // ---------------------------------------------------------------------------
 
 describe('ExecuteCliReviewUseCase', () => {
+    /**
+     * Regression coverage for issue #1541. This used to default to the literal
+     * 'github', which is wrong twice over: it names a platform the
+     * organization may not use, and its lowercase spelling never matches
+     * PlatformType.GITHUB ('GITHUB'), so the repository lookup it feeds could
+     * not hit even for real GitHub users.
+     */
+    describe('resolveCliPlatform', () => {
+        it('uses the platform the CLI inferred from a known SaaS host', async () => {
+            const { useCase, codeManagementService } = createMocks();
+
+            const result = await (useCase as any).resolveCliPlatform(
+                { organizationId: 'org-1', teamId: 'team-1' },
+                { inferredPlatform: PlatformType.GITHUB },
+                false,
+            );
+
+            expect(result).toBe(PlatformType.GITHUB);
+            expect(
+                codeManagementService.getCodeManagementPlatforms,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('falls back to the sole connected integration for a self-managed host', async () => {
+            const { useCase, codeManagementService } = createMocks();
+            codeManagementService.getCodeManagementPlatforms.mockResolvedValue([
+                PlatformType.GITLAB,
+            ]);
+
+            const result = await (useCase as any).resolveCliPlatform(
+                { organizationId: 'org-1', teamId: 'team-1' },
+                { remote: 'https://gitlab.acme.com/group/repo.git' },
+                false,
+            );
+
+            expect(result).toBe(PlatformType.GITLAB);
+        });
+
+        it('never guesses GitHub when the organization has no integration', async () => {
+            const { useCase, codeManagementService } = createMocks();
+            codeManagementService.getCodeManagementPlatforms.mockResolvedValue([]);
+
+            const result = await (useCase as any).resolveCliPlatform(
+                { organizationId: 'org-1', teamId: 'team-1' },
+                { remote: 'https://gitlab.acme.com/group/repo.git' },
+                false,
+            );
+
+            expect(result).toBeUndefined();
+        });
+
+        it('stays undefined when several integrations could match', async () => {
+            const { useCase, codeManagementService } = createMocks();
+            codeManagementService.getCodeManagementPlatforms.mockResolvedValue([
+                PlatformType.GITHUB,
+                PlatformType.GITLAB,
+            ]);
+
+            const result = await (useCase as any).resolveCliPlatform(
+                { organizationId: 'org-1', teamId: 'team-1' },
+                { remote: 'https://gitlab.acme.com/group/repo.git' },
+                false,
+            );
+
+            // Only the remote's host could disambiguate, and the sandbox stage
+            // already does that properly. Guessing here would be worse.
+            expect(result).toBeUndefined();
+        });
+
+        it('skips the integration lookup for anonymous trial traffic', async () => {
+            const { useCase, codeManagementService } = createMocks();
+
+            const result = await (useCase as any).resolveCliPlatform(
+                { organizationId: 'org-1', teamId: 'team-1' },
+                { remote: 'https://gitlab.acme.com/group/repo.git' },
+                true,
+            );
+
+            expect(result).toBeUndefined();
+            expect(
+                codeManagementService.getCodeManagementPlatforms,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('degrades to undefined when the lookup blows up', async () => {
+            const { useCase, codeManagementService } = createMocks();
+            codeManagementService.getCodeManagementPlatforms.mockRejectedValue(
+                new Error('db down'),
+            );
+
+            await expect(
+                (useCase as any).resolveCliPlatform(
+                    { organizationId: 'org-1', teamId: 'team-1' },
+                    { remote: 'https://gitlab.acme.com/group/repo.git' },
+                    false,
+                ),
+            ).resolves.toBeUndefined();
+        });
+    });
+
     describe('resolveRepositoryFromRemote', () => {
         let useCase: any;
 

--- a/libs/cli-review/application/use-cases/execute-cli-review.use-case.ts
+++ b/libs/cli-review/application/use-cases/execute-cli-review.use-case.ts
@@ -386,12 +386,8 @@ export class ExecuteCliReviewUseCase implements IUseCase {
      * organization may not use, and it does not even match PlatformType.GITHUB
      * ('GITHUB'), so the repository lookup it feeds could never hit (#1541).
      *
-     * Ask the organization's integrations instead. With exactly one connected
-     * platform the answer is unambiguous; with several, only the remote's host
-     * could disambiguate, and that costs a credential round-trip per candidate
-     * — the sandbox stage already pays it and picks correctly. Here we would
-     * rather return undefined than guess: the only consumer is an optional
-     * repository lookup that degrades to "no call graph".
+     * Ask the team's connected integration instead — the same fallback the
+     * CodeManagementService methods apply when the caller names no platform.
      */
     private async resolveCliPlatform(
         organizationAndTeamData: OrganizationAndTeamData,
@@ -408,12 +404,11 @@ export class ExecuteCliReviewUseCase implements IUseCase {
         }
 
         try {
-            const platforms =
-                await this.codeManagementService.getCodeManagementPlatforms(
+            return (
+                (await this.codeManagementService.getTypeIntegration(
                     organizationAndTeamData,
-                );
-
-            return platforms.length === 1 ? platforms[0] : undefined;
+                )) ?? undefined
+            );
         } catch (error) {
             this.logger.warn({
                 message: 'Could not resolve the platform for the CLI review',

--- a/libs/cli-review/application/use-cases/execute-cli-review.use-case.ts
+++ b/libs/cli-review/application/use-cases/execute-cli-review.use-case.ts
@@ -10,6 +10,7 @@ import {
 } from '@libs/cli-review/domain/types/cli-review.types';
 import { OrganizationAndTeamData } from '@libs/core/infrastructure/config/types/general/organizationAndTeamData';
 import { CliInputConverter } from '@libs/cli-review/infrastructure/converters/cli-input.converter';
+import { CodeManagementService } from '@libs/platform/infrastructure/adapters/services/codeManagement.service';
 import { CliReviewPipelineContext } from '@libs/cli-review/pipeline/context/cli-review-pipeline.context';
 import { CliReviewPipelineStrategy } from '@libs/cli-review/pipeline/strategy/cli-review-pipeline.strategy';
 import { PipelineExecutor } from '@libs/core/infrastructure/pipeline/services/pipeline-executor.service';
@@ -94,6 +95,7 @@ export class ExecuteCliReviewUseCase implements IUseCase {
     constructor(
         private readonly converter: CliInputConverter,
         private readonly pipelineStrategy: CliReviewPipelineStrategy,
+        private readonly codeManagementService: CodeManagementService,
         @Inject(PARAMETERS_SERVICE_TOKEN)
         private readonly parametersService: IParametersService,
         @Inject(AUTOMATION_EXECUTION_SERVICE_TOKEN)
@@ -194,6 +196,12 @@ export class ExecuteCliReviewUseCase implements IUseCase {
                 ? { ...codeReviewConfig, reviewMode: 'fast' as const }
                 : codeReviewConfig;
 
+            const resolvedPlatform = await this.resolveCliPlatform(
+                organizationAndTeamData,
+                gitContext,
+                isTrialMode,
+            );
+
             const context: CliReviewPipelineContext = {
                 // CLI-specific fields
                 isFastMode,
@@ -247,7 +255,7 @@ export class ExecuteCliReviewUseCase implements IUseCase {
                 teamAutomationId: 'cli-automation',
                 origin: 'cli',
                 action: 'review',
-                platformType: (gitContext?.inferredPlatform || 'github') as any,
+                platformType: resolvedPlatform as any,
 
                 // Git context for cross-file analysis (CLI mode)
                 gitContext: gitContext
@@ -368,6 +376,55 @@ export class ExecuteCliReviewUseCase implements IUseCase {
      * Load user's code review configuration from database,
      * including kody rules resolved for the repository matched by git remote.
      */
+    /**
+     * Platform backing this CLI review.
+     *
+     * The CLI infers it from the remote's hostname, which only works for the
+     * known SaaS hosts — every self-managed instance (GitLab CE/EE, Bitbucket
+     * Server, Forgejo, GHES) arrives undefined. This used to fall back to the
+     * literal 'github', which is doubly wrong: it names a platform the
+     * organization may not use, and it does not even match PlatformType.GITHUB
+     * ('GITHUB'), so the repository lookup it feeds could never hit (#1541).
+     *
+     * Ask the organization's integrations instead. With exactly one connected
+     * platform the answer is unambiguous; with several, only the remote's host
+     * could disambiguate, and that costs a credential round-trip per candidate
+     * — the sandbox stage already pays it and picks correctly. Here we would
+     * rather return undefined than guess: the only consumer is an optional
+     * repository lookup that degrades to "no call graph".
+     */
+    private async resolveCliPlatform(
+        organizationAndTeamData: OrganizationAndTeamData,
+        gitContext?: GitContext,
+        isTrialMode?: boolean,
+    ): Promise<PlatformType | undefined> {
+        if (gitContext?.inferredPlatform) {
+            return gitContext.inferredPlatform;
+        }
+
+        // Anonymous traffic has no integration row to look up.
+        if (isTrialMode) {
+            return undefined;
+        }
+
+        try {
+            const platforms =
+                await this.codeManagementService.getCodeManagementPlatforms(
+                    organizationAndTeamData,
+                );
+
+            return platforms.length === 1 ? platforms[0] : undefined;
+        } catch (error) {
+            this.logger.warn({
+                message: 'Could not resolve the platform for the CLI review',
+                context: ExecuteCliReviewUseCase.name,
+                error,
+                metadata: { organizationAndTeamData },
+            });
+            return undefined;
+        }
+    }
+
     private async loadUserConfigWithRules(
         organizationAndTeamData: OrganizationAndTeamData,
         gitContext?: GitContext,

--- a/libs/cli-review/cli-review.module.ts
+++ b/libs/cli-review/cli-review.module.ts
@@ -29,6 +29,7 @@ import { CliReviewJobProcessorService } from './workflow/cli-review-job-processo
 import { GitHubRateLimitGateService } from '@libs/platform/infrastructure/adapters/services/github/github-rate-limit-gate.service';
 import { RATE_LIMIT_GATE_SERVICE_TOKEN } from '@libs/core/workflow/domain/contracts/rate-limit-gate.service.contract';
 import { GithubModule } from '@libs/platform/modules/github.module';
+import { PlatformCoreModule } from '@libs/platform/modules/platform-core.module';
 
 // Services
 import { CliInputConverter } from './infrastructure/converters/cli-input.converter';
@@ -116,6 +117,7 @@ import { OutboxMessageModel } from '@libs/core/workflow/infrastructure/repositor
         forwardRef(() => LicenseModule), // For license validation and auto-assign
         forwardRef(() => KodyRulesModule), // For loading kody rules in CLI review
         forwardRef(() => GithubModule), // For GitHubRateLimitGateService dependency
+        forwardRef(() => PlatformCoreModule), // For CodeManagementService (platform resolution)
     ],
     providers: [
         // Strategy

--- a/libs/cli-review/workflow/cli-review-job-processor.service.ts
+++ b/libs/cli-review/workflow/cli-review-job-processor.service.ts
@@ -56,9 +56,14 @@ export class CliReviewJobProcessorService implements IJobProcessorService {
         // republishes with a delay aligned to the bucket reset instead
         // of burning the full router timeout. Non-GitHub platforms pass
         // through silently inside the gate.
+        //
+        // No GitHub default here: the CLI leaves this undefined for hosts it
+        // cannot recognize (any self-managed instance), and claiming GitHub
+        // would make the gate probe the GitHub API for organizations that have
+        // no GitHub integration at all (#1541).
         await this.rateLimitGate.check(
             payload.organizationAndTeamData,
-            payload.gitContext?.inferredPlatform ?? PlatformType.GITHUB,
+            payload.gitContext?.inferredPlatform,
         );
 
         await this.jobRepository.update(jobId, {

--- a/libs/code-review/pipeline/services/clone-params-resolver.contract.spec.ts
+++ b/libs/code-review/pipeline/services/clone-params-resolver.contract.spec.ts
@@ -45,18 +45,15 @@ describe('CloneParamsResolver × real platform adapters (self-managed host)', ()
      * Builds the real object graph. `integrations` drives what the
      * organization has connected; `authDetails` what each adapter reads back.
      */
-    const buildResolver = (integrations: PlatformType[]) => {
+    const buildResolver = (connected?: PlatformType) => {
         const integrationService = {
-            find: jest.fn(async (filter: any) => {
-                if (
-                    filter?.integrationCategory !==
-                    IntegrationCategory.CODE_MANAGEMENT
-                ) {
-                    return [];
-                }
-                return integrations.map((platform) => ({ platform }));
-            }),
-            findOne: jest.fn().mockResolvedValue({ uuid: 'integration-1' }),
+            // getTypeIntegration reads the team's connected integration here.
+            findOne: jest.fn(async (filter: any) =>
+                filter?.integrationCategory ===
+                    IntegrationCategory.CODE_MANAGEMENT && connected
+                    ? { platform: connected }
+                    : null,
+            ),
             getPlatformAuthDetails: jest.fn(async (_org, platform) => {
                 if (platform === PlatformType.GITLAB) {
                     // OAUTH: the adapter returns accessToken as-is. (TOKEN mode
@@ -112,7 +109,7 @@ describe('CloneParamsResolver × real platform adapters (self-managed host)', ()
     };
 
     it('clones a self-managed GitLab remote from its own host, with its own token', async () => {
-        const { resolver } = buildResolver([PlatformType.GITLAB]);
+        const { resolver } = buildResolver(PlatformType.GITLAB);
 
         const result = await resolver.resolve(
             pipelineContext(),
@@ -128,9 +125,9 @@ describe('CloneParamsResolver × real platform adapters (self-managed host)', ()
     });
 
     it('does not reach the GitHub adapter for a GitLab-only organization', async () => {
-        const { resolver, integrationService } = buildResolver([
+        const { resolver, integrationService } = buildResolver(
             PlatformType.GITLAB,
-        ]);
+        );
 
         await resolver.resolve(
             pipelineContext(),
@@ -145,25 +142,8 @@ describe('CloneParamsResolver × real platform adapters (self-managed host)', ()
         expect(platformsAskedFor).not.toContain(PlatformType.GITHUB);
     });
 
-    it('picks GitLab over GitHub when both are connected and the remote is self-managed', async () => {
-        // GitHub first: it would win an unordered findOne.
-        const { resolver } = buildResolver([
-            PlatformType.GITHUB,
-            PlatformType.GITLAB,
-        ]);
-
-        const result = await resolver.resolve(
-            pipelineContext(),
-            cliContext(`https://${SELF_MANAGED_HOST}/group/repo.git`),
-        );
-
-        expect(new URL(result!.url).hostname).toBe(SELF_MANAGED_HOST);
-        expect(result!.platform).toBe(PlatformType.GITLAB);
-        expect(result!.authToken).toBe(GITLAB_TOKEN);
-    });
-
     it('skips the sandbox when the organization connected nothing', async () => {
-        const { resolver } = buildResolver([]);
+        const { resolver } = buildResolver(undefined);
 
         const result = await resolver.resolve(
             pipelineContext(),

--- a/libs/code-review/pipeline/services/clone-params-resolver.contract.spec.ts
+++ b/libs/code-review/pipeline/services/clone-params-resolver.contract.spec.ts
@@ -106,6 +106,7 @@ describe('CloneParamsResolver × real platform adapters (self-managed host)', ()
 
         return {
             resolver: new CloneParamsResolverService(codeManagementService),
+            codeManagementService,
             integrationService,
         };
     };
@@ -170,5 +171,76 @@ describe('CloneParamsResolver × real platform adapters (self-managed host)', ()
         );
 
         expect(result).toBeNull();
+    });
+});
+
+/**
+ * getCloneParams resolves the platform itself when the caller does not name
+ * one — the same fallback the list-returning methods in CodeManagementService
+ * use. Those all guard the null that getTypeIntegration returns for an
+ * organization with no integration; getCloneParams did not, and handed the
+ * null straight to the factory.
+ */
+describe('CodeManagementService.getCloneParams (platform not supplied)', () => {
+    const repository = {
+        id: 'repo-1',
+        defaultBranch: 'main',
+        fullName: 'group/repo',
+        name: 'repo',
+    };
+    const organizationAndTeamData = {
+        organizationId: 'org-1',
+        teamId: 'team-1',
+    };
+
+    const buildService = (connected?: PlatformType) => {
+        const integrationService = {
+            findOne: jest
+                .fn()
+                .mockResolvedValue(
+                    connected ? { platform: connected } : null,
+                ),
+            getPlatformAuthDetails: jest.fn().mockResolvedValue({
+                accessToken: 'oauth-token',
+                authMode: AuthMode.OAUTH,
+                host: 'https://gitlab.acme.com',
+            }),
+        };
+
+        const factory = new PlatformIntegrationFactory();
+        factory.registerCodeManagementService(
+            PlatformType.GITLAB,
+            new GitlabService(
+                integrationService as any,
+                {} as any,
+                {} as any,
+                { get: jest.fn() } as unknown as ConfigService,
+                {} as any,
+            ) as any,
+        );
+
+        return new CodeManagementService(integrationService as any, factory);
+    };
+
+    it('resolves the connected platform when none is passed', async () => {
+        const service = buildService(PlatformType.GITLAB);
+
+        const cloneParams = await service.getCloneParams({
+            repository,
+            organizationAndTeamData,
+        });
+
+        expect(cloneParams?.url).toBe('https://gitlab.acme.com/group/repo');
+        expect(cloneParams?.provider).toBe(PlatformType.GITLAB);
+    });
+
+    it('returns null instead of throwing when nothing is connected', async () => {
+        const service = buildService(undefined);
+
+        // Previously: getTypeIntegration → null → factory throws
+        // "Repository service for type 'null' not found."
+        await expect(
+            service.getCloneParams({ repository, organizationAndTeamData }),
+        ).resolves.toBeNull();
     });
 });

--- a/libs/code-review/pipeline/services/clone-params-resolver.contract.spec.ts
+++ b/libs/code-review/pipeline/services/clone-params-resolver.contract.spec.ts
@@ -1,0 +1,174 @@
+import { ConfigService } from '@nestjs/config';
+
+import {
+    IntegrationCategory,
+    PlatformType,
+} from '@libs/core/domain/enums';
+import { AuthMode } from '@libs/platform/domain/platformIntegrations/enums/codeManagement/authMode.enum';
+import { CodeManagementService } from '@libs/platform/infrastructure/adapters/services/codeManagement.service';
+import { GithubService } from '@libs/platform/infrastructure/adapters/services/github/github.service';
+import { GitlabService } from '@libs/platform/infrastructure/adapters/services/gitlab.service';
+import { PlatformIntegrationFactory } from '@libs/platform/infrastructure/adapters/services/platformIntegration.factory';
+
+import { CloneParamsResolverService } from './clone-params-resolver.service';
+
+jest.mock('@libs/mcp-server/services/mcp-manager.service', () => ({
+    MCPManagerService: jest.fn(),
+}));
+
+/**
+ * Contract-level coverage for issue #1541.
+ *
+ * The sibling unit spec mocks CodeManagementService, which only proves the
+ * resolver behaves given clone params of a shape *we assumed*. This one wires
+ * the REAL adapters (GithubService, GitlabService) behind the REAL
+ * CodeManagementService and fakes only the integration lookup — so the clone
+ * URL, the provider and the token are the ones production actually builds.
+ * If an adapter's contract drifts, this fails; the mocked spec would not.
+ */
+describe('CloneParamsResolver × real platform adapters (self-managed host)', () => {
+    const SELF_MANAGED_HOST = 'gitlab.acme.com';
+    const GITLAB_TOKEN = 'glpat-self-managed';
+
+    const organizationAndTeamData = {
+        organizationId: 'org-1',
+        teamId: 'team-1',
+    };
+
+    const cliContext = (remote: string) =>
+        ({ gitContext: { remote, branch: 'feature/x' } }) as any;
+
+    const pipelineContext = () =>
+        ({ origin: 'cli', organizationAndTeamData }) as any;
+
+    /**
+     * Builds the real object graph. `integrations` drives what the
+     * organization has connected; `authDetails` what each adapter reads back.
+     */
+    const buildResolver = (integrations: PlatformType[]) => {
+        const integrationService = {
+            find: jest.fn(async (filter: any) => {
+                if (
+                    filter?.integrationCategory !==
+                    IntegrationCategory.CODE_MANAGEMENT
+                ) {
+                    return [];
+                }
+                return integrations.map((platform) => ({ platform }));
+            }),
+            findOne: jest.fn().mockResolvedValue({ uuid: 'integration-1' }),
+            getPlatformAuthDetails: jest.fn(async (_org, platform) => {
+                if (platform === PlatformType.GITLAB) {
+                    // OAUTH: the adapter returns accessToken as-is. (TOKEN mode
+                    // would run it through decrypt(), which needs a real
+                    // ciphertext — out of scope for this contract.)
+                    return {
+                        accessToken: GITLAB_TOKEN,
+                        authMode: AuthMode.OAUTH,
+                        host: `https://${SELF_MANAGED_HOST}`,
+                    };
+                }
+                // No GitHub integration for this organization.
+                return undefined;
+            }),
+        };
+
+        const gitlabService = new GitlabService(
+            integrationService as any,
+            {} as any,
+            {} as any,
+            { get: jest.fn() } as unknown as ConfigService,
+            {} as any,
+        );
+
+        const githubService = new GithubService(
+            integrationService as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            { get: jest.fn() } as unknown as ConfigService,
+        );
+
+        const factory = new PlatformIntegrationFactory();
+        factory.registerCodeManagementService(
+            PlatformType.GITLAB,
+            gitlabService as any,
+        );
+        factory.registerCodeManagementService(
+            PlatformType.GITHUB,
+            githubService as any,
+        );
+
+        const codeManagementService = new CodeManagementService(
+            integrationService as any,
+            factory,
+        );
+
+        return {
+            resolver: new CloneParamsResolverService(codeManagementService),
+            integrationService,
+        };
+    };
+
+    it('clones a self-managed GitLab remote from its own host, with its own token', async () => {
+        const { resolver } = buildResolver([PlatformType.GITLAB]);
+
+        const result = await resolver.resolve(
+            pipelineContext(),
+            cliContext(`https://${SELF_MANAGED_HOST}/group/repo.git`),
+        );
+
+        // The exact failure from the issue: this used to be
+        // https://github.com/group/repo with an empty token.
+        expect(new URL(result!.url).hostname).toBe(SELF_MANAGED_HOST);
+        expect(result!.url).not.toContain('github.com');
+        expect(result!.authToken).toBe(GITLAB_TOKEN);
+        expect(result!.platform).toBe(PlatformType.GITLAB);
+    });
+
+    it('does not reach the GitHub adapter for a GitLab-only organization', async () => {
+        const { resolver, integrationService } = buildResolver([
+            PlatformType.GITLAB,
+        ]);
+
+        await resolver.resolve(
+            pipelineContext(),
+            cliContext(`https://${SELF_MANAGED_HOST}/group/repo.git`),
+        );
+
+        const platformsAskedFor =
+            integrationService.getPlatformAuthDetails.mock.calls.map(
+                ([, platform]) => platform,
+            );
+
+        expect(platformsAskedFor).not.toContain(PlatformType.GITHUB);
+    });
+
+    it('picks GitLab over GitHub when both are connected and the remote is self-managed', async () => {
+        // GitHub first: it would win an unordered findOne.
+        const { resolver } = buildResolver([
+            PlatformType.GITHUB,
+            PlatformType.GITLAB,
+        ]);
+
+        const result = await resolver.resolve(
+            pipelineContext(),
+            cliContext(`https://${SELF_MANAGED_HOST}/group/repo.git`),
+        );
+
+        expect(new URL(result!.url).hostname).toBe(SELF_MANAGED_HOST);
+        expect(result!.platform).toBe(PlatformType.GITLAB);
+        expect(result!.authToken).toBe(GITLAB_TOKEN);
+    });
+
+    it('skips the sandbox when the organization connected nothing', async () => {
+        const { resolver } = buildResolver([]);
+
+        const result = await resolver.resolve(
+            pipelineContext(),
+            cliContext(`https://${SELF_MANAGED_HOST}/group/repo.git`),
+        );
+
+        expect(result).toBeNull();
+    });
+});

--- a/libs/code-review/pipeline/services/clone-params-resolver.service.spec.ts
+++ b/libs/code-review/pipeline/services/clone-params-resolver.service.spec.ts
@@ -52,19 +52,15 @@ describe('CloneParamsResolverService (CLI mode, self-managed host)', () => {
     const REMOTE = `https://${SELF_MANAGED_HOST}/group/repo.git`;
 
     let service: CloneParamsResolverService;
-    let codeManagementService: {
-        getCloneParams: jest.Mock;
-        getCodeManagementPlatforms: jest.Mock;
-    };
+    let codeManagementService: { getCloneParams: jest.Mock };
 
     beforeEach(() => {
         codeManagementService = {
-            // This organization connected a self-managed GitLab, nothing else.
-            getCodeManagementPlatforms: jest
-                .fn()
-                .mockResolvedValue([PlatformType.GITLAB]),
+            // Stands in for CodeManagementService: an undefined platform makes
+            // it resolve the team's connected integration — a self-managed
+            // GitLab here.
             getCloneParams: jest.fn(async (params: any, type?: PlatformType) =>
-                paramsFor(type, params.repository.fullName),
+                paramsFor(type ?? PlatformType.GITLAB, params.repository.fullName),
             ),
         };
 
@@ -87,8 +83,9 @@ describe('CloneParamsResolverService (CLI mode, self-managed host)', () => {
         const platformsAskedFor =
             codeManagementService.getCloneParams.mock.calls.map(([, type]) => type);
 
-        expect(platformsAskedFor).not.toContain(PlatformType.GITHUB);
-        expect(platformsAskedFor).toEqual([PlatformType.GITLAB]);
+        // Undefined, not GITHUB: the service resolves the connected
+        // integration itself. Naming GitHub here was the bug.
+        expect(platformsAskedFor).toEqual([undefined]);
     });
 
     it('resolves the credentials of the connected integration', async () => {
@@ -107,10 +104,10 @@ describe('CloneParamsResolverService (CLI mode, self-managed host)', () => {
             cliContext(REMOTE, PlatformType.GITLAB),
         );
 
-        // Inferred from the hostname: no need to enumerate integrations.
-        expect(
-            codeManagementService.getCodeManagementPlatforms,
-        ).not.toHaveBeenCalled();
+        expect(codeManagementService.getCloneParams).toHaveBeenCalledWith(
+            expect.anything(),
+            PlatformType.GITLAB,
+        );
         expect(new URL(result!.url).hostname).toBe(SELF_MANAGED_HOST);
     });
 
@@ -124,11 +121,10 @@ describe('CloneParamsResolverService (CLI mode, self-managed host)', () => {
         expect(result?.authToken).toBe(GITLAB_TOKEN);
     });
 
-    it('trusts a lone integration whose host differs from the remote', async () => {
+    it('trusts the integration when its host differs from the remote', async () => {
         // Internal DNS alias / mirror / vanity hostname: the remote and the
-        // configured integration name the same server differently. With a
-        // single integration there is nothing to disambiguate against, and
-        // rejecting it would regress a setup that works today.
+        // configured integration name the same server differently. Rejecting
+        // that would regress a setup that works today.
         const result = await service.resolve(
             pipelineContext(),
             cliContext('https://git-mirror.acme.com/group/repo.git'),
@@ -139,7 +135,8 @@ describe('CloneParamsResolverService (CLI mode, self-managed host)', () => {
     });
 
     it('skips the sandbox when the organization has no integration at all', async () => {
-        codeManagementService.getCodeManagementPlatforms.mockResolvedValue([]);
+        // getCloneParams resolves no platform and returns null.
+        codeManagementService.getCloneParams.mockResolvedValue(null);
 
         const result = await service.resolve(
             pipelineContext(),
@@ -147,85 +144,51 @@ describe('CloneParamsResolverService (CLI mode, self-managed host)', () => {
         );
 
         expect(result).toBeNull();
-        expect(codeManagementService.getCloneParams).not.toHaveBeenCalled();
     });
 });
 
 /**
+ * KNOWN LIMITATION, deliberately not handled here.
+ *
  * A team can hold more than one active code-management integration: nothing
- * deactivates the previous one on connect, there is no unique constraint on
- * (org, team, category), and getTypeIntegration resolves it with a findOne
- * carrying no ORDER BY. The remote's host is the only thing that says which
- * integration a CLI review actually belongs to.
+ * deactivates the previous one on connect, and there is no unique constraint
+ * on (organization, team, category). getTypeIntegration then resolves it with
+ * a findOne carrying no ORDER BY, so the answer is arbitrary — and for a
+ * remote whose host belongs to the *other* integration, the CLI sandbox
+ * reproduces #1541 for that team.
+ *
+ * The resolver could disambiguate by matching the remote's host against each
+ * integration, but that treats the symptom: the real defect is that the state
+ * is reachable at all. The invariant belongs in the integration layer (a
+ * partial unique index on status = true, or deactivating the previous one on
+ * connect), so this spec pins the current behavior rather than papering over
+ * it. See the follow-up issue.
  */
 describe('CloneParamsResolverService (team with several integrations)', () => {
-    let service: CloneParamsResolverService;
-    let codeManagementService: {
-        getCloneParams: jest.Mock;
-        getCodeManagementPlatforms: jest.Mock;
-    };
-
-    beforeEach(() => {
-        codeManagementService = {
-            // GitHub was connected first and would win an unordered findOne.
-            getCodeManagementPlatforms: jest
-                .fn()
-                .mockResolvedValue([PlatformType.GITHUB, PlatformType.GITLAB]),
-            getCloneParams: jest.fn(async (params: any, type?: PlatformType) =>
-                paramsFor(type, params.repository.fullName),
+    it('follows whichever integration the service resolves, right or wrong', async () => {
+        const codeManagementService = {
+            // The unordered findOne landed on GitHub, though the remote is a
+            // self-managed GitLab.
+            getCloneParams: jest.fn(async (params: any) =>
+                paramsFor(PlatformType.GITHUB, params.repository.fullName),
             ),
         };
+        const service = new CloneParamsResolverService(
+            codeManagementService as any,
+        );
 
-        service = new CloneParamsResolverService(codeManagementService as any);
-    });
-
-    it('picks the integration that serves the remote host', async () => {
         const result = await service.resolve(
             pipelineContext(),
             cliContext(`https://${SELF_MANAGED_HOST}/group/repo.git`),
         );
 
-        expect(new URL(result!.url).hostname).toBe(SELF_MANAGED_HOST);
-        expect(result?.platform).toBe(PlatformType.GITLAB);
-        expect(result?.authToken).toBe(GITLAB_TOKEN);
-    });
-
-    it('picks GitHub for a github.com remote in the same organization', async () => {
-        const result = await service.resolve(
-            pipelineContext(),
-            cliContext('https://github.com/group/repo.git'),
-        );
-
+        // Documented, not endorsed: the clone targets the wrong host and the
+        // sandbox will fail to acquire. Fixing this means enforcing one
+        // code-management integration per team.
         expect(new URL(result!.url).hostname).toBe('github.com');
-        expect(result?.platform).toBe(PlatformType.GITHUB);
-        expect(result?.authToken).toBe(GITHUB_TOKEN);
-    });
-
-    it('never hands back credentials from the non-matching integration', async () => {
-        const result = await service.resolve(
-            pipelineContext(),
-            cliContext(`https://${SELF_MANAGED_HOST}/group/repo.git`),
-        );
-
-        expect(result?.authToken).not.toBe(GITHUB_TOKEN);
-    });
-
-    it('skips the sandbox when no integration serves the remote host', async () => {
-        const result = await service.resolve(
-            pipelineContext(),
-            cliContext('https://git.elsewhere.com/group/repo.git'),
-        );
-
-        // Every token on file authenticates against another platform. Better
-        // no sandbox than a wrong one — the review still runs without it.
-        expect(result).toBeNull();
     });
 });
 
-/**
- * The mechanism must not be GitHub-shaped: every platform resolves the same
- * way, through the organization's connected integration.
- */
 describe('CloneParamsResolverService (platform coverage)', () => {
     const cases = [
         {
@@ -264,7 +227,6 @@ describe('CloneParamsResolverService (platform coverage)', () => {
         'clones $name from its own host with its own credentials',
         async ({ host, provider }) => {
             const codeManagementService = {
-                getCodeManagementPlatforms: jest.fn().mockResolvedValue([provider]),
                 getCloneParams: jest.fn().mockResolvedValue({
                     url: `https://${host}/group/repo`,
                     provider,

--- a/libs/code-review/pipeline/services/clone-params-resolver.service.spec.ts
+++ b/libs/code-review/pipeline/services/clone-params-resolver.service.spec.ts
@@ -1,0 +1,289 @@
+import { PlatformType } from '@libs/core/domain/enums';
+
+import { CloneParamsResolverService } from './clone-params-resolver.service';
+
+/**
+ * Regression coverage for issue #1541.
+ *
+ * A CLI review against a repository on a self-managed git host (GitLab
+ * self-managed, Bitbucket Server, Gitea/Forgejo, GHES) used to clone from
+ * github.com: the CLI can only infer a platform from well-known SaaS
+ * hostnames, so `inferredPlatform` arrives undefined, the resolver defaulted
+ * to GITHUB, and the GitHub clone params then overwrote the real remote with
+ * `https://github.com/<fullName>`.
+ */
+
+const SELF_MANAGED_HOST = 'git.acme.com';
+const GITLAB_TOKEN = 'glpat-self-managed';
+const GITHUB_TOKEN = 'ghs-github-token';
+
+const cliContext = (remote: string, inferredPlatform?: PlatformType) =>
+    ({
+        gitContext: { remote, branch: 'feature/x', inferredPlatform },
+    }) as any;
+
+const pipelineContext = () =>
+    ({
+        origin: 'cli',
+        organizationAndTeamData: { organizationId: 'org-1', teamId: 'team-1' },
+    }) as any;
+
+/** Clone params shaped like the ones each real adapter returns. */
+const paramsFor = (platform: PlatformType, fullName: string) => {
+    switch (platform) {
+        case PlatformType.GITHUB:
+            return {
+                url: `https://github.com/${fullName}`,
+                provider: PlatformType.GITHUB,
+                auth: { type: 'oauth', token: GITHUB_TOKEN },
+            };
+        case PlatformType.GITLAB:
+            return {
+                url: `https://${SELF_MANAGED_HOST}/${fullName}`,
+                provider: PlatformType.GITLAB,
+                auth: { type: 'token', token: GITLAB_TOKEN },
+            };
+        default:
+            return null;
+    }
+};
+
+describe('CloneParamsResolverService (CLI mode, self-managed host)', () => {
+    const REMOTE = `https://${SELF_MANAGED_HOST}/group/repo.git`;
+
+    let service: CloneParamsResolverService;
+    let codeManagementService: {
+        getCloneParams: jest.Mock;
+        getCodeManagementPlatforms: jest.Mock;
+    };
+
+    beforeEach(() => {
+        codeManagementService = {
+            // This organization connected a self-managed GitLab, nothing else.
+            getCodeManagementPlatforms: jest
+                .fn()
+                .mockResolvedValue([PlatformType.GITLAB]),
+            getCloneParams: jest.fn(async (params: any, type?: PlatformType) =>
+                paramsFor(type, params.repository.fullName),
+            ),
+        };
+
+        service = new CloneParamsResolverService(codeManagementService as any);
+    });
+
+    it('does not clone from github.com when the platform cannot be inferred', async () => {
+        const result = await service.resolve(
+            pipelineContext(),
+            cliContext(REMOTE),
+        );
+
+        expect(result?.url).not.toContain('github.com');
+        expect(new URL(result!.url).hostname).toBe(SELF_MANAGED_HOST);
+    });
+
+    it('does not assume GitHub when asking for clone params', async () => {
+        await service.resolve(pipelineContext(), cliContext(REMOTE));
+
+        const platformsAskedFor =
+            codeManagementService.getCloneParams.mock.calls.map(([, type]) => type);
+
+        expect(platformsAskedFor).not.toContain(PlatformType.GITHUB);
+        expect(platformsAskedFor).toEqual([PlatformType.GITLAB]);
+    });
+
+    it('resolves the credentials of the connected integration', async () => {
+        const result = await service.resolve(
+            pipelineContext(),
+            cliContext(REMOTE),
+        );
+
+        expect(result?.authToken).toBe(GITLAB_TOKEN);
+        expect(result?.platform).toBe(PlatformType.GITLAB);
+    });
+
+    it('still honors an explicitly inferred platform', async () => {
+        const result = await service.resolve(
+            pipelineContext(),
+            cliContext(REMOTE, PlatformType.GITLAB),
+        );
+
+        // Inferred from the hostname: no need to enumerate integrations.
+        expect(
+            codeManagementService.getCodeManagementPlatforms,
+        ).not.toHaveBeenCalled();
+        expect(new URL(result!.url).hostname).toBe(SELF_MANAGED_HOST);
+    });
+
+    it('resolves an scp-like SSH remote against the same host', async () => {
+        const result = await service.resolve(
+            pipelineContext(),
+            cliContext(`git@${SELF_MANAGED_HOST}:group/repo.git`),
+        );
+
+        expect(new URL(result!.url).hostname).toBe(SELF_MANAGED_HOST);
+        expect(result?.authToken).toBe(GITLAB_TOKEN);
+    });
+
+    it('trusts a lone integration whose host differs from the remote', async () => {
+        // Internal DNS alias / mirror / vanity hostname: the remote and the
+        // configured integration name the same server differently. With a
+        // single integration there is nothing to disambiguate against, and
+        // rejecting it would regress a setup that works today.
+        const result = await service.resolve(
+            pipelineContext(),
+            cliContext('https://git-mirror.acme.com/group/repo.git'),
+        );
+
+        expect(result?.authToken).toBe(GITLAB_TOKEN);
+        expect(result?.platform).toBe(PlatformType.GITLAB);
+    });
+
+    it('skips the sandbox when the organization has no integration at all', async () => {
+        codeManagementService.getCodeManagementPlatforms.mockResolvedValue([]);
+
+        const result = await service.resolve(
+            pipelineContext(),
+            cliContext(REMOTE),
+        );
+
+        expect(result).toBeNull();
+        expect(codeManagementService.getCloneParams).not.toHaveBeenCalled();
+    });
+});
+
+/**
+ * A team can hold more than one active code-management integration: nothing
+ * deactivates the previous one on connect, there is no unique constraint on
+ * (org, team, category), and getTypeIntegration resolves it with a findOne
+ * carrying no ORDER BY. The remote's host is the only thing that says which
+ * integration a CLI review actually belongs to.
+ */
+describe('CloneParamsResolverService (team with several integrations)', () => {
+    let service: CloneParamsResolverService;
+    let codeManagementService: {
+        getCloneParams: jest.Mock;
+        getCodeManagementPlatforms: jest.Mock;
+    };
+
+    beforeEach(() => {
+        codeManagementService = {
+            // GitHub was connected first and would win an unordered findOne.
+            getCodeManagementPlatforms: jest
+                .fn()
+                .mockResolvedValue([PlatformType.GITHUB, PlatformType.GITLAB]),
+            getCloneParams: jest.fn(async (params: any, type?: PlatformType) =>
+                paramsFor(type, params.repository.fullName),
+            ),
+        };
+
+        service = new CloneParamsResolverService(codeManagementService as any);
+    });
+
+    it('picks the integration that serves the remote host', async () => {
+        const result = await service.resolve(
+            pipelineContext(),
+            cliContext(`https://${SELF_MANAGED_HOST}/group/repo.git`),
+        );
+
+        expect(new URL(result!.url).hostname).toBe(SELF_MANAGED_HOST);
+        expect(result?.platform).toBe(PlatformType.GITLAB);
+        expect(result?.authToken).toBe(GITLAB_TOKEN);
+    });
+
+    it('picks GitHub for a github.com remote in the same organization', async () => {
+        const result = await service.resolve(
+            pipelineContext(),
+            cliContext('https://github.com/group/repo.git'),
+        );
+
+        expect(new URL(result!.url).hostname).toBe('github.com');
+        expect(result?.platform).toBe(PlatformType.GITHUB);
+        expect(result?.authToken).toBe(GITHUB_TOKEN);
+    });
+
+    it('never hands back credentials from the non-matching integration', async () => {
+        const result = await service.resolve(
+            pipelineContext(),
+            cliContext(`https://${SELF_MANAGED_HOST}/group/repo.git`),
+        );
+
+        expect(result?.authToken).not.toBe(GITHUB_TOKEN);
+    });
+
+    it('skips the sandbox when no integration serves the remote host', async () => {
+        const result = await service.resolve(
+            pipelineContext(),
+            cliContext('https://git.elsewhere.com/group/repo.git'),
+        );
+
+        // Every token on file authenticates against another platform. Better
+        // no sandbox than a wrong one — the review still runs without it.
+        expect(result).toBeNull();
+    });
+});
+
+/**
+ * The mechanism must not be GitHub-shaped: every platform resolves the same
+ * way, through the organization's connected integration.
+ */
+describe('CloneParamsResolverService (platform coverage)', () => {
+    const cases = [
+        {
+            name: 'GitLab self-managed',
+            host: 'gitlab.acme.com',
+            provider: PlatformType.GITLAB,
+        },
+        {
+            name: 'GitHub Enterprise Server',
+            host: 'github.acme.com',
+            provider: PlatformType.GITHUB,
+        },
+        {
+            name: 'Bitbucket Server',
+            host: 'bitbucket.acme.com',
+            provider: PlatformType.BITBUCKET,
+        },
+        {
+            name: 'Forgejo self-hosted',
+            host: 'forgejo.acme.com',
+            provider: PlatformType.FORGEJO,
+        },
+        {
+            name: 'Azure DevOps',
+            host: 'dev.azure.com',
+            provider: PlatformType.AZURE_REPOS,
+        },
+        {
+            name: 'GitHub SaaS',
+            host: 'github.com',
+            provider: PlatformType.GITHUB,
+        },
+    ];
+
+    it.each(cases)(
+        'clones $name from its own host with its own credentials',
+        async ({ host, provider }) => {
+            const codeManagementService = {
+                getCodeManagementPlatforms: jest.fn().mockResolvedValue([provider]),
+                getCloneParams: jest.fn().mockResolvedValue({
+                    url: `https://${host}/group/repo`,
+                    provider,
+                    auth: { type: 'token', token: `token-for-${provider}` },
+                }),
+            };
+
+            const service = new CloneParamsResolverService(
+                codeManagementService as any,
+            );
+
+            const result = await service.resolve(
+                pipelineContext(),
+                cliContext(`https://${host}/group/repo.git`),
+            );
+
+            expect(new URL(result!.url).hostname).toBe(host);
+            expect(result?.platform).toBe(provider);
+            expect(result?.authToken).toBe(`token-for-${provider}`);
+        },
+    );
+});

--- a/libs/code-review/pipeline/services/clone-params-resolver.service.ts
+++ b/libs/code-review/pipeline/services/clone-params-resolver.service.ts
@@ -139,6 +139,10 @@ export class CloneParamsResolverService {
             this.logger.warn({
                 message: `Could not parse git remote URL: ${gitContext.remote}`,
                 context: CloneParamsResolverService.name,
+                metadata: {
+                    organizationAndTeamData: context.organizationAndTeamData,
+                    remoteHost: extractRemoteHost(gitContext.remote),
+                },
             });
             return null;
         }
@@ -198,6 +202,11 @@ export class CloneParamsResolverService {
                     message: `Could not get auth token for CLI sandbox, trying without auth`,
                     context: CloneParamsResolverService.name,
                     error,
+                    metadata: {
+                        organizationAndTeamData: context.organizationAndTeamData,
+                        remoteHost: extractRemoteHost(gitContext.remote),
+                        inferredPlatform,
+                    },
                 });
             }
         }
@@ -210,7 +219,10 @@ export class CloneParamsResolverService {
             this.logger.warn({
                 message: `Could not resolve the platform for the CLI sandbox remote; skipping sandbox`,
                 context: CloneParamsResolverService.name,
-                metadata: { remoteHost: extractRemoteHost(gitContext.remote) },
+                metadata: {
+                    organizationAndTeamData: context.organizationAndTeamData,
+                    remoteHost: extractRemoteHost(gitContext.remote),
+                },
             });
             return null;
         }
@@ -224,6 +236,11 @@ export class CloneParamsResolverService {
                 this.logger.warn({
                     message: `Could not parse SSH-like git remote URL: ${cloneUrl}`,
                     context: CloneParamsResolverService.name,
+                    metadata: {
+                        organizationAndTeamData: context.organizationAndTeamData,
+                        remoteHost: extractRemoteHost(cloneUrl),
+                        platform,
+                    },
                 });
                 return null;
             }

--- a/libs/code-review/pipeline/services/clone-params-resolver.service.ts
+++ b/libs/code-review/pipeline/services/clone-params-resolver.service.ts
@@ -165,33 +165,47 @@ export class CloneParamsResolverService {
             authToken = gitContext.githubPat;
             platform = platform ?? PlatformType.GITHUB;
         } else {
-            const cloneParams = await this.resolveCliCloneParams({
-                organizationAndTeamData: context.organizationAndTeamData,
-                repository: {
-                    id: '0',
-                    defaultBranch: branch,
-                    fullName: parsed.fullName,
-                    name: parsed.name,
-                },
-                remote: gitContext.remote,
-                inferredPlatform,
-            });
+            try {
+                // Passing an undefined platform is deliberate: getCloneParams
+                // then resolves the team's connected integration itself, which
+                // is the only thing that knows a self-managed host.
+                const cloneParams =
+                    await this.codeManagementService.getCloneParams(
+                        {
+                            repository: {
+                                id: '0',
+                                defaultBranch: branch,
+                                fullName: parsed.fullName,
+                                name: parsed.name,
+                            },
+                            organizationAndTeamData:
+                                context.organizationAndTeamData,
+                        },
+                        inferredPlatform,
+                    );
 
-            if (cloneParams) {
-                authToken = cloneParams.auth?.token || '';
-                authUsername = cloneParams.auth?.username;
-                platform = cloneParams.provider ?? platform;
+                if (cloneParams) {
+                    authToken = cloneParams.auth?.token || '';
+                    authUsername = cloneParams.auth?.username;
+                    platform = cloneParams.provider ?? platform;
 
-                if (cloneParams.url) {
-                    cloneUrl = cloneParams.url;
+                    if (cloneParams.url) {
+                        cloneUrl = cloneParams.url;
+                    }
                 }
+            } catch (error) {
+                this.logger.warn({
+                    message: `Could not get auth token for CLI sandbox, trying without auth`,
+                    context: CloneParamsResolverService.name,
+                    error,
+                });
             }
         }
 
-        // Self-managed host with no connected integration: we know neither the
-        // platform nor a credential, and platform drives the git auth header
-        // shape. Skip the sandbox instead of guessing — the review still runs,
-        // just without the sandbox-dependent stages.
+        // No integration and nothing inferable: we know neither the platform
+        // nor a credential, and platform drives the git auth header shape.
+        // Skip the sandbox instead of guessing — the review still runs, just
+        // without the sandbox-dependent stages.
         if (!platform) {
             this.logger.warn({
                 message: `Could not resolve the platform for the CLI sandbox remote; skipping sandbox`,
@@ -224,91 +238,5 @@ export class CloneParamsResolverService {
             platform,
             checkoutSha: gitContext.mergeBaseSha,
         };
-    }
-
-    /**
-     * Pick the clone params that actually belong to the user's remote.
-     *
-     * The CLI infers a platform only for well-known SaaS hostnames, so for a
-     * self-managed host we have to ask the organization's integrations. A team
-     * can legitimately hold several active ones (GitHub *and* a self-managed
-     * GitLab, say), and the platform is only knowable from the remote's host —
-     * so when there is a choice to make, make it by host rather than taking
-     * whichever row the database returned first.
-     */
-    private async resolveCliCloneParams(params: {
-        organizationAndTeamData: CodeReviewPipelineContext['organizationAndTeamData'];
-        repository: {
-            id: string;
-            defaultBranch: string;
-            fullName: string;
-            name: string;
-        };
-        remote: string;
-        inferredPlatform?: PlatformType;
-    }) {
-        const { organizationAndTeamData, repository, remote, inferredPlatform } =
-            params;
-
-        const candidates = inferredPlatform
-            ? [inferredPlatform]
-            : await this.codeManagementService.getCodeManagementPlatforms(
-                  organizationAndTeamData,
-              );
-
-        if (!candidates.length) {
-            this.logger.warn({
-                message: `No code management integration to resolve the CLI sandbox remote against`,
-                context: CloneParamsResolverService.name,
-                metadata: { remoteHost: extractRemoteHost(remote) },
-            });
-            return null;
-        }
-
-        const remoteHost = extractRemoteHost(remote);
-
-        for (const candidate of candidates) {
-            let cloneParams: Awaited<
-                ReturnType<CodeManagementService['getCloneParams']>
-            >;
-
-            try {
-                cloneParams = await this.codeManagementService.getCloneParams(
-                    { repository, organizationAndTeamData },
-                    candidate,
-                );
-            } catch (error) {
-                this.logger.warn({
-                    message: `Could not get clone params for ${candidate}, trying without auth`,
-                    context: CloneParamsResolverService.name,
-                    error,
-                });
-                continue;
-            }
-
-            if (!cloneParams) {
-                continue;
-            }
-
-            // Single candidate: trust it. Its host may legitimately differ from
-            // the remote's (internal DNS alias, mirror, vanity hostname) and
-            // there is no other integration this repo could belong to.
-            if (candidates.length === 1) {
-                return cloneParams;
-            }
-
-            if (extractRemoteHost(cloneParams.url) === remoteHost) {
-                return cloneParams;
-            }
-        }
-
-        // Several integrations and none serves this host: any of their tokens
-        // would authenticate against the wrong platform.
-        this.logger.warn({
-            message: `None of the connected integrations matches the git remote host; skipping sandbox`,
-            context: CloneParamsResolverService.name,
-            metadata: { remoteHost, candidates },
-        });
-        return null;
     }
 }

--- a/libs/code-review/pipeline/services/clone-params-resolver.service.ts
+++ b/libs/code-review/pipeline/services/clone-params-resolver.service.ts
@@ -6,6 +6,29 @@ import { CliReviewPipelineContext } from '@libs/cli-review/pipeline/context/cli-
 import { CodeManagementService } from '@libs/platform/infrastructure/adapters/services/codeManagement.service';
 
 /**
+ * Extract the host of a git remote, accepting both URL forms we deal with
+ * (`https://host/path` and the scp-like `git@host:path`).
+ */
+export function extractRemoteHost(url: string): string | undefined {
+    const value = url.trim();
+    if (!value) {
+        return undefined;
+    }
+
+    // scp-like (`git@host:path`) is not a parseable URL — match it first.
+    const scpLike = value.match(/^[^@\s/]+@([^:/]+):/);
+    if (scpLike) {
+        return scpLike[1].toLowerCase();
+    }
+
+    try {
+        return new URL(value).hostname.toLowerCase() || undefined;
+    } catch {
+        return undefined;
+    }
+}
+
+/**
  * Parse a git remote URL (HTTPS or SSH) into fullName/name parts.
  *
  * Accepts any number of path segments so hosts with nested namespaces work
@@ -120,9 +143,17 @@ export class CloneParamsResolverService {
             return null;
         }
 
-        const platform = gitContext.inferredPlatform || PlatformType.GITHUB;
+        // The CLI can only infer a platform from well-known SaaS hostnames
+        // (github.com, gitlab.com, ...), so a self-managed host — GitLab
+        // CE/EE, Bitbucket Server, Gitea/Forgejo, GHES — arrives here
+        // undefined. Do NOT guess GitHub: getCloneParams would then hand back
+        // a github.com URL built from `fullName` and the sandbox would clone
+        // from the wrong server entirely (#1541). Left undefined,
+        // getCloneParams resolves the organization's connected integration.
+        const inferredPlatform = gitContext.inferredPlatform;
         const branch = gitContext.branch || 'main';
 
+        let platform = inferredPlatform;
         let authToken = '';
         let authUsername: string | undefined;
         let cloneUrl = gitContext.remote;
@@ -132,35 +163,42 @@ export class CloneParamsResolverService {
         // there's no integration row to find for anonymous traffic.
         if (gitContext.githubPat) {
             authToken = gitContext.githubPat;
+            platform = platform ?? PlatformType.GITHUB;
         } else {
-            try {
-                const cloneParams =
-                    await this.codeManagementService.getCloneParams(
-                        {
-                            repository: {
-                                id: '0',
-                                defaultBranch: branch,
-                                fullName: parsed.fullName,
-                                name: parsed.name,
-                            },
-                            organizationAndTeamData:
-                                context.organizationAndTeamData,
-                        },
-                        platform,
-                    );
+            const cloneParams = await this.resolveCliCloneParams({
+                organizationAndTeamData: context.organizationAndTeamData,
+                repository: {
+                    id: '0',
+                    defaultBranch: branch,
+                    fullName: parsed.fullName,
+                    name: parsed.name,
+                },
+                remote: gitContext.remote,
+                inferredPlatform,
+            });
+
+            if (cloneParams) {
                 authToken = cloneParams.auth?.token || '';
                 authUsername = cloneParams.auth?.username;
+                platform = cloneParams.provider ?? platform;
 
                 if (cloneParams.url) {
                     cloneUrl = cloneParams.url;
                 }
-            } catch (error) {
-                this.logger.warn({
-                    message: `Could not get auth token for CLI sandbox, trying without auth`,
-                    context: CloneParamsResolverService.name,
-                    error,
-                });
             }
+        }
+
+        // Self-managed host with no connected integration: we know neither the
+        // platform nor a credential, and platform drives the git auth header
+        // shape. Skip the sandbox instead of guessing — the review still runs,
+        // just without the sandbox-dependent stages.
+        if (!platform) {
+            this.logger.warn({
+                message: `Could not resolve the platform for the CLI sandbox remote; skipping sandbox`,
+                context: CloneParamsResolverService.name,
+                metadata: { remoteHost: extractRemoteHost(gitContext.remote) },
+            });
+            return null;
         }
 
         // Ensure HTTPS (E2B requires HTTPS for token auth)
@@ -186,5 +224,91 @@ export class CloneParamsResolverService {
             platform,
             checkoutSha: gitContext.mergeBaseSha,
         };
+    }
+
+    /**
+     * Pick the clone params that actually belong to the user's remote.
+     *
+     * The CLI infers a platform only for well-known SaaS hostnames, so for a
+     * self-managed host we have to ask the organization's integrations. A team
+     * can legitimately hold several active ones (GitHub *and* a self-managed
+     * GitLab, say), and the platform is only knowable from the remote's host —
+     * so when there is a choice to make, make it by host rather than taking
+     * whichever row the database returned first.
+     */
+    private async resolveCliCloneParams(params: {
+        organizationAndTeamData: CodeReviewPipelineContext['organizationAndTeamData'];
+        repository: {
+            id: string;
+            defaultBranch: string;
+            fullName: string;
+            name: string;
+        };
+        remote: string;
+        inferredPlatform?: PlatformType;
+    }) {
+        const { organizationAndTeamData, repository, remote, inferredPlatform } =
+            params;
+
+        const candidates = inferredPlatform
+            ? [inferredPlatform]
+            : await this.codeManagementService.getCodeManagementPlatforms(
+                  organizationAndTeamData,
+              );
+
+        if (!candidates.length) {
+            this.logger.warn({
+                message: `No code management integration to resolve the CLI sandbox remote against`,
+                context: CloneParamsResolverService.name,
+                metadata: { remoteHost: extractRemoteHost(remote) },
+            });
+            return null;
+        }
+
+        const remoteHost = extractRemoteHost(remote);
+
+        for (const candidate of candidates) {
+            let cloneParams: Awaited<
+                ReturnType<CodeManagementService['getCloneParams']>
+            >;
+
+            try {
+                cloneParams = await this.codeManagementService.getCloneParams(
+                    { repository, organizationAndTeamData },
+                    candidate,
+                );
+            } catch (error) {
+                this.logger.warn({
+                    message: `Could not get clone params for ${candidate}, trying without auth`,
+                    context: CloneParamsResolverService.name,
+                    error,
+                });
+                continue;
+            }
+
+            if (!cloneParams) {
+                continue;
+            }
+
+            // Single candidate: trust it. Its host may legitimately differ from
+            // the remote's (internal DNS alias, mirror, vanity hostname) and
+            // there is no other integration this repo could belong to.
+            if (candidates.length === 1) {
+                return cloneParams;
+            }
+
+            if (extractRemoteHost(cloneParams.url) === remoteHost) {
+                return cloneParams;
+            }
+        }
+
+        // Several integrations and none serves this host: any of their tokens
+        // would authenticate against the wrong platform.
+        this.logger.warn({
+            message: `None of the connected integrations matches the git remote host; skipping sandbox`,
+            context: CloneParamsResolverService.name,
+            metadata: { remoteHost, candidates },
+        });
+        return null;
     }
 }

--- a/libs/core/workflow/domain/contracts/rate-limit-gate.service.contract.ts
+++ b/libs/core/workflow/domain/contracts/rate-limit-gate.service.contract.ts
@@ -22,8 +22,14 @@ export interface IRateLimitGateService {
      * is below the configured threshold, throws RateLimitError carrying
      * the bucket's `resetAt`. Otherwise resolves silently.
      */
+    /**
+     * `platformType` is optional: callers that cannot determine it (the CLI
+     * cannot infer a platform from a self-managed host) must be able to say so
+     * rather than name a platform the organization may not even use. An
+     * unknown platform is treated like any non-GitHub one — pass through.
+     */
     check(
         organizationAndTeamData: OrganizationAndTeamData,
-        platformType: PlatformType,
+        platformType?: PlatformType,
     ): Promise<void>;
 }

--- a/libs/platform/infrastructure/adapters/services/bitbucket/bitbucket-cloud.service.ts
+++ b/libs/platform/infrastructure/adapters/services/bitbucket/bitbucket-cloud.service.ts
@@ -703,7 +703,13 @@ export class BitbucketCloudService implements Omit<
                 params.organizationAndTeamData,
             );
 
-            if (!bitbucketAuthDetail) {
+            // getAuthDetails spreads the lookup and defaults authMode, so it is
+            // always truthy — a plain `!bitbucketAuthDetail` check never fires
+            // for an organization with no Bitbucket integration. Assert on the
+            // auth material instead: without it we would hand back a
+            // bitbucket.org clone URL carrying an empty token (same failure as
+            // #1541).
+            if (!bitbucketAuthDetail?.appPassword) {
                 throw new BadRequestException('Installation not found');
             }
             const fullBitbucketUrl = `https://bitbucket.org/${params?.repository?.fullName}`;

--- a/libs/platform/infrastructure/adapters/services/clone-params-no-integration.spec.ts
+++ b/libs/platform/infrastructure/adapters/services/clone-params-no-integration.spec.ts
@@ -1,0 +1,162 @@
+import { ConfigService } from '@nestjs/config';
+
+import { AzureReposService } from './azureRepos/azureRepos.service';
+import { BitbucketCloudService } from './bitbucket/bitbucket-cloud.service';
+import { BitbucketDataCenterService } from './bitbucket/bitbucket-data-center.service';
+import { ForgejoService } from './forgejo.service';
+import { GithubService } from './github/github.service';
+import { GitlabService } from './gitlab.service';
+
+jest.mock('@libs/mcp-server/services/mcp-manager.service', () => ({
+    MCPManagerService: jest.fn(),
+}));
+
+/**
+ * Cross-adapter guard for the failure behind issue #1541.
+ *
+ * Every adapter's getAuthDetails/getGithubAuthDetails spreads the integration
+ * lookup and defaults authMode, so it returns a truthy object even when the
+ * organization has no integration of that platform at all. The
+ * `if (!authDetail) throw` guard each getCloneParams carries therefore never
+ * fires, and the method goes on to build a clone URL from a hardcoded SaaS
+ * base — github.com, gitlab.com, bitbucket.org — with no usable token.
+ *
+ * That is exactly how a CLI review on a self-managed host ended up cloning
+ * github.com. No adapter may hand back clone params it cannot authenticate.
+ */
+describe('getCloneParams with no integration connected', () => {
+    const organizationAndTeamData = {
+        organizationId: 'org-1',
+        teamId: 'team-1',
+    };
+
+    const repository = {
+        id: 'repo-1',
+        name: 'repo',
+        fullName: 'group/repo',
+        defaultBranch: 'main',
+    };
+
+    const cfg = { get: jest.fn() } as unknown as ConfigService;
+
+    /** No integration of any platform for this organization. */
+    const integrationService = () => ({
+        getPlatformAuthDetails: jest.fn().mockResolvedValue(undefined),
+        findOne: jest.fn().mockResolvedValue(null),
+        find: jest.fn().mockResolvedValue([]),
+    });
+
+    const adapters: Array<{ name: string; build: () => any }> = [
+        {
+            name: 'GitHub',
+            build: () =>
+                new GithubService(
+                    integrationService() as any,
+                    {} as any,
+                    {} as any,
+                    {} as any,
+                    cfg,
+                ),
+        },
+        {
+            name: 'GitLab',
+            build: () =>
+                new GitlabService(
+                    integrationService() as any,
+                    {} as any,
+                    {} as any,
+                    cfg,
+                    {} as any,
+                ),
+        },
+        {
+            name: 'Bitbucket Cloud',
+            build: () =>
+                new BitbucketCloudService(
+                    integrationService() as any,
+                    {} as any,
+                    {} as any,
+                    cfg,
+                    {} as any,
+                ),
+        },
+        {
+            name: 'Bitbucket Data Center',
+            build: () =>
+                new BitbucketDataCenterService(
+                    integrationService() as any,
+                    {} as any,
+                    {} as any,
+                    cfg,
+                    {} as any,
+                ),
+        },
+        {
+            name: 'Azure Repos',
+            build: () =>
+                // Extra slot vs the others: azureReposRequestHelper.
+                new AzureReposService(
+                    integrationService() as any,
+                    {} as any,
+                    {} as any,
+                    {} as any,
+                    cfg,
+                ),
+        },
+    ];
+
+    it.each(adapters)(
+        '$name does not invent a SaaS clone URL',
+        async ({ build }) => {
+            let cloneParams: any = null;
+
+            try {
+                cloneParams = await build().getCloneParams({
+                    repository,
+                    organizationAndTeamData,
+                });
+            } catch {
+                // Throwing is an acceptable answer; returning a usable-looking
+                // URL is not.
+                cloneParams = null;
+            }
+
+            expect(cloneParams).toBeNull();
+        },
+    );
+
+    it.each(adapters)(
+        '$name never returns an empty auth token',
+        async ({ build }) => {
+            let cloneParams: any = null;
+
+            try {
+                cloneParams = await build().getCloneParams({
+                    repository,
+                    organizationAndTeamData,
+                });
+            } catch {
+                cloneParams = null;
+            }
+
+            // The empty token is what made #1541 silent: the clone was
+            // attempted anonymously and only failed later, as "not found".
+            expect(cloneParams?.auth?.token).not.toBe('');
+        },
+    );
+
+    it('Forgejo rejects rather than resolving auth details', async () => {
+        const service = new ForgejoService(
+            integrationService() as any,
+            {} as any,
+            {} as any,
+            cfg,
+        );
+
+        // Forgejo already returns null from getAuthDetails — pinned so the
+        // spread pattern does not creep in here too.
+        await expect(
+            service.getAuthDetails(organizationAndTeamData),
+        ).resolves.toBeNull();
+    });
+});

--- a/libs/platform/infrastructure/adapters/services/codeManagement.service.ts
+++ b/libs/platform/infrastructure/adapters/services/codeManagement.service.ts
@@ -81,44 +81,6 @@ export class CodeManagementService implements ICodeManagementService {
         }
     }
 
-    /**
-     * Every active code-management platform connected to the team.
-     *
-     * getTypeIntegration answers "which platform?" with a findOne that carries
-     * no ORDER BY — fine while a team has a single integration, arbitrary once
-     * it has more (nothing deactivates the previous one on connect, and there
-     * is no unique constraint on organization+team+category). Callers that can
-     * disambiguate — e.g. by matching the git remote's host — need the full
-     * list instead of an arbitrary pick.
-     */
-    async getCodeManagementPlatforms(
-        organizationAndTeamData: OrganizationAndTeamData,
-    ): Promise<PlatformType[]> {
-        try {
-            const integrations = await this.integrationService.find({
-                organization: { uuid: organizationAndTeamData.organizationId },
-                team: { uuid: organizationAndTeamData.teamId },
-                integrationCategory: IntegrationCategory.CODE_MANAGEMENT,
-                status: true,
-            });
-
-            return (integrations || [])
-                .map((integration) => integration.platform)
-                .filter(Boolean);
-        } catch (error) {
-            this.logger.error({
-                message: 'Failed to list code management integrations',
-                context: CodeManagementService.name,
-                error,
-                metadata: {
-                    organizationId: organizationAndTeamData.organizationId,
-                    teamId: organizationAndTeamData.teamId,
-                },
-            });
-            return [];
-        }
-    }
-
     async listIssues(
         params: ListIssuesParams,
         type?: PlatformType,

--- a/libs/platform/infrastructure/adapters/services/codeManagement.service.ts
+++ b/libs/platform/infrastructure/adapters/services/codeManagement.service.ts
@@ -1054,6 +1054,15 @@ export class CodeManagementService implements ICodeManagementService {
             );
         }
 
+        // Same guard the list-returning methods here already apply: with no
+        // integration, getTypeIntegration answers null and the factory would
+        // throw "Repository service for type 'null' not found". Callers already
+        // treat a null result as "no clone params" — the adapters return null
+        // on failure too.
+        if (!type) {
+            return null;
+        }
+
         const codeManagementService =
             this.platformIntegrationFactory.getCodeManagementService(type);
 

--- a/libs/platform/infrastructure/adapters/services/codeManagement.service.ts
+++ b/libs/platform/infrastructure/adapters/services/codeManagement.service.ts
@@ -81,6 +81,44 @@ export class CodeManagementService implements ICodeManagementService {
         }
     }
 
+    /**
+     * Every active code-management platform connected to the team.
+     *
+     * getTypeIntegration answers "which platform?" with a findOne that carries
+     * no ORDER BY — fine while a team has a single integration, arbitrary once
+     * it has more (nothing deactivates the previous one on connect, and there
+     * is no unique constraint on organization+team+category). Callers that can
+     * disambiguate — e.g. by matching the git remote's host — need the full
+     * list instead of an arbitrary pick.
+     */
+    async getCodeManagementPlatforms(
+        organizationAndTeamData: OrganizationAndTeamData,
+    ): Promise<PlatformType[]> {
+        try {
+            const integrations = await this.integrationService.find({
+                organization: { uuid: organizationAndTeamData.organizationId },
+                team: { uuid: organizationAndTeamData.teamId },
+                integrationCategory: IntegrationCategory.CODE_MANAGEMENT,
+                status: true,
+            });
+
+            return (integrations || [])
+                .map((integration) => integration.platform)
+                .filter(Boolean);
+        } catch (error) {
+            this.logger.error({
+                message: 'Failed to list code management integrations',
+                context: CodeManagementService.name,
+                error,
+                metadata: {
+                    organizationId: organizationAndTeamData.organizationId,
+                    teamId: organizationAndTeamData.teamId,
+                },
+            });
+            return [];
+        }
+    }
+
     async listIssues(
         params: ListIssuesParams,
         type?: PlatformType,

--- a/libs/platform/infrastructure/adapters/services/github/github-rate-limit-gate.service.spec.ts
+++ b/libs/platform/infrastructure/adapters/services/github/github-rate-limit-gate.service.spec.ts
@@ -1,0 +1,69 @@
+import { PlatformType } from '@libs/core/domain/enums';
+
+import { GitHubRateLimitGateService } from './github-rate-limit-gate.service';
+
+jest.mock('@libs/mcp-server/services/mcp-manager.service', () => ({
+    MCPManagerService: jest.fn(),
+}));
+
+/**
+ * Regression coverage for issue #1541.
+ *
+ * The CLI job processor used to hand this gate `inferredPlatform ?? GITHUB`.
+ * For any self-managed host the CLI cannot recognize, that meant claiming
+ * GitHub for organizations that may have no GitHub integration at all — and
+ * the gate would then probe the GitHub API on their behalf. The platform is
+ * now optional, and an unknown one must pass through untouched.
+ */
+describe('GitHubRateLimitGateService.check (platform gating)', () => {
+    const organizationAndTeamData = {
+        organizationId: 'org-1',
+        teamId: 'team-1',
+    };
+
+    let gate: GitHubRateLimitGateService;
+    let cacheService: { getFromCache: jest.Mock; addToCache: jest.Mock };
+    let githubService: Record<string, jest.Mock>;
+
+    beforeEach(() => {
+        cacheService = {
+            getFromCache: jest.fn().mockResolvedValue(undefined),
+            addToCache: jest.fn().mockResolvedValue(undefined),
+        };
+        githubService = {
+            getGithubAuthDetails: jest.fn().mockResolvedValue(undefined),
+        };
+
+        gate = new GitHubRateLimitGateService(
+            githubService as any,
+            cacheService as any,
+        );
+    });
+
+    it('does not touch the GitHub bucket when the platform is unknown', async () => {
+        await expect(
+            gate.check(organizationAndTeamData, undefined),
+        ).resolves.toBeUndefined();
+
+        expect(cacheService.getFromCache).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        PlatformType.GITLAB,
+        PlatformType.BITBUCKET,
+        PlatformType.AZURE_REPOS,
+        PlatformType.FORGEJO,
+    ])('passes %s through without probing GitHub', async (platform) => {
+        await expect(
+            gate.check(organizationAndTeamData, platform),
+        ).resolves.toBeUndefined();
+
+        expect(cacheService.getFromCache).not.toHaveBeenCalled();
+    });
+
+    it('still checks the bucket for GitHub', async () => {
+        await gate.check(organizationAndTeamData, PlatformType.GITHUB);
+
+        expect(cacheService.getFromCache).toHaveBeenCalled();
+    });
+});

--- a/libs/platform/infrastructure/adapters/services/github/github-rate-limit-gate.service.ts
+++ b/libs/platform/infrastructure/adapters/services/github/github-rate-limit-gate.service.ts
@@ -66,11 +66,12 @@ export class GitHubRateLimitGateService implements IRateLimitGateService {
 
     async check(
         organizationAndTeamData: OrganizationAndTeamData,
-        platformType: PlatformType,
+        platformType?: PlatformType,
     ): Promise<void> {
         // Only GitHub is implemented today. Other platforms (GitLab,
         // Bitbucket, Azure, Forgejo) have their own rate-limit semantics
-        // and are out of scope for this gate — they pass through.
+        // and are out of scope for this gate — they pass through, as does an
+        // unknown platform (a self-managed host the CLI could not infer).
         if (platformType !== PlatformType.GITHUB) return;
 
         const cacheKey = this.makeCacheKey(organizationAndTeamData);

--- a/libs/platform/infrastructure/adapters/services/github/github.service.clone-params.spec.ts
+++ b/libs/platform/infrastructure/adapters/services/github/github.service.clone-params.spec.ts
@@ -1,0 +1,82 @@
+import { ConfigService } from '@nestjs/config';
+
+import { GithubService } from './github.service';
+
+jest.mock('@libs/mcp-server/services/mcp-manager.service', () => ({
+    MCPManagerService: jest.fn(),
+}));
+
+/**
+ * Regression coverage for issue #1541.
+ *
+ * When an organization has NO GitHub integration, getCloneParams must not
+ * hand back a usable-looking github.com clone URL. It used to: the spread of
+ * an undefined auth detail produced a truthy `{ authMode: 'oauth' }`, which
+ * slipped past the `!githubAuthDetail` guard, and `decrypt(undefined)`
+ * returns '' rather than throwing — so the method happily built
+ * `https://github.com/<fullName>` with an empty token. Callers then cloned
+ * from the wrong host entirely.
+ */
+describe('GithubService.getCloneParams (no GitHub integration)', () => {
+    const organizationAndTeamData = {
+        organizationId: 'org-1',
+        teamId: 'team-1',
+    };
+
+    const repository = {
+        id: '0',
+        defaultBranch: 'main',
+        fullName: 'group/repo',
+        name: 'repo',
+    };
+
+    let service: GithubService;
+    let integrationService: { getPlatformAuthDetails: jest.Mock };
+
+    beforeEach(() => {
+        integrationService = {
+            // No GitHub integration connected for this organization.
+            getPlatformAuthDetails: jest.fn().mockResolvedValue(undefined),
+        };
+
+        service = new GithubService(
+            integrationService as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            { get: jest.fn() } as unknown as ConfigService,
+        );
+    });
+
+    it('still returns a truthy auth detail (61 callers rely on it)', async () => {
+        // Documents why getCloneParams cannot rely on a `!githubAuthDetail`
+        // check: the spread of an undefined lookup plus the authMode default
+        // always produces an object. Tightening this method itself would
+        // change the failure mode of every caller that reads a field off it
+        // without a guard, so the assertion lives in getCloneParams instead.
+        await expect(
+            service.getGithubAuthDetails(organizationAndTeamData),
+        ).resolves.toEqual({ authMode: 'oauth' });
+    });
+
+    it('does not build a github.com clone URL when there is no integration', async () => {
+        const cloneParams = await service.getCloneParams({
+            repository,
+            organizationAndTeamData,
+        });
+
+        expect(cloneParams).toBeNull();
+    });
+
+    it('never returns clone params carrying an empty auth token', async () => {
+        const cloneParams = await service.getCloneParams({
+            repository,
+            organizationAndTeamData,
+        });
+
+        // The empty token is what made the failure silent: the clone was
+        // attempted anonymously against github.com and only failed later,
+        // as "repository not found".
+        expect(cloneParams?.auth?.token).not.toBe('');
+    });
+});

--- a/libs/platform/infrastructure/adapters/services/github/github.service.ts
+++ b/libs/platform/infrastructure/adapters/services/github/github.service.ts
@@ -6014,7 +6014,16 @@ This is an experimental feature that generates committable changes. Review the d
                 params.organizationAndTeamData,
             );
 
-            if (!githubAuthDetail) {
+            // getGithubAuthDetails always returns a truthy object (it spreads
+            // the lookup and defaults authMode), so a plain `!githubAuthDetail`
+            // check never fires for an org with no GitHub integration. Assert
+            // on the auth material instead: without it we would build a
+            // github.com URL with an empty token and let the caller clone from
+            // the wrong host (#1541).
+            if (
+                !githubAuthDetail?.authToken &&
+                !githubAuthDetail?.installationId
+            ) {
                 throw new BadRequestException('Instalation not found');
             }
 

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -3338,7 +3338,13 @@ export class GitlabService implements Omit<
                 params.organizationAndTeamData,
             );
 
-            if (!gitlabAuthDetail) {
+            // getAuthDetails spreads the lookup and defaults authMode, so it is
+            // always truthy — a plain `!gitlabAuthDetail` check never fires for
+            // an organization with no GitLab integration. Assert on the auth
+            // material instead: without it we would fall back to the
+            // gitlab.com base URL and hand back a tokenless clone URL for a
+            // host the caller never asked for (same failure as #1541).
+            if (!gitlabAuthDetail?.accessToken) {
                 throw new Error('GitLab authentication details not found');
             }
 

--- a/test/integration/sandbox/self-managed-clone.integration.spec.ts
+++ b/test/integration/sandbox/self-managed-clone.integration.spec.ts
@@ -167,14 +167,15 @@ describe('CLI sandbox clone against a self-managed git host', () => {
     });
 
     /** Real adapters, with only the integration lookup faked. */
-    const buildResolver = (host: string, platforms: PlatformType[]) => {
+    const buildResolver = (host: string, connected?: PlatformType) => {
         const integrationService = {
-            find: jest.fn(async (filter: any) =>
-                filter?.integrationCategory === IntegrationCategory.CODE_MANAGEMENT
-                    ? platforms.map((platform) => ({ platform }))
-                    : [],
+            // What getTypeIntegration reads to resolve the team's platform.
+            findOne: jest.fn(async (filter: any) =>
+                filter?.integrationCategory ===
+                    IntegrationCategory.CODE_MANAGEMENT && connected
+                    ? { platform: connected }
+                    : null,
             ),
-            findOne: jest.fn().mockResolvedValue({ uuid: 'integration-1' }),
             getPlatformAuthDetails: jest.fn(async (_org, platform) =>
                 platform === PlatformType.GITLAB
                     ? {
@@ -215,7 +216,7 @@ describe('CLI sandbox clone against a self-managed git host', () => {
 
     it('materializes the working tree from the self-managed host', async () => {
         const host = `http://127.0.0.1:${port}`;
-        const resolver = buildResolver(host, [PlatformType.GITLAB]);
+        const resolver = buildResolver(host, PlatformType.GITLAB);
 
         const cloneInfo = await resolver.resolve(
             { origin: 'cli', organizationAndTeamData: { organizationId: 'org-1', teamId: 'team-1' } } as any,
@@ -257,7 +258,7 @@ describe('CLI sandbox clone against a self-managed git host', () => {
 
     it('fails loudly instead of silently cloning github.com when nothing is connected', async () => {
         const host = `http://127.0.0.1:${port}`;
-        const resolver = buildResolver(host, []);
+        const resolver = buildResolver(host, undefined);
 
         const cloneInfo = await resolver.resolve(
             { origin: 'cli', organizationAndTeamData: { organizationId: 'org-1', teamId: 'team-1' } } as any,

--- a/test/integration/sandbox/self-managed-clone.integration.spec.ts
+++ b/test/integration/sandbox/self-managed-clone.integration.spec.ts
@@ -1,0 +1,277 @@
+import { spawn } from 'node:child_process';
+import { execFile } from 'node:child_process';
+import { createServer, type Server } from 'node:http';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+
+import { ConfigService } from '@nestjs/config';
+
+import { IntegrationCategory, PlatformType } from '@libs/core/domain/enums';
+import { AuthMode } from '@libs/platform/domain/platformIntegrations/enums/codeManagement/authMode.enum';
+import { CloneParamsResolverService } from '@libs/code-review/pipeline/services/clone-params-resolver.service';
+import { CodeManagementService } from '@libs/platform/infrastructure/adapters/services/codeManagement.service';
+import { GithubService } from '@libs/platform/infrastructure/adapters/services/github/github.service';
+import { GitlabService } from '@libs/platform/infrastructure/adapters/services/gitlab.service';
+import { PlatformIntegrationFactory } from '@libs/platform/infrastructure/adapters/services/platformIntegration.factory';
+import { LocalSandboxService } from '@libs/sandbox/infrastructure/providers/local-sandbox.service';
+
+jest.mock('@libs/mcp-server/services/mcp-manager.service', () => ({
+    MCPManagerService: jest.fn(),
+}));
+
+const execFileAsync = promisify(execFile);
+const GIT_ENV = {
+    GIT_AUTHOR_NAME: 'kodus-test',
+    GIT_AUTHOR_EMAIL: 'test@kodus.io',
+    GIT_COMMITTER_NAME: 'kodus-test',
+    GIT_COMMITTER_EMAIL: 'test@kodus.io',
+};
+
+/**
+ * End-to-end coverage for issue #1541 — the one layer the mocked specs cannot
+ * give us.
+ *
+ * A real git repository is served over HTTP by git-http-backend on 127.0.0.1,
+ * standing in for a self-managed instance: a host that, by definition, is not
+ * on the CLI's SaaS allowlist, so `inferredPlatform` arrives undefined exactly
+ * as it does for the reporter's GitLab. The real platform adapters resolve the
+ * clone params, and the real sandbox runs the real `git fetch` — the same
+ * command that appears in the issue's log:
+ *
+ *   git -C /tmp/kodus-sandbox-XXXX fetch --depth=1 <url> <sha>:cli-base
+ *
+ * Before the fix this fetched github.com and died with "repository not found".
+ * The assertion here is that the working tree really materializes from the
+ * self-managed host.
+ */
+describe('CLI sandbox clone against a self-managed git host', () => {
+    jest.setTimeout(60_000);
+
+    let server: Server;
+    let port: number;
+    let serverRoot: string;
+    let workDir: string;
+    let sandboxService: LocalSandboxService;
+    let headSha: string;
+
+    /** Minimal git-http-backend CGI bridge — enough for a smart-protocol fetch. */
+    const startGitServer = async (root: string) =>
+        new Promise<{ server: Server; port: number }>((resolve) => {
+            const srv = createServer((req, res) => {
+                const [path, query = ''] = (req.url || '').split('?');
+
+                const cgi = spawn(
+                    join(
+                        process.env.GIT_EXEC_PATH || '',
+                        'git-http-backend',
+                    ),
+                    [],
+                    {
+                        env: {
+                            ...process.env,
+                            GIT_PROJECT_ROOT: root,
+                            GIT_HTTP_EXPORT_ALL: '1',
+                            PATH_INFO: path,
+                            QUERY_STRING: query,
+                            REQUEST_METHOD: req.method || 'GET',
+                            CONTENT_TYPE: req.headers['content-type'] || '',
+                        },
+                    },
+                );
+
+                req.pipe(cgi.stdin);
+
+                let raw = Buffer.alloc(0);
+                cgi.stdout.on('data', (c) => {
+                    raw = Buffer.concat([raw, c]);
+                });
+                cgi.stdout.on('end', () => {
+                    // Split CGI headers from body.
+                    const sep = raw.indexOf('\r\n\r\n');
+                    const head = raw.subarray(0, sep).toString();
+                    const body = raw.subarray(sep + 4);
+
+                    for (const line of head.split('\r\n')) {
+                        const idx = line.indexOf(':');
+                        if (idx > 0) {
+                            res.setHeader(
+                                line.slice(0, idx),
+                                line.slice(idx + 1).trim(),
+                            );
+                        }
+                    }
+                    res.end(body);
+                });
+            });
+
+            srv.listen(0, '127.0.0.1', () => {
+                resolve({ server: srv, port: (srv.address() as any).port });
+            });
+        });
+
+    beforeAll(async () => {
+        // Resolve git's exec path so the CGI binary can be spawned.
+        const { stdout } = await execFileAsync('git', ['--exec-path']);
+        process.env.GIT_EXEC_PATH = stdout.trim();
+
+        serverRoot = await mkdtemp(join(tmpdir(), 'kodus-git-server-'));
+        workDir = await mkdtemp(join(tmpdir(), 'kodus-git-work-'));
+
+        // A real repository with a real commit.
+        await execFileAsync('git', ['init', '-b', 'main', workDir]);
+        await writeFile(
+            join(workDir, 'app.ts'),
+            'export const answer = 42;\n',
+            'utf8',
+        );
+        await execFileAsync('git', ['-C', workDir, 'add', '.']);
+        await execFileAsync(
+            'git',
+            ['-C', workDir, 'commit', '-m', 'initial'],
+            { env: { ...process.env, ...GIT_ENV } },
+        );
+
+        const { stdout: sha } = await execFileAsync('git', [
+            '-C',
+            workDir,
+            'rev-parse',
+            'HEAD',
+        ]);
+        headSha = sha.trim();
+
+        // Publish it as group/repo.git under the server root.
+        const barePath = join(serverRoot, 'group', 'repo.git');
+        await execFileAsync('git', ['clone', '--bare', workDir, barePath]);
+        // The CLI path fetches a bare SHA, which upload-pack refuses by default.
+        await execFileAsync('git', [
+            '-C',
+            barePath,
+            'config',
+            'uploadpack.allowAnySHA1InWant',
+            'true',
+        ]);
+
+        ({ server, port } = await startGitServer(serverRoot));
+
+        sandboxService = new LocalSandboxService({
+            get: jest.fn(),
+        } as unknown as ConfigService);
+    });
+
+    afterAll(async () => {
+        await new Promise<void>((resolve) => server?.close(() => resolve()));
+        await rm(serverRoot, { recursive: true, force: true });
+        await rm(workDir, { recursive: true, force: true });
+    });
+
+    /** Real adapters, with only the integration lookup faked. */
+    const buildResolver = (host: string, platforms: PlatformType[]) => {
+        const integrationService = {
+            find: jest.fn(async (filter: any) =>
+                filter?.integrationCategory === IntegrationCategory.CODE_MANAGEMENT
+                    ? platforms.map((platform) => ({ platform }))
+                    : [],
+            ),
+            findOne: jest.fn().mockResolvedValue({ uuid: 'integration-1' }),
+            getPlatformAuthDetails: jest.fn(async (_org, platform) =>
+                platform === PlatformType.GITLAB
+                    ? {
+                          accessToken: 'oauth-token',
+                          authMode: AuthMode.OAUTH,
+                          host,
+                      }
+                    : undefined,
+            ),
+        };
+
+        const factory = new PlatformIntegrationFactory();
+        factory.registerCodeManagementService(
+            PlatformType.GITLAB,
+            new GitlabService(
+                integrationService as any,
+                {} as any,
+                {} as any,
+                { get: jest.fn() } as unknown as ConfigService,
+                {} as any,
+            ) as any,
+        );
+        factory.registerCodeManagementService(
+            PlatformType.GITHUB,
+            new GithubService(
+                integrationService as any,
+                {} as any,
+                {} as any,
+                {} as any,
+                { get: jest.fn() } as unknown as ConfigService,
+            ) as any,
+        );
+
+        return new CloneParamsResolverService(
+            new CodeManagementService(integrationService as any, factory),
+        );
+    };
+
+    it('materializes the working tree from the self-managed host', async () => {
+        const host = `http://127.0.0.1:${port}`;
+        const resolver = buildResolver(host, [PlatformType.GITLAB]);
+
+        const cloneInfo = await resolver.resolve(
+            { origin: 'cli', organizationAndTeamData: { organizationId: 'org-1', teamId: 'team-1' } } as any,
+            {
+                gitContext: {
+                    // No inferredPlatform: 127.0.0.1 is not a SaaS host, which
+                    // is precisely the reporter's situation.
+                    remote: `${host}/group/repo.git`,
+                    branch: 'main',
+                    mergeBaseSha: headSha,
+                },
+            } as any,
+        );
+
+        expect(cloneInfo).not.toBeNull();
+        expect(cloneInfo!.url).not.toContain('github.com');
+        expect(new URL(cloneInfo!.url).port).toBe(String(port));
+
+        const sandbox = await sandboxService.createSandboxWithRepo({
+            cloneUrl: cloneInfo!.url,
+            authToken: cloneInfo!.authToken,
+            authUsername: cloneInfo!.authUsername,
+            branch: cloneInfo!.branch,
+            platform: cloneInfo!.platform,
+            checkoutSha: cloneInfo!.checkoutSha,
+        } as any);
+
+        try {
+            // The real proof: the file only exists if the real fetch hit the
+            // real self-managed host and checked the commit out.
+            const read = await sandbox.run('cat app.ts');
+
+            expect(read.exitCode).toBe(0);
+            expect(read.stdout).toContain('export const answer = 42;');
+        } finally {
+            await sandbox.cleanup?.();
+        }
+    });
+
+    it('fails loudly instead of silently cloning github.com when nothing is connected', async () => {
+        const host = `http://127.0.0.1:${port}`;
+        const resolver = buildResolver(host, []);
+
+        const cloneInfo = await resolver.resolve(
+            { origin: 'cli', organizationAndTeamData: { organizationId: 'org-1', teamId: 'team-1' } } as any,
+            {
+                gitContext: {
+                    remote: `${host}/group/repo.git`,
+                    branch: 'main',
+                    mergeBaseSha: headSha,
+                },
+            } as any,
+        );
+
+        // Pre-fix this returned https://github.com/group/repo with an empty
+        // token, and the sandbox burned three lease retries on it.
+        expect(cloneInfo).toBeNull();
+    });
+});


### PR DESCRIPTION
## Summary

A CLI review (`kodus review`) against a repository on a self-managed git host cloned from **github.com** and failed with `repository not found`. The sandbox lease was never acquired, so the review silently ran without cross-file context and agent verification.

Fixes #1541

## Root cause

The CLI only infers a platform from well-known SaaS hostnames (`github.com`, `gitlab.com`, `bitbucket.org`, Azure), so every self-managed instance — GitLab CE/EE, Bitbucket Server, Forgejo, GHES — sends no platform at all. Three places independently defaulted that absence to GitHub:

- **`CloneParamsResolverService`** asked the GitHub adapter for clone params, which built `https://github.com/<fullName>` and overwrote the user's real remote.
- **`GithubService.getCloneParams`** could not catch it: `getGithubAuthDetails` spreads the lookup and defaults `authMode`, so it is *always* truthy and the `!githubAuthDetail` guard never fired. `decrypt(undefined)` returns `''` instead of throwing, so the method returned a plausible-looking URL with an empty token.
- The CLI **rate-limit gate** probed the GitHub API for organizations with no GitHub integration, and the pipeline context carried the literal `'github'` — which does not even match `PlatformType.GITHUB` (`'GITHUB'`), so the repository lookup it feeds could never hit.

## Approach

Stop guessing. The resolver no longer names a platform when the CLI could not infer one; `getCloneParams` then resolves the team's connected integration itself, which is the convention the rest of `CodeManagementService` already follows.

Two supporting fixes fell out of that:

- `getCloneParams` now guards the null `getTypeIntegration` returns for an org with no integration, like its 9 sibling methods do — it was handing that null to the factory, which throws `Repository service for type 'null' not found.`
- `GitlabService` and `BitbucketCloudService` share the truthy-spread defect and invented `gitlab.com` / `bitbucket.org` URLs of their own. Probing every adapter showed Bitbucket Data Center and Azure Repos already fail safe, and Forgejo returns null auth details, so only those two needed the guard.

## Test coverage

Three levels:

- **Unit** — resolver behavior, including a table-driven pass over GitLab self-managed, GHES, Bitbucket Server, Forgejo, Azure and GitHub SaaS.
- **Contract** — wires the *real* `GitlabService` / `GithubService` behind the real `CodeManagementService`, faking only the integration lookup, so an adapter contract drift fails here. Plus a cross-adapter spec asserting no adapter invents a SaaS URL it cannot authenticate.
- **Integration** — serves a real repository over `git-http-backend` on `127.0.0.1` (a host outside the SaaS allowlist, reproducing the reporter's situation) and asserts the real `git fetch --depth=1 <url> <sha>:cli-base` materializes the working tree.

Reverting the fix fails 16 of 21 of these, with the exact payload from the issue's log: `url: "https://github.com/group/repo"`, `authToken: ""`, `platform: "GITHUB"`.

## Known limitation, deliberately not handled

A team can hold several active code-management integrations: nothing deactivates the previous one on connect, and there is no unique constraint on `(organization, team, category)`. `getTypeIntegration` then resolves via a `findOne` with no `ORDER BY`, so for such a team the CLI sandbox can still follow the wrong integration and reproduce #1541.

An earlier revision of this PR disambiguated by matching the remote's host against every connected integration. That was dropped: it treats the symptom, and the invariant belongs in the integration layer (a partial unique index on `status = true`, or deactivating the previous one on connect). A spec pins the current behavior rather than papering over it. See the follow-up issue.

The PR path is unaffected throughout — it passes `platformType` explicitly from the webhook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)