### PR TITLE
test(code-review): freeze the pipeline context by default in stage specs

### DIFF
--- a/libs/code-review/pipeline/stages/agent-review.stage.frozen-context.spec.ts
+++ b/libs/code-review/pipeline/stages/agent-review.stage.frozen-context.spec.ts
@@ -1,0 +1,90 @@
+import { frozenContext } from '../../../../test/fixtures/frozen-pipeline-context';
+import { AgentReviewStage } from './agent-review.stage';
+import { CodeReviewPipelineContext } from '../context/code-review-pipeline.context';
+
+/**
+ * Executes the stage against a DEEP-FROZEN context — the shape production
+ * hands it (issue #1452 matrix-gaps item 3).
+ *
+ * This stage is where the frozen-mutation family started: #1522 stamped the
+ * resolved heavy flag with a direct `context.heavy = …` on a context that an
+ * earlier stage's produce() had already frozen. It threw before the
+ * orchestrator ran, the stage's catch swallowed it, and every review for ~27h
+ * finished "in seconds with 0 suggestions".
+ *
+ * The existing agent-review spec only covers two pure helpers
+ * (extractValidDiffLines / snapLinesToDiff) and never runs the stage, so
+ * re-introducing that exact mutation passes CI today — verified by injecting
+ * it. Freezing the other stage specs' builders doesn't help here: there was no
+ * context to freeze. This spec closes that.
+ */
+describe('AgentReviewStage — frozen context (regression #1522)', () => {
+    const makeStage = () => {
+        const reviewOrchestrator = {
+            execute: jest.fn().mockResolvedValue({
+                suggestions: [],
+                overallComment: undefined,
+            }),
+        };
+        const featureGate = {
+            // heavy-review alpha gate: ON, so resolveHeavy returns true and the
+            // stage reaches the write-back.
+            isEnabled: jest.fn().mockResolvedValue(true),
+        };
+        const observabilityService = {
+            runLLMInSpan: jest.fn(async ({ runFn }: any) => runFn?.()),
+        };
+        const stage = new AgentReviewStage(
+            { findLatestExecutionByDataExecutionFilter: jest.fn() } as any,
+            { findByExternalId: jest.fn().mockResolvedValue(null) } as any,
+            reviewOrchestrator as any,
+            observabilityService as any,
+            { generateContext: jest.fn(), generateContextLegacy: jest.fn() } as any,
+            featureGate as any,
+            {
+                getReleaseTrack: jest.fn().mockResolvedValue('stable'),
+            } as any,
+        );
+        return { stage, reviewOrchestrator, featureGate };
+    };
+
+    const makeContext = (over: Record<string, unknown> = {}) =>
+        frozenContext({
+            organizationAndTeamData: { organizationId: 'org-1', teamId: 'team-1' },
+            repository: { id: 'repo-1', name: 'repo-1' },
+            pullRequest: { number: 42 },
+            platformType: 'GITHUB',
+            changedFiles: [
+                { filename: 'src/a.ts', patch: '@@ -1 +1 @@\n+const a = 1;' },
+            ],
+            // heavy comes from the CONFIG and must be STAMPED onto the
+            // context by the stage. Starting at false is what makes the assert
+            // below meaningful: a `true` result can only come from the write-back.
+            codeReviewConfig: { reviewOptions: {}, heavy: true },
+            heavy: false,
+            validSuggestions: [],
+            discardedSuggestions: [],
+            errors: [],
+            dryRun: { enabled: false },
+            ...over,
+        }) as any as CodeReviewPipelineContext;
+
+    it('stamps the resolved heavy flag without mutating the frozen context', async () => {
+        const { stage } = makeStage();
+
+        // The OLD code threw "Cannot assign to read only property 'heavy'"
+        // right here, before the orchestrator ever ran.
+        const result = await (stage as any).executeStage(makeContext());
+
+        expect(result.heavy).toBe(true);
+    });
+
+    it('reaches the orchestrator (the heavy write-back is not swallowed)', async () => {
+        const { stage, reviewOrchestrator } = makeStage();
+
+        await (stage as any).executeStage(makeContext());
+
+        // #1522's tell: the stage "finished" without ever calling the finder.
+        expect(reviewOrchestrator.execute).toHaveBeenCalledTimes(1);
+    });
+});

