### PR TITLE
chore(code-review): pin kodus-graph to 0.3.0 and fix version drift

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -149,7 +149,7 @@ ENV NODE_ENV=production
 # Redeclare ARGs to make them available in this stage
 ARG API_CLOUD_MODE=false
 ARG RELEASE_VERSION=local
-ARG KODUS_GRAPH_VERSION=0.2.19
+ARG KODUS_GRAPH_VERSION=0.3.0
 
 # Set ENVs for runtime
 ENV API_CLOUD_MODE=${API_CLOUD_MODE}

--- a/docker/Dockerfile.dev
+++ b/docker/Dockerfile.dev
@@ -37,8 +37,9 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=private \
       ca-certificates python3 make g++ procps git ripgrep
 
 # Copy the bun binary from the official image and install kodus-graph globally.
+ARG KODUS_GRAPH_VERSION=0.3.0
 COPY --from=bun-source /usr/local/bin/bun /usr/local/bin/bun
-RUN bun install -g @kodus/kodus-graph
+RUN bun install -g @kodus/kodus-graph@${KODUS_GRAPH_VERSION}
 
 RUN npm i -g yalc nodemon @ast-grep/cli
 

--- a/libs/code-review/infrastructure/adapters/services/graph/kodus-graph-cli.ts
+++ b/libs/code-review/infrastructure/adapters/services/graph/kodus-graph-cli.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@nestjs/common';
 import { SandboxInstance } from '@libs/sandbox/domain/contracts/sandbox.provider';
 import { shSingleQuote } from '../shell-quote';
 
-export const KODUS_GRAPH_VERSION = '0.2.19';
+export const KODUS_GRAPH_VERSION = '0.3.0';
 
 export const KODUS_GRAPH_TIMEOUTS = {
     install: 120_000,

--- a/libs/code-review/infrastructure/adapters/services/sandboxSyntaxValidator.service.ts
+++ b/libs/code-review/infrastructure/adapters/services/sandboxSyntaxValidator.service.ts
@@ -5,6 +5,7 @@ import { Sandbox } from 'e2b';
 import pLimit from 'p-limit';
 import { ValidationCandidate } from '@libs/code-review/domain/types/astValidate.type';
 import { shSingleQuote } from './shell-quote';
+import { KODUS_GRAPH_VERSION } from './graph/kodus-graph-cli';
 
 const PARSE_TIMEOUT_MS = 30_000;
 const CONCURRENCY_LIMIT = 10;
@@ -122,7 +123,7 @@ export class SandboxSyntaxValidator {
             [
                 'which bun > /dev/null 2>&1 || (curl -fsSL https://bun.sh/install | bash > /dev/null 2>&1)',
                 'export PATH="$HOME/.bun/bin:$PATH"',
-                'bun install -g @kodus/kodus-graph@latest 2>&1',
+                `bun install -g @kodus/kodus-graph@${KODUS_GRAPH_VERSION} 2>&1`,
             ].join(' && '),
             { timeoutMs: INSTALL_TIMEOUT_MS },
         );

--- a/test/unit/code-review/infrastructure/adapters/services/graph/graph-indexer.service.spec.ts
+++ b/test/unit/code-review/infrastructure/adapters/services/graph/graph-indexer.service.spec.ts
@@ -141,7 +141,7 @@ describe('GraphIndexerService', () => {
         it('should find preinstalled kodus-graph through the Bun global bin path', async () => {
             mockSandbox.run
                 .mockResolvedValueOnce({
-                    stdout: '/home/node/.bun/bin/kodus-graph\n0.2.19',
+                    stdout: '/home/node/.bun/bin/kodus-graph\n0.3.0',
                     stderr: '',
                     exitCode: 0,
                 })


### PR DESCRIPTION
Bump the kodus-graph dependency from 0.2.19 to 0.3.0 so the review pipeline picks
up the call-resolution fixes shipped in that release (same-file/import shadowing,
DI/self inherited-method resolution, DI-before-noise) — better call graphs feed the
review context for free.

- `docker/Dockerfile`: `ARG KODUS_GRAPH_VERSION` 0.2.19 → 0.3.0.
- `kodus-graph-cli.ts`: `KODUS_GRAPH_VERSION` const 0.2.19 → 0.3.0.
- `sandboxSyntaxValidator.service.ts`: install used `@latest` while every other path
  pinned `KODUS_GRAPH_VERSION` — after 0.3.0 ships, the syntax validator would drift
  to a different version than the graph-context path. Now imports and pins the const.
- `docker/Dockerfile.dev`: was installing an unpinned `@kodus/kodus-graph` (floating
  latest); now pins via an ARG for reproducibility.

> ⚠️ **Merge only after `@kodus/kodus-graph@0.3.0` is published to npm** — pinning to
> a version that does not yet exist would break the install.