### PR TITLE
feat(pr-review): evolve the review screen (cohorts, progress, jump-to-finding, render perf)

### DIFF
--- a/apps/web/src/app/(app)/pull-requests/[repositoryId]/[prNumber]/_components/diff-viewer.tsx
+++ b/apps/web/src/app/(app)/pull-requests/[repositoryId]/[prNumber]/_components/diff-viewer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { PullRequestFile } from "@services/pull-requests";
 import { ColumnsIcon, FileIcon, RowsIcon } from "lucide-react";
 import { cn } from "src/core/utils/components";
@@ -35,6 +35,20 @@ export function DiffViewer({
     // purely a diff-pane affordance, so it stays local.
     const viewed = state.viewedFiles;
     const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
+
+    // Stable identities so the memoized FileBlocks below don't all re-render
+    // (and re-tokenize their diffs) every time this wrapper re-renders — e.g.
+    // on each jump-to-issue. dispatch/setCollapsed are stable across renders.
+    const handleToggleViewed = useCallback(
+        (path: string, v: boolean) =>
+            dispatch({ type: "SET_VIEWED", path, viewed: v }),
+        [dispatch],
+    );
+    const handleToggleCollapsed = useCallback(
+        (path: string) =>
+            setCollapsed((prev) => ({ ...prev, [path]: !prev[path] })),
+        [],
+    );
 
     // Flatten every file's suggestions into one list, honoring the existing
     // severity/category filters from the store so the summary-panel filters
@@ -139,16 +153,9 @@ export function DiffViewer({
                         pr={pr}
                         diffStyle={diffStyle}
                         viewed={viewed}
-                        onToggleViewed={(path, v) =>
-                            dispatch({ type: "SET_VIEWED", path, viewed: v })
-                        }
+                        onToggleViewed={handleToggleViewed}
                         collapsed={collapsed}
-                        onToggleCollapsed={(path) =>
-                            setCollapsed((prev) => ({
-                                ...prev,
-                                [path]: !prev[path],
-                            }))
-                        }
+                        onToggleCollapsed={handleToggleCollapsed}
                         isReviewing={patchesLoading}
                         highlightIssueId={highlightIssueId}
                     />

--- a/apps/web/src/app/(app)/pull-requests/[repositoryId]/[prNumber]/_components/page.client.tsx
+++ b/apps/web/src/app/(app)/pull-requests/[repositoryId]/[prNumber]/_components/page.client.tsx
@@ -335,13 +335,21 @@ function ReviewLayout({
         () => treeFiles.filter((f) => state.viewedFiles[f.path]).length,
         [treeFiles, state.viewedFiles],
     );
-    const attentionCount = useMemo(
-        () =>
-            treeIssues.filter((i) =>
-                ["critical", "high"].includes((i.severity ?? "").toLowerCase()),
-            ).length,
-        [treeIssues],
-    );
+    // Count critical/high across BOTH file-level and PR-level findings so the
+    // "needs attention" figure — and the derived "minor" count below — line up
+    // with suggestionCount, which also includes prLevelSuggestions. Counting
+    // only treeIssues here let PR-level criticals leak into the "minor" tally.
+    const attentionCount = useMemo(() => {
+        const isAttention = (severity?: string) =>
+            ["critical", "high"].includes((severity ?? "").toLowerCase());
+        const fromFiles = treeIssues.filter((i) =>
+            isAttention(i.severity),
+        ).length;
+        const fromPrLevel = prLevelSuggestions.filter((s) =>
+            isAttention(s?.severity),
+        ).length;
+        return fromFiles + fromPrLevel;
+    }, [treeIssues, prLevelSuggestions]);
 
     const jumpToFile = (path: string) =>
         dispatch({ type: "SELECT_FILE", path });
@@ -372,6 +380,14 @@ function ReviewLayout({
         };
         requestAnimationFrame(tryScroll);
     };
+
+    // Keep the highlight in sync with the URL: navigating to (or away from) a
+    // deep-linked finding overrides a stale activeIssueId left by a prior
+    // sidebar click, so back/forward doesn't light up the wrong card.
+    useEffect(() => {
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        setActiveIssueId(deepLinkIssue ?? null);
+    }, [deepLinkIssue]);
 
     // Keyboard shortcuts
     useEffect(() => {

--- a/apps/web/src/app/(app)/pull-requests/[repositoryId]/[prNumber]/_components/page.client.tsx
+++ b/apps/web/src/app/(app)/pull-requests/[repositoryId]/[prNumber]/_components/page.client.tsx
@@ -26,6 +26,7 @@ import { CommitsList } from "./try-port/CommitsList";
 import { FileTree, type FileTreeMode } from "./try-port/FileTree";
 import { PrHeader, type PrTab } from "./try-port/PrHeader";
 import { RightSidebar } from "./try-port/RightSidebar";
+import type { ReviewIssue } from "./try-port/types";
 
 // Web only carries data for these two tabs (Kody doesn't store the PR body
 // or comment threads), so we render a narrower tab bar than try's four.
@@ -43,6 +44,64 @@ function PanelError({ error }: FallbackProps) {
             <p className="max-w-md font-mono text-xs break-words text-[var(--text-dim)]">
                 {message}
             </p>
+        </div>
+    );
+}
+
+/**
+ * Slim bar above the diff: signal hierarchy on the left (what needs attention
+ * vs. what's minor) and review progress on the right (files viewed / total).
+ * Gives the reviewer an overview and a sense of "where am I" before the diff —
+ * the two things GitHub's raw file list never answers.
+ */
+function ReviewProgressBar({
+    viewed,
+    total,
+    attention,
+    minor,
+}: {
+    viewed: number;
+    total: number;
+    attention: number;
+    minor: number;
+}) {
+    const pct = total > 0 ? Math.round((100 * viewed) / total) : 0;
+    return (
+        <div className="mt-3 mb-4 flex flex-wrap items-center justify-between gap-3 rounded-lg border border-[var(--border)] bg-[var(--bg-2)]/70 px-4 py-2.5">
+            <div className="flex items-center gap-2.5 text-sm">
+                {attention > 0 ? (
+                    <span className="inline-flex items-center gap-1.5 font-medium text-[var(--warn)]">
+                        <span className="size-1.5 rounded-full bg-[var(--warn)]" />
+                        {attention} preciso de atenção
+                    </span>
+                ) : (
+                    <span className="inline-flex items-center gap-1.5 font-medium text-[var(--green)]">
+                        <span className="size-1.5 rounded-full bg-[var(--green)]" />
+                        nada crítico
+                    </span>
+                )}
+                {minor > 0 && (
+                    <span className="text-[var(--text-dim)]">
+                        · {minor} menor{minor === 1 ? "" : "es"}
+                    </span>
+                )}
+            </div>
+            <div className="flex items-center gap-2.5">
+                <span className="font-mono text-xs text-[var(--text-muted)] tabular-nums">
+                    {viewed} / {total} vistos
+                </span>
+                <span
+                    className="h-1.5 w-24 overflow-hidden rounded-full bg-[var(--bg-4)]"
+                    role="progressbar"
+                    aria-valuenow={pct}
+                    aria-valuemin={0}
+                    aria-valuemax={100}>
+                    <span
+                        className="block h-full rounded-full bg-[var(--accent)] transition-[width] duration-300"
+                        style={{ width: `${pct}%` }}
+                    />
+                </span>
+            </div>
         </div>
     );
 }
@@ -269,8 +328,50 @@ function ReviewLayout({
 
     const suggestionCount = fileSuggestions.length + prLevelSuggestions.length;
 
+    // Orientation + signal hierarchy for the review header: how far the
+    // reviewer has gotten, and how many findings actually need attention vs.
+    // are minor. Bucketed case-insensitively so it survives severity casing.
+    const viewedCount = useMemo(
+        () => treeFiles.filter((f) => state.viewedFiles[f.path]).length,
+        [treeFiles, state.viewedFiles],
+    );
+    const attentionCount = useMemo(
+        () =>
+            treeIssues.filter((i) =>
+                ["critical", "high"].includes((i.severity ?? "").toLowerCase()),
+            ).length,
+        [treeIssues],
+    );
+
     const jumpToFile = (path: string) =>
         dispatch({ type: "SELECT_FILE", path });
+
+    // Click on a sidebar finding → land ON that suggestion (not the file top)
+    // and pulse it. Targets the `suggestion-<id>` anchor, which is keyed on the
+    // finding's own id, so it works even when the finding's file path doesn't
+    // match the diff's — the reason clicking used to do nothing. Retries a few
+    // frames while the diff finishes mounting.
+    const [activeIssueId, setActiveIssueId] = useState<string | null>(null);
+    const jumpToIssue = (issue: ReviewIssue) => {
+        if (issue.file) dispatch({ type: "SELECT_FILE", path: issue.file });
+        const targetId = issue.id
+            ? `suggestion-${issue.id}`
+            : issue.file
+              ? `file-${issue.file}`
+              : null;
+        if (issue.id) setActiveIssueId(issue.id);
+        if (!targetId) return;
+        let tries = 0;
+        const tryScroll = () => {
+            const el = document.getElementById(targetId);
+            if (el) {
+                el.scrollIntoView({ behavior: "smooth", block: "center" });
+                return;
+            }
+            if (tries++ < 60) requestAnimationFrame(tryScroll);
+        };
+        requestAnimationFrame(tryScroll);
+    };
 
     // Keyboard shortcuts
     useEffect(() => {
@@ -405,6 +506,18 @@ function ReviewLayout({
                             />
 
                             {activeTab === "review" && (
+                                <ReviewProgressBar
+                                    viewed={viewedCount}
+                                    total={treeFiles.length}
+                                    attention={attentionCount}
+                                    minor={Math.max(
+                                        0,
+                                        suggestionCount - attentionCount,
+                                    )}
+                                />
+                            )}
+
+                            {activeTab === "review" && (
                                 <ErrorBoundary FallbackComponent={PanelError}>
                                     <DiffViewer
                                         patchFiles={patchFiles}
@@ -414,7 +527,9 @@ function ReviewLayout({
                                         prUrl={prUrl}
                                         repositoryName={repositoryName}
                                         highlightIssueId={
-                                            deepLinkIssue ?? undefined
+                                            activeIssueId ??
+                                            deepLinkIssue ??
+                                            undefined
                                         }
                                     />
                                 </ErrorBoundary>
@@ -432,7 +547,7 @@ function ReviewLayout({
                                     pr={pr}
                                     issues={treeIssues}
                                     isCompleted
-                                    onJumpToIssue={jumpToFile}
+                                    onJumpToIssue={jumpToIssue}
                                 />
                             </ErrorBoundary>
                         </aside>

--- a/apps/web/src/app/(app)/pull-requests/[repositoryId]/[prNumber]/_components/page.client.tsx
+++ b/apps/web/src/app/(app)/pull-requests/[repositoryId]/[prNumber]/_components/page.client.tsx
@@ -94,11 +94,28 @@ export function ReviewPageClient({
         error: filesError,
     } = usePullRequestFiles(repositoryId, prNumber, teamId, repoName);
 
-    const fileSuggestions = suggestionsData?.data?.suggestions?.files ?? [];
-    const prLevelSuggestions =
-        suggestionsData?.data?.suggestions?.prLevel ?? [];
-    const patchFiles: PullRequestFile[] = filesData?.data?.files ?? [];
-    const commits: PullRequestCommit[] = filesData?.data?.commits ?? [];
+    // Derive these through useMemo so their reference is stable across renders
+    // while the underlying query data is unchanged. Without it, `?? []` (and
+    // the optional-chain miss during loading) hands a fresh array to every
+    // downstream memo — adaptForTryDiffViewer, buildTree, buildCohorts — on
+    // each render, defeating their memoization on a screen whose diffs are the
+    // expensive part to recompute.
+    const fileSuggestions = useMemo(
+        () => suggestionsData?.data?.suggestions?.files ?? [],
+        [suggestionsData],
+    );
+    const prLevelSuggestions = useMemo(
+        () => suggestionsData?.data?.suggestions?.prLevel ?? [],
+        [suggestionsData],
+    );
+    const patchFiles: PullRequestFile[] = useMemo(
+        () => filesData?.data?.files ?? [],
+        [filesData],
+    );
+    const commits: PullRequestCommit[] = useMemo(
+        () => filesData?.data?.commits ?? [],
+        [filesData],
+    );
     const patchFilenames = useMemo(
         () => patchFiles.map((f) => f.filename),
         [patchFiles],

--- a/apps/web/src/app/(app)/pull-requests/[repositoryId]/[prNumber]/_components/page.client.tsx
+++ b/apps/web/src/app/(app)/pull-requests/[repositoryId]/[prNumber]/_components/page.client.tsx
@@ -23,13 +23,14 @@ import { DiffViewer } from "./diff-viewer";
 import { ReviewStateProvider, useReviewStore } from "./review-store";
 import { adaptForTryDiffViewer, buildHeaderPrInfo } from "./try-port/adapt";
 import { CommitsList } from "./try-port/CommitsList";
-import { FileTree } from "./try-port/FileTree";
+import { FileTree, type FileTreeMode } from "./try-port/FileTree";
 import { PrHeader, type PrTab } from "./try-port/PrHeader";
 import { RightSidebar } from "./try-port/RightSidebar";
 
 // Web only carries data for these two tabs (Kody doesn't store the PR body
 // or comment threads), so we render a narrower tab bar than try's four.
 const WEB_TABS: PrTab[] = ["review", "commits"];
+const FILE_TREE_MODE_KEY = "kodus:pr-file-tree-mode";
 
 function PanelError({ error }: FallbackProps) {
     const message =
@@ -200,6 +201,24 @@ function ReviewLayout({
 }) {
     const { state, dispatch, navigateFile } = useReviewStore();
     const [activeTab, setActiveTab] = useState<PrTab>("review");
+    // Folder tree vs. role-grouped cohorts. Persisted so the choice sticks
+    // across PRs. Applied AFTER mount (not in the initializer) so the server
+    // and the first client render agree on the "tree" default — reading
+    // localStorage in the initializer would diverge and trip a hydration
+    // mismatch. This one-time sync of a client-only preference is the case the
+    // set-state-in-effect heuristic doesn't cover, hence the scoped disable.
+    const [treeMode, setTreeMode] = useState<FileTreeMode>("tree");
+    useEffect(() => {
+        const saved = window.localStorage.getItem(FILE_TREE_MODE_KEY);
+        // eslint-disable-next-line react-hooks/set-state-in-effect
+        if (saved === "grouped" || saved === "tree") setTreeMode(saved);
+    }, []);
+    const toggleTreeMode = () =>
+        setTreeMode((m) => {
+            const next = m === "tree" ? "grouped" : "tree";
+            window.localStorage.setItem(FILE_TREE_MODE_KEY, next);
+            return next;
+        });
 
     // Deep link: /pull-requests/<repo>/<num>?file=<path>&suggestion=<id>
     // Lands the user on the exact finding — scrolls to it and lights it up.
@@ -342,6 +361,8 @@ function ReviewLayout({
                                     viewed={state.viewedFiles}
                                     onPick={jumpToFile}
                                     prRef={`PR #${prNumber}`}
+                                    mode={treeMode}
+                                    onToggleMode={toggleTreeMode}
                                     onHide={() =>
                                         dispatch({ type: "TOGGLE_SIDEBAR" })
                                     }

--- a/apps/web/src/app/(app)/pull-requests/[repositoryId]/[prNumber]/_components/try-port/DiffViewer.tsx
+++ b/apps/web/src/app/(app)/pull-requests/[repositoryId]/[prNumber]/_components/try-port/DiffViewer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { PatchDiff } from "@pierre/diffs/react";
 import { ErrorBoundary } from "react-error-boundary";
 import type { DiffFile, PrInfo, PromptContext, ReviewIssue } from "./types";
@@ -58,6 +58,17 @@ function LazyDiff({
     // so we don't auto-mount it — the user opts in with a click.
     const isLarge = lineCount > 1500;
 
+    // Stable options identity so PatchDiff doesn't re-tokenize whenever an
+    // ancestor re-renders (only diffStyle actually changes the render).
+    const patchOptions = useMemo(
+        () => ({
+            theme: "pierre-dark" as const,
+            diffStyle,
+            overflow: "scroll" as const,
+        }),
+        [diffStyle],
+    );
+
     // Rough height guess (~18px/line) so the placeholder reserves space and
     // the page doesn't jump as blocks mount. Capped so giant files don't
     // reserve absurd amounts of empty scroll.
@@ -95,14 +106,7 @@ function LazyDiff({
                 <ErrorBoundary
                     fallback={<RawPatch patch={patch} />}
                     resetKeys={[patch]}>
-                    <PatchDiff
-                        patch={patch}
-                        options={{
-                            theme: "pierre-dark",
-                            diffStyle,
-                            overflow: "scroll",
-                        }}
-                    />
+                    <PatchDiff patch={patch} options={patchOptions} />
                 </ErrorBoundary>
             ) : isLarge ? (
                 <div className="flex flex-col items-center justify-center gap-2 p-6 text-center">
@@ -159,12 +163,16 @@ export function DiffViewer({
      *  accent ring. */
     highlightIssueId?: string;
 }) {
-    const promptCtx: PromptContext = pr
-        ? {
-              prRef: `${pr.owner}/${pr.repo}#${pr.prNumber}`,
-              htmlUrl: pr.htmlUrl,
-          }
-        : {};
+    const promptCtx: PromptContext = useMemo(
+        () =>
+            pr
+                ? {
+                      prRef: `${pr.owner}/${pr.repo}#${pr.prNumber}`,
+                      htmlUrl: pr.htmlUrl,
+                  }
+                : {},
+        [pr],
+    );
 
     const patchByPath = useMemo(() => {
         const map = new Map<string, string>();
@@ -196,27 +204,32 @@ export function DiffViewer({
             {files.map((file, idx) => {
                 const patch = patchByPath.get(file.path);
                 if (!patch) return null;
+                const fileIssues = issuesByFile.get(file.path) ?? [];
+                // Only the block that actually owns the highlighted finding
+                // receives the id — so changing the target re-renders just the
+                // old and new owners, not every FileBlock on the page.
+                const ownsHighlight =
+                    highlightIssueId != null &&
+                    fileIssues.some((i) => i.id === highlightIssueId);
                 return (
                     <FileBlock
                         key={file.path}
                         index={idx + 1}
                         file={file}
                         patch={patch}
-                        issues={issuesByFile.get(file.path) ?? []}
+                        issues={fileIssues}
                         pr={pr}
                         promptCtx={promptCtx}
                         viewed={!!viewed[file.path]}
-                        onToggleViewed={(v) => onToggleViewed(file.path, v)}
+                        onToggleViewed={onToggleViewed}
                         diffStyle={diffStyle}
                         hideHighlights={hideHighlights}
                         collapsed={!!collapsed?.[file.path]}
-                        onToggleCollapsed={
-                            onToggleCollapsed
-                                ? () => onToggleCollapsed(file.path)
-                                : undefined
-                        }
+                        onToggleCollapsed={onToggleCollapsed}
                         isReviewing={isReviewing}
-                        highlightIssueId={highlightIssueId}
+                        highlightIssueId={
+                            ownsHighlight ? highlightIssueId : undefined
+                        }
                     />
                 );
             })}
@@ -224,7 +237,7 @@ export function DiffViewer({
     );
 }
 
-function FileBlock({
+const FileBlock = memo(function FileBlock({
     index,
     file,
     patch,
@@ -247,30 +260,34 @@ function FileBlock({
     pr?: PrInfo;
     promptCtx: PromptContext;
     viewed: boolean;
-    onToggleViewed: (viewed: boolean) => void;
+    onToggleViewed: (path: string, viewed: boolean) => void;
     diffStyle: "split" | "unified";
     hideHighlights: boolean;
     collapsed: boolean;
-    onToggleCollapsed?: () => void;
+    onToggleCollapsed?: (path: string) => void;
     isReviewing: boolean;
     highlightIssueId?: string;
 }) {
     return (
         <article
             id={`file-${file.path}`}
-            className={`rounded-lg border bg-[var(--bg-elevated)] overflow-hidden transition-opacity ${
+            className={`rounded-lg border transition-opacity ${
                 viewed
                     ? "border-[var(--border)] opacity-70"
                     : "border-[var(--border)]"
             }`}>
+            {/* Sticky so the file's identity (path + stats + Viewed) stays
+                pinned while you scroll a long diff — the "where am I" the raw
+                file list never gives. The article dropped overflow-hidden
+                (which would trap the sticky inside its own box). */}
             <header
-                className={`flex items-center justify-between gap-4 px-4 py-3 ${
-                    collapsed ? "" : "border-b"
+                className={`sticky top-0 z-20 flex items-center justify-between gap-4 rounded-t-lg px-4 py-3 ${
+                    collapsed ? "rounded-b-lg" : "border-b"
                 } border-[var(--border)] bg-[var(--bg)]`}>
                 <div className="flex items-center gap-3 min-w-0">
                     {onToggleCollapsed && (
                         <button
-                            onClick={onToggleCollapsed}
+                            onClick={() => onToggleCollapsed(file.path)}
                             aria-label={
                                 collapsed ? "Expand file" : "Collapse file"
                             }
@@ -318,7 +335,7 @@ function FileBlock({
                     </span>
                     <ViewedToggle
                         viewed={viewed}
-                        onToggleViewed={onToggleViewed}
+                        onToggleViewed={(v) => onToggleViewed(file.path, v)}
                     />
                 </div>
             </header>
@@ -360,7 +377,7 @@ function FileBlock({
             )}
         </article>
     );
-}
+});
 
 function FileStatusBadge({ status }: { status: DiffFile["status"] }) {
     const label =

--- a/apps/web/src/app/(app)/pull-requests/[repositoryId]/[prNumber]/_components/try-port/FileTree.tsx
+++ b/apps/web/src/app/(app)/pull-requests/[repositoryId]/[prNumber]/_components/try-port/FileTree.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useState, type ReactNode } from "react";
 import {
     ChevronDown,
     ChevronsDownUp,
@@ -8,10 +8,16 @@ import {
     File as FileIconLucide,
     Folder,
     FolderOpen,
+    FolderTree,
     LayoutList,
     PanelLeftClose,
 } from "lucide-react";
+
+import { buildCohorts } from "./cohorts";
 import type { DiffFile, ReviewIssue } from "./types";
+
+/** Which grouping the file list renders in. */
+export type FileTreeMode = "tree" | "grouped";
 
 type DirNode = {
     kind: "dir";
@@ -40,6 +46,7 @@ export function FileTree({
     prRef,
     onHide,
     onToggleMode,
+    mode = "tree",
 }: {
     files: DiffFile[];
     issues: ReviewIssue[];
@@ -51,7 +58,10 @@ export function FileTree({
     onHide?: () => void;
     /** When provided, renders a Tree↔Grouped toggle in the header. */
     onToggleMode?: () => void;
+    /** Folder tree (default) or role-grouped cohort view. */
+    mode?: FileTreeMode;
 }) {
+    const grouped = mode === "grouped";
     const tree = useMemo(() => buildTree(files), [files]);
     const issueCount = useMemo(() => {
         const m = new Map<string, number>();
@@ -80,37 +90,38 @@ export function FileTree({
     return (
         <nav
             aria-label="Changed files"
-            className="rounded-lg border border-[var(--border)] bg-[var(--bg-2)]/70 overflow-hidden"
-        >
-            <header className="px-3 py-2 border-b border-[var(--border)] bg-[var(--bg)] flex items-center justify-between gap-2">
-                <div className="flex items-center gap-2 min-w-0">
+            className="overflow-hidden rounded-lg border border-[var(--border)] bg-[var(--bg-2)]/70">
+            <header className="flex items-center justify-between gap-2 border-b border-[var(--border)] bg-[var(--bg)] px-3 py-2">
+                <div className="flex min-w-0 items-center gap-2">
                     {prRef && (
-                        <p className="text-xs font-mono text-[var(--text-muted)] truncate">
+                        <p className="truncate font-mono text-xs text-[var(--text-muted)]">
                             {prRef}
                         </p>
                     )}
-                    <p className="text-[10px] uppercase tracking-wider text-[var(--text-dim)] shrink-0">
+                    <p className="shrink-0 text-[10px] tracking-wider text-[var(--text-dim)] uppercase">
                         {files.length} file{files.length === 1 ? "" : "s"}
                     </p>
                 </div>
-                <div className="flex items-center gap-0.5 shrink-0">
+                <div className="flex shrink-0 items-center gap-0.5">
                     {onToggleMode && (
                         <TreeAction
-                            label="Switch to grouped view"
-                            onClick={onToggleMode}
-                        >
-                            <LayoutList size={13} />
+                            label={
+                                grouped
+                                    ? "Switch to folder tree"
+                                    : "Group by role"
+                            }
+                            onClick={onToggleMode}>
+                            {grouped ? (
+                                <FolderTree size={13} />
+                            ) : (
+                                <LayoutList size={13} />
+                            )}
                         </TreeAction>
                     )}
-                    {allDirPaths.length > 0 && (
+                    {!grouped && allDirPaths.length > 0 && (
                         <TreeAction
-                            label={
-                                allCollapsed ? "Expand all" : "Collapse all"
-                            }
-                            onClick={
-                                allCollapsed ? expandAll : collapseAll
-                            }
-                        >
+                            label={allCollapsed ? "Expand all" : "Collapse all"}
+                            onClick={allCollapsed ? expandAll : collapseAll}>
                             {allCollapsed ? (
                                 <ChevronsUpDown size={13} />
                             ) : (
@@ -119,29 +130,36 @@ export function FileTree({
                         </TreeAction>
                     )}
                     {onHide && (
-                        <TreeAction
-                            label="Hide file tree"
-                            onClick={onHide}
-                        >
+                        <TreeAction label="Hide file tree" onClick={onHide}>
                             <PanelLeftClose size={13} />
                         </TreeAction>
                     )}
                 </div>
             </header>
             <div className="py-1.5 text-[13px] select-none">
-                {tree.map((node) => (
-                    <TreeRow
-                        key={nodeKey(node)}
-                        node={node}
-                        depth={0}
+                {grouped ? (
+                    <CohortView
+                        files={files}
                         activePath={activePath}
                         viewed={viewed}
-                        collapsed={collapsed}
-                        onToggle={toggle}
-                        onPick={onPick}
                         issueCount={issueCount}
+                        onPick={onPick}
                     />
-                ))}
+                ) : (
+                    tree.map((node) => (
+                        <TreeRow
+                            key={nodeKey(node)}
+                            node={node}
+                            depth={0}
+                            activePath={activePath}
+                            viewed={viewed}
+                            collapsed={collapsed}
+                            onToggle={toggle}
+                            onPick={onPick}
+                            issueCount={issueCount}
+                        />
+                    ))
+                )}
             </div>
         </nav>
     );
@@ -176,12 +194,11 @@ function TreeRow({
             <div>
                 <button
                     onClick={() => onToggle(node.path)}
-                    className="w-full flex items-center gap-1.5 px-2.5 py-1 hover:bg-[var(--bg-input)]/60 text-left transition-colors"
-                    style={{ paddingLeft: 10 + indent }}
-                >
+                    className="flex w-full items-center gap-1.5 px-2.5 py-1 text-left transition-colors hover:bg-[var(--bg-input)]/60"
+                    style={{ paddingLeft: 10 + indent }}>
                     <Chevron open={isOpen} />
                     <FolderIcon open={isOpen} />
-                    <span className="text-[var(--text-muted)] truncate">
+                    <span className="truncate text-[var(--text-muted)]">
                         {node.name}
                     </span>
                 </button>
@@ -206,7 +223,43 @@ function TreeRow({
         );
     }
 
-    const file = node.file;
+    // Files line up with their parent dir's name (past the chevron +
+    // folder-icon column).
+    return (
+        <FileRow
+            file={node.file}
+            paddingLeft={10 + indent + 14}
+            activePath={activePath}
+            viewed={viewed}
+            issueCount={issueCount}
+            onPick={onPick}>
+            <span className="flex-1 truncate">{node.name}</span>
+        </FileRow>
+    );
+}
+
+/**
+ * A single file row — the leaf shared by the folder tree and the grouped
+ * (cohort) view. `children` is the name area, so the tree can show a bare
+ * basename while the grouped view shows a dimmed directory + basename.
+ */
+function FileRow({
+    file,
+    paddingLeft,
+    activePath,
+    viewed,
+    issueCount,
+    onPick,
+    children,
+}: {
+    file: DiffFile;
+    paddingLeft: number;
+    activePath: string | null;
+    viewed: Record<string, boolean>;
+    issueCount: Map<string, number>;
+    onPick: (path: string) => void;
+    children: ReactNode;
+}) {
     const isActive = activePath === file.path;
     const isViewed = !!viewed[file.path];
     const count = issueCount.get(file.path) ?? 0;
@@ -214,33 +267,104 @@ function TreeRow({
     return (
         <button
             onClick={() => onPick(file.path)}
-            className={`w-full flex items-center gap-1.5 px-2.5 py-1 text-left transition-colors group ${
+            className={`group flex w-full items-center gap-1.5 px-2.5 py-1 text-left transition-colors ${
                 isActive
                     ? "bg-[var(--bg-input)] text-[var(--text)]"
                     : "text-[var(--text-muted)] hover:bg-[var(--bg-input)]/60 hover:text-[var(--text)]"
+            } ${
+                isViewed
+                    ? "[&_.file-name]:line-through [&_.file-name]:decoration-[var(--text-dim)] [&_.file-name]:opacity-60"
+                    : ""
             }`}
-            // Files line up with their parent dir's name (past the
-            // chevron + folder-icon column).
-            style={{ paddingLeft: 10 + indent + 14 }}
-        >
+            style={{ paddingLeft }}>
             <FileIcon viewed={isViewed} />
-            <span
-                className={`truncate flex-1 ${
-                    isViewed ? "opacity-60 line-through decoration-[var(--text-dim)]" : ""
-                }`}
-            >
-                {node.name}
+            <span className="file-name min-w-0 flex-1 truncate">
+                {children}
             </span>
             {count > 0 && (
-                <span className="shrink-0 text-[10px] font-semibold px-1.5 py-px rounded bg-[var(--yellow)]/15 text-[var(--yellow)]">
+                <span className="shrink-0 rounded bg-[var(--yellow)]/15 px-1.5 py-px text-[10px] font-semibold text-[var(--yellow)]">
                     {count}
                 </span>
             )}
-            <span className="shrink-0 text-[11px] font-mono">
+            <span className="shrink-0 font-mono text-[11px]">
                 <span className="text-[var(--green)]">+{file.additions}</span>{" "}
                 <span className="text-[var(--red)]">−{file.deletions}</span>
             </span>
         </button>
+    );
+}
+
+/**
+ * Grouped ("cohort") view: files organized by the role they play in the
+ * change, in reading order (contracts → implementation → tests → config →
+ * docs). Each group shows its file count and aggregate +/−. Files display
+ * their full path (dimmed directory + basename) since there's no folder
+ * hierarchy to convey it.
+ */
+function CohortView({
+    files,
+    activePath,
+    viewed,
+    issueCount,
+    onPick,
+}: {
+    files: DiffFile[];
+    activePath: string | null;
+    viewed: Record<string, boolean>;
+    issueCount: Map<string, number>;
+    onPick: (path: string) => void;
+}) {
+    const cohorts = useMemo(() => buildCohorts(files), [files]);
+    return (
+        <div>
+            {cohorts.map((cohort) => (
+                <section key={cohort.meta.key}>
+                    <div
+                        className="flex items-center gap-2 border-t border-[var(--border)] bg-[var(--bg)]/60 px-2.5 py-1 first:border-t-0"
+                        title={cohort.meta.hint}>
+                        <span className="truncate text-[10px] font-semibold tracking-wider text-[var(--text-muted)] uppercase">
+                            {cohort.meta.label}
+                        </span>
+                        <span className="shrink-0 text-[10px] text-[var(--text-dim)]">
+                            {cohort.files.length}
+                        </span>
+                        <span className="ml-auto shrink-0 font-mono text-[11px]">
+                            <span className="text-[var(--green)]">
+                                +{cohort.additions}
+                            </span>{" "}
+                            <span className="text-[var(--red)]">
+                                −{cohort.deletions}
+                            </span>
+                        </span>
+                    </div>
+                    {cohort.files.map((file) => (
+                        <FileRow
+                            key={file.path}
+                            file={file}
+                            paddingLeft={16}
+                            activePath={activePath}
+                            viewed={viewed}
+                            issueCount={issueCount}
+                            onPick={onPick}>
+                            <PathLabel path={file.path} />
+                        </FileRow>
+                    ))}
+                </section>
+            ))}
+        </div>
+    );
+}
+
+/** Dimmed directory prefix + emphasized basename, e.g. `libs/x/` + `foo.ts`. */
+function PathLabel({ path }: { path: string }) {
+    const slash = path.lastIndexOf("/");
+    const dir = slash >= 0 ? path.slice(0, slash + 1) : "";
+    const base = slash >= 0 ? path.slice(slash + 1) : path;
+    return (
+        <span className="truncate">
+            {dir && <span className="text-[var(--text-dim)]">{dir}</span>}
+            <span>{base}</span>
+        </span>
     );
 }
 
@@ -331,13 +455,15 @@ function firstChild(node: Mut): Mut {
 }
 
 function sortNodes(nodes: TreeNode[]): TreeNode[] {
-    return [...nodes].sort((a, b) => {
-        // Folders first, then alpha. Matches the Devin/VS Code default.
-        if (a.kind !== b.kind) return a.kind === "dir" ? -1 : 1;
-        return a.name.localeCompare(b.name);
-    }).map((n) =>
-        n.kind === "dir" ? { ...n, children: sortNodes(n.children) } : n,
-    );
+    return [...nodes]
+        .sort((a, b) => {
+            // Folders first, then alpha. Matches the Devin/VS Code default.
+            if (a.kind !== b.kind) return a.kind === "dir" ? -1 : 1;
+            return a.name.localeCompare(b.name);
+        })
+        .map((n) =>
+            n.kind === "dir" ? { ...n, children: sortNodes(n.children) } : n,
+        );
 }
 
 function nodeKey(n: TreeNode): string {
@@ -351,7 +477,7 @@ function TreeAction({
 }: {
     label: string;
     onClick: () => void;
-    children: React.ReactNode;
+    children: ReactNode;
 }) {
     return (
         <button
@@ -359,8 +485,7 @@ function TreeAction({
             onClick={onClick}
             aria-label={label}
             title={label}
-            className="w-6 h-6 rounded text-[var(--text-dim)] hover:text-[var(--text)] hover:bg-[var(--bg-input)] flex items-center justify-center transition-colors"
-        >
+            className="flex h-6 w-6 items-center justify-center rounded text-[var(--text-dim)] transition-colors hover:bg-[var(--bg-input)] hover:text-[var(--text)]">
             {children}
         </button>
     );
@@ -384,7 +509,7 @@ function Chevron({ open }: { open: boolean }) {
     return (
         <ChevronDown
             size={12}
-            className={`text-[var(--text-dim)] shrink-0 transition-transform ${
+            className={`shrink-0 text-[var(--text-dim)] transition-transform ${
                 open ? "" : "-rotate-90"
             }`}
             aria-hidden
@@ -395,11 +520,7 @@ function Chevron({ open }: { open: boolean }) {
 function FolderIcon({ open }: { open: boolean }) {
     const Icon = open ? FolderOpen : Folder;
     return (
-        <Icon
-            size={14}
-            className="text-[var(--accent)] shrink-0"
-            aria-hidden
-        />
+        <Icon size={14} className="shrink-0 text-[var(--accent)]" aria-hidden />
     );
 }
 

--- a/apps/web/src/app/(app)/pull-requests/[repositoryId]/[prNumber]/_components/try-port/FileTree.tsx
+++ b/apps/web/src/app/(app)/pull-requests/[repositoryId]/[prNumber]/_components/try-port/FileTree.tsx
@@ -371,8 +371,8 @@ function PathLabel({ path }: { path: string }) {
 /**
  * Build a directory tree from the flat list of changed files, then
  * collapse any directory that has a single directory child into a
- * "chain" label (e.g. `routers/grpc/common`). Devin Review does this
- * so deep paths don't waste vertical space on empty rungs.
+ * "chain" label (e.g. `routers/grpc/common`) so deep paths don't
+ * waste vertical space on empty rungs.
  */
 type Mut = {
     name: string;
@@ -457,7 +457,7 @@ function firstChild(node: Mut): Mut {
 function sortNodes(nodes: TreeNode[]): TreeNode[] {
     return [...nodes]
         .sort((a, b) => {
-            // Folders first, then alpha. Matches the Devin/VS Code default.
+            // Folders first, then alpha. Matches the VS Code default.
             if (a.kind !== b.kind) return a.kind === "dir" ? -1 : 1;
             return a.name.localeCompare(b.name);
         })

--- a/apps/web/src/app/(app)/pull-requests/[repositoryId]/[prNumber]/_components/try-port/RightSidebar.tsx
+++ b/apps/web/src/app/(app)/pull-requests/[repositoryId]/[prNumber]/_components/try-port/RightSidebar.tsx
@@ -20,14 +20,33 @@ export function RightSidebar({
     pr?: PrInfo;
     issues: ReviewIssue[];
     isCompleted: boolean;
-    onJumpToIssue: (file: string) => void;
+    onJumpToIssue: (issue: ReviewIssue) => void;
 }) {
-    const bugs = issues.filter((i) =>
-        ["critical", "high"].includes((i.severity || "").toLowerCase()),
-    );
-    const flags = issues.filter(
-        (i) => !["critical", "high"].includes((i.severity || "").toLowerCase()),
-    );
+    // Signal hierarchy: most severe first within each group so the finding
+    // most likely to matter sits at the top, not buried mid-list.
+    const SEV_RANK: Record<string, number> = {
+        critical: 0,
+        high: 1,
+        medium: 2,
+        low: 3,
+        info: 4,
+    };
+    const bySeverity = (a: ReviewIssue, b: ReviewIssue) =>
+        (SEV_RANK[(a.severity || "info").toLowerCase()] ?? 5) -
+        (SEV_RANK[(b.severity || "info").toLowerCase()] ?? 5);
+    const bugs = issues
+        .filter((i) =>
+            ["critical", "high"].includes((i.severity || "").toLowerCase()),
+        )
+        .sort(bySeverity);
+    const flags = issues
+        .filter(
+            (i) =>
+                !["critical", "high"].includes(
+                    (i.severity || "").toLowerCase(),
+                ),
+        )
+        .sort(bySeverity);
 
     return (
         <aside className="space-y-3">
@@ -137,7 +156,7 @@ function BugsCard({
     onJumpToIssue,
 }: {
     bugs: ReviewIssue[];
-    onJumpToIssue: (file: string) => void;
+    onJumpToIssue: (issue: ReviewIssue) => void;
 }) {
     const [open, setOpen] = useState(true);
     return (
@@ -161,7 +180,7 @@ function BugsCard({
                         <IssueRow
                             key={i}
                             issue={bug}
-                            onClick={() => onJumpToIssue(bug.file)}
+                            onClick={() => onJumpToIssue(bug)}
                         />
                     ))}
                 </ul>
@@ -175,7 +194,7 @@ function FlagsCard({
     onJumpToIssue,
 }: {
     flags: ReviewIssue[];
-    onJumpToIssue: (file: string) => void;
+    onJumpToIssue: (issue: ReviewIssue) => void;
 }) {
     const [open, setOpen] = useState(false);
     return (
@@ -191,7 +210,7 @@ function FlagsCard({
                         <IssueRow
                             key={i}
                             issue={flag}
-                            onClick={() => onJumpToIssue(flag.file)}
+                            onClick={() => onJumpToIssue(flag)}
                         />
                     ))}
                 </ul>

--- a/apps/web/src/app/(app)/pull-requests/[repositoryId]/[prNumber]/_components/try-port/SuggestionCard.tsx
+++ b/apps/web/src/app/(app)/pull-requests/[repositoryId]/[prNumber]/_components/try-port/SuggestionCard.tsx
@@ -107,26 +107,18 @@ export function SuggestionCard({
 
 function Identity() {
     return (
-        <div className="flex items-center justify-between">
-            <div className="flex items-center gap-2">
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img
-                    src={KODY_AVATAR_URL}
-                    alt=""
-                    width={20}
-                    height={20}
-                    className="rounded-full ring-1 ring-[var(--border)]"
-                />
-                <span className="text-[13px] font-medium text-[var(--text)]">
-                    Kody
-                </span>
-            </div>
-            <button
-                type="button"
-                aria-label="More"
-                className="text-[var(--text-dim)] hover:text-[var(--text-muted)] w-6 h-6 flex items-center justify-center rounded hover:bg-[var(--bg-3)]">
-                <DotsIcon />
-            </button>
+        <div className="flex items-center gap-2">
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+                src={KODY_AVATAR_URL}
+                alt=""
+                width={20}
+                height={20}
+                className="rounded-full ring-1 ring-[var(--border)]"
+            />
+            <span className="text-[13px] font-medium text-[var(--text)]">
+                Kody
+            </span>
         </div>
     );
 }
@@ -382,21 +374,6 @@ function Chevron({ open }: { open: boolean }) {
                 open ? "rotate-180" : ""
             }`}>
             <polyline points="6 9 12 15 18 9" />
-        </svg>
-    );
-}
-
-function DotsIcon() {
-    return (
-        <svg
-            width="14"
-            height="14"
-            viewBox="0 0 24 24"
-            fill="currentColor"
-            aria-hidden>
-            <circle cx="5" cy="12" r="1.6" />
-            <circle cx="12" cy="12" r="1.6" />
-            <circle cx="19" cy="12" r="1.6" />
         </svg>
     );
 }

--- a/apps/web/src/app/(app)/pull-requests/[repositoryId]/[prNumber]/_components/try-port/cohorts.spec.ts
+++ b/apps/web/src/app/(app)/pull-requests/[repositoryId]/[prNumber]/_components/try-port/cohorts.spec.ts
@@ -1,0 +1,125 @@
+import { buildCohorts, classifyCohort, type CohortKey } from "./cohorts";
+import type { DiffFile } from "./types";
+
+const file = (path: string, additions = 3, deletions = 1): DiffFile => ({
+    path,
+    oldPath: null,
+    status: "modified",
+    additions,
+    deletions,
+});
+
+describe("classifyCohort", () => {
+    const cases: [string, CohortKey][] = [
+        // Contracts & types — the surface others depend on.
+        ["libs/x/contracts/CommentManagerService.contract.ts", "contracts"],
+        ["libs/x/dtos/pull-request.dto.ts", "contracts"],
+        ["libs/x/interfaces/pr.interface.ts", "contracts"],
+        ["libs/x/schemas/mongoose/pr.model.ts", "contracts"],
+        ["api/openapi.yaml", "contracts"],
+        ["proto/service.proto", "contracts"],
+        ["shared/global.d.ts", "contracts"],
+        // Migrations.
+        ["libs/db/migrations/2026042000000-Init.ts", "migrations"],
+        ["db/schema.sql", "migrations"],
+        // Implementation (fallback for source code).
+        ["apps/web/src/app/page.tsx", "implementation"],
+        ["libs/foo/bar.service.ts", "implementation"],
+        ["worker/main.py", "implementation"],
+        ["cmd/server/main.go", "implementation"],
+        // Tests — must win over the directory a test lives in.
+        ["apps/web/src/x/foo.spec.ts", "tests"],
+        ["tests/e2e/lib/runner.test.ts", "tests"],
+        ["src/__tests__/thing.ts", "tests"],
+        ["src/button.stories.tsx", "tests"],
+        ["libs/x/contracts/foo.spec.ts", "tests"],
+        // Config & CI.
+        [".github/workflows/ci.yml", "config"],
+        ["Dockerfile", "config"],
+        ["package.json", "config"],
+        ["tsconfig.json", "config"],
+        ["pnpm-lock.yaml", "config"],
+        ["apps/web/next.config.js", "config"],
+        ["k8s/deploy.yaml", "config"],
+        ["infra/random.yml", "config"],
+        // Styles.
+        ["apps/web/src/globals.css", "styles"],
+        ["ui/theme.scss", "styles"],
+        // Docs.
+        ["docs/how_to/byok.mdx", "docs"],
+        ["README.md", "docs"],
+        ["LICENSE", "docs"],
+        // Anything unrecognized.
+        ["assets/logo.png", "other"],
+        ["data/fixture.json", "other"],
+    ];
+
+    it.each(cases)("classifies %s as %s", (path, want) => {
+        expect(classifyCohort(path)).toBe(want);
+    });
+
+    it("treats a spec file inside contracts/ as a test, not a contract", () => {
+        // Precedence regression: the role-specific signal (spec) wins over the
+        // directory (contracts). Getting this backwards buries tests under the
+        // contract layer.
+        expect(classifyCohort("libs/x/contracts/thing.spec.ts")).toBe("tests");
+    });
+
+    it("treats a root tsconfig.json as config, not implementation", () => {
+        expect(classifyCohort("tsconfig.json")).toBe("config");
+    });
+});
+
+describe("buildCohorts", () => {
+    it("orders groups by reading order and drops empty ones", () => {
+        const files = [
+            file("README.md"),
+            file("apps/web/src/foo.service.ts"),
+            file("libs/x/dtos/foo.dto.ts"),
+            file("apps/web/src/foo.spec.ts"),
+        ];
+        const keys = buildCohorts(files).map((c) => c.meta.key);
+        // contracts before implementation before tests before docs; no empty
+        // groups (migrations/styles/config/other absent).
+        expect(keys).toEqual(["contracts", "implementation", "tests", "docs"]);
+    });
+
+    it("aggregates additions/deletions per group", () => {
+        const cohorts = buildCohorts([
+            file("libs/a/x.dto.ts", 10, 2),
+            file("libs/b/y.schema.ts", 5, 3),
+        ]);
+        expect(cohorts).toHaveLength(1);
+        expect(cohorts[0].meta.key).toBe("contracts");
+        expect(cohorts[0].additions).toBe(15);
+        expect(cohorts[0].deletions).toBe(5);
+    });
+
+    it("sorts files within a group by path", () => {
+        const cohorts = buildCohorts([
+            file("libs/z.service.ts"),
+            file("libs/a.service.ts"),
+        ]);
+        expect(cohorts[0].files.map((f) => f.path)).toEqual([
+            "libs/a.service.ts",
+            "libs/z.service.ts",
+        ]);
+    });
+
+    it("prefers a backend-supplied cohort hint over the heuristic", () => {
+        // Paves the Kody-decided path: a file carrying its own cohort wins.
+        const hinted = {
+            ...file("libs/x/foo.service.ts"),
+            cohort: "contracts",
+        } as DiffFile & { cohort: string };
+        expect(buildCohorts([hinted])[0].meta.key).toBe("contracts");
+    });
+
+    it("ignores an unknown hint and falls back to the classifier", () => {
+        const hinted = {
+            ...file("libs/x/foo.service.ts"),
+            cohort: "nonsense",
+        } as DiffFile & { cohort: string };
+        expect(buildCohorts([hinted])[0].meta.key).toBe("implementation");
+    });
+});

--- a/apps/web/src/app/(app)/pull-requests/[repositoryId]/[prNumber]/_components/try-port/cohorts.ts
+++ b/apps/web/src/app/(app)/pull-requests/[repositoryId]/[prNumber]/_components/try-port/cohorts.ts
@@ -1,0 +1,176 @@
+import type { DiffFile } from "./types";
+
+/**
+ * "Cohorts" group a PR's changed files by the ROLE each file plays in the
+ * change, and order the groups by natural reading order — the API surface and
+ * data shapes others depend on first, the code that consumes them next, tests
+ * after that, and config/docs last. It's the "read this change in layers"
+ * idea: foundational files before the code that builds on them.
+ *
+ * This v1 is a DETERMINISTIC classifier over the path/extension we already
+ * have on the client — no extra request, no model call. The cohort shape is
+ * deliberately the seam where a Kody-decided grouping can later drop in: if a
+ * file arrives carrying its own `cohort` hint from the backend, prefer that
+ * over the heuristic (see resolveCohort) and the rest of this file — ordering,
+ * rendering — keeps working unchanged.
+ */
+
+export type CohortKey =
+    | "contracts"
+    | "migrations"
+    | "implementation"
+    | "styles"
+    | "tests"
+    | "config"
+    | "docs"
+    | "other";
+
+export interface CohortMeta {
+    key: CohortKey;
+    /** Human label shown as the group header. */
+    label: string;
+    /** One-line reason the group exists — shown as a subtitle/tooltip. */
+    hint: string;
+}
+
+/**
+ * Display order = reading order. Foundational layers first (the things other
+ * code depends on), consumers next, verification and prose last. Only groups
+ * with files render, so a docs-only PR still reads top-to-bottom sensibly.
+ */
+export const COHORT_ORDER: readonly CohortMeta[] = [
+    {
+        key: "contracts",
+        label: "Contracts & types",
+        hint: "APIs, types, schemas and entities other code depends on — read these first",
+    },
+    {
+        key: "migrations",
+        label: "Data & migrations",
+        hint: "Schema and data migrations",
+    },
+    {
+        key: "implementation",
+        label: "Implementation",
+        hint: "Application code that consumes the contracts above",
+    },
+    {
+        key: "styles",
+        label: "Styles",
+        hint: "Stylesheets and design tokens",
+    },
+    {
+        key: "tests",
+        label: "Tests",
+        hint: "Specs and end-to-end coverage for the changes above",
+    },
+    {
+        key: "config",
+        label: "Config & CI",
+        hint: "Build, dependency, CI and infrastructure config",
+    },
+    {
+        key: "docs",
+        label: "Docs",
+        hint: "Documentation and prose",
+    },
+    {
+        key: "other",
+        label: "Other",
+        hint: "Files that didn't match a known role",
+    },
+] as const;
+
+const COHORT_META: Record<CohortKey, CohortMeta> = Object.fromEntries(
+    COHORT_ORDER.map((c) => [c.key, c]),
+) as Record<CohortKey, CohortMeta>;
+
+const TEST_RE =
+    /(^|\/)(__tests__|__mocks__|e2e|cypress)(\/)|\.(spec|test|stories|e2e)\.[cm]?[jt]sx?$/i;
+const MIGRATION_RE = /(^|\/)migrations?(\/)|\.sql$/i;
+const STYLE_RE = /\.(css|scss|sass|less|styl)$/i;
+const DOC_RE =
+    /(^|\/)docs?(\/)|\.(md|mdx|rst|adoc)$|(^|\/)(readme|license|changelog|contributing)(\.[^/]*)?$/i;
+// Config files are matched by well-known basenames as well as extensions,
+// because many carry no telltale directory (a root tsconfig.json, a Dockerfile).
+const CONFIG_BASENAME_RE =
+    /(^|\/)(dockerfile|docker-compose\.ya?ml|\.dockerignore|\.gitignore|\.gitattributes|package\.json|package-lock\.json|yarn\.lock|pnpm-lock\.ya?ml|pnpm-workspace\.ya?ml|cargo\.(toml|lock)|go\.(mod|sum)|requirements\.txt|pyproject\.toml|poetry\.lock|gemfile(\.lock)?|makefile|tsconfig[^/]*\.json|jsconfig\.json|\.eslintrc[^/]*|eslint\.config\.[cm]?[jt]s|\.prettierrc[^/]*|prettier\.config\.[^/]*|vitest\.config\.[^/]*|jest\.config\.[^/]*|next\.config\.[^/]*|tailwind\.config\.[^/]*|postcss\.config\.[^/]*|vite\.config\.[^/]*|\.npmrc|\.nvmrc|\.env(\.[^/]*)?)$/i;
+const CONFIG_PATH_RE =
+    /(^|\/)(\.github|\.circleci|\.husky|\.vscode|k8s|helm|terraform|charts)(\/)/i;
+const CONFIG_EXT_RE = /\.(ya?ml|toml|ini|cfg|conf)$/i;
+const CONTRACT_PATH_RE =
+    /(^|\/)(contracts?|dtos?|interfaces?|schemas?|types?|entities|proto|graphql)(\/)/i;
+const CONTRACT_NAME_RE =
+    /\.(dto|contract|interface|schema|entity|model|type|types)\.[cm]?[jt]sx?$|\.(proto|graphql|gql)$|\.d\.ts$|(^|\/)(openapi|swagger)[^/]*\.(ya?ml|json)$/i;
+const CODE_EXT_RE =
+    /\.([cm]?[jt]sx?|py|go|rb|rs|java|kt|kts|swift|scala|php|c|cc|cpp|h|hpp|cs|vue|svelte|ex|exs|clj|dart|lua|sh|bash)$/i;
+
+/**
+ * Classify one file into a cohort. Order matters: the most role-specific
+ * signals win. A `foo.spec.ts` under `contracts/` is a TEST, not a contract,
+ * so the test check runs before the contract check; config basenames win over
+ * their generic extension (a `tsconfig.json` is config, not "implementation").
+ */
+export function classifyCohort(path: string): CohortKey {
+    const p = path.trim();
+    if (!p) return "other";
+    if (TEST_RE.test(p)) return "tests";
+    if (MIGRATION_RE.test(p)) return "migrations";
+    if (DOC_RE.test(p)) return "docs";
+    if (CONFIG_BASENAME_RE.test(p) || CONFIG_PATH_RE.test(p)) return "config";
+    if (STYLE_RE.test(p)) return "styles";
+    if (CONTRACT_NAME_RE.test(p) || CONTRACT_PATH_RE.test(p))
+        return "contracts";
+    if (CODE_EXT_RE.test(p)) return "implementation";
+    // A bare .yml/.toml that isn't CI/infra still reads as config.
+    if (CONFIG_EXT_RE.test(p)) return "config";
+    return "other";
+}
+
+export interface Cohort {
+    meta: CohortMeta;
+    files: DiffFile[];
+    additions: number;
+    deletions: number;
+}
+
+/**
+ * Group files into cohorts, ordered by COHORT_ORDER, dropping empty groups.
+ * Files inside a cohort keep a stable path-alpha order so the list is
+ * predictable across renders. A future backend `cohort` hint on the file
+ * overrides the heuristic without touching callers.
+ */
+export function buildCohorts(files: DiffFile[]): Cohort[] {
+    const buckets = new Map<CohortKey, DiffFile[]>();
+    for (const file of files) {
+        const key = resolveCohort(file);
+        const list = buckets.get(key);
+        if (list) list.push(file);
+        else buckets.set(key, [file]);
+    }
+
+    const out: Cohort[] = [];
+    for (const meta of COHORT_ORDER) {
+        const bucket = buckets.get(meta.key);
+        if (!bucket || bucket.length === 0) continue;
+        const sorted = [...bucket].sort((a, b) => a.path.localeCompare(b.path));
+        out.push({
+            meta,
+            files: sorted,
+            additions: sorted.reduce((n, f) => n + (f.additions ?? 0), 0),
+            deletions: sorted.reduce((n, f) => n + (f.deletions ?? 0), 0),
+        });
+    }
+    return out;
+}
+
+/**
+ * Prefer a backend-supplied cohort hint when present (the Kody-decided path),
+ * else fall back to the deterministic classifier. Kept isolated so wiring the
+ * LLM grouping later is a one-field change here, not a rewrite.
+ */
+function resolveCohort(file: DiffFile): CohortKey {
+    const hint = (file as DiffFile & { cohort?: string }).cohort;
+    if (hint && hint in COHORT_META) return hint as CohortKey;
+    return classifyCohort(file.path);
+}

--- a/apps/web/src/app/(app)/pull-requests/_components/pr-list-item.tsx
+++ b/apps/web/src/app/(app)/pull-requests/_components/pr-list-item.tsx
@@ -14,6 +14,7 @@ import {
 import { useGetTimezone } from "@services/organizationParameters/hooks";
 import {
     buildPullRequestUrl,
+    usePrefetchPullRequestReview,
     type CodeReviewTimelineItem,
     type ReviewWarning,
     type ReviewWarningKind,
@@ -404,6 +405,12 @@ const isAutomationStartMessage = (message: string) => {
 export const PrListItem = ({ group }: PrListItemProps) => {
     const { latest, executions, reviewCount } = group;
     const timezone = useGetTimezone();
+    const prefetchReview = usePrefetchPullRequestReview();
+    // Warm the review screen's blocking query on intent (hover/focus of a link
+    // into it). Idempotent and deduped by a staleTime, so wiring it to several
+    // entry points costs nothing extra.
+    const prefetchThisReview = () =>
+        prefetchReview(latest.repositoryId, latest.prNumber);
     const [isOpen, setIsOpen] = useState(false);
     const [collapsedReviews, setCollapsedReviews] = useState<Set<number>>(
         () => new Set(executions.slice(1).map((_, i) => i + 1)),
@@ -578,6 +585,8 @@ export const PrListItem = ({ group }: PrListItemProps) => {
                 <NextLink
                     href={`/pull-requests/${latest.repositoryId}/${latest.prNumber}`}
                     onClick={(e) => e.stopPropagation()}
+                    onMouseEnter={prefetchThisReview}
+                    onFocus={prefetchThisReview}
                     className="hover:bg-card-lv3/40 flex w-fit items-center gap-1.5 rounded-md px-1 py-1 transition-colors">
                     <Tooltip>
                         <TooltipTrigger asChild>
@@ -637,6 +646,8 @@ export const PrListItem = ({ group }: PrListItemProps) => {
                             <NextLink
                                 href={`/pull-requests/${latest.repositoryId}/${latest.prNumber}`}
                                 onClick={(e) => e.stopPropagation()}
+                                onMouseEnter={prefetchThisReview}
+                                onFocus={prefetchThisReview}
                                 className="text-text-tertiary hover:text-primary-light inline-flex items-center gap-1 text-xs font-medium transition-colors">
                                 Open full review
                                 <ArrowRightIcon className="size-3.5" />

--- a/apps/web/src/lib/services/pull-requests/hooks.ts
+++ b/apps/web/src/lib/services/pull-requests/hooks.ts
@@ -258,24 +258,59 @@ export const usePullRequestAuthors = (teamId?: string, enabled = true) => {
     });
 };
 
+// Key + fetcher shared by the hook and the hover-prefetch below, so the
+// prefetched entry lands under the EXACT key the screen's useQuery reads —
+// any drift and the prefetch silently misses and the screen refetches anyway.
+const suggestionsQuery = (
+    repositoryId: string | undefined,
+    prNumber: number | undefined,
+    filters?: { severity?: string; category?: string },
+) => ({
+    queryKey: ["pull-request-suggestions", repositoryId, prNumber, filters],
+    queryFn: () =>
+        axiosAuthorized.fetcher<PullRequestSuggestionsResponse>(
+            PULL_REQUEST_API.GET_SUGGESTIONS({
+                repositoryId: repositoryId!,
+                prNumber: prNumber!,
+                ...filters,
+            }),
+        ),
+});
+
 export const usePullRequestSuggestions = (
     repositoryId: string | undefined,
     prNumber: number | undefined,
     filters?: { severity?: string; category?: string },
 ) => {
     return useQuery({
-        queryKey: ["pull-request-suggestions", repositoryId, prNumber, filters],
-        queryFn: () =>
-            axiosAuthorized.fetcher<PullRequestSuggestionsResponse>(
-                PULL_REQUEST_API.GET_SUGGESTIONS({
-                    repositoryId: repositoryId!,
-                    prNumber: prNumber!,
-                    ...filters,
-                }),
-            ),
+        ...suggestionsQuery(repositoryId, prNumber, filters),
         enabled: !!repositoryId && !!prNumber,
         retry: false,
     });
+};
+
+/**
+ * Warms the react-query cache for a PR's suggestions on hover/focus of a link
+ * into its review screen. `next/link` already prefetches the ROUTE; this
+ * prefetches the DATA the screen blocks on (page.client gates the whole view
+ * on suggestionsLoading), so an intentful hover turns the open from
+ * spinner→content into content-immediately. The 30s staleTime dedupes repeated
+ * hovers; the screen still background-revalidates on mount, so freshness is
+ * unchanged — this only buys a head start.
+ */
+export const usePrefetchPullRequestReview = () => {
+    const queryClient = useQueryClient();
+    return useCallback(
+        (repositoryId: string, prNumber: number) => {
+            // prefetchQuery swallows its own errors; fire-and-forget matches
+            // the codebase's other prefetch call sites (navbar).
+            queryClient.prefetchQuery({
+                ...suggestionsQuery(repositoryId, prNumber),
+                staleTime: 30_000,
+            });
+        },
+        [queryClient],
+    );
 };
 
 export const usePullRequestFiles = (

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -17,7 +17,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "baseUrl": ".",
     "paths": {
       "@app-types/*": [

--- a/libs/code-review/infrastructure/adapters/services/suggestion.service.ts
+++ b/libs/code-review/infrastructure/adapters/services/suggestion.service.ts
@@ -43,6 +43,7 @@ import { LLM_ANALYSIS_SERVICE_TOKEN } from './llmAnalysis.service';
 
 import { CodeReviewPipelineContext } from '@libs/code-review/pipeline/context/code-review-pipeline.context';
 import { PlatformType } from '@libs/core/domain/enums/platform-type.enum';
+import { CacheService } from '@libs/core/cache/cache.service';
 import {
     DocumentationContextItem,
     Repository,
@@ -63,6 +64,7 @@ export class SuggestionService implements ISuggestionService {
         @Inject(COMMENT_MANAGER_SERVICE_TOKEN)
         private readonly commentManagerService: ICommentManagerService,
         private readonly codeManagementService: CodeManagementService,
+        private readonly cacheService: CacheService,
     ) {}
 
     /**
@@ -1993,24 +1995,47 @@ export class SuggestionService implements ISuggestionService {
         }
 
         try {
-            const reviewComments =
-                platformType === PlatformType.GITHUB
-                    ? await this.codeManagementService.getPullRequestReviewThreads(
-                          {
-                              organizationAndTeamData,
-                              repository,
-                              prNumber,
-                          },
-                          platformType,
-                      )
-                    : await this.codeManagementService.getPullRequestReviewComments(
-                          {
-                              organizationAndTeamData,
-                              repository,
-                              prNumber,
-                          },
-                          platformType,
-                      );
+            // The provider round-trip (GraphQL review threads on GitHub, REST
+            // review comments elsewhere) is the dominant cost of the review
+            // screen's blocking suggestions fetch and its main rate-limit (429)
+            // surface — it runs on every open, and the PR list warms it on
+            // hover. Cache the raw provider result under a short TTL so repeat
+            // opens and prefetches collapse onto one call. TTL is deliberately
+            // short (unlike the files cache, which keys on the immutable head
+            // SHA): review threads mutate when a comment is resolved or added
+            // without any SHA change, so we trade a few seconds of staleness
+            // for the burst absorption. A miss returns null; an empty result is
+            // cached as [] so PRs with no comments don't re-hit the provider.
+            const cacheKey = `pr-active-review-comments:${organizationAndTeamData.organizationId}:${repository.id}:${prNumber}:${platformType}`;
+            let reviewComments =
+                await this.cacheService.getFromCache<any[]>(cacheKey);
+
+            if (reviewComments == null) {
+                reviewComments =
+                    platformType === PlatformType.GITHUB
+                        ? await this.codeManagementService.getPullRequestReviewThreads(
+                              {
+                                  organizationAndTeamData,
+                                  repository,
+                                  prNumber,
+                              },
+                              platformType,
+                          )
+                        : await this.codeManagementService.getPullRequestReviewComments(
+                              {
+                                  organizationAndTeamData,
+                                  repository,
+                                  prNumber,
+                              },
+                              platformType,
+                          );
+
+                await this.cacheService.addToCache(
+                    cacheKey,
+                    reviewComments ?? [],
+                    45_000,
+                );
+            }
 
             if (!reviewComments?.length) {
                 return suggestions;

--- a/libs/platform/infrastructure/adapters/services/bitbucket/bitbucket-cloud.service.ts
+++ b/libs/platform/infrastructure/adapters/services/bitbucket/bitbucket-cloud.service.ts
@@ -3209,7 +3209,7 @@ export class BitbucketCloudService implements Omit<
                     .then((res) => this.getPaginatedResults(bitbucketAPI, res));
 
                 const hookExists = existingHooks.some(
-                    (hook) => hook.url === webhookUrl,
+                    (hook) => hook?.url === webhookUrl,
                 );
 
                 if (!hookExists) {
@@ -4715,7 +4715,7 @@ export class BitbucketCloudService implements Omit<
                             );
 
                         const webhook = existingHooks.find(
-                            (hook) => hook.url === webhookUrl,
+                            (hook) => hook?.url === webhookUrl,
                         );
 
                         if (webhook) {

--- a/libs/platform/infrastructure/adapters/services/bitbucket/bitbucket-data-center.service.ts
+++ b/libs/platform/infrastructure/adapters/services/bitbucket/bitbucket-data-center.service.ts
@@ -909,7 +909,7 @@ export class BitbucketDataCenterService implements Omit<
                 );
                 const existingHooks = existingHooksRes.data.values || [];
                 const hookExists = existingHooks.some(
-                    (hook: any) => hook.url === webhookUrl,
+                    (hook: any) => hook?.url === webhookUrl,
                 );
 
                 // 2. Create if it doesn't exist
@@ -980,7 +980,7 @@ export class BitbucketDataCenterService implements Omit<
 
             return (
                 response.data.values?.some(
-                    (hook: any) => hook.url === webhookUrl && hook.active,
+                    (hook: any) => hook?.url === webhookUrl && hook?.active,
                 ) ?? false
             );
         } catch (error) {
@@ -3034,7 +3034,7 @@ export class BitbucketDataCenterService implements Omit<
 
                     // Find our webhook
                     const hookToDelete = existingHooks.find(
-                        (hook: any) => hook.url === webhookUrl,
+                        (hook: any) => hook?.url === webhookUrl,
                     );
 
                     if (hookToDelete) {

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -2814,7 +2814,7 @@ export class GitlabService implements Omit<
                 const existingHooks = await gitlabAPI.ProjectHooks.all(repo.id);
 
                 const hookExists = existingHooks.some(
-                    (hook) => hook.url === webhookUrl,
+                    (hook) => hook?.url === webhookUrl,
                 );
 
                 if (!hookExists) {
@@ -4247,7 +4247,7 @@ export class GitlabService implements Omit<
                         );
 
                         const webhookToDelete = webhooks.find(
-                            (webhook) => webhook.url === webhookUrl,
+                            (webhook) => webhook?.url === webhookUrl,
                         );
 
                         if (webhookToDelete) {

--- a/scripts/env/generate.ts
+++ b/scripts/env/generate.ts
@@ -47,6 +47,14 @@ const INSTALLER_SCHEMA_VARS_OUT_ARG = process.argv.find((a) =>
 const INSTALLER_SCHEMA_VARS_OUT = INSTALLER_SCHEMA_VARS_OUT_ARG
     ? INSTALLER_SCHEMA_VARS_OUT_ARG.replace('--installer-schema-vars-out=', '')
     : join(REPO_ROOT, '..', 'kodus-installer', 'scripts', 'schema-vars.sh');
+const INSTALLER_HELM_VALUES_OUT_ARG = process.argv.find((a) =>
+    a.startsWith('--installer-helm-values-out='),
+);
+// Anti-drift source of truth for the Helm chart. Ships next to the chart in the
+// installer repo; CI there validates the chart against it.
+const INSTALLER_HELM_VALUES_OUT = INSTALLER_HELM_VALUES_OUT_ARG
+    ? INSTALLER_HELM_VALUES_OUT_ARG.replace('--installer-helm-values-out=', '')
+    : join(REPO_ROOT, '..', 'kodus-installer', 'charts', 'kodus', 'schema.generated.yaml');
 const POC_DIR = join(REPO_ROOT, '.env-preview');
 
 const TARGETS = APPLY
@@ -62,6 +70,9 @@ const TARGETS = APPLY
           installerSchemaVars: APPLY_INSTALLER
               ? INSTALLER_SCHEMA_VARS_OUT
               : join(POC_DIR, 'kodus-installer.schema-vars.sh'),
+          installerHelmValues: APPLY_INSTALLER
+              ? INSTALLER_HELM_VALUES_OUT
+              : join(POC_DIR, 'kodus-installer.schema.generated.yaml'),
           // docs lives inside this repo now (was a sister repo before).
           docsSnippet: join(
               REPO_ROOT,
@@ -75,6 +86,10 @@ const TARGETS = APPLY
           envTemplate: join(POC_DIR, 'kodus-ai.env.template'),
           installerEnv: join(POC_DIR, 'kodus-installer.env.example'),
           installerSchemaVars: join(POC_DIR, 'kodus-installer.schema-vars.sh'),
+          installerHelmValues: join(
+              POC_DIR,
+              'kodus-installer.schema.generated.yaml',
+          ),
           docsSnippet: join(POC_DIR, 'env-vars-generated.mdx'),
       };
 
@@ -271,6 +286,68 @@ function renderInstallerSchemaVars(sections: SchemaSection[]): string {
     return lines.join('\n');
 }
 
+function yamlScalar(v: string): string {
+    if (v === '') return '""';
+    // Quote anything that isn't an obviously-safe bare scalar.
+    if (
+        /[\s:#"'{}[\],&*?|<>=!%@`]/.test(v) ||
+        /^[-?:,[\]{}#&*!|>'"%@` ]/.test(v) ||
+        /^(true|false|null|yes|no|on|off|~)$/i.test(v) ||
+        /^[+-]?(\d|\.\d)/.test(v)
+    ) {
+        return `"${v.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+    }
+    return v;
+}
+
+// Anti-drift manifest for the Kodus Helm chart: the config keys (ConfigMap) and
+// secret keys (Secret) the chart must expose, derived from the same schema that
+// produces .env.example / schema-vars.sh. The installer CI validates the chart
+// against this so the two can never drift (the class of bug that broke the
+// community charts — wrong secret names / hex-vs-base64 formats).
+function renderHelmValues(sections: SchemaSection[]): string {
+    const items = flatten(sections);
+    const selfHosted = items.filter((it) => includesAudience(it, 'self-hosted'));
+    const config = selfHosted.filter(
+        (it) => !it.sensitive && !it.installerComment,
+    );
+    const sensitive = selfHosted.filter((it) => it.sensitive);
+    const required = sensitive
+        .filter((it) => it.required && !it.installerComment)
+        .map((it) => it.name);
+    const optional = sensitive
+        .filter((it) => !(it.required && !it.installerComment))
+        .map((it) => it.name);
+    const autogen = selfHosted.filter((it) => it.autogen);
+
+    const lines: string[] = [];
+    lines.push('# AUTO-GENERATED from kodus-ai/.env.schema. Do NOT edit by hand.');
+    lines.push('# Anti-drift source of truth for the Kodus Helm chart. The installer CI');
+    lines.push('# (scripts/validate-chart-schema.sh) validates the chart against this file so');
+    lines.push('# the chart can never fall out of sync with the schema.');
+    lines.push('# Regenerate: `pnpm run env:generate --apply --installer` in kodus-ai.');
+    lines.push('');
+    lines.push('# Non-sensitive self-hosted vars (ConfigMap keys) with installer defaults.');
+    lines.push('config:');
+    for (const it of config) {
+        const def = it.installerDefault ?? it.value;
+        lines.push(`  ${it.name}: ${yamlScalar(def)}`);
+    }
+    lines.push('');
+    lines.push('# Secret keys the app consumes.');
+    lines.push('secrets:');
+    lines.push('  required:');
+    for (const n of required) lines.push(`    - ${n}`);
+    lines.push('  optional:');
+    for (const n of optional) lines.push(`    - ${n}`);
+    lines.push('  # Method to mint each secret unattended. hex32 MUST stay hex — the app');
+    lines.push('  # parses API_CRYPTO_KEY/CODE_MANAGEMENT_SECRET with Buffer.from(x,"hex").');
+    lines.push('  autogen:');
+    for (const it of autogen) lines.push(`    ${it.name}: ${it.autogen}`);
+    lines.push('');
+    return lines.join('\n');
+}
+
 function renderDocsSnippet(sections: SchemaSection[]): string {
     const out: string[] = [];
     out.push('{/* AUTO-GENERATED from kodus-ai/.env.schema. Do NOT edit. */}');
@@ -315,18 +392,21 @@ function main(): void {
     const envTemplate = renderEnvTemplate(sections);
     const installerEnv = renderInstallerEnv(sections);
     const installerSchemaVars = renderInstallerSchemaVars(sections);
+    const installerHelmValues = renderHelmValues(sections);
     const docs = renderDocsSnippet(sections);
 
     ensureDir(TARGETS.envExample);
     ensureDir(TARGETS.envTemplate);
     ensureDir(TARGETS.installerEnv);
     ensureDir(TARGETS.installerSchemaVars);
+    ensureDir(TARGETS.installerHelmValues);
     ensureDir(TARGETS.docsSnippet);
 
     writeFileSync(TARGETS.envExample, envExample);
     writeFileSync(TARGETS.envTemplate, envTemplate);
     writeFileSync(TARGETS.installerEnv, installerEnv);
     writeFileSync(TARGETS.installerSchemaVars, installerSchemaVars);
+    writeFileSync(TARGETS.installerHelmValues, installerHelmValues);
     writeFileSync(TARGETS.docsSnippet, docs);
 
     const cloudCount = items.filter((it) => includesAudience(it, 'cloud')).length;
@@ -346,6 +426,7 @@ function main(): void {
     console.log(`  ${TARGETS.envTemplate}`);
     console.log(`  ${TARGETS.installerEnv}`);
     console.log(`  ${TARGETS.installerSchemaVars}`);
+    console.log(`  ${TARGETS.installerHelmValues}`);
     console.log(`  ${TARGETS.docsSnippet}`);
 }
 

--- a/test/integration/code-review/map-lookup-optimizations.spec.ts
+++ b/test/integration/code-review/map-lookup-optimizations.spec.ts
@@ -10,6 +10,7 @@ import { LLM_ANALYSIS_SERVICE_TOKEN } from '@/code-review/infrastructure/adapter
 import { PULL_REQUESTS_SERVICE_TOKEN } from '@/platformData/domain/pullRequests/contracts/pullRequests.service.contracts';
 import { COMMENT_MANAGER_SERVICE_TOKEN } from '@/code-review/domain/contracts/CommentManagerService.contract';
 import { CodeManagementService } from '@/platform/infrastructure/adapters/services/codeManagement.service';
+import { CacheService } from '@libs/core/cache/cache.service';
 import {
     ClusteringType,
     CodeSuggestion,
@@ -66,6 +67,13 @@ describe('Map-based Lookup Optimizations - Integration Tests', () => {
                 {
                     provide: CodeManagementService,
                     useValue: mockCodeManagementService,
+                },
+                {
+                    provide: CacheService,
+                    useValue: {
+                        getFromCache: jest.fn(),
+                        addToCache: jest.fn(),
+                    },
                 },
             ],
         }).compile();

--- a/test/unit/code-review/services/suggestion.service.spec.ts
+++ b/test/unit/code-review/services/suggestion.service.spec.ts
@@ -14,6 +14,7 @@ import { PULL_REQUESTS_SERVICE_TOKEN } from '@/platformData/domain/pullRequests/
 import { DeliveryStatus } from '@/platformData/domain/pullRequests/enums/deliveryStatus.enum';
 import { ImplementationStatus } from '@/platformData/domain/pullRequests/enums/implementationStatus.enum';
 import { PriorityStatus } from '@/platformData/domain/pullRequests/enums/priorityStatus.enum';
+import { CacheService } from '@libs/core/cache/cache.service';
 import { PlatformType } from '@libs/core/domain/enums/platform-type.enum';
 import { Test, TestingModule } from '@nestjs/testing';
 
@@ -47,6 +48,13 @@ describe('SuggestionService', () => {
         teamId: 'team-456',
     };
 
+    // getFromCache returns undefined (cache miss) so the review-thread path
+    // still exercises the real provider call the tests assert on.
+    const mockCacheService = {
+        getFromCache: jest.fn(),
+        addToCache: jest.fn(),
+    };
+
     beforeEach(async () => {
         const module: TestingModule = await Test.createTestingModule({
             providers: [
@@ -66,6 +74,10 @@ describe('SuggestionService', () => {
                 {
                     provide: CodeManagementService,
                     useValue: mockCodeManagementService,
+                },
+                {
+                    provide: CacheService,
+                    useValue: mockCacheService,
                 },
             ],
         }).compile();

--- a/test/unit/core/infrastructure/adapters/services/codeBase/kodyRulesFilterControl.spec.ts
+++ b/test/unit/core/infrastructure/adapters/services/codeBase/kodyRulesFilterControl.spec.ts
@@ -14,6 +14,7 @@ import { LLM_ANALYSIS_SERVICE_TOKEN } from '@libs/core/infrastructure/adapters/s
 import { SuggestionService } from '@libs/core/infrastructure/adapters/services/codeBase/suggestion.service';
 import { SeverityLevel } from '@libs/common/enums/severityLevel.enum';
 import { CodeManagementService } from '@libs/platform/infrastructure/adapters/services/codeManagement.service';
+import { CacheService } from '@libs/core/cache/cache.service';
 
 describe('SuggestionService - Kody Rules Filter Control', () => {
     let service: SuggestionService;
@@ -70,6 +71,13 @@ describe('SuggestionService - Kody Rules Filter Control', () => {
                         getPullRequestReviewThreads: jest.fn(),
                         getPullRequestReviewComments: jest.fn(),
                         markReviewCommentAsResolved: jest.fn(),
+                    },
+                },
+                {
+                    provide: CacheService,
+                    useValue: {
+                        getFromCache: jest.fn(),
+                        addToCache: jest.fn(),
                     },
                 },
             ],


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Pull Request Description

**feat(pr-review): evolve the review screen (cohorts, progress, jump-to-finding, render perf)**

### Overview
This PR upgrades the pull-request review screen with progress awareness, a new role-based file grouping ("cohorts"), precise jump-to-finding navigation, and a set of rendering/data-fetch performance improvements so reviews are faster to read, navigate, and open.

---

### Review progress & signal hierarchy
- New progress bar above the diff shows, at a glance: how many findings need attention (critical/high) vs. how many are minor, and the reviewer's progress through the files (`viewed / total` with a progress bar). Counts include both file-level and PR-level findings so the numbers line up with the sidebar total.
- Sidebar findings are now sorted by severity (critical → high → medium → low → info) so the most important issue appears first.

### Cohorts: role-grouped file list
- The changed-files sidebar gains a second view mode — **Group by role** — toggled from the tree header. Files are grouped and ordered by their role in the change: contracts/types → migrations → implementation → styles → tests → config/CI → docs, so a PR can be read as layers (foundation first).
- Each cohort header shows the group's file count and aggregate `+/-`; files display a dimmed directory prefix plus emphasized basename.
- The mode preference is persisted in `localStorage` (folder tree remains the default and is applied after mount to avoid hydration mismatch).
- Classification is a deterministic client-side heuristic over path/extension, with a clean seam for a future backend-supplied `cohort` hint. Unit tests cover the classifier, ordering, aggregation, and hint override behavior.

### Jump-to-finding
- Clicking a finding in the sidebar now scrolls to the exact suggestion in the diff and highlights it — not just to the top of the file — and retries for a few frames while the diff mounts. This also fixes cases where clicking did nothing because the finding's file path didn't match the diff's.
- The highlight stays in sync with deep-link URLs (`?suggestion=<id>`), so back/forward navigation doesn't light up the wrong finding.

### Render performance
- File blocks are memoized and all toggle callbacks have stable identities, so wrapper re-renders (e.g., a jump-to-finding) only re-render the owning file block rather than every block on the page.
- Diff options and prompt context are memoized, preventing `PatchDiff` from re-tokenizing diffs on unrelated ancestor re-renders.
- Data arrays and derived values (`files`, `suggestions`, `commits`, counts) are memoized to preserve downstream memoization.
- File headers are now sticky, so file path/stats stay visible while scrolling long diffs.

### Faster review-screen opening
- PR-list links now prefetch the review screen's blocking data on hover/focus, so an intentional click often opens the review with content immediately (deduped by a 30s stale time; still background-revalidates on mount).
- The provider round-trip for pull-request review threads/comments (GraphQL on GitHub, REST elsewhere) is cached for 45 seconds — empty results included — to absorb bursts from repeated opens and prefetches, reducing provider rate-limit pressure.

### Fixes & polish
- Webhook management on Bitbucket Cloud, Bitbucket Data Center, and GitLab no longer throws when a webhook entry is nullish.
- Removed the unused "more" (⋯) menu from suggestion card headers; viewed files now appear struck-through in the sidebar file list.
- Cache mocks added to affected unit/integration tests.
<!-- kody-pr-summary:end -->