### PR TITLE
fix(e2e): unbreak the hermetic suite — 4 red tests hidden behind a 5min timeout

### DIFF
--- a/.github/workflows/e2e-suite-tests.yml
+++ b/.github/workflows/e2e-suite-tests.yml
@@ -59,7 +59,7 @@ jobs:
               working-directory: tests/e2e
               run: ./node_modules/.bin/tsc --noEmit
 
-            - name: Unit + integration tests (43 tests)
+            - name: Unit + integration tests
               working-directory: tests/e2e
               run: node --import tsx --test lib/__tests__/*.test.ts
 

--- a/tests/e2e/lib/__tests__/integration-license.test.ts
+++ b/tests/e2e/lib/__tests__/integration-license.test.ts
@@ -219,6 +219,10 @@ async function runLicenseScenario(opts: RunOpts): Promise<{
         // production timeout. These envs are read by pollUntil.
         process.env.E2E_POLL_INTERVAL_OVERRIDE_SEC = "0.05";
         process.env.E2E_POLL_TIMEOUT_OVERRIDE_SEC = "3";
+        // The polls were already collapsed; the runner's absence-retry SETTLE
+        // was not, so the "review never arrives" case slept a real 120s before
+        // its retry — 146s for that one test.
+        process.env.E2E_SETTLE_OVERRIDE_SEC = "0";
 
         global.fetch = async (input, init) => {
             const url = typeof input === "string" ? input : input.toString();

--- a/tests/e2e/lib/__tests__/integration-providers.test.ts
+++ b/tests/e2e/lib/__tests__/integration-providers.test.ts
@@ -61,6 +61,15 @@ async function runScenarioAgainstMocks(opts: {
         process.env.TARGET_TUNNEL_URL = "https://dummy.trycloudflare.com";
         process.env.SH_TENANT_EMAIL = "test@kodus.test";
         process.env.SH_TENANT_PASSWORD = "secret123";
+        // Collapse the production waits — the mocks answer instantly, so every
+        // second spent here is dead time. Without these this file alone ran
+        // 13min (three providers × a 120s persistence poll + a 120s retry
+        // settle each) against a 5min job budget, and CI killed the job before
+        // Bitbucket and Azure ever reported. Same knobs the sibling
+        // integration tests already use; production sets none of them.
+        process.env.E2E_POLL_INTERVAL_OVERRIDE_SEC = "0.05";
+        process.env.E2E_POLL_TIMEOUT_OVERRIDE_SEC = "3";
+        process.env.E2E_SETTLE_OVERRIDE_SEC = "0";
         for (const [k, v] of Object.entries(opts.providerEnv)) {
             process.env[k] = v;
         }

--- a/tests/e2e/lib/__tests__/integration.test.ts
+++ b/tests/e2e/lib/__tests__/integration.test.ts
@@ -238,6 +238,11 @@ test("integration: code-review-basic runs end-to-end against mocked Kodus + GitH
         process.env.TARGET_TUNNEL_URL = "https://dummy.trycloudflare.com";
         process.env.SH_TENANT_EMAIL = "test@kodus.test";
         process.env.SH_TENANT_PASSWORD = "secret123";
+        // Mocks answer instantly — collapse the production polls and settles
+        // rather than sleeping through them. See providers/base.ts settle().
+        process.env.E2E_POLL_INTERVAL_OVERRIDE_SEC = "0.05";
+        process.env.E2E_POLL_TIMEOUT_OVERRIDE_SEC = "3";
+        process.env.E2E_SETTLE_OVERRIDE_SEC = "0";
         process.env.GH_TEST_TOKEN = "fake-token";
         process.env.GH_TEST_REPO = TEST_REPO;
         process.env.GH_TEST_PR_NUMBER = String(TEST_PR_NUMBER);
@@ -459,6 +464,11 @@ test("integration: scenario fails clearly when Kody does NOT respond", async () 
         process.env.TARGET_TUNNEL_URL = "https://dummy.trycloudflare.com";
         process.env.SH_TENANT_EMAIL = "test@kodus.test";
         process.env.SH_TENANT_PASSWORD = "secret123";
+        // Mocks answer instantly — collapse the production polls and settles
+        // rather than sleeping through them. See providers/base.ts settle().
+        process.env.E2E_POLL_INTERVAL_OVERRIDE_SEC = "0.05";
+        process.env.E2E_POLL_TIMEOUT_OVERRIDE_SEC = "3";
+        process.env.E2E_SETTLE_OVERRIDE_SEC = "0";
         process.env.GH_TEST_TOKEN = "fake-token";
         process.env.GH_TEST_REPO = TEST_REPO;
         process.env.GH_TEST_PR_NUMBER = String(TEST_PR_NUMBER);

--- a/tests/e2e/lib/__tests__/mock-server.ts
+++ b/tests/e2e/lib/__tests__/mock-server.ts
@@ -191,9 +191,18 @@ export function healthRoute(): RouteHandler {
  * from 2026-07-10). Exported separately because integration.test.ts and
  * integration-license.test.ts carry their own inline route tables.
  * Returns one settled execution (default "success") for any PR queried.
+ *
+ * The SAME trap fired again in #1547: assertPersistedSuggestions was added to
+ * code-review-basic and polls this route for `suggestionsCount.sent`, which the
+ * row did not carry — so it polled its full 120s, failed, and the runner's
+ * retry burned another 120s. That one test alone spent 260s of the job's 5min
+ * budget and turned main red (as a *timeout*, reported as "cancelled") from
+ * 2026-07-14. An assert that reads a field the mock never emits cannot pass:
+ * when adding one, extend this row in the same commit.
  */
 export function executionsRoute(
     status: string = "success",
+    suggestionsSent: number = 1,
 ): RouteHandler {
     return {
         method: "GET",
@@ -216,6 +225,9 @@ export function executionsRoute(
                             status: "open",
                             executionId: "exec-1",
                             automationExecution: { status },
+                            // Read back by assertPersistedSuggestions — the
+                            // store-side counterpart of the posted comments.
+                            suggestionsCount: { sent: suggestionsSent },
                         },
                     ],
                 },

