### PR TITLE
fix(centralized-config): guard sync against empty/failed discovery + honest partial status

### DIFF
--- a/libs/centralized-config/application/use-cases/__tests__/centralized-config-sync.use-case.spec.ts
+++ b/libs/centralized-config/application/use-cases/__tests__/centralized-config-sync.use-case.spec.ts
@@ -354,4 +354,47 @@ describe('CentralizedConfigSyncUseCase', () => {
             centralizedConfigService.synchronizeKodyRules,
         ).not.toHaveBeenCalled();
     });
+
+    it('surfaces a partial Kody-rules sync as a failure and skips stale removal (#1518)', async () => {
+        const centralizedConfigService = {
+            validateCentralizedConfig: jest
+                .fn()
+                .mockResolvedValue({ success: true, message: 'ok' }),
+            getCentralizedConfigRepository: jest
+                .fn()
+                .mockResolvedValue({ id: 'r', name: 'kodus' }),
+            discoverConfigFiles: jest.fn().mockResolvedValue([]),
+            discoverKodyRulesFiles: jest
+                .fn()
+                .mockResolvedValue([{ path: 'a.yml' }]),
+            synchronizeConfigs: jest
+                .fn()
+                .mockResolvedValue({ success: true, message: 'ok' }),
+            // 27 of 61 materialized, the rest failed — must NOT be success.
+            synchronizeKodyRules: jest.fn().mockResolvedValue({
+                success: false,
+                message: 'Kody rules sync incomplete — synced 27, failed 34',
+            }),
+            removeStaleConfigs: jest.fn(),
+            removeStaleKodyRules: jest.fn(),
+        };
+
+        const useCase = new CentralizedConfigSyncUseCase(
+            centralizedConfigService as any,
+        );
+
+        const result = await useCase.execute({
+            organizationAndTeamData,
+        } as any);
+
+        expect(result.success).toBe(false);
+        expect(result.message).toContain('incomplete');
+        // A partial materialization must not trigger stale deletion.
+        expect(
+            centralizedConfigService.removeStaleKodyRules,
+        ).not.toHaveBeenCalled();
+        expect(
+            centralizedConfigService.removeStaleConfigs,
+        ).not.toHaveBeenCalled();
+    });
 });

--- a/libs/centralized-config/application/use-cases/__tests__/centralized-config-sync.use-case.spec.ts
+++ b/libs/centralized-config/application/use-cases/__tests__/centralized-config-sync.use-case.spec.ts
@@ -308,4 +308,50 @@ describe('CentralizedConfigSyncUseCase', () => {
             }),
         );
     });
+
+    it('aborts before ANY deletion when discovery fails (issue #1518 safety net)', async () => {
+        const centralizedConfigService = {
+            validateCentralizedConfig: jest
+                .fn()
+                .mockResolvedValue({ success: true, message: 'ok' }),
+            getCentralizedConfigRepository: jest
+                .fn()
+                .mockResolvedValue({ id: 'central-repo-id', name: 'kodus' }),
+            discoverConfigFiles: jest.fn().mockResolvedValue([]),
+            // A transient read failure now THROWS (scanRepositoryTree) instead
+            // of returning [] — the use-case must abort before any removeStale
+            // runs, or it would wipe every rule + the org's global config.
+            discoverKodyRulesFiles: jest
+                .fn()
+                .mockRejectedValue(
+                    new Error(
+                        'repositories integration config unavailable',
+                    ),
+                ),
+            synchronizeConfigs: jest.fn(),
+            synchronizeKodyRules: jest.fn(),
+            removeStaleConfigs: jest.fn(),
+            removeStaleKodyRules: jest.fn(),
+        };
+
+        const useCase = new CentralizedConfigSyncUseCase(
+            centralizedConfigService as any,
+        );
+
+        const result = await useCase.execute({
+            organizationAndTeamData,
+        } as any);
+
+        expect(result.success).toBe(false);
+        // The critical safety property: nothing destructive ran.
+        expect(
+            centralizedConfigService.removeStaleKodyRules,
+        ).not.toHaveBeenCalled();
+        expect(
+            centralizedConfigService.removeStaleConfigs,
+        ).not.toHaveBeenCalled();
+        expect(
+            centralizedConfigService.synchronizeKodyRules,
+        ).not.toHaveBeenCalled();
+    });
 });

