### PR TITLE
fix: sandbox lease cleanup follow-ups + map invalid-uuid input to 400

### DIFF
--- a/libs/code-review/pipeline/stages/create-sandbox.stage.ts
+++ b/libs/code-review/pipeline/stages/create-sandbox.stage.ts
@@ -5,6 +5,7 @@ import { Inject, Injectable } from '@nestjs/common';
 import {
     ISandboxLeaseManager,
     SANDBOX_LEASE_MANAGER_TOKEN,
+    SandboxInvalidatedError,
 } from '@libs/sandbox/domain/contracts/sandbox-lease-manager.contract';
 import { BasePipelineStage } from '@libs/core/infrastructure/pipeline/abstracts/base-stage.abstract';
 import { StageVisibility } from '@libs/core/infrastructure/pipeline/enums/stage-visibility.enum';
@@ -194,6 +195,21 @@ export class CreateSandboxStage extends BasePipelineStage<CodeReviewPipelineCont
                 };
             });
         } catch (err) {
+            // A mid-acquire invalidation is a SUPERSEDE, not a failure: the PR
+            // was closed or force-pushed, so this review is moot (a force-push
+            // re-triggers a fresh review on the new head). Log it as such
+            // instead of a false "all retries exhausted" error that pollutes
+            // error rates / alerts. The review still continues self-contained.
+            if (err instanceof SandboxInvalidatedError) {
+                this.logger.warn({
+                    message: `Sandbox lease superseded for ${label} (PR closed or force-pushed) — continuing without it`,
+                    context: this.stageName,
+                    metadata: {
+                        prNumber: context?.pullRequest?.number,
+                    },
+                });
+                return context;
+            }
             this.logger.error({
                 message: `Failed to acquire sandbox lease for ${label} (all retries exhausted), continuing without it`,
                 context: this.stageName,

--- a/libs/code-review/pipeline/stages/create-sandbox.stage.ts
+++ b/libs/code-review/pipeline/stages/create-sandbox.stage.ts
@@ -205,6 +205,8 @@ export class CreateSandboxStage extends BasePipelineStage<CodeReviewPipelineCont
                     message: `Sandbox lease superseded for ${label} (PR closed or force-pushed) — continuing without it`,
                     context: this.stageName,
                     metadata: {
+                        organizationAndTeamData:
+                            context?.organizationAndTeamData,
                         prNumber: context?.pullRequest?.number,
                     },
                 });

--- a/libs/core/infrastructure/filters/exceptions.filter.spec.ts
+++ b/libs/core/infrastructure/filters/exceptions.filter.spec.ts
@@ -3,6 +3,7 @@ import {
     InternalServerErrorException,
 } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
+import { QueryFailedError } from 'typeorm';
 import { ExceptionsFilter } from './exceptions.filter';
 import { reportExceptionToSentry } from '../config/log/sentry';
 
@@ -49,5 +50,27 @@ describe('ExceptionsFilter', () => {
         );
 
         expect(reportExceptionToSentry).toHaveBeenCalledTimes(1);
+    });
+
+    it('maps Postgres 22P02 (invalid uuid/int input) to 400 and skips sentry', () => {
+        // A malformed uuid reaching a query (e.g. an empty ?teamId=) throws a
+        // QueryFailedError with driver code 22P02 — a client input error, not a
+        // 500. It must not be reported to Sentry nor counted as a server error.
+        const qfe = new QueryFailedError(
+            'SELECT * FROM team WHERE uuid = $1',
+            [''],
+            {
+                code: '22P02',
+                message: 'invalid input syntax for type uuid: ""',
+            } as any,
+        );
+
+        filter.catch(qfe, host as any);
+
+        expect(response.status).toHaveBeenCalledWith(400);
+        expect(reportExceptionToSentry).not.toHaveBeenCalled();
+        const body = (response.json as jest.Mock).mock.calls[0][0];
+        expect(body.statusCode).toBe(400);
+        expect(body.message).toBe('Invalid parameter format');
     });
 });