--- a/tests/e2e/lib/__tests__/scenarios.test.ts
+++ b/tests/e2e/lib/__tests__/scenarios.test.ts
@@ -13,6 +13,7 @@ test("allScenarios: includes the registered release-gate scenarios", () => {
         "command-review-focus",
         "conversation-anthropic-byok",
         "conversation-vertex-byok",
+        "finish-onboarding-slo",
         "kody-rules-coverage",
         "kody-rules-create-and-apply",
         "kody-rules-file-sync",

--- a/tests/e2e/lib/onboarding.ts
+++ b/tests/e2e/lib/onboarding.ts
@@ -12,6 +12,7 @@ import {
     type HttpResponse,
 } from "./http.js";
 import { logger } from "./log.js";
+import { settle } from "../providers/base.js";
 
 const log = logger("onboarding");
 
@@ -700,7 +701,7 @@ export async function finishOnboarding(
         // observed case. See task #84 for the corresponding server-
         // side fix (validate-prerequisites should retry with backoff
         // when no automation is found).
-        await new Promise((r) => setTimeout(r, 10_000));
+        await settle(10_000);
         await resetCodeReviewConfig(target, session);
         return;
     }

--- a/tests/e2e/lib/runner.ts
+++ b/tests/e2e/lib/runner.ts
@@ -24,6 +24,7 @@ import {
     signUp,
 } from './onboarding.js';
 import { randomBytes } from 'node:crypto';
+import { settle } from '../providers/base.js';
 import { registryRepoFor } from './cloud-tenant-registry.js';
 import { logger } from './log.js';
 import { collectServerEvidence, isTargetReachable } from './server-evidence.js';
@@ -663,7 +664,7 @@ export async function runMatrix(opts: RunOptions): Promise<RunOutcome> {
                             `RETRY ${cellLabel}: transient failure shape, re-running once${settleMs ? ` after a ${settleMs / 1000}s settle (absence shape — likely a deploy/worker rollout window)` : ''} (${e.message.slice(0, 160)})`,
                         );
                         if (settleMs) {
-                            await new Promise((r) => setTimeout(r, settleMs));
+                            await settle(settleMs);
                         }
                         continue;
                     }

--- a/tests/e2e/providers/base.ts
+++ b/tests/e2e/providers/base.ts
@@ -70,6 +70,26 @@ export async function sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * A SETTLE is a fixed wall-clock wait for real infrastructure to converge —
+ * a worker still rolling out, a team_automation row not yet committed. Unlike
+ * a poll there is nothing to re-check: the wait itself is the mechanism.
+ *
+ * Against a mock there is no worker and nothing to settle, so the wait is pure
+ * dead time. It is not free: the hermetic suite (which drives the real runner
+ * over mock servers) spent ~4 of its 5min budget asleep in these, timing the
+ * job out — reported as "cancelled", which read as noise rather than red, and
+ * left main broken from 2026-07-14.
+ *
+ * E2E_SETTLE_OVERRIDE_SEC collapses them, mirroring the existing
+ * E2E_POLL_*_OVERRIDE_SEC knobs that pollUntil honours. Production sets
+ * nothing and keeps the real delay.
+ */
+export async function settle(ms: number): Promise<void> {
+    const override = process.env.E2E_SETTLE_OVERRIDE_SEC;
+    return sleep(override === undefined ? ms : Number(override) * 1000);
+}
+
 export interface PollOptions {
     timeoutSec: number;
     intervalSec: number;


### PR DESCRIPTION
## O que está acontecendo

**A hermetic suite está vermelha na `main` desde 14/07 (#1547, `d99d81c1f`) e ninguém viu.**

O job estoura `timeout-minutes: 5`, e o GitHub reporta timeout como **`cancelled`**, não `failure` — então lê como ruído, não como red. Todo run da main desde então: **5min18s ± 2s**. O último verde: 3min24s.

| run | branch | duração | resultado |
|---|---|---|---|
| 29196963862 | main | 3min24s | success |
| — merge do #1547 (`d99d81c1f`, 14/07 19:00) — |
| 29371553897 | main | 5min18s | **cancelled** |
| 29373291183 | main | 5min20s | **cancelled** |
| 29436674221 | PR #1550 | 5min16s | **cancelled** |

## Os 4 reds — todos do meu próprio #1547 (`6e88dd112`)

**1. `assertPersistedSuggestions` lê um campo que o mock nunca emitiu.**
Ela faz poll de `/pull-requests/executions` procurando `suggestionsCount.sent`. A linha do mock não carregava esse campo. **Não tinha como passar.** Rodava os 120s inteiros, falhava, e o absence-retry do runner queimava mais 120s — **×3 providers** (GitLab, Bitbucket, Azure). `integration-providers` levava **13min**, e o CI matava o job antes de Bitbucket e Azure sequer reportarem.

`mock-server.ts:187` **já documentava essa armadilha exata**, do #1494: *"added the assert without teaching the mocks the route, which silently broke the whole hermetic integration layer"*. Mesmo erro, um campo ao lado. O docstring agora registra as duas ocorrências.

**2. `finish-onboarding-slo`** foi registrado sem atualizar o `deepEqual` do `scenarios.test.ts`.

## O ponto que vale mais que o fix

Uma suite chamada *hermetic* não deveria dormir. Ela gastava **~4 dos 5 minutos** em wall-clock real contra mocks que respondem na hora: um settle de 120s antes de cada retry e um race-guard de 10s por cenário.

Esses settles existem para **infra real** (worker rolando, `team_automation` ainda não commitado). Contra mock não há nada pra assentar. Agora passam por `settle()` em `providers/base.ts`, honrando `E2E_SETTLE_OVERRIDE_SEC` — espelhando os `E2E_POLL_*_OVERRIDE_SEC` que o `pollUntil` já honra e que os testes de integração já setavam. **Produção não seta nenhum e mantém o delay real.**

Só os dois race-guards viraram settle. `onboarding.ts:443/741` são intervalos de poll dentro de loops com deadline — deixei em paz.

## Verificação (medida, não deduzida)

| | antes | depois |
|---|---|---|
| `integration-providers` | 0 pass / **3 fail** / **792s** | **3 pass** / 0 fail / **9.2s** |
| suite completa | timeout, 4 red | **84 pass / 0 fail / 10.2s** |
| dry-run matrix | — | 62/169, `failed=0`, 2.4s |

O red do `scenarios.test.ts` foi **confirmado pré-existente** revertendo o patch e rodando contra a `origin/main` pura antes de corrigir — não assumido.

**Não bumpei o timeout.** Os 5min agora sobram de folga.

## Nota

Removi o `(43 tests)` hardcoded do nome do step — são 84 agora, e contador desatualizado no CI é como esse tipo de drift começa.

**Este merge desbloqueia a main** e tem precedência sobre #1550/#1551.

## O que este PR NÃO resolve

Nada impede a terceira repetição. Um assert novo lendo campo que o mock não emite segue indetectável até alguém cronometrar o CI, e o timeout mascarado como `cancelled` continua sendo o mecanismo. Dá pra atacar — mas é outro PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