--- a/libs/centralized-config/infrastructure/adapters/services/__tests__/centralized-config.service.spec.ts
+++ b/libs/centralized-config/infrastructure/adapters/services/__tests__/centralized-config.service.spec.ts
@@ -705,7 +705,12 @@ describe('CentralizedConfigService', () => {
 
     describe('removeStaleConfigs', () => {
         it('should remove stale custom messages even when regular config does not change', async () => {
-            const configFiles: IConfigFileMeta[] = [];
+            // Non-empty discovery (a repo scope) so the #1518 empty-discovery
+            // guard does not trigger; the GLOBAL message is stale because no
+            // global config file was discovered.
+            const configFiles: IConfigFileMeta[] = [
+                { repositoryId: 'repo-1' } as any,
+            ];
 
             const codeReviewConfig = {
                 configValue: {
@@ -746,6 +751,120 @@ describe('CentralizedConfigService', () => {
             );
             expect(
                 mockCreateOrUpdateParametersUseCase.execute,
+            ).not.toHaveBeenCalled();
+        });
+    });
+
+    // ---------------------------------------------------------------------
+    // Issue #1518 — empty/failed discovery must NOT wipe data. A read failure
+    // (repositories mapping unavailable, tree read failed) yields the same
+    // empty result as a genuinely empty repo, and the non-transactional
+    // reconcile then deleted every rule and reset the org's global config
+    // (default model / BYOK) plus custom messages. These assert the SAFE
+    // post-guard behavior and are the regression coverage for the fix.
+    // ---------------------------------------------------------------------
+    describe('#1518 empty-discovery wipe guard', () => {
+        it('discoverKodyRulesFiles THROWS (not []) when the repositories mapping cannot be loaded', async () => {
+            mockCodeManagementService.getRepositoryTree.mockResolvedValue([
+                { type: 'file', path: 'my-repo/.kody-rules/review/a.yml' },
+            ]);
+            // Transient integration-config read failure → null (a FAILURE, not
+            // "zero files"). Must surface so the sync aborts before deletion.
+            mockIntegrationConfigService.findIntegrationConfigFormatted.mockResolvedValue(
+                null,
+            );
+
+            await expect(
+                service.discoverKodyRulesFiles({
+                    organizationAndTeamData,
+                    repository: { name: 'config-repo', id: 'repo-1' },
+                }),
+            ).rejects.toThrow();
+        });
+
+        it('removeStaleKodyRules does NOT delete centralized rules when discovery is empty', async () => {
+            const ruleFiles: any[] = []; // empty discovery
+
+            mockKodyRulesService.findByOrganizationId.mockResolvedValue({
+                toJson: () => ({
+                    rules: [
+                        {
+                            uuid: 'r1',
+                            title: 'A',
+                            centralizedConfig: {
+                                path: '.kody-rules/review/a.yml',
+                            },
+                        },
+                        {
+                            uuid: 'r2',
+                            title: 'B',
+                            centralizedConfig: {
+                                path: '.kody-rules/review/b.yml',
+                            },
+                        },
+                    ],
+                }),
+            });
+
+            const result = await service.removeStaleKodyRules({
+                organizationAndTeamData,
+                ruleFiles,
+                actor,
+            });
+
+            expect(result.success).toBe(true);
+            expect(result.removedRuleCount).toBe(0);
+            expect(
+                mockDeleteRuleInOrganizationByIdKodyRulesUseCase.execute,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('removeStaleConfigs does NOT reset global config / delete repo configs / delete messages when discovery is empty', async () => {
+            const configFiles: IConfigFileMeta[] = []; // empty discovery
+
+            const codeReviewConfig = {
+                configValue: {
+                    // org-wide defaults: LLM provider + model + BYOK reference
+                    configs: {
+                        llmProvider: 'openai_byok',
+                        byokConfig: { apiKey: 'sk-live-secret' },
+                    },
+                    repositories: [
+                        {
+                            id: 'repo-1',
+                            isSelected: true,
+                            configs: { reviewOptions: { security: true } },
+                            directories: [],
+                        },
+                    ],
+                },
+            };
+
+            mockParametersService.findByKey.mockImplementation((key: any) =>
+                key === ParametersKey.CODE_REVIEW_CONFIG
+                    ? Promise.resolve(codeReviewConfig)
+                    : Promise.resolve({ configValue: {} }),
+            );
+            mockPullRequestMessagesService.find.mockResolvedValue([
+                { uuid: 'global-message-1', configLevel: ConfigLevel.GLOBAL },
+            ]);
+
+            const result = await service.removeStaleConfigs({
+                organizationAndTeamData,
+                configFiles,
+                actor,
+            });
+
+            expect(result.success).toBe(true);
+            // None of the destructive paths may fire on empty discovery.
+            expect(
+                mockCreateOrUpdateParametersUseCase.execute,
+            ).not.toHaveBeenCalled();
+            expect(
+                mockDeleteRepositoryCodeReviewParameterUseCase.execute,
+            ).not.toHaveBeenCalled();
+            expect(
+                mockPullRequestMessagesService.delete,
             ).not.toHaveBeenCalled();
         });
     });
@@ -1269,7 +1388,12 @@ describe('CentralizedConfigService', () => {
             const result = await service.removeStaleKodyRules({
                 organizationAndTeamData,
                 actor,
-                ruleFiles: [],
+                // Non-empty discovery (a real file list that just doesn't
+                // include pending.yml) so the #1518 empty-discovery guard does
+                // not trigger — this validates genuine stale removal.
+                ruleFiles: [
+                    { path: '.kody-rules/review/other.yml' } as any,
+                ],
             });
 
             expect(result.success).toBe(true);

--- a/libs/centralized-config/infrastructure/adapters/services/__tests__/centralized-config.service.spec.ts
+++ b/libs/centralized-config/infrastructure/adapters/services/__tests__/centralized-config.service.spec.ts
@@ -887,6 +887,139 @@ describe('CentralizedConfigService', () => {
         });
     });
 
+    // Backfill for the four methods that had no direct unit test — the gap
+    // that let #1518 through (methods only exercised via mocks in the use-case
+    // spec, never their own logic).
+    describe('untested method coverage', () => {
+        describe('validateCentralizedConfig', () => {
+            it('fails when centralized config is not enabled', async () => {
+                mockParametersService.findByKey.mockResolvedValue({
+                    configValue: { enabled: false },
+                });
+                const r = await service.validateCentralizedConfig({
+                    organizationAndTeamData,
+                });
+                expect(r.success).toBe(false);
+                expect(r.message).toContain('not enabled');
+            });
+
+            it('fails when enabled but no repository is configured', async () => {
+                mockParametersService.findByKey.mockResolvedValue({
+                    configValue: { enabled: true, repository: {} },
+                });
+                const r = await service.validateCentralizedConfig({
+                    organizationAndTeamData,
+                });
+                expect(r.success).toBe(false);
+                expect(r.message).toContain('no repository');
+            });
+
+            it('succeeds when enabled and a repository is configured', async () => {
+                mockParametersService.findByKey.mockResolvedValue({
+                    configValue: {
+                        enabled: true,
+                        repository: { id: 'r1', name: 'kodus' },
+                    },
+                });
+                const r = await service.validateCentralizedConfig({
+                    organizationAndTeamData,
+                });
+                expect(r.success).toBe(true);
+            });
+        });
+
+        describe('getCentralizedConfigRepository', () => {
+            it('returns the configured repository', async () => {
+                mockParametersService.findByKey.mockResolvedValue({
+                    configValue: { repository: { id: 'r1', name: 'kodus' } },
+                });
+                const repo =
+                    await service.getCentralizedConfigRepository(
+                        organizationAndTeamData,
+                    );
+                expect(repo).toEqual({ id: 'r1', name: 'kodus' });
+            });
+
+            it('throws when no repository is configured', async () => {
+                mockParametersService.findByKey.mockResolvedValue({
+                    configValue: {},
+                });
+                await expect(
+                    service.getCentralizedConfigRepository(
+                        organizationAndTeamData,
+                    ),
+                ).rejects.toThrow(
+                    'Centralized config repository not configured',
+                );
+            });
+        });
+
+        describe('fetchConfigFile', () => {
+            it('returns the config file on success', async () => {
+                mockCodeBaseConfigService.getKodusConfigFile.mockResolvedValue({
+                    version: 2,
+                });
+                const file = await service.fetchConfigFile({
+                    organizationAndTeamData,
+                    repository: { name: 'r', id: 'r1' },
+                });
+                expect(file).toEqual({ version: 2 });
+            });
+
+            it('returns null (does not throw) when the read fails', async () => {
+                mockCodeBaseConfigService.getKodusConfigFile.mockRejectedValue(
+                    new Error('boom'),
+                );
+                const file = await service.fetchConfigFile({
+                    organizationAndTeamData,
+                    repository: { name: 'r', id: 'r1' },
+                });
+                expect(file).toBeNull();
+            });
+        });
+
+        describe('fetchKodyRuleFile', () => {
+            it('returns null when the file has no content', async () => {
+                mockCodeManagementService.getDefaultBranch.mockResolvedValue(
+                    'main',
+                );
+                mockCodeManagementService.getRepositoryContentFile.mockResolvedValue(
+                    { data: {} },
+                );
+                const rule = await service.fetchKodyRuleFile({
+                    organizationAndTeamData,
+                    repository: { name: 'r', id: 'r1' },
+                    filePath: '.kody-rules/review/a.yml',
+                });
+                expect(rule).toBeNull();
+            });
+
+            it('decodes and parses a base64 YAML rule file', async () => {
+                mockCodeManagementService.getDefaultBranch.mockResolvedValue(
+                    'main',
+                );
+                const yamlContent = 'title: My rule\nrule: do the thing\n';
+                mockCodeManagementService.getRepositoryContentFile.mockResolvedValue(
+                    {
+                        data: {
+                            content: Buffer.from(
+                                yamlContent,
+                                'utf-8',
+                            ).toString('base64'),
+                            encoding: 'base64',
+                        },
+                    },
+                );
+                const rule = await service.fetchKodyRuleFile({
+                    organizationAndTeamData,
+                    repository: { name: 'r', id: 'r1' },
+                    filePath: '.kody-rules/review/a.yml',
+                });
+                expect(rule).toMatchObject({ title: 'My rule' });
+            });
+        });
+    });
+
     describe('discoverKodyRulesFiles', () => {
         it('should discover Kody rule files from centralized repository', async () => {
             const mockRepoTree = [
@@ -1373,7 +1506,10 @@ describe('CentralizedConfigService', () => {
                 actor,
             });
 
-            expect(result.success).toBe(true);
+            // #1518: a per-file failure must NOT be reported as an overall
+            // success — the sync is incomplete and the caller has to know.
+            expect(result.success).toBe(false);
+            expect(result.message).toContain('incomplete');
             expect(result.failureDetails).toHaveLength(1);
             expect(result.failureDetails![0].file).toBe(
                 '.kody-rules/memories/invalid.yml',

--- a/libs/centralized-config/infrastructure/adapters/services/__tests__/centralized-config.service.spec.ts
+++ b/libs/centralized-config/infrastructure/adapters/services/__tests__/centralized-config.service.spec.ts
@@ -782,6 +782,24 @@ describe('CentralizedConfigService', () => {
             ).rejects.toThrow();
         });
 
+        it('discoverConfigFiles THROWS (not []) when the repositories mapping cannot be loaded', async () => {
+            // Twin of discoverKodyRulesFiles — both go through scanRepositoryTree,
+            // and both feed removeStale*, so both must fail loudly on a read error.
+            mockCodeManagementService.getRepositoryTree.mockResolvedValue([
+                { type: 'file', path: 'my-repo/kodus-config.yml' },
+            ]);
+            mockIntegrationConfigService.findIntegrationConfigFormatted.mockResolvedValue(
+                null,
+            );
+
+            await expect(
+                service.discoverConfigFiles({
+                    organizationAndTeamData,
+                    repository: { name: 'config-repo', id: 'repo-1' },
+                }),
+            ).rejects.toThrow();
+        });
+
         it('removeStaleKodyRules does NOT delete centralized rules when discovery is empty', async () => {
             const ruleFiles: any[] = []; // empty discovery
 

--- a/libs/centralized-config/infrastructure/adapters/services/centralized-config.service.ts
+++ b/libs/centralized-config/infrastructure/adapters/services/centralized-config.service.ts
@@ -508,6 +508,25 @@ export class CentralizedConfigService implements ICentralizedConfigService {
                 };
             }
 
+            // #1518 guard: an empty discovery would reset the global config
+            // (default model / BYOK) to {}, delete every repository config, and
+            // wipe custom messages. An empty configFiles set almost always
+            // means a failed/empty read, not "the user removed everything" —
+            // refuse to reconcile-delete and surface it.
+            if (configFiles.length === 0) {
+                this.logger.warn({
+                    message:
+                        'Skipping stale config removal: discovery returned zero config files — refusing to reset global config / delete repo configs / wipe messages (likely a failed read)',
+                    context: CentralizedConfigService.name,
+                    metadata: { organizationAndTeamData },
+                });
+                return {
+                    success: true,
+                    message:
+                        'Skipped stale config removal (empty-discovery guard)',
+                };
+            }
+
             const desiredHasGlobalConfig = configFiles.some(
                 (meta) => !meta.repositoryId,
             );
@@ -2144,6 +2163,31 @@ export class CentralizedConfigService implements ICentralizedConfigService {
 
             const existingRules = existingEntity?.toJson?.()?.rules || [];
 
+            // #1518 guard: an empty discovery (currentSourcePaths empty) while
+            // centralized rules exist would delete every synced rule. That is
+            // almost always a failed/empty read, not an intentional "delete
+            // all" — refuse to wipe and surface it.
+            const centralizedRuleCount = existingRules.filter(
+                (rule) => rule.centralizedConfig?.path,
+            ).length;
+            if (currentSourcePaths.size === 0 && centralizedRuleCount > 0) {
+                this.logger.warn({
+                    message:
+                        'Skipping stale Kody rule removal: discovery returned zero rule files but centralized rules exist — refusing to wipe (likely a failed read)',
+                    context: CentralizedConfigService.name,
+                    metadata: {
+                        organizationAndTeamData,
+                        centralizedRuleCount,
+                    },
+                });
+                return {
+                    success: true,
+                    message:
+                        'Skipped stale Kody rule removal (empty-discovery guard)',
+                    removedRuleCount: 0,
+                };
+            }
+
             for (const rule of existingRules) {
                 const sourcePath = rule.centralizedConfig?.path;
 
@@ -2250,13 +2294,20 @@ export class CentralizedConfigService implements ICentralizedConfigService {
             });
 
         if (!repositories || !Array.isArray(repositories)) {
-            this.logger.warn({
+            // A missing/failed repositories mapping is a READ FAILURE, not
+            // "zero files". Returning [] here made discovery indistinguishable
+            // from an empty repo, which then drove removeStale* to wipe every
+            // rule and reset the org's global config (issue #1518). Throw so
+            // the sync aborts before any deletion runs.
+            this.logger.error({
                 message:
-                    'No repositories found in integration config during tree scan',
+                    'Could not load repositories integration config during tree scan — aborting discovery to avoid a destructive empty result',
                 context: CentralizedConfigService.name,
                 metadata: { organizationAndTeamData },
             });
-            return [];
+            throw new Error(
+                'Centralized config discovery: repositories integration config unavailable',
+            );
         }
 
         const resolvedRepoIds = new Map(

--- a/libs/centralized-config/infrastructure/adapters/services/centralized-config.service.ts
+++ b/libs/centralized-config/infrastructure/adapters/services/centralized-config.service.ts
@@ -2038,7 +2038,10 @@ export class CentralizedConfigService implements ICentralizedConfigService {
                 }
             }
 
-            const message = `Kody rules synchronized successfully. Synced: ${syncedCount}, Failed: ${failureDetails.length}`;
+            const hasFailures = failureDetails.length > 0;
+            const message = hasFailures
+                ? `Kody rules sync incomplete — synced ${syncedCount}, failed ${failureDetails.length}`
+                : `Kody rules synchronized successfully. Synced: ${syncedCount}, Failed: 0`;
 
             if (failureDetails.length > 0) {
                 this.logger.warn({
@@ -2063,11 +2066,14 @@ export class CentralizedConfigService implements ICentralizedConfigService {
             }
 
             return {
-                success: true,
+                // #1518: a partial sync must NOT report success — the use-case
+                // surfaces this so the caller sees the real state (not a
+                // success-shaped result), and removeStale* does not run on an
+                // incomplete materialization.
+                success: !hasFailures,
                 message,
                 syncedRuleCount: syncedCount,
-                failureDetails:
-                    failureDetails.length > 0 ? failureDetails : undefined,
+                failureDetails: hasFailures ? failureDetails : undefined,
             };
         } catch (error) {
             this.logger.error({


### PR DESCRIPTION
Fixes the data-loss + silent-failure issues in centralized-config sync (issue #1518) and backfills the test coverage gap that let them through.

## 1. Data-loss on empty/failed discovery (the wipe + cascade)

The reconcile is non-transactional and driven by discovery that couldn't tell a **failed read** from a **genuinely empty repo**. On a transient failure, discovery returned `[]`, and `removeStale*` treated everything as stale — deleting all Kody rules AND resetting the org's global config (default model / BYOK) to `{}`, plus wiping repo configs and custom messages.

- **Root:** `scanRepositoryTree` now **throws** on a repositories-read failure instead of returning `[]`; the sync use-case's try/catch aborts before any deletion.
- **Defense-in-depth:** `removeStaleKodyRules` and `removeStaleConfigs` skip deletion when discovery is empty but data exists.

## 2. Partial sync reported as success (the "27/61 then silent")

`synchronizeKodyRules` swallowed per-file failures and returned `success: true` regardless. It now returns `success: false` with an `incomplete — synced X, failed Y` message when any file fails; the use-case surfaces it (and skips stale removal on an incomplete materialization).

## 3. Test coverage backfill

The gap that let this through: methods were only exercised via mocks in the use-case spec, never their own logic; and no test modeled a failing discovery feeding the reconcile.

- **Data-loss regression** (RED→GREEN proven): rules, global model/BYOK, repo configs, custom messages.
- **Discovery-failure safety net** at the use-case level (aborts before any deletion) + `discoverConfigFiles` throw (the untested twin).
- **Partial-sync** surfaced as failure (service + use-case).
- **Backfill** of the four previously-untested methods: `validateCentralizedConfig`, `getCentralizedConfigRepository`, `fetchConfigFile`, `fetchKodyRuleFile`.
- **Full suite: 96 tests / 7 suites green.** `tsc --noEmit`: no new errors in changed files.

## Behavior notes (intentional)

- A genuine "user deleted every file" now **skips auto-cleanup** rather than wiping (issue Expected #1).
- A **partial** sync now reports **failure** instead of a misleading success (issue Expected #3).

## Scope

Addresses the data-loss + silent-failure root causes of #1518. Left as follow-ups on the issue: the `rejected` landing status for `repo_file_sync` rules (a product/UX decision — the CLI has no activate path in 0.4.19) and `centralized download` availability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)