--- a/libs/core/infrastructure/filters/exceptions.filter.ts
+++ b/libs/core/infrastructure/filters/exceptions.filter.ts
@@ -10,6 +10,7 @@ import { ConfigService } from '@nestjs/config';
 import { StatusCodes, getReasonPhrase } from 'http-status-codes';
 import { MetricsCollectorService } from '@libs/core/infrastructure/metrics/metrics-collector.service';
 import { reportExceptionToSentry } from '../config/log/sentry';
+import { QueryFailedError } from 'typeorm';
 
 interface ExceptionResponse {
     statusCode?: number;
@@ -37,14 +38,26 @@ export class ExceptionsFilter implements ExceptionFilter {
     catch(exception: unknown, context: ExecutionContext): void {
         const response = context.switchToHttp().getResponse();
         const request = context.switchToHttp().getRequest();
-        const status =
-            exception instanceof HttpException
-                ? exception.getStatus()
-                : StatusCodes.INTERNAL_SERVER_ERROR;
+        // Postgres 22P02 = invalid_text_representation: a malformed uuid / int
+        // / enum reached a query (e.g. an empty or garbage `?teamId=`, a `:id`
+        // that isn't a UUID). That is a client input error, not a server fault,
+        // so map it to 400 — otherwise it surfaces as a 500 (Sentry noise,
+        // error-rate spikes, http_errors_total) for what is simply bad input.
+        const isPgInvalidInput =
+            exception instanceof QueryFailedError &&
+            (exception as { driverError?: { code?: string } }).driverError
+                ?.code === '22P02';
+
+        const status = isPgInvalidInput
+            ? StatusCodes.BAD_REQUEST
+            : exception instanceof HttpException
+              ? exception.getStatus()
+              : StatusCodes.INTERNAL_SERVER_ERROR;
 
         const requestId = request?.requestId || 'unknown-request-id';
         const shouldReportToSentry =
-            !(exception instanceof HttpException) || status >= 500;
+            !isPgInvalidInput &&
+            (!(exception instanceof HttpException) || status >= 500);
 
         if (shouldReportToSentry) {
             void reportExceptionToSentry(exception, {
@@ -65,7 +78,9 @@ export class ExceptionsFilter implements ExceptionFilter {
 
         const errorResponse =
             exception instanceof HttpException ? exception.getResponse() : {};
-        let message = 'An unexpected error occurred';
+        let message = isPgInvalidInput
+            ? 'Invalid parameter format'
+            : 'An unexpected error occurred';
         let error_key: string | undefined;
         let code: string | undefined;
         let details: unknown | undefined;
@@ -87,11 +102,11 @@ export class ExceptionsFilter implements ExceptionFilter {
         }
 
         const error =
-            exception instanceof HttpException
+            exception instanceof HttpException || isPgInvalidInput
                 ? getReasonPhrase(status)
                 : 'Internal Server Error';
 
-        this.loggerService.error({
+        this.loggerService[isPgInvalidInput ? 'warn' : 'error']({
             message: `[${status}] ${error}: ${message}`,
             context: 'ExceptionsFilter',
             serviceName: 'ExceptionsFilter',

--- a/libs/sandbox/domain/contracts/sandbox-lease-manager.contract.ts
+++ b/libs/sandbox/domain/contracts/sandbox-lease-manager.contract.ts
@@ -2,6 +2,25 @@ import { CreateSandboxParams, SandboxInstance } from './sandbox.provider';
 
 export const SANDBOX_LEASE_MANAGER_TOKEN = Symbol('SandboxLeaseManager');
 
+/**
+ * Thrown by acquire() when the lease was invalidated — the PR was closed or
+ * force-pushed — while the sandbox was being acquired or created. This is a
+ * SUPERSEDE, not a failure: the review is moot (a force-push re-triggers a
+ * fresh review on the new head; a closed PR needs none). Callers should treat
+ * it as such and continue self-contained, NOT log it as an error.
+ */
+export class SandboxInvalidatedError extends Error {
+    constructor(prKey: string, midCreate = false, options?: ErrorOptions) {
+        super(
+            `SandboxLeaseManager: sandbox invalidated${
+                midCreate ? ' mid-create' : ''
+            } for prKey="${prKey}"`,
+            options,
+        );
+        this.name = 'SandboxInvalidatedError';
+    }
+}
+
 export interface AcquireResult {
     sandbox: SandboxInstance;
     leaseId: string;

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.service.ts
@@ -3,6 +3,7 @@ import {
     AcquireResult,
     assertValidPrKey,
     ISandboxLeaseManager,
+    SandboxInvalidatedError,
 } from '@libs/sandbox/domain/contracts/sandbox-lease-manager.contract';
 import {
     CreateSandboxParams,
@@ -180,6 +181,12 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
         // (doc will be deleted), then retry acquire from scratch. Prevents
         // attaching to a doc that's being cleaned up.
         if (doc.cleanupStatus === SANDBOX_LEASE_CLEANUP_STATUS.IN_PROGRESS) {
+            // upsertAcquire() already incremented leaseCount on this doc. Undo
+            // it BEFORE waiting: cleanup's claim requires leaseCount <= 0, so
+            // holding the increment while we poll would deadlock the very
+            // cleanup we're waiting on (and each retry would inflate the count
+            // further). Mirrors the FAILED/INVALIDATED branches below.
+            await this.leaseRepo.decrementLease(prKey);
             this.logger.log({
                 message: `SandboxLeaseManager: cleanup in progress, waiting for completion prKey="${prKey}"`,
                 context: SandboxLeaseManager.name,
@@ -215,9 +222,7 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                 context: SandboxLeaseManager.name,
                 metadata: { prKey, leaseCount: updated?.leaseCount },
             });
-            throw new Error(
-                `SandboxLeaseManager: sandbox invalidated for prKey="${prKey}"`,
-            );
+            throw new SandboxInvalidatedError(prKey);
         }
 
         const leaseId = randomUUID();
@@ -470,10 +475,24 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                         latest.state === 'READY'
                     ) {
                         await this.leaseRepo.markInvalidated(prKey);
+                        this.logger.log({
+                            message: `SandboxLeaseManager: invalidated READY local lease after losing cleanup claim prKey="${prKey}"`,
+                            context: SandboxLeaseManager.name,
+                            metadata: { prKey, sandboxId: doc.sandboxId },
+                        });
                     }
                 }
             } else {
                 await this.leaseRepo.markInvalidated(prKey);
+                this.logger.log({
+                    message: `SandboxLeaseManager: invalidated active local lease (leaseCount>0) prKey="${prKey}"`,
+                    context: SandboxLeaseManager.name,
+                    metadata: {
+                        prKey,
+                        sandboxId: doc.sandboxId,
+                        leaseCount: doc.leaseCount,
+                    },
+                });
             }
             return;
         }
@@ -563,10 +582,9 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                             // Finding 4 fix: don't delete the lease doc when
                             // local cleanup fails — keep it so the reaper can
                             // retry the cleanup.
-                            throw new Error(
-                                `SandboxLeaseManager: sandbox invalidated mid-create for prKey="${prKey}"`,
-                                { cause: localErr },
-                            );
+                            throw new SandboxInvalidatedError(prKey, true, {
+                                cause: localErr,
+                            });
                         }
                     } else {
                         const apiKey =
@@ -579,9 +597,7 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
                     }
                 }
                 await this.leaseRepo.delete(prKey);
-                throw new Error(
-                    `SandboxLeaseManager: sandbox invalidated mid-create for prKey="${prKey}"`,
-                );
+                throw new SandboxInvalidatedError(prKey, true);
             }
 
             this.leaseIdToPrKey.set(leaseId, prKey);
@@ -697,9 +713,7 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
             // Finding 2 fix: do NOT delete the sandbox here — active leases
             // may still be using it. The reaper will clean up when all leases
             // release and the TTL expires.
-            throw new Error(
-                `SandboxLeaseManager: sandbox invalidated for prKey="${prKey}"`,
-            );
+            throw new SandboxInvalidatedError(prKey);
         }
 
         if (state === 'READY' && sandboxId) {
@@ -725,9 +739,7 @@ export class SandboxLeaseManager implements ISandboxLeaseManager {
             }
 
             if (doc.state === 'INVALIDATED') {
-                throw new Error(
-                    `SandboxLeaseManager: sandbox invalidated for prKey="${prKey}"`,
-                );
+                throw new SandboxInvalidatedError(prKey);
             }
 
             if (doc.state === 'READY' && doc.sandboxId) {

--- a/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
+++ b/libs/sandbox/infrastructure/services/sandbox-lease-manager.spec.ts
@@ -1326,6 +1326,56 @@ describe('SandboxLeaseManager', () => {
             // Two upsertAcquire calls: first hit IN_PROGRESS, second succeeded
             expect(leaseRepo.upsertAcquire).toHaveBeenCalledTimes(2);
         });
+
+        it('acquire on IN_PROGRESS undoes the leaseCount increment before waiting', async () => {
+            // Regression: upsertAcquire() increments leaseCount on a doc that is
+            // being cleaned up. The wait path must decrement it immediately —
+            // cleanup's claim requires leaseCount <= 0, so holding the increment
+            // while polling would deadlock the very cleanup we're waiting for.
+            const prKey = '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:51';
+
+            leaseRepo.upsertAcquire
+                .mockResolvedValueOnce({
+                    _id: prKey,
+                    leaseCount: 1,
+                    state: 'READY',
+                    cleanupStatus: 'in_progress',
+                    sandboxId: '/tmp/kodus-sandbox-inprogress-undo',
+                    createdAt: new Date(),
+                    expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+                } as any)
+                .mockResolvedValueOnce({
+                    _id: prKey,
+                    leaseCount: 1,
+                    state: 'CREATING',
+                    createdAt: new Date(),
+                    expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+                } as any);
+
+            // Cleanup completes: doc gone on first poll.
+            leaseRepo.findByPrKey.mockResolvedValueOnce(null);
+            // Post-create check for the retry's creator path: READY.
+            leaseRepo.findByPrKey.mockResolvedValue({
+                _id: prKey,
+                leaseCount: 1,
+                state: 'READY',
+                sandboxId: '',
+                createdAt: new Date(),
+                expiresAt: new Date(Date.now() + 30 * 60 * 1000),
+            } as any);
+
+            jest.useFakeTimers();
+            const acquirePromise = manager.acquire(prKey, 'review');
+            await jest.runAllTimersAsync();
+            await acquirePromise;
+            jest.useRealTimers();
+
+            // The IN_PROGRESS branch must have released its increment. The
+            // creator retry (state CREATING, leaseCount 1) does not decrement,
+            // so exactly one decrement — the IN_PROGRESS undo — is expected.
+            expect(leaseRepo.decrementLease).toHaveBeenCalledWith(prKey);
+            expect(leaseRepo.decrementLease).toHaveBeenCalledTimes(1);
+        });
     });
 });
 

--- a/test/unit/code-review/pipeline/stages/create-sandbox.stage.spec.ts
+++ b/test/unit/code-review/pipeline/stages/create-sandbox.stage.spec.ts
@@ -5,6 +5,7 @@ import {
     ISandboxLeaseManager,
     SANDBOX_LEASE_MANAGER_TOKEN,
     AcquireResult,
+    SandboxInvalidatedError,
 } from '@libs/sandbox/domain/contracts/sandbox-lease-manager.contract';
 import { NULL_SANDBOX_INSTANCE } from '@libs/sandbox/infrastructure/providers/null-sandbox.service';
 import { CodeManagementService } from '@/platform/infrastructure/adapters/services/codeManagement.service';
@@ -268,6 +269,30 @@ describe('CreateSandboxStage', () => {
             const result = await (stage as any).executeStage(context);
 
             expect(result.sandboxHandle).toBeUndefined();
+        });
+
+        it('logs an invalidation as a supersede (warn, not error) and continues', async () => {
+            // A PR closed / force-pushed mid-acquire surfaces as
+            // SandboxInvalidatedError — a supersede, not a failure. The stage
+            // must log it at warn (so it doesn't pollute error rates/alerts)
+            // and still continue self-contained.
+            mockLeaseManager.acquire.mockRejectedValue(
+                new SandboxInvalidatedError(
+                    '7e2e97b8-aefa-422e-92d4-30b378c0332e:repo:5',
+                    true,
+                ),
+            );
+
+            const context = createBaseContext({
+                changedFiles: [{ filename: 'test.ts' } as any],
+            });
+
+            const result = await (stage as any).executeStage(context);
+            const logger = (stage as any).logger;
+
+            expect(result.sandboxHandle).toBeUndefined();
+            expect(logger.warn).toHaveBeenCalled();
+            expect(logger.error).not.toHaveBeenCalled();
         });
 
         it('does not retry acquire itself — retry+backoff lives inside the lease manager', async () => {


### PR DESCRIPTION
Groups a few production-error fixes surfaced during a bug sweep.

## 1. Sandbox: IN_PROGRESS cleanup deadlock / leaseCount leak
`acquire()` on a lease whose cleanup is `IN_PROGRESS` held the `leaseCount` increment from `upsertAcquire()` while polling, then recursed **without undoing it**. Cleanup's claim requires `leaseCount <= 0`, so the pending increment could **deadlock the very cleanup being waited on**, inflating the count on each retry. Fix: decrement before waiting (mirrors the `FAILED`/`INVALIDATED` branches). Regression test proves RED→GREEN.

## 2. Sandbox: mid-acquire invalidation logged as a false error
A lease invalidated while acquiring (PR **closed** or **force-pushed**) is a **supersede**, not a failure. It was logged in `CreateSandboxStage` as `error "Failed to acquire ... all retries exhausted"`, polluting error rates/alerts. Fix: `acquire()` throws a typed `SandboxInvalidatedError` (domain contract); the stage logs it at `warn` ("superseded — continuing without it") and still continues self-contained. Message text preserved.

Plus the two missing logs on the `invalidate()` fallback `markInvalidated` paths.

## 3. API: invalid uuid/int input → 400 instead of 500
No controller validates uuid params at the HTTP boundary (`ParseUUIDPipe` is used in **zero** controllers), so an empty/garbage `?teamId=` or `:id` reaches a query and Postgres throws "invalid input syntax for type uuid" (SQLSTATE **22P02**) — surfacing as a **500** (Sentry noise, error-rate, http_errors_total). The global `ExceptionsFilter` now maps `QueryFailedError` code `22P02` to **400 Bad Request** (not reported to Sentry, logged at warn). One choke point covers every endpoint.

## Testing
- `sandbox-lease-manager.spec.ts` + `create-sandbox.stage.spec.ts`: 104 passed / 3 skipped.
- `exceptions.filter.spec.ts`: 3 passed (incl. new 22P02→400 case).

## Deliberately NOT included
- **`Repository service for type 'null'`** (integration-not-configured): 45 of 70 methods in `codeManagement.service.ts` pass a null platform type to the factory. Their return contracts are **incompatible** (void / `X|null` / non-null arrays / `string` / `Map`), so there is no safe uniform guard — it needs a deliberate per-method / null-object decision, not a rushed sweep. Tracked separately.
- `cleanupRetryAt` dead field, DI-token for local-cleanup helpers, two rare multi-consumer sandbox edges — low-value follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)