### PR TITLE
fix(settings): show Overridden badge on first paint

### DIFF
--- a/apps/web/src/app/(app)/settings/code-review/_components/override.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/_components/override.tsx
@@ -1,8 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Badge } from "@components/ui/badge";
-import { Button } from "@components/ui/button";
 import {
     Tooltip,
     TooltipContent,
@@ -96,11 +95,12 @@ export const OverrideIndicator = <T,>({
         setPortalContainer(document.body);
     });
 
-    if (
-        currentLevel === FormattedConfigLevel.GLOBAL ||
-        !initialState ||
-        !portalContainer
-    ) {
+    // Don't gate the badge itself on portalContainer: it's only needed for the
+    // tooltip portal, and it's null until the post-mount effect runs — gating
+    // here hid the "Overridden" badge on first paint (it popped in a frame
+    // later, or stayed missing until a re-render). The tooltip falls back to
+    // the default portal target while portalContainer is still null.
+    if (currentLevel === FormattedConfigLevel.GLOBAL || !initialState) {
         return null;
     }
 
@@ -134,7 +134,7 @@ export const OverrideIndicator = <T,>({
                 </TooltipTrigger>
 
                 {/* Prevent tooltip from being cut off in overflow hidden containers */}
-                <TooltipPortal container={portalContainer}>
+                <TooltipPortal container={portalContainer ?? undefined}>
                     <TooltipContent>
                         <p>
                             This overrides the setting from the{" "}


### PR DESCRIPTION
## Problem

The **"Overridden"** badge (which tells the user a per-repository setting overrides the default) is missing on first paint and only pops in a frame later — or stays absent until a re-render. Reproduced in QA on **Custom Messages → Error message**: with the global message empty and the per-repo one filled, the badge should be there but wasn't.

## Cause

`OverrideIndicator` returned `null` while `portalContainer` was `null`. But `portalContainer` is only needed for the **tooltip portal**, and it's **always** `null` on the first render (set post-mount via `useEffectOnce`). So every first render was gated out, showing the badge only after the effect ran.

## Fix

- Gate only on `GLOBAL` level + `initialState` (what actually determines whether there is an override).
- The tooltip falls back to the default portal target (`document.body`) while `portalContainer` is still unresolved (`container={portalContainer ?? undefined}`).
- Dropped two dead imports (`useEffect`, `Button`) that were already failing lint on this file.

Covers every consumer (tab-content, hidden-comments, llm-prompt, and the form wrapper) — the fix is in the base component.

## Verification

- `tsc --noEmit` (web): clean on the file.
- `eslint`: clean.
- Pre-push gate (env:check + unit suite): green on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)