### PR TITLE
fix(sandbox): resolve reconnect-path RemoteCommands against repo root

### DIFF
--- a/libs/sandbox/infrastructure/providers/e2b-sandbox.service.ts
+++ b/libs/sandbox/infrastructure/providers/e2b-sandbox.service.ts
@@ -1,4 +1,4 @@
-import { createLogger } from '@libs/core/log/logger';
+import { createLogger, SimpleLogger } from '@libs/core/log/logger';
 import { PlatformType } from '@libs/core/domain/enums';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
@@ -34,6 +34,160 @@ const TIMEOUTS = {
     COMMAND_LONG_MS: 30_000,
     COMMAND_SHORT_MS: 10_000,
 };
+
+export interface BuildE2BRemoteCommandsOptions {
+    /** Logger for the [SANDBOX-READ] empty-read warning (optional). */
+    logger?: SimpleLogger;
+    /** `context` field on the warning (e.g. the calling service name). */
+    logContext?: string;
+    /** Extra structured metadata merged into the warning (e.g. { prKey }). */
+    logMetadata?: Record<string, unknown>;
+}
+
+/**
+ * Resolve a repo-relative path against REPO_DIR, rejecting absolute paths and
+ * '..' traversal. Shared by every RemoteCommands implementation so the
+ * path-isolation contract cannot silently diverge.
+ */
+function resolveRepoPath(path: string): string {
+    if (path.startsWith('/')) {
+        throw new Error('Absolute paths are not allowed');
+    }
+    if (path.includes('..')) {
+        throw new Error('Path traversal using ".." is not allowed');
+    }
+    return `${REPO_DIR}/${path}`;
+}
+
+/**
+ * Build the read-only RemoteCommands (grep/read/listDir/exec) backed by an E2B
+ * sandbox. SINGLE SOURCE OF TRUTH: used by BOTH E2BSandboxService (creator) and
+ * SandboxLeaseManager (reconnect/joiner) so the two paths cannot drift — an
+ * earlier inline duplicate in the reconnect path ran commands from the wrong
+ * CWD and swallowed errors, silently blinding reconnected review passes.
+ *
+ * All relative paths resolve against REPO_DIR (the repo lives at
+ * /home/user/repo, NOT the sandbox CWD /home/user). Errors surface instead of
+ * being swallowed, and empty reads emit a [SANDBOX-READ] warning.
+ */
+export function buildE2BRemoteCommands(
+    sandbox: Sandbox,
+    opts: BuildE2BRemoteCommandsOptions = {},
+): RemoteCommands {
+    const { logger, logContext, logMetadata } = opts;
+
+    // E2B's commands.run THROWS a CommandExitError on any non-zero exit. Normalize
+    // it back to a result so read-only tools can inspect exitCode/stderr instead
+    // of treating "no matches" (rg exit 1) or a missing file as a broken tool.
+    const runCmd = async (
+        cmd: string,
+        runOpts?: { timeoutMs?: number },
+    ): Promise<{ stdout: string; stderr: string; exitCode: number }> => {
+        try {
+            return await sandbox.commands.run(cmd, runOpts);
+        } catch (err) {
+            if (err instanceof CommandExitError) {
+                return {
+                    stdout: err.stdout,
+                    stderr: err.stderr,
+                    exitCode: err.exitCode,
+                };
+            }
+            throw err;
+        }
+    };
+
+    return {
+        grep: async (
+            pattern: string,
+            path: string,
+            glob?: string,
+        ): Promise<string> => {
+            // Validate path (throws on '..' / absolute). rg then runs the ORIGINAL
+            // relative path inside REPO_DIR via `cd`, so only the throw is used.
+            resolveRepoPath(path);
+            const globArg = glob
+                ? ` --glob '${glob.replace(/'/g, "'\\''")}'`
+                : '';
+            const escapedPattern = pattern.replace(/'/g, "'\\''");
+            const safeRelativePath = path.replace(/'/g, "'\\''");
+            const result = await runCmd(
+                `cd ${REPO_DIR} && rg --no-heading -n '${escapedPattern}' '${safeRelativePath}'${globArg}`,
+                { timeoutMs: TIMEOUTS.COMMAND_LONG_MS },
+            );
+            // rg exit 1 = "no matches" (valid); exit >= 2 with stderr = real error.
+            if (!result.stdout && result.exitCode >= 2 && result.stderr) {
+                return `Error: ${result.stderr}`;
+            }
+            if (!result.stdout) {
+                return 'No matches found.';
+            }
+            return result.stdout;
+        },
+
+        read: async (
+            path: string,
+            start: number,
+            end: number,
+        ): Promise<string> => {
+            const escapedPath = resolveRepoPath(path).replace(/'/g, "'\\''");
+            // GNU sed rejects address 0, so start=end=0 means "whole file" (cat).
+            const cmd =
+                start === 0 && end === 0
+                    ? `cat '${escapedPath}'`
+                    : `sed -n '${start < 1 ? 1 : start},${end}p' '${escapedPath}'`;
+            const result = await runCmd(cmd, {
+                timeoutMs: TIMEOUTS.COMMAND_SHORT_MS,
+            });
+            if (!result.stdout) {
+                logger?.warn({
+                    message: `[SANDBOX-READ] Empty result for ${path}: exitCode=${result.exitCode} stderr=${(result.stderr || '').substring(0, 200)} cmd=${cmd}`,
+                    context: logContext,
+                    metadata: {
+                        ...logMetadata,
+                        path,
+                        exitCode: result.exitCode,
+                        stderr: (result.stderr || '').substring(0, 200),
+                    },
+                });
+            }
+            // THROW (not return a string) when the read failed — empty stdout +
+            // stderr means "No such file" / permission denied. Returning the error
+            // as content bypassed the readFile tool's catch block.
+            if (!result.stdout && result.stderr) {
+                throw new Error(result.stderr.trim());
+            }
+            return result.stdout;
+        },
+
+        listDir: async (
+            path: string,
+            maxDepth: number,
+        ): Promise<string> => {
+            const escapedPath = resolveRepoPath(path).replace(/'/g, "'\\''");
+            const result = await runCmd(
+                `find '${escapedPath}' -maxdepth ${maxDepth} -type f`,
+                { timeoutMs: TIMEOUTS.COMMAND_LONG_MS },
+            );
+            return result.stdout;
+        },
+
+        exec: async (
+            command: string,
+        ): Promise<{ stdout: string; stderr: string; exitCode: number }> => {
+            const result = await runCmd(`cd ${REPO_DIR} && ${command}`, {
+                timeoutMs: TIMEOUTS.COMMAND_LONG_MS,
+            });
+            // stdout and stderr kept SEPARATE — merging let a subprocess error
+            // masquerade as command output. Tools that want diagnostics use 2>&1.
+            return {
+                stdout: result.stdout,
+                stderr: result.stderr || '',
+                exitCode: result.exitCode,
+            };
+        },
+    };
+}
 
 @Injectable()
 export class E2BSandboxService implements ISandboxProvider {
@@ -634,153 +788,12 @@ export class E2BSandboxService implements ISandboxProvider {
     }
 
     private buildRemoteCommands(sandbox: Sandbox): RemoteCommands {
-        // E2B's `commands.run` THROWS a CommandExitError on any non-zero exit.
-        // That is wrong for the agent's read-only tools: ripgrep exits 1 on
-        // "no matches" (a legitimate, informative result — "no caller found"
-        // is evidence, not a failure), `cat`/`sed` exit 1 on a missing file,
-        // etc. If we let the throw propagate, the model receives a generic
-        // "Error" and treats the tool as broken, triggering retry cascades and
-        // discarding valid negative evidence. This helper normalizes the throw
-        // back into a CommandResult so each tool can inspect exitCode/stderr and
-        // decide for itself what is an error vs. an empty-but-valid result.
-        const runCmd = async (
-            cmd: string,
-            opts?: { timeoutMs?: number },
-        ): Promise<{ stdout: string; stderr: string; exitCode: number }> => {
-            try {
-                return await sandbox.commands.run(cmd, opts);
-            } catch (err) {
-                if (err instanceof CommandExitError) {
-                    return {
-                        stdout: err.stdout,
-                        stderr: err.stderr,
-                        exitCode: err.exitCode,
-                    };
-                }
-                throw err;
-            }
-        };
-
-        return {
-            grep: async (
-                pattern: string,
-                path: string,
-                glob?: string,
-            ): Promise<string> => {
-                // Validate path with the same security checks
-                const fullPath = this.resolvePath(path);
-                const escapedPath = fullPath.replace(/'/g, "'\\''");
-                const globArg = glob
-                    ? ` --glob '${glob.replace(/'/g, "'\\''")}'`
-                    : '';
-                // Use single quotes to prevent bash from interpreting
-                // regex escape sequences (e.g. \b as backspace).
-                const escapedPattern = pattern.replace(/'/g, "'\\''");
-
-                // Run inside REPO_DIR so rg outputs relative paths (e.g. "./src/foo.ts")
-                // instead of absolute ones. We pass the original `path` parameter instead of `fullPath`
-                // because `resolvePath` already validated that `path` is safe (no .. or /).
-                const safeRelativePath = path.replace(/'/g, "'\\''");
-
-                const result = await runCmd(
-                    `cd ${REPO_DIR} && rg --no-heading -n '${escapedPattern}' '${safeRelativePath}'${globArg}`,
-                    { timeoutMs: TIMEOUTS.COMMAND_LONG_MS },
-                );
-                // rg returns exit code 1 for "no matches" (not an error)
-                // but stderr may contain actual errors like "permission denied".
-                // exitCode >= 2 is a real ripgrep error; exit 1 with empty
-                // stdout means simply "no matches", which we surface as such so
-                // the model reads it as valid evidence rather than a failure.
-                if (!result.stdout && result.exitCode >= 2 && result.stderr) {
-                    return `Error: ${result.stderr}`;
-                }
-                if (!result.stdout) {
-                    return 'No matches found.';
-                }
-                return result.stdout;
-            },
-
-            read: async (
-                path: string,
-                start: number,
-                end: number,
-            ): Promise<string> => {
-                const fullPath = this.resolvePath(path);
-                const escapedPath = fullPath.replace(/'/g, "'\\''");
-                // When start=0 and end=0, read the entire file (cat).
-                // GNU sed rejects address 0 so we must avoid `sed -n '0,0p'`.
-                const cmd =
-                    start === 0 && end === 0
-                        ? `cat '${escapedPath}'`
-                        : // sed is 1-indexed; a start address of 0 is invalid in GNU sed.
-                          `sed -n '${start < 1 ? 1 : start},${end}p' '${escapedPath}'`;
-                const result = await runCmd(cmd, {
-                    timeoutMs: TIMEOUTS.COMMAND_SHORT_MS,
-                });
-                // Debug: log when read returns empty
-                if (!result.stdout) {
-                    this.logger.warn({
-                        message: `[SANDBOX-READ] Empty result for ${path}: exitCode=${result.exitCode} stderr=${(result.stderr || '').substring(0, 200)} cmd=${cmd}`,
-                        context: E2BSandboxService.name,
-                    });
-                }
-                // THROW (not return a string) when the read failed — empty
-                // stdout + stderr means "No such file or directory" / permission
-                // denied. Returning the error as if it were file content
-                // bypassed the readFile tool's catch block (which runs the
-                // near-miss path suggestion) and caused retry cascades.
-                if (!result.stdout && result.stderr) {
-                    throw new Error(result.stderr.trim());
-                }
-                return result.stdout;
-            },
-
-            listDir: async (
-                path: string,
-                maxDepth: number,
-            ): Promise<string> => {
-                const fullPath = this.resolvePath(path);
-                const escapedPath = fullPath.replace(/'/g, "'\\''");
-                const result = await runCmd(
-                    `find '${escapedPath}' -maxdepth ${maxDepth} -type f`,
-                    { timeoutMs: TIMEOUTS.COMMAND_LONG_MS },
-                );
-                return result.stdout;
-            },
-
-            exec: async (
-                command: string,
-            ): Promise<{ stdout: string; stderr: string; exitCode: number }> => {
-                const result = await runCmd(
-                    `cd ${REPO_DIR} && ${command}`,
-                    { timeoutMs: TIMEOUTS.COMMAND_LONG_MS },
-                );
-                // With runCmd, a non-zero exit no longer throws: the model now
-                // receives the real exitCode plus stderr. stdout and stderr are
-                // kept SEPARATE — merging them let a subprocess error (e.g.
-                // "fd: command not found") masquerade as command output in the
-                // tools. Tools that want compiler diagnostics already redirect
-                // with `2>&1` at the shell, so nothing they need is lost.
-                return {
-                    stdout: result.stdout,
-                    stderr: result.stderr || '',
-                    exitCode: result.exitCode,
-                };
-            },
-        };
-    }
-
-    private resolvePath(path: string): string {
-        // Security: Prevent path traversal by disallowing absolute paths
-        if (path.startsWith('/')) {
-            throw new Error('Absolute paths are not allowed');
-        }
-        // Security: Prevent path traversal by disallowing '..' segments
-        if (path.includes('..')) {
-            throw new Error('Path traversal using ".." is not allowed');
-        }
-        // Resolve relative paths against the repo directory
-        return `${REPO_DIR}/${path}`;
+        // Delegates to the single shared implementation so the creator and the
+        // SandboxLeaseManager reconnect path can never drift again.
+        return buildE2BRemoteCommands(sandbox, {
+            logger: this.logger,
+            logContext: E2BSandboxService.name,
+        });
     }
 }
 // sandbox-test

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
@@ -12,7 +12,7 @@ import {
 } from '@libs/sandbox/domain/contracts/sandbox.provider';
 import { Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { Sandbox } from 'e2b';
+import { CommandExitError, Sandbox } from 'e2b';
 import { randomUUID } from 'crypto';
 
 import { calculateBackoffInterval } from '@libs/common/utils/polling';
@@ -582,33 +582,104 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
      * This is used by the joiner path when connecting to an already-READY sandbox.
      */
     private buildSandboxInstance(e2bSandbox: Sandbox, prKey: string, leaseId: string): SandboxInstance {
+        // Repo is cloned at REPO_DIR — NOT the sandbox default CWD (/home/user).
+        // The read-only tools MUST resolve relative paths against it, otherwise
+        // sed/rg/find run from /home/user and silently find nothing.
+        const REPO_DIR = '/home/user/repo';
+
+        // e2b's commands.run THROWS a CommandExitError on any non-zero exit.
+        // Normalize it back to a result so read-only tools can inspect
+        // exitCode/stderr instead of treating "no matches" (rg exit 1) or a
+        // missing file as a broken tool. Mirrors E2BSandboxService.runCmd.
+        const runCmd = async (
+            cmd: string,
+            timeoutMs: number,
+        ): Promise<{ stdout: string; stderr: string; exitCode: number }> => {
+            try {
+                const r = await e2bSandbox.commands.run(cmd, { timeoutMs });
+                return { stdout: r.stdout, stderr: r.stderr, exitCode: r.exitCode };
+            } catch (err) {
+                if (err instanceof CommandExitError) {
+                    return {
+                        stdout: err.stdout,
+                        stderr: err.stderr,
+                        exitCode: err.exitCode,
+                    };
+                }
+                throw err;
+            }
+        };
+
+        // Same guards + repo-root prefix as E2BSandboxService.resolvePath. This
+        // is the core fix: relative paths are resolved against the repo, not CWD.
+        const resolvePath = (p: string): string => {
+            if (p.startsWith('/')) {
+                throw new Error('Absolute paths are not allowed');
+            }
+            if (p.includes('..')) {
+                throw new Error('Path traversal using ".." is not allowed');
+            }
+            return `${REPO_DIR}/${p}`;
+        };
+
         return {
             remoteCommands: {
                 grep: async (pattern: string, path: string, glob?: string) => {
-                    const globArg = glob ? `--glob '${glob}'` : '';
-                    const result = await e2bSandbox.commands.run(
-                        `rg --no-heading -n ${globArg} -e '${pattern}' '${path}' 2>/dev/null || true`,
-                        { timeoutMs: 30_000 },
+                    const globArg = glob
+                        ? ` --glob '${glob.replace(/'/g, "'\\''")}'`
+                        : '';
+                    const safePattern = pattern.replace(/'/g, "'\\''");
+                    // rg runs inside REPO_DIR, so the original relative path is correct.
+                    const safePath = path.replace(/'/g, "'\\''");
+                    const result = await runCmd(
+                        `cd ${REPO_DIR} && rg --no-heading -n '${safePattern}' '${safePath}'${globArg}`,
+                        30_000,
                     );
-                    return result.stdout || '';
+                    // rg exit 1 = "no matches" (valid); exit >= 2 with stderr = real error.
+                    if (!result.stdout && result.exitCode >= 2 && result.stderr) {
+                        return `Error: ${result.stderr}`;
+                    }
+                    if (!result.stdout) {
+                        return 'No matches found.';
+                    }
+                    return result.stdout;
                 },
                 read: async (path: string, start: number, end: number) => {
-                    const result = await e2bSandbox.commands.run(
-                        `sed -n '${start},${end}p' '${path}' 2>/dev/null || true`,
-                        { timeoutMs: 10_000 },
-                    );
-                    return result.stdout || '';
+                    const fullPath = resolvePath(path).replace(/'/g, "'\\''");
+                    const cmd =
+                        start === 0 && end === 0
+                            ? `cat '${fullPath}'`
+                            : `sed -n '${start < 1 ? 1 : start},${end}p' '${fullPath}'`;
+                    const result = await runCmd(cmd, 10_000);
+                    if (!result.stdout) {
+                        this.logger.warn({
+                            message: `[SANDBOX-READ] Empty result (reconnect) for ${path}: exitCode=${result.exitCode} stderr=${(result.stderr || '').substring(0, 200)} cmd=${cmd}`,
+                            context: SandboxLeaseManager.name,
+                        });
+                    }
+                    if (!result.stdout && result.stderr) {
+                        throw new Error(result.stderr.trim());
+                    }
+                    return result.stdout;
                 },
                 listDir: async (path: string, maxDepth: number) => {
-                    const result = await e2bSandbox.commands.run(
-                        `find '${path}' -maxdepth ${maxDepth} 2>/dev/null | head -200 || true`,
-                        { timeoutMs: 10_000 },
+                    const fullPath = resolvePath(path).replace(/'/g, "'\\''");
+                    const result = await runCmd(
+                        `find '${fullPath}' -maxdepth ${maxDepth} -type f`,
+                        10_000,
                     );
-                    return result.stdout || '';
+                    return result.stdout;
                 },
                 exec: async (command: string) => {
-                    const result = await e2bSandbox.commands.run(command, { timeoutMs: 30_000 });
-                    return { stdout: result.stdout || '', exitCode: result.exitCode };
+                    const result = await runCmd(
+                        `cd ${REPO_DIR} && ${command}`,
+                        30_000,
+                    );
+                    return {
+                        stdout: result.stdout || '',
+                        stderr: result.stderr || '',
+                        exitCode: result.exitCode,
+                    };
                 },
             },
             cleanup: async () => {

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
@@ -625,6 +625,11 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
         return {
             remoteCommands: {
                 grep: async (pattern: string, path: string, glob?: string) => {
+                    // Validate path (throws on '..' or absolute) — same guard as
+                    // read/listDir and E2BSandboxService.grep. rg then runs the
+                    // ORIGINAL relative path inside REPO_DIR via `cd`, so the
+                    // resolved path itself is only needed for its throw side-effect.
+                    resolvePath(path);
                     const globArg = glob
                         ? ` --glob '${glob.replace(/'/g, "'\\''")}'`
                         : '';
@@ -655,6 +660,13 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                         this.logger.warn({
                             message: `[SANDBOX-READ] Empty result (reconnect) for ${path}: exitCode=${result.exitCode} stderr=${(result.stderr || '').substring(0, 200)} cmd=${cmd}`,
                             context: SandboxLeaseManager.name,
+                            metadata: {
+                                organizationId: prKey.split(':')[0],
+                                prKey,
+                                path,
+                                exitCode: result.exitCode,
+                                stderr: (result.stderr || '').substring(0, 200),
+                            },
                         });
                     }
                     if (!result.stdout && result.stderr) {

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
@@ -12,12 +12,13 @@ import {
 } from '@libs/sandbox/domain/contracts/sandbox.provider';
 import { Inject, Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { CommandExitError, Sandbox } from 'e2b';
+import { Sandbox } from 'e2b';
 import { randomUUID } from 'crypto';
 
 import { calculateBackoffInterval } from '@libs/common/utils/polling';
 import { SandboxLeaseRepository } from '../repositories/sandbox-lease.repository';
 import { NULL_SANDBOX_INSTANCE } from '../providers/null-sandbox.service';
+import { buildE2BRemoteCommands } from '../providers/e2b-sandbox.service';
 
 /**
  * Default idle timeout applied when the last lease on a sandbox is released.
@@ -582,118 +583,18 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
      * This is used by the joiner path when connecting to an already-READY sandbox.
      */
     private buildSandboxInstance(e2bSandbox: Sandbox, prKey: string, leaseId: string): SandboxInstance {
-        // Repo is cloned at REPO_DIR — NOT the sandbox default CWD (/home/user).
-        // The read-only tools MUST resolve relative paths against it, otherwise
-        // sed/rg/find run from /home/user and silently find nothing.
-        const REPO_DIR = '/home/user/repo';
-
-        // e2b's commands.run THROWS a CommandExitError on any non-zero exit.
-        // Normalize it back to a result so read-only tools can inspect
-        // exitCode/stderr instead of treating "no matches" (rg exit 1) or a
-        // missing file as a broken tool. Mirrors E2BSandboxService.runCmd.
-        const runCmd = async (
-            cmd: string,
-            timeoutMs: number,
-        ): Promise<{ stdout: string; stderr: string; exitCode: number }> => {
-            try {
-                const r = await e2bSandbox.commands.run(cmd, { timeoutMs });
-                return { stdout: r.stdout, stderr: r.stderr, exitCode: r.exitCode };
-            } catch (err) {
-                if (err instanceof CommandExitError) {
-                    return {
-                        stdout: err.stdout,
-                        stderr: err.stderr,
-                        exitCode: err.exitCode,
-                    };
-                }
-                throw err;
-            }
-        };
-
-        // Same guards + repo-root prefix as E2BSandboxService.resolvePath. This
-        // is the core fix: relative paths are resolved against the repo, not CWD.
-        const resolvePath = (p: string): string => {
-            if (p.startsWith('/')) {
-                throw new Error('Absolute paths are not allowed');
-            }
-            if (p.includes('..')) {
-                throw new Error('Path traversal using ".." is not allowed');
-            }
-            return `${REPO_DIR}/${p}`;
-        };
-
         return {
-            remoteCommands: {
-                grep: async (pattern: string, path: string, glob?: string) => {
-                    // Validate path (throws on '..' or absolute) — same guard as
-                    // read/listDir and E2BSandboxService.grep. rg then runs the
-                    // ORIGINAL relative path inside REPO_DIR via `cd`, so the
-                    // resolved path itself is only needed for its throw side-effect.
-                    resolvePath(path);
-                    const globArg = glob
-                        ? ` --glob '${glob.replace(/'/g, "'\\''")}'`
-                        : '';
-                    const safePattern = pattern.replace(/'/g, "'\\''");
-                    // rg runs inside REPO_DIR, so the original relative path is correct.
-                    const safePath = path.replace(/'/g, "'\\''");
-                    const result = await runCmd(
-                        `cd ${REPO_DIR} && rg --no-heading -n '${safePattern}' '${safePath}'${globArg}`,
-                        30_000,
-                    );
-                    // rg exit 1 = "no matches" (valid); exit >= 2 with stderr = real error.
-                    if (!result.stdout && result.exitCode >= 2 && result.stderr) {
-                        return `Error: ${result.stderr}`;
-                    }
-                    if (!result.stdout) {
-                        return 'No matches found.';
-                    }
-                    return result.stdout;
+            // Single shared implementation (see e2b-sandbox.service.ts) — resolves
+            // paths against the repo root, surfaces errors, logs empty reads.
+            // Sharing it prevents the creator/reconnect drift that blinded reviews.
+            remoteCommands: buildE2BRemoteCommands(e2bSandbox, {
+                logger: this.logger,
+                logContext: SandboxLeaseManager.name,
+                logMetadata: {
+                    organizationId: prKey.split(':')[0],
+                    prKey,
                 },
-                read: async (path: string, start: number, end: number) => {
-                    const fullPath = resolvePath(path).replace(/'/g, "'\\''");
-                    const cmd =
-                        start === 0 && end === 0
-                            ? `cat '${fullPath}'`
-                            : `sed -n '${start < 1 ? 1 : start},${end}p' '${fullPath}'`;
-                    const result = await runCmd(cmd, 10_000);
-                    if (!result.stdout) {
-                        this.logger.warn({
-                            message: `[SANDBOX-READ] Empty result (reconnect) for ${path}: exitCode=${result.exitCode} stderr=${(result.stderr || '').substring(0, 200)} cmd=${cmd}`,
-                            context: SandboxLeaseManager.name,
-                            metadata: {
-                                organizationId: prKey.split(':')[0],
-                                prKey,
-                                path,
-                                exitCode: result.exitCode,
-                                stderr: (result.stderr || '').substring(0, 200),
-                            },
-                        });
-                    }
-                    if (!result.stdout && result.stderr) {
-                        throw new Error(result.stderr.trim());
-                    }
-                    return result.stdout;
-                },
-                listDir: async (path: string, maxDepth: number) => {
-                    const fullPath = resolvePath(path).replace(/'/g, "'\\''");
-                    const result = await runCmd(
-                        `find '${fullPath}' -maxdepth ${maxDepth} -type f`,
-                        10_000,
-                    );
-                    return result.stdout;
-                },
-                exec: async (command: string) => {
-                    const result = await runCmd(
-                        `cd ${REPO_DIR} && ${command}`,
-                        30_000,
-                    );
-                    return {
-                        stdout: result.stdout || '',
-                        stderr: result.stderr || '',
-                        exitCode: result.exitCode,
-                    };
-                },
-            },
+            }),
             cleanup: async () => {
                 await this.release(leaseId);
             },

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
@@ -1349,4 +1349,48 @@ describe('SandboxLeaseManager reconnect RemoteCommands (blind-read fix)', () => 
             /\.\./,
         );
     });
+
+    it('grep rejects absolute paths and ".." traversal (security guard)', async () => {
+        const run = jest.fn(async () => ({
+            stdout: '',
+            stderr: '',
+            exitCode: 1,
+        }));
+        const { remoteCommands } = buildReconnectCommands(
+            makeFakeE2bSandbox(run),
+        );
+
+        await expect(remoteCommands.grep('x', '/etc', undefined)).rejects.toThrow(
+            /Absolute/,
+        );
+        await expect(
+            remoteCommands.grep('x', '../secrets', undefined),
+        ).rejects.toThrow(/\.\./);
+        // The command must never have run for a rejected path.
+        expect(run).not.toHaveBeenCalled();
+    });
+
+    it('empty read warning carries structured metadata (path, exitCode, org)', async () => {
+        const fake = makeFakeE2bSandbox(async () => ({
+            stdout: '',
+            stderr: 'boom',
+            exitCode: 3,
+        }));
+        const { manager, remoteCommands } = buildReconnectCommands(fake);
+        const warnSpy = jest
+            .spyOn((manager as any).logger, 'warn')
+            .mockImplementation(() => undefined);
+
+        // prKey passed by buildReconnectCommands is 'org:repo:225'.
+        await expect(remoteCommands.read('x.ts', 1, 10)).rejects.toThrow(/boom/);
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                metadata: expect.objectContaining({
+                    organizationId: 'org',
+                    path: 'x.ts',
+                    exitCode: 3,
+                }),
+            }),
+        );
+    });
 });

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
@@ -1210,3 +1210,143 @@ describe('SandboxLeaseReaperService', () => {
         expect(leaseRepo.delete).toHaveBeenCalledTimes(3);
     });
 });
+
+// ─── Reconnect-path RemoteCommands (regression: blind reads bug) ──────────────
+//
+// The joiner/reconnect path (buildSandboxInstance) used to run sed/rg/find with
+// relative paths from the sandbox default CWD (/home/user) instead of the repo
+// root (/home/user/repo), and swallowed errors with `2>/dev/null || true` with
+// no log. Net effect: every reconnected review pass read '' for real files and
+// approved PRs blind. These tests pin the corrected behavior.
+describe('SandboxLeaseManager reconnect RemoteCommands (blind-read fix)', () => {
+    const REPO_DIR = '/home/user/repo';
+
+    function makeFakeE2bSandbox(
+        run: (cmd: string, opts?: any) => Promise<any>,
+    ): any {
+        return {
+            sandboxId: 'sbx-reconnect-1',
+            commands: { run: jest.fn(run) },
+            files: { read: jest.fn(), write: jest.fn() },
+        };
+    }
+
+    function buildReconnectCommands(fake: any) {
+        const manager = makeLeaseManager(
+            makeMockLeaseRepo(),
+            makeMockSandboxProvider(true),
+            makeMockConfigService('test-e2b-key'),
+        );
+        const instance = (manager as any).buildSandboxInstance(
+            fake,
+            'org:repo:225',
+            'lease-1',
+        );
+        return { manager, remoteCommands: instance.remoteCommands };
+    }
+
+    it('read resolves relative paths against the repo root, not the sandbox CWD', async () => {
+        const relPath = 'src/components/Button/Button.tsx';
+        // Simulate a real sandbox: the file only exists under REPO_DIR.
+        const fake = makeFakeE2bSandbox(async (cmd: string) => {
+            if (cmd.includes(`${REPO_DIR}/${relPath}`)) {
+                return {
+                    stdout: 'export function Button() {}\n',
+                    stderr: '',
+                    exitCode: 0,
+                };
+            }
+            return { stdout: '', stderr: '', exitCode: 0 }; // wrong CWD → nothing
+        });
+        const { remoteCommands } = buildReconnectCommands(fake);
+
+        const out = await remoteCommands.read(relPath, 100, 130);
+
+        expect(out).toContain('export function Button');
+        expect(fake.commands.run).toHaveBeenCalledWith(
+            expect.stringContaining(`${REPO_DIR}/${relPath}`),
+            expect.anything(),
+        );
+    });
+
+    it('grep runs inside the repo dir (cd $REPO_DIR)', async () => {
+        const fake = makeFakeE2bSandbox(async (cmd: string) =>
+            cmd.startsWith(`cd ${REPO_DIR} &&`)
+                ? { stdout: 'src/a.ts:1:hit\n', stderr: '', exitCode: 0 }
+                : { stdout: '', stderr: '', exitCode: 1 },
+        );
+        const { remoteCommands } = buildReconnectCommands(fake);
+
+        const out = await remoteCommands.grep('hit', '.', undefined);
+
+        expect(out).toContain('src/a.ts');
+        expect(fake.commands.run).toHaveBeenCalledWith(
+            expect.stringMatching(new RegExp(`^cd ${REPO_DIR} &&`)),
+            expect.anything(),
+        );
+    });
+
+    it('listDir resolves against the repo root', async () => {
+        const fake = makeFakeE2bSandbox(async (cmd: string) =>
+            cmd.includes(`${REPO_DIR}/src`)
+                ? { stdout: `${REPO_DIR}/src/a.ts\n`, stderr: '', exitCode: 0 }
+                : { stdout: '', stderr: '', exitCode: 0 },
+        );
+        const { remoteCommands } = buildReconnectCommands(fake);
+
+        const out = await remoteCommands.listDir('src', 2);
+
+        expect(out).toContain('src/a.ts');
+    });
+
+    it('read propagates real errors instead of silently returning empty', async () => {
+        // Previously `2>/dev/null || true` masked this as empty stdout, exit 0.
+        const fake = makeFakeE2bSandbox(async () => ({
+            stdout: '',
+            stderr: "sed: can't read /home/user/repo/nope.ts: No such file or directory",
+            exitCode: 2,
+        }));
+        const { remoteCommands } = buildReconnectCommands(fake);
+
+        await expect(remoteCommands.read('nope.ts', 1, 10)).rejects.toThrow(
+            /No such file/,
+        );
+    });
+
+    it('read emits a [SANDBOX-READ] warning on an empty result (observability)', async () => {
+        const fake = makeFakeE2bSandbox(async () => ({
+            stdout: '',
+            stderr: '',
+            exitCode: 0,
+        }));
+        const { manager, remoteCommands } = buildReconnectCommands(fake);
+        const warnSpy = jest
+            .spyOn((manager as any).logger, 'warn')
+            .mockImplementation(() => undefined);
+
+        await remoteCommands.read('empty.ts', 1, 10);
+
+        expect(warnSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: expect.stringContaining('[SANDBOX-READ] Empty result'),
+            }),
+        );
+    });
+
+    it('read rejects absolute paths and ".." traversal (security guard)', async () => {
+        const { remoteCommands } = buildReconnectCommands(
+            makeFakeE2bSandbox(async () => ({
+                stdout: '',
+                stderr: '',
+                exitCode: 0,
+            })),
+        );
+
+        await expect(remoteCommands.read('/etc/passwd', 0, 0)).rejects.toThrow(
+            /Absolute/,
+        );
+        await expect(remoteCommands.read('../secrets', 0, 0)).rejects.toThrow(
+            /\.\./,
+        );
+    });
+});


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR fixes a critical blind-reads bug in the sandbox reconnect path and prevents future drift between the two code paths that build sandbox read-only commands.

### What was wrong

When a sandbox was reconnected via `SandboxLeaseManager.buildSandboxInstance`, the `RemoteCommands` (grep/read/listDir/exec) were built from an inline, simplified implementation that:

- Resolved relative paths like `src/...` against the sandbox default CWD (`/home/user`) instead of the repo root (`/home/user/repo`), so reads/greps silently returned empty results for real files.
- Swallowed all errors with `2>/dev/null || true` and returned `''` with no logging, making failures invisible.
- Did not separate `stderr` from `stdout`.
- Ran from the wrong working directory.

**Impact:** Every reconnected review pass could read files as empty, which meant the review proceeded without seeing actual code — effectively approving PRs blind.

### What changed

- **Extracted a single shared `buildE2BRemoteCommands()` implementation** in `e2b-sandbox.service.ts`.
- Both `E2BSandboxService` (sandbox creation path) and `SandboxLeaseManager` (reconnect/joiner path) now use this same shared builder, so the two paths can no longer drift.
- All relative paths are now resolved against the repo root (`/home/user/repo`), and absolute paths / `..` traversal are rejected as a security guard.
- Commands run with `cd /home/user/repo` so tools operate from the correct directory.
- Errors are surfaced instead of silently swallowed:
  - `read` throws on real failures (e.g. missing file) and logs a `[SANDBOX-READ]` warning with structured metadata on empty results.
  - `grep` distinguishes legitimate "no matches" from real errors and returns `No matches found` when appropriate.
  - `exec` keeps `stdout` and `stderr` separate and returns the actual `exitCode`.
- Added regression tests covering reconnect-path behavior: repo-root path resolution, grep running from repo root, error propagation, empty-read warning observability, and path traversal/absolute-path rejection.
<!-- kody-pr-summary:end -->