--- a/libs/code-review/pipeline/stages/create-file-comments.stage.spec.ts
+++ b/libs/code-review/pipeline/stages/create-file-comments.stage.spec.ts
@@ -1,5 +1,5 @@
 import { Test, TestingModule } from '@nestjs/testing';
-import { produce } from 'immer';
+import { frozenContext } from '../../../../test/fixtures/frozen-pipeline-context';
 import { CreateFileCommentsStage } from './create-file-comments.stage';
 import { COMMENT_MANAGER_SERVICE_TOKEN } from '@libs/code-review/domain/contracts/CommentManagerService.contract';
 import { SUGGESTION_SERVICE_TOKEN } from '@libs/code-review/domain/contracts/SuggestionService.contract';
@@ -23,8 +23,10 @@ describe('CreateFileCommentsStage — empty-suggestions persistence', () => {
     let mockSuggestionService: any;
     let mockDryRunService: any;
 
+    // Frozen by DEFAULT: that is the shape production hands every stage after
+    // the first produce(). See test/fixtures/frozen-pipeline-context.ts.
     const baseContext = (overrides: Partial<CodeReviewPipelineContext> = {}) =>
-        ({
+        frozenContext({
             organizationAndTeamData: {
                 organizationId: 'org-A',
                 teamId: 'team-1',
@@ -47,6 +49,7 @@ describe('CreateFileCommentsStage — empty-suggestions persistence', () => {
             dryRun: { enabled: false },
             ...overrides,
         }) as any as CodeReviewPipelineContext;
+
 
     beforeEach(async () => {
         mockCommentManagerService = {};
@@ -128,12 +131,9 @@ describe('CreateFileCommentsStage — empty-suggestions persistence', () => {
         // posted, but no suggestion was ever persisted (found live in QA,
         // broken env-wide since the heavy-mode rollout). Same failure class
         // as the context.heavy write fixed in agent-review.stage (#1522).
-        const frozenCtx = produce(
-            baseContext({ heavy: true } as any),
-            () => {},
-        );
-
-        await stage.execute(frozenCtx);
+        // baseContext() is frozen now, so this reads like every other test —
+        // which is the point: the guard is the default, not this one case.
+        await stage.execute(baseContext({ heavy: true } as any));
 
         expect(
             mockPullRequestService.aggregateAndSaveDataStructure,

--- a/libs/code-review/pipeline/stages/finish-comments.stage.spec.ts
+++ b/libs/code-review/pipeline/stages/finish-comments.stage.spec.ts
@@ -1,4 +1,4 @@
-import { produce } from 'immer';
+import { frozenContext } from '../../../../test/fixtures/frozen-pipeline-context';
 import { UpdateCommentsAndGenerateSummaryStage } from './finish-comments.stage';
 import { PullRequestMessageStatus } from '@libs/core/infrastructure/config/types/general/pullRequestMessages.type';
 
@@ -37,8 +37,11 @@ describe('UpdateCommentsAndGenerateSummaryStage - lineComments forwarding', () =
         },
     ];
 
+    // Frozen by DEFAULT — the shape production hands this stage. This spec's
+    // own subject once threw INSIDE its catch because `context.errors.push()`
+    // hit the freeze (#1548). See test/fixtures/frozen-pipeline-context.ts.
     const baseContext = (over: Record<string, unknown> = {}) =>
-        ({
+        frozenContext({
             lastExecution: undefined,
             errors: [],
             // No summary config → shouldGenerateOrUpdateSummary is false, so the
@@ -128,7 +131,7 @@ describe('UpdateCommentsAndGenerateSummaryStage - frozen-context error recording
     };
 
     const summaryFailContext = () =>
-        ({
+        frozenContext({
             lastExecution: undefined, // isCommitRun=false
             // generatePRSummary=true → shouldGenerateOrUpdateSummary=true,
             // entering the try/catch whose failure path records the error.
@@ -151,8 +154,8 @@ describe('UpdateCommentsAndGenerateSummaryStage - frozen-context error recording
 
     it('records the summary failure without throwing when the context is Immer-frozen', async () => {
         const { stage } = makeStage();
-        // produce(x, () => {}) deep-freezes exactly like the real pipeline.
-        const frozenCtx = produce(summaryFailContext(), () => {});
+        // summaryFailContext() is deep-frozen by default.
+        const frozenCtx = summaryFailContext();
 
         // The whole point: the OLD implementation threw here
         // ("Cannot add property N, object is not extensible") because the
@@ -172,10 +175,10 @@ describe('UpdateCommentsAndGenerateSummaryStage - frozen-context error recording
             error: new Error('earlier'),
             metadata: { reason: 'earlier_failure' },
         };
-        const frozenCtx = produce(
-            { ...summaryFailContext(), errors: [priorError] } as any,
-            () => {},
-        );
+        const frozenCtx = frozenContext({
+            ...summaryFailContext(),
+            errors: [priorError],
+        } as any);
 
         const result = await (stage as any).executeStage(frozenCtx);
 

--- a/libs/code-review/pipeline/stages/finish-process-review.stage.spec.ts
+++ b/libs/code-review/pipeline/stages/finish-process-review.stage.spec.ts
@@ -1,3 +1,4 @@
+import { frozenContext } from '../../../../test/fixtures/frozen-pipeline-context';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { NotificationEvent } from '@libs/notifications/domain/catalog/events';
@@ -31,8 +32,12 @@ describe('RequestChangesOrApproveStage — review.auto_approved emit', () => {
     let notificationService: jest.Mocked<Pick<NotificationService, 'emit'>>;
     let prAuthorResolver: jest.Mocked<Pick<PrAuthorRecipientResolver, 'resolve'>>;
 
-    const makeContext = (): CodeReviewPipelineContext =>
-        ({
+    // Frozen by DEFAULT — production hands every stage after the first
+    // produce() a deep-frozen context. See test/fixtures/frozen-pipeline-context.ts.
+    const makeContext = (
+        over: Record<string, unknown> = {},
+    ): CodeReviewPipelineContext =>
+        frozenContext({
             organizationAndTeamData: {
                 organizationId: 'org-1',
                 teamId: 'team-1',
@@ -48,6 +53,7 @@ describe('RequestChangesOrApproveStage — review.auto_approved emit', () => {
                 pullRequestApprovalActive: true,
                 isRequestChangesActive: false,
             } as any,
+            ...over,
         }) as CodeReviewPipelineContext;
 
     beforeEach(async () => {
@@ -113,8 +119,8 @@ describe('RequestChangesOrApproveStage — review.auto_approved emit', () => {
     });
 
     it('does not emit when approval is skipped due to existing line comments', async () => {
-        const ctx = makeContext();
-        ctx.lineComments = [{}] as any; // any comment short-circuits approval
+        // any comment short-circuits approval
+        const ctx = makeContext({ lineComments: [{}] as any });
 
         await stage.execute(ctx);
 
@@ -157,14 +163,14 @@ describe('RequestChangesOrApproveStage — review.auto_approved emit', () => {
         // critical errors[] entries mean the main agent / a structural
         // stage failed — 0 line comments here is not a clean PR, it's
         // an unanalyzed one. The stage must refuse to approve.
-        const ctx = makeContext();
-        ctx.errors = [
+        const ctx = makeContext({
+            errors: [
             {
                 stage: 'AgentReviewStage',
                 error: new Error('byok auth failed'),
                 severity: 'critical',
-            } as any,
-        ];
+            } as any,            ] as any,
+        });
 
         await stage.execute(ctx);
 
@@ -175,14 +181,14 @@ describe('RequestChangesOrApproveStage — review.auto_approved emit', () => {
     it('does not approve on any partial failure (regardless of which stage)', async () => {
         // Any partial-severity entry means some part of the review didn't
         // run cleanly; auto-approve must wait for the user to decide.
-        const ctx = makeContext();
-        ctx.errors = [
+        const ctx = makeContext({
+            errors: [
             {
                 stage: 'ValidateSuggestionsStage',
                 error: new Error('validator timed out'),
                 severity: 'partial',
-            } as any,
-        ];
+            } as any,            ] as any,
+        });
 
         await stage.execute(ctx);
 

--- a/libs/code-review/pipeline/stages/validate-prerequisites.stage.notify.spec.ts
+++ b/libs/code-review/pipeline/stages/validate-prerequisites.stage.notify.spec.ts
@@ -1,3 +1,4 @@
+import { frozenContext } from '../../../../test/fixtures/frozen-pipeline-context';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { AutomationStatus } from '@libs/automation/domain/automation/enum/automation-status';
@@ -47,8 +48,12 @@ describe('ValidatePrerequisitesStage — review.skipped_no_license emit', () => 
     let permissionValidationService: { validateExecutionPermissions: jest.Mock };
     let autoAssignLicenseUseCase: { execute: jest.Mock };
 
-    const makeContext = (): CodeReviewPipelineContext =>
-        ({
+    // Frozen by DEFAULT — production hands every stage after the first
+    // produce() a deep-frozen context. See test/fixtures/frozen-pipeline-context.ts.
+    const makeContext = (
+        over: Record<string, unknown> = {},
+    ): CodeReviewPipelineContext =>
+        frozenContext({
             organizationAndTeamData: {
                 organizationId: 'org-1',
                 teamId: 'team-1',
@@ -77,6 +82,7 @@ describe('ValidatePrerequisitesStage — review.skipped_no_license emit', () => 
             pipelineMetadata: {},
             statusInfo: { status: 'in_progress' as any, message: 'started' },
             pipelineVersion: '1.0.0',
+            ...over,
         }) as CodeReviewPipelineContext;
 
     beforeEach(async () => {
@@ -209,8 +215,11 @@ describe('ValidatePrerequisitesStage — review.skipped_no_license emit', () => 
                 { email: 'owner@acme.com' } as any,
             ]);
 
-            const context = makeContext();
-            (context.pullRequest as any).user = user;
+            // Built frozen, so the author shape is an override, not a
+            // post-hoc mutation.
+            const context = makeContext({
+                pullRequest: { number: 42, state: 'open', locked: false, user },
+            });
 
             await stage.execute(context);
 

--- a/libs/code-review/pipeline/stages/validate-prerequisites.stage.spec.ts
+++ b/libs/code-review/pipeline/stages/validate-prerequisites.stage.spec.ts
@@ -1,3 +1,4 @@
+import { frozenContext } from '../../../../test/fixtures/frozen-pipeline-context';
 import { Test, TestingModule } from '@nestjs/testing';
 
 import { AutomationStatus } from '@libs/automation/domain/automation/enum/automation-status';
@@ -59,8 +60,12 @@ describe('ValidatePrerequisitesStage', () => {
         createResponseToComment: jest.Mock;
     };
 
-    const makeContext = (): CodeReviewPipelineContext =>
-        ({
+    // Frozen by DEFAULT — production hands every stage after the first
+    // produce() a deep-frozen context. See test/fixtures/frozen-pipeline-context.ts.
+    const makeContext = (
+        over: Record<string, unknown> = {},
+    ): CodeReviewPipelineContext =>
+        frozenContext({
             organizationAndTeamData: {
                 organizationId: 'org-1',
                 teamId: 'team-1',
@@ -93,6 +98,7 @@ describe('ValidatePrerequisitesStage', () => {
                 message: 'started',
             },
             pipelineVersion: '1.0.0',
+            ...over,
         }) as CodeReviewPipelineContext;
 
     beforeEach(async () => {
@@ -340,8 +346,10 @@ describe('ValidatePrerequisitesStage', () => {
     });
 
     it('should skip review for centralized config repository when centralized config is enabled', async () => {
-        const context = makeContext();
-        context.repository.id = 'centralized-config-repo';
+        // Override at build time: the context is frozen, like production.
+        const context = makeContext({
+            repository: { id: 'centralized-config-repo', name: 'repo-1' },
+        });
 
         mockParametersService.findByKey.mockImplementation((key: string) => {
             if (key === ParametersKey.CENTRALIZED_CONFIG) {
@@ -368,8 +376,10 @@ describe('ValidatePrerequisitesStage', () => {
     });
 
     it('should not skip review for non-centralized config repository when centralized config is enabled', async () => {
-        const context = makeContext();
-        context.repository.id = 'non-centralized-config-repo';
+        // Override at build time: the context is frozen, like production.
+        const context = makeContext({
+            repository: { id: 'non-centralized-config-repo', name: 'repo-1' },
+        });
 
         mockParametersService.findByKey.mockImplementation((key: string) => {
             if (key === ParametersKey.CENTRALIZED_CONFIG) {

--- a/test/fixtures/frozen-pipeline-context.ts
+++ b/test/fixtures/frozen-pipeline-context.ts
@@ -1,0 +1,33 @@
+import { produce } from 'immer';
+
+/**
+ * Hands a stage spec the context shape production actually gives it: frozen.
+ *
+ * BasePipelineStage.updateContext runs `produce(context, updater)` (see
+ * base-stage.abstract.ts), and Immer auto-freezes what produce returns. So from
+ * the second stage onward every stage receives a DEEP-FROZEN context, and a
+ * direct write — `context.heavy = x`, `pullRequest.heavy = x`,
+ * `context.errors.push(e)` — throws "Cannot assign to read only property".
+ *
+ * Specs that build a plain object never see that: the write succeeds, the test
+ * passes, and the bug ships. This exact blind spot cost two incidents in one
+ * week — #1522 (context.heavy in agent-review, ~27h of reviews finishing with 0
+ * suggestions) and c886e369a (pullRequest.heavy in create-file-comments, the
+ * same class, found only after the first fix shipped) — plus a third instance
+ * in finish-comments' own error handler, where `context.errors.push()` threw
+ * INSIDE the catch and replaced the real error with a frozen-mutation one.
+ *
+ * Freezing by default means the next instance fails in CI instead of in QA.
+ * Nothing to remember, nothing to opt into.
+ *
+ * Use it in the builder, not per-test:
+ *
+ *   const baseContext = (over = {}) =>
+ *       frozenContext({ ...defaults, ...over } as CodeReviewPipelineContext);
+ *
+ * If a spec legitimately needs a mutable context (asserting on a builder, say),
+ * skip this and say why — an unfrozen context is now the exception.
+ */
+export function frozenContext<T>(context: T): T {
+    return produce(context, () => {});
+}


### PR DESCRIPTION
## Summary

Matrix-gaps **item 3**. Production hands every stage after the first a **deep-frozen** context — `BasePipelineStage.updateContext` runs `produce(context, updater)` and Immer auto-freezes the result. Stage specs built plain objects, so a direct write (`context.heavy = x`, `pullRequest.heavy = x`, `context.errors.push(e)`) passed in CI and threw in production.

That blind spot shipped **three** incidents:

- **#1522** — `context.heavy` in agent-review. ~27h of reviews finishing "in seconds with 0 suggestions".
- **c886e369a** — `pullRequest.heavy` in create-file-comments. Same class, found only *after* the first fix shipped.
- **#1548** — finish-comments' catch pushing to `context.errors`: the error handler itself threw, replacing the real error with a frozen-mutation one.

Each fix added ONE frozen test next to N unfrozen ones, so the next instance kept the same escape hatch.

## Approach

`frozenContext()` (test/fixtures) runs the fixture through the **same** `produce()` the executor uses, and the builders call it. Freezing is the default now — nothing to remember, nothing to opt into.

Freezing broke four tests that mutated the context after building it (`ctx.errors = […]`, `ctx.lineComments = […]`, `context.repository.id = …`, `pullRequest.user = …`). None was a product bug: they asserted against a shape production never hands a stage. Converted to build-time overrides.

## The gap this closes second

`agent-review` — where the family started — had **no spec that ran it**. Its only spec covers two pure helpers (`extractValidDiffLines` / `snapLinesToDiff`) and never calls `executeStage`, so freezing the other builders left it uncovered: there was no context to freeze.

Verified, not assumed: re-injecting #1522's exact line (`context.heavy = resolvedHeavy` on the frozen context) **still passed every existing test**. The second commit adds a spec that executes the stage against a frozen context and asserts both halves of that failure — the flag reaches the context, and the orchestrator is reached at all.

Its fixture starts at `heavy: false` with `heavy: true` in the config, so a `true` result can only come from the write-back. The first version of that assert passed either way — an unfrozen fixture made it decorative, which is exactly the bug class this PR is about.

**RED verified:** both tests fail with the mutation re-introduced, pass without it.

## Test

66 suites / 561 tests green in `libs/code-review`; 104 suites / 987 tests across the touched areas. Full suite green in the pre-push hook (5227 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)