### PR TITLE
fix(agent-harness): hard per-request context clamp + real tokenizer

### DIFF
--- a/.github/workflows/code-review-evals.yml
+++ b/.github/workflows/code-review-evals.yml
@@ -43,6 +43,7 @@ on:
         branches: [main]
         paths:
             - "libs/code-review/**"
+            - "libs/agent-harness/**"
             - "libs/ee/codeReview/**"
             - "libs/ee/kodyRules/**"
             - "libs/kodyRules/**"
@@ -52,6 +53,7 @@ on:
     pull_request:
         paths:
             - "libs/code-review/**"
+            - "libs/agent-harness/**"
             - "libs/ee/codeReview/**"
             - "libs/ee/kodyRules/**"
             - "libs/kodyRules/**"

--- a/libs/agent-harness/infrastructure/ai-sdk/ai-sdk-agent-runner.compression.e2e.spec.ts
+++ b/libs/agent-harness/infrastructure/ai-sdk/ai-sdk-agent-runner.compression.e2e.spec.ts
@@ -30,7 +30,12 @@ import { AiSdkAgentRunner } from './ai-sdk-agent-runner';
 
 // A tool result big enough (well above the compressor's 3_000-char "recent"
 // cap) that compression actually truncates it and reports real token savings.
-const BIG_RESULT = 'x'.repeat(8_000);
+// Varied tokens (not a single repeated char, which tiktoken would collapse to
+// a handful of tokens) so the token estimate reflects realistic dense content.
+const BIG_RESULT = Array.from(
+    { length: 1_600 },
+    (_, i) => `const value${i} = compute(${i}, "path/to/file${i}.ts");`,
+).join('\n');
 
 // Scripted model: step 0 -> call readFile (produces a large `tool` message),
 // step 1 -> call submitResult (finalize). Deterministic, no real LLM.
@@ -62,6 +67,34 @@ function scriptedModel() {
 const resolver: ModelResolver<any> = {
     resolve: () => scriptedModel() as any,
 };
+
+// Scripted model that runs `readSteps` readFile calls (each returns a big
+// result that piles into the window) before finalizing. Drives the tool-loop
+// accumulation that overflows the window in issue #1574.
+function accumulatingModel(readSteps: number) {
+    let call = 0;
+    const doGenerate = (async () => {
+        call += 1;
+        const tc =
+            call <= readSteps
+                ? { id: `c${call}`, name: 'readFile', input: { path: `f${call}.ts` } }
+                : { id: 'done', name: 'submitResult', input: { findings: [] } };
+        return {
+            content: [
+                {
+                    type: 'tool-call',
+                    toolCallId: tc.id,
+                    toolName: tc.name,
+                    input: JSON.stringify(tc.input),
+                },
+            ],
+            finishReason: 'tool-calls',
+            usage: { inputTokens: 10, outputTokens: 5 },
+            warnings: [],
+        };
+    }) as any;
+    return new MockLanguageModelV3({ doGenerate });
+}
 
 const readFileTool: AgentTool = {
     name: 'readFile',
@@ -96,7 +129,10 @@ function noCriticalLedger(): ProgressLedger {
 
 const ctx: ToolContext = { runId: 'compress-e2e-1' };
 
-function specWithContextWindow(contextWindowTokens: number): AgentSpec {
+function specWithContextWindow(
+    contextWindowTokens: number,
+    overheadTokens = 0,
+): AgentSpec {
     return {
         id: 'generalist',
         systemPrompt: 'review the diff',
@@ -104,13 +140,15 @@ function specWithContextWindow(contextWindowTokens: number): AgentSpec {
         tools: new InMemoryToolRegistry([readFileTool, doneTool]),
         policies: [
             new CompressionPolicy(
-                new ContextWindowCompressor(contextWindowTokens),
+                new ContextWindowCompressor(contextWindowTokens, {
+                    overheadTokens,
+                }),
             ),
             new CompletionGatePolicy(noCriticalLedger(), {
                 doneToolName: 'submitResult',
             }),
         ],
-        maxSteps: 10,
+        maxSteps: 20,
         resultToolName: 'submitResult',
     };
 }
@@ -178,5 +216,37 @@ describe('AiSdkAgentRunner + CompressionPolicy (context compression e2e)', () =>
             type: 'submitResult',
             payload: { findings: [] },
         });
+    });
+
+    // REGRESSION (issue #1574): a tool loop that accumulates far more than the
+    // window of tool results must be clamped every step and finish, instead of
+    // shipping an oversized request. Realistic window + overhead so the real
+    // budget (window − overhead − margin) is what the clamp must respect.
+    it('clamps an accumulating tool loop that would otherwise overflow the window', async () => {
+        const accResolver: ModelResolver<any> = {
+            resolve: () => accumulatingModel(12) as any,
+        };
+        const runner = new AiSdkAgentRunner(accResolver);
+
+        // 12 readFile steps × 8_000-char results ≈ well over a 40K-token window.
+        const state = await runner.run(
+            specWithContextWindow(40_000, 12_000),
+            { prompt: 'go' },
+            ctx,
+        );
+
+        // Compression must have fired (the loop overflowed and was clamped)...
+        expect(
+            state.trace.some((e) => e.kind === 'context.compress'),
+        ).toBe(true);
+        // ...and the run finished cleanly (no provider CONTEXT_OVERFLOW throw,
+        // no content.filter crash).
+        expect(state.status).not.toBe('error');
+        expect(
+            state.trace.some((e) => e.kind === 'error'),
+        ).toBe(false);
+        // Findings still produced — the review completes rather than failing.
+        expect(state.artifacts).toHaveLength(1);
+        expect(state.artifacts[0]).toMatchObject({ type: 'submitResult' });
     });
 });

--- a/libs/agent-harness/infrastructure/compression/context-compressor.spec.ts
+++ b/libs/agent-harness/infrastructure/compression/context-compressor.spec.ts
@@ -1,0 +1,125 @@
+/**
+ * context-compressor unit tests — hard per-request clamp (issue #1574).
+ *
+ * The clamp must GUARANTEE the returned window fits a real token budget while
+ * keeping the message structure valid for the AI SDK (no orphaned tool result:
+ * every `tool` message stays paired with the assistant turn it answers).
+ */
+import {
+    clampMessagesToBudget,
+    compressMessages,
+    estimateMessagesTokens,
+    type ModelMessage,
+} from './context-compressor';
+
+/** Build a realistic tool-loop window: head user (diff) + N assistant/tool rounds. */
+function buildWindow(rounds: number, resultChars: number): ModelMessage[] {
+    const msgs: ModelMessage[] = [
+        { role: 'user', content: 'Review this diff:\n' + 'x'.repeat(2_000) },
+    ];
+    for (let i = 0; i < rounds; i++) {
+        msgs.push({
+            role: 'assistant',
+            content: [
+                { type: 'text', text: `step ${i}` },
+                {
+                    type: 'tool-call',
+                    toolCallId: `c${i}`,
+                    toolName: 'readFile',
+                    input: { path: `file${i}.ts` },
+                },
+            ],
+        });
+        msgs.push({
+            role: 'tool',
+            content: [
+                {
+                    type: 'tool-result',
+                    toolCallId: `c${i}`,
+                    toolName: 'readFile',
+                    output: 'y'.repeat(resultChars),
+                },
+            ],
+        });
+    }
+    return msgs;
+}
+
+/** A `tool` message is orphaned if no preceding assistant carries its callId. */
+function hasOrphanToolResult(messages: ModelMessage[]): boolean {
+    const seenCallIds = new Set<string>();
+    for (const m of messages) {
+        if (m.role === 'assistant' && Array.isArray(m.content)) {
+            for (const part of m.content as any[]) {
+                if (part?.type === 'tool-call' && part.toolCallId) {
+                    seenCallIds.add(part.toolCallId);
+                }
+            }
+        }
+        if (m.role === 'tool' && Array.isArray(m.content)) {
+            for (const part of m.content as any[]) {
+                if (part?.type === 'tool-result' && part.toolCallId) {
+                    if (!seenCallIds.has(part.toolCallId)) {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    return false;
+}
+
+describe('clampMessagesToBudget', () => {
+    it('leaves a window that already fits untouched', () => {
+        const msgs = buildWindow(2, 100);
+        const budget = estimateMessagesTokens(msgs) + 1_000;
+        expect(clampMessagesToBudget(msgs, budget)).toBe(msgs);
+    });
+
+    it('clamps an overflowing window to at or below the budget', () => {
+        // 30 rounds × ~8K-char results — far over any small budget.
+        const msgs = buildWindow(30, 8_000);
+        const before = estimateMessagesTokens(msgs);
+        const budget = 5_000;
+        const clamped = clampMessagesToBudget(msgs, budget);
+        const after = estimateMessagesTokens(clamped);
+        expect(before).toBeGreaterThan(budget);
+        expect(after).toBeLessThanOrEqual(budget);
+    });
+
+    it('preserves the head (first user diff turn)', () => {
+        const msgs = buildWindow(30, 8_000);
+        const clamped = clampMessagesToBudget(msgs, 5_000);
+        expect(clamped[0].role).toBe('user');
+        expect(String(clamped[0].content)).toContain('Review this diff');
+    });
+
+    it('never produces an orphaned tool result', () => {
+        const msgs = buildWindow(30, 8_000);
+        const clamped = clampMessagesToBudget(msgs, 5_000);
+        expect(hasOrphanToolResult(clamped)).toBe(false);
+    });
+
+    it('fits even when a single recent round alone exceeds the budget', () => {
+        // One massive round; budget smaller than it → phase 3 (truncate) fires.
+        const msgs = buildWindow(1, 200_000);
+        const budget = 1_000;
+        const clamped = clampMessagesToBudget(msgs, budget);
+        expect(estimateMessagesTokens(clamped)).toBeLessThanOrEqual(budget);
+        expect(hasOrphanToolResult(clamped)).toBe(false);
+    });
+
+    it('is a no-op for a non-positive budget (nonsensical window)', () => {
+        const msgs = buildWindow(2, 100);
+        expect(clampMessagesToBudget(msgs, 0)).toBe(msgs);
+    });
+});
+
+describe('compressMessages (soft pass) still structurally preserves tool turns', () => {
+    it('keeps tool content as an array (no re-flatten to string)', () => {
+        const msgs = buildWindow(10, 8_000);
+        const compressed = compressMessages(msgs, []);
+        const toolMsg = compressed.find((m) => m.role === 'tool');
+        expect(Array.isArray(toolMsg?.content)).toBe(true);
+    });
+});

--- a/libs/agent-harness/infrastructure/compression/context-compressor.ts
+++ b/libs/agent-harness/infrastructure/compression/context-compressor.ts
@@ -28,8 +28,7 @@
  * next LLM call.
  */
 
-/** Rough token estimate: 1 token ≈ 4 characters. */
-const CHARS_PER_TOKEN = 4;
+import { estimateValueTokens } from './token-estimator';
 
 /** Trigger compression when context usage crosses this fraction of the window. */
 export const COMPRESSION_THRESHOLD_RATIO = 0.7;
@@ -50,6 +49,14 @@ const OLDER_MAX_CHARS_PER_RESULT = 400;
 /** Max characters per entry in the investigation summary. */
 const SUMMARY_MAX_CHARS_PER_ENTRY = 200;
 
+/**
+ * Aggressive per-tool-result cap used by the hard clamp (phase 1). Applied to
+ * EVERY tool result (recent included), unlike the soft pass which spares the
+ * recent tail. Small enough to reclaim the bulk of an overflowing window while
+ * still leaving the agent a usable preview of each call.
+ */
+const HARD_CLAMP_MAX_CHARS_PER_RESULT = 500;
+
 export interface ModelMessage {
     role: 'system' | 'user' | 'assistant' | 'tool';
     content: unknown;
@@ -64,19 +71,19 @@ interface ToolCallRecord {
 }
 
 /**
- * Estimates the token count of a message array by JSON-stringifying each
- * message and dividing char length by 4.
+ * Estimates the token count of a message array with a real tokenizer
+ * (`token-estimator`), serializing each message so the structured `tool` /
+ * `tool-call` parts are counted the way the provider sees them on the wire.
+ * Replaces the old flat 4-chars/token estimate that under-counted dense code by
+ * ~1.6× and let the compressor believe it was under budget while the request
+ * already overflowed (issue #1574).
  */
 export function estimateMessagesTokens(messages: ModelMessage[]): number {
-    let chars = 0;
+    let total = 0;
     for (const msg of messages) {
-        try {
-            chars += JSON.stringify(msg).length;
-        } catch {
-            chars += 0;
-        }
+        total += estimateValueTokens(msg);
     }
-    return Math.ceil(chars / CHARS_PER_TOKEN);
+    return total;
 }
 
 /**
@@ -293,4 +300,155 @@ export function compressMessages(
     }
 
     return [...head, ...compressedTail];
+}
+
+/**
+ * Splits the head (leading `system` messages + the first `user` message, which
+ * carries the non-negotiable <Diffs> block) from the rest of the window.
+ */
+function splitHead(messages: ModelMessage[]): {
+    head: ModelMessage[];
+    rest: ModelMessage[];
+} {
+    const head: ModelMessage[] = [];
+    let idx = 0;
+    while (idx < messages.length && messages[idx].role === 'system') {
+        head.push(messages[idx]);
+        idx++;
+    }
+    if (idx < messages.length && messages[idx].role === 'user') {
+        head.push(messages[idx]);
+        idx++;
+    }
+    return { head, rest: messages.slice(idx) };
+}
+
+/**
+ * Groups a message sequence into "rounds": each non-`tool` message (an
+ * assistant turn, or a steering user note) plus the `tool` messages that
+ * immediately follow it (its results). Evicting whole rounds keeps the window
+ * structurally valid for the AI SDK — a `tool` result never survives without
+ * the assistant tool-call it answers, so no provider sees an orphaned result.
+ */
+function groupRounds(messages: ModelMessage[]): ModelMessage[][] {
+    const rounds: ModelMessage[][] = [];
+    let current: ModelMessage[] | null = null;
+    for (const m of messages) {
+        if (m.role === 'tool' && current) {
+            current.push(m);
+        } else {
+            if (current) {
+                rounds.push(current);
+            }
+            current = [m];
+        }
+    }
+    if (current) {
+        rounds.push(current);
+    }
+    return rounds;
+}
+
+/**
+ * Evicts the OLDEST rounds from the middle of the window, keeping the head and
+ * as many of the most-recent rounds as fit under `budgetTokens`. Always keeps
+ * at least the single newest round (phase 3 truncates it if even that
+ * overflows). Structure-preserving via {@link groupRounds}.
+ */
+function evictOldestRounds(
+    messages: ModelMessage[],
+    budgetTokens: number,
+): ModelMessage[] {
+    const { head, rest } = splitHead(messages);
+    const rounds = groupRounds(rest);
+    if (rounds.length === 0) {
+        return messages;
+    }
+
+    let running = estimateMessagesTokens(head);
+    const keptReversed: ModelMessage[][] = [];
+    for (let i = rounds.length - 1; i >= 0; i--) {
+        const rtok = estimateMessagesTokens(rounds[i]);
+        if (keptReversed.length === 0 || running + rtok <= budgetTokens) {
+            keptReversed.push(rounds[i]);
+            running += rtok;
+        } else {
+            // Rounds only get older (and never smaller in aggregate) as we walk
+            // backwards, so once one doesn't fit, neither will the rest.
+            break;
+        }
+    }
+    return [...head, ...keptReversed.reverse().flat()];
+}
+
+/**
+ * Last-resort clamp: shrink every message's text content with a geometrically
+ * decreasing cap until the window estimates under `budgetTokens`. Truncates
+ * only text/output/result/content fields (never tool-call `input`/`args`), so
+ * assistant tool-call parts stay structurally intact. Bounded iteration count —
+ * returns the best effort if a pathological window can't be reduced further.
+ */
+function hardTruncateToFit(
+    messages: ModelMessage[],
+    budgetTokens: number,
+): ModelMessage[] {
+    let cap = HARD_CLAMP_MAX_CHARS_PER_RESULT;
+    let work = messages;
+    for (let i = 0; i < 12; i++) {
+        work = messages.map(
+            (m) => truncateToolMessage(m, cap).msg,
+        );
+        if (estimateMessagesTokens(work) <= budgetTokens) {
+            return work;
+        }
+        if (cap <= 80) {
+            break;
+        }
+        cap = Math.max(80, Math.floor(cap / 2));
+    }
+    return work;
+}
+
+/**
+ * Hard per-request clamp. Guarantees the returned window estimates at or below
+ * `budgetTokens` (the model window minus fixed system + tool-schema overhead
+ * and a safety margin) whenever possible, so the agent NEVER emits a request
+ * larger than the context window even when the soft pass can't reduce enough.
+ *
+ * Order of operations (least → most destructive), each structure-preserving so
+ * the AI SDK never sees an orphaned tool result:
+ *   1. Aggressively truncate EVERY tool-result text to a tiny cap.
+ *   2. Evict whole oldest rounds (an assistant turn + its tool results),
+ *      keeping the head (diff) and the most-recent rounds.
+ *   3. Last resort: hard-truncate the remaining message contents until it fits.
+ */
+export function clampMessagesToBudget(
+    messages: ModelMessage[],
+    budgetTokens: number,
+): ModelMessage[] {
+    if (!messages || messages.length === 0 || budgetTokens <= 0) {
+        return messages;
+    }
+    if (estimateMessagesTokens(messages) <= budgetTokens) {
+        return messages;
+    }
+
+    // Phase 1: aggressive tool-result truncation across the whole window.
+    let work = messages.map((m) =>
+        m.role === 'tool'
+            ? truncateToolMessage(m, HARD_CLAMP_MAX_CHARS_PER_RESULT).msg
+            : m,
+    );
+    if (estimateMessagesTokens(work) <= budgetTokens) {
+        return work;
+    }
+
+    // Phase 2: evict oldest rounds, preserving head + most-recent rounds.
+    work = evictOldestRounds(work, budgetTokens);
+    if (estimateMessagesTokens(work) <= budgetTokens) {
+        return work;
+    }
+
+    // Phase 3: shrink every remaining message's content until the window fits.
+    return hardTruncateToFit(work, budgetTokens);
 }

--- a/libs/agent-harness/infrastructure/compression/context-window-compressor.spec.ts
+++ b/libs/agent-harness/infrastructure/compression/context-window-compressor.spec.ts
@@ -1,0 +1,119 @@
+/**
+ * ContextWindowCompressor unit tests — the budget/clamp seam (issue #1574).
+ *
+ * The regression that mattered: an oversized window used to be returned
+ * unchanged (maybeCompress → null) once soft truncation couldn't save tokens,
+ * so the provider received a request larger than its context window and 400-ed
+ * the whole review. These tests pin the new invariant: the compressor NEVER
+ * hands back a window that still exceeds the real budget.
+ */
+import type { AgentMessage } from '@libs/agent-harness/domain/contracts/run-state.contract';
+
+import { ContextWindowCompressor } from './context-window-compressor';
+import { estimateMessagesTokens } from './context-compressor';
+
+function toModel(messages: AgentMessage[]) {
+    return messages.map((m) => ({ role: m.role, content: m.content }) as any);
+}
+
+/** A tool-loop window that has already blown well past the given window size. */
+function overflowingWindow(rounds: number, resultChars: number): AgentMessage[] {
+    const msgs: AgentMessage[] = [
+        { role: 'user', content: 'Review this diff:\n' + 'x'.repeat(2_000) },
+    ];
+    for (let i = 0; i < rounds; i++) {
+        msgs.push({
+            role: 'assistant',
+            content: [
+                { type: 'text', text: `investigating ${i}` },
+                {
+                    type: 'tool-call',
+                    toolCallId: `c${i}`,
+                    toolName: 'readFile',
+                    input: { path: `f${i}.ts` },
+                },
+            ] as any,
+        });
+        msgs.push({
+            role: 'tool',
+            content: [
+                {
+                    type: 'tool-result',
+                    toolCallId: `c${i}`,
+                    toolName: 'readFile',
+                    output: 'y'.repeat(resultChars),
+                },
+            ] as any,
+        });
+    }
+    return msgs;
+}
+
+describe('ContextWindowCompressor', () => {
+    it('returns null when the window is comfortably under budget', () => {
+        const c = new ContextWindowCompressor(200_000);
+        const small: AgentMessage[] = [
+            { role: 'user', content: 'tiny prompt' },
+            { role: 'assistant', content: 'ok' },
+        ];
+        expect(c.maybeCompress(small)).toBeNull();
+    });
+
+    it('returns null for a non-positive window', () => {
+        expect(new ContextWindowCompressor(0).maybeCompress([])).toBeNull();
+    });
+
+    it('clamps an overflowing window to fit window − overhead − margin', () => {
+        const contextWindow = 40_000;
+        const overheadTokens = 12_000; // system + tool schemas
+        const c = new ContextWindowCompressor(contextWindow, {
+            overheadTokens,
+            safetyMarginTokens: 2_000,
+        });
+        const msgs = overflowingWindow(40, 8_000);
+
+        const result = c.maybeCompress(msgs);
+        expect(result).not.toBeNull();
+
+        const budget = contextWindow - overheadTokens - 2_000; // 26_000
+        // The clamped messages must fit the real budget...
+        expect(result!.afterTokens).toBeLessThanOrEqual(budget);
+        // ...and the total request (messages + overhead) must fit the window.
+        expect(result!.afterTokens + overheadTokens).toBeLessThanOrEqual(
+            contextWindow,
+        );
+        // Sanity: it actually reduced the window.
+        expect(result!.afterTokens).toBeLessThan(result!.beforeTokens);
+    });
+
+    it('never returns a window that still overflows, even when soft truncation cannot save enough', () => {
+        // Overhead alone eats most of the window → the messages budget is tiny,
+        // so the soft pass can't get under it and the hard clamp MUST engage.
+        const contextWindow = 20_000;
+        const c = new ContextWindowCompressor(contextWindow, {
+            overheadTokens: 10_000,
+            safetyMarginTokens: 1_000,
+        });
+        const msgs = overflowingWindow(25, 6_000);
+
+        const result = c.maybeCompress(msgs);
+        // The old code returned null here (no savings) and shipped the overflow.
+        expect(result).not.toBeNull();
+
+        const budget = 20_000 - 10_000 - 1_000; // 9_000
+        expect(
+            estimateMessagesTokens(toModel(result!.messages as AgentMessage[])),
+        ).toBeLessThanOrEqual(budget);
+    });
+
+    it('preserves tool content as an array so the AI SDK does not crash on content.filter', () => {
+        const c = new ContextWindowCompressor(40_000, {
+            overheadTokens: 12_000,
+        });
+        const result = c.maybeCompress(overflowingWindow(40, 8_000));
+        const toolMsg = (result!.messages as AgentMessage[]).find(
+            (m) => m.role === 'tool',
+        );
+        expect(Array.isArray(toolMsg?.content)).toBe(true);
+    });
+});

--- a/libs/agent-harness/infrastructure/compression/context-window-compressor.ts
+++ b/libs/agent-harness/infrastructure/compression/context-window-compressor.ts
@@ -5,10 +5,18 @@
  * context) doesn't risk context overflow. Generic across consumers — both
  * code-review and the skills fetcher plug this in via CompressionPolicy.
  *
- * Maps the harness AgentMessage <-> AI SDK ModelMessage and reuses the
- * battle-tested shouldCompress/compressMessages. The investigation recap
- * (allToolCalls) is not threaded yet — passes [] (weaker recap, still
- * functional); a later step can wire the live tool-call history.
+ * Two-tier behavior (issue #1574):
+ *   - SOFT: when usage crosses the compression threshold, truncate older
+ *     tool-result text (recap-preserving) — the original best-effort pass.
+ *   - HARD CLAMP: when the messages alone still exceed the REAL budget
+ *     (window − system/tool-schema overhead − safety margin), evict oldest
+ *     turns and truncate until the request provably fits. Unlike the old
+ *     behavior, this NEVER returns the window unchanged while it overflows — an
+ *     oversized request used to be sent verbatim and 400-ed the whole review.
+ *
+ * The investigation recap (allToolCalls) is not threaded yet — passes []
+ * (weaker recap, still functional); a later step can wire the live tool-call
+ * history.
  */
 import type { ModelMessage } from 'ai';
 
@@ -19,13 +27,47 @@ import type {
 import type { AgentMessage } from '@libs/agent-harness/domain/contracts/run-state.contract';
 
 import {
+    clampMessagesToBudget,
     compressMessages,
     estimateMessagesTokens,
-    shouldCompress,
+    COMPRESSION_THRESHOLD_RATIO,
 } from './context-compressor';
 
+/**
+ * Fraction of the window kept free by default for the model's own response plus
+ * drift between our tokenizer and the provider's exact count. Overridable.
+ */
+const DEFAULT_SAFETY_MARGIN_RATIO = 0.08;
+
+export interface ContextWindowCompressorOptions {
+    /**
+     * Fixed per-request overhead (system prompt + tool-schema block) the
+     * provider always adds on top of the messages. Excluded from the old
+     * estimate — part of why the request overflowed. Defaults to 0.
+     */
+    overheadTokens?: number;
+    /**
+     * Absolute token headroom kept free (response + tokenizer drift). Defaults
+     * to `DEFAULT_SAFETY_MARGIN_RATIO` of the window.
+     */
+    safetyMarginTokens?: number;
+}
+
 export class ContextWindowCompressor implements Compressor {
-    constructor(private readonly contextWindowTokens: number) {}
+    private readonly overheadTokens: number;
+    private readonly safetyMarginTokens: number;
+
+    constructor(
+        private readonly contextWindowTokens: number,
+        options: ContextWindowCompressorOptions = {},
+    ) {
+        this.overheadTokens = Math.max(0, options.overheadTokens ?? 0);
+        this.safetyMarginTokens = Math.max(
+            0,
+            options.safetyMarginTokens ??
+                Math.ceil(contextWindowTokens * DEFAULT_SAFETY_MARGIN_RATIO),
+        );
+    }
 
     maybeCompress(
         messages: readonly AgentMessage[],
@@ -36,23 +78,55 @@ export class ContextWindowCompressor implements Compressor {
         const modelMsgs: ModelMessage[] = messages.map(
             (m) => ({ role: m.role, content: m.content }) as ModelMessage,
         );
-        const check = shouldCompress(modelMsgs, this.contextWindowTokens);
-        if (!check.should) return null;
 
-        const compressed = compressMessages(modelMsgs, []);
-        const after = estimateMessagesTokens(compressed);
-        if (after >= check.currentTokens) return null; // no real savings
+        // Real budget available to the MESSAGES themselves: the window minus the
+        // fixed overhead the provider re-adds every request and a safety margin.
+        const budget = Math.max(
+            0,
+            this.contextWindowTokens -
+                this.overheadTokens -
+                this.safetyMarginTokens,
+        );
+
+        const current = estimateMessagesTokens(modelMsgs);
+        const usage = current + this.overheadTokens;
+
+        // Soft trigger: total usage crosses the compression threshold. Hard
+        // trigger: the messages alone already exceed the real budget.
+        const softTrigger =
+            usage > this.contextWindowTokens * COMPRESSION_THRESHOLD_RATIO;
+        const overBudget = current > budget;
+        if (!softTrigger && !overBudget) {
+            return null;
+        }
+
+        // 1. Soft pass: truncate older tool-result text (recap-preserving).
+        let compressed = compressMessages(modelMsgs, []);
+        let after = estimateMessagesTokens(compressed);
+
+        // 2. Hard clamp: guarantee the messages fit the real budget. This is the
+        //    invariant the old "return null on no savings" path violated — an
+        //    oversized window was sent verbatim and overflowed the provider.
+        if (after > budget) {
+            compressed = clampMessagesToBudget(compressed, budget);
+            after = estimateMessagesTokens(compressed);
+        }
+
+        // Nothing to gain AND we were never over budget → leave the window as-is.
+        if (after >= current && !overBudget) {
+            return null;
+        }
 
         return {
-            // Return content as-is: compressMessages already truncated the
-            // tool-result text while preserving the parts structure. Stringifying
-            // here would re-flatten `tool` turns and crash the SDK on
-            // `content.filter` when this window is handed back to generateText.
+            // Return content as-is: the truncation/eviction above already
+            // preserved the parts structure. Stringifying here would re-flatten
+            // `tool` turns and crash the SDK on `content.filter` when this
+            // window is handed back to generateText.
             messages: compressed.map((m) => ({
                 role: m.role as AgentMessage['role'],
                 content: m.content as AgentMessage['content'],
             })),
-            beforeTokens: check.currentTokens,
+            beforeTokens: current,
             afterTokens: after,
         };
     }

--- a/libs/agent-harness/infrastructure/compression/token-estimator.spec.ts
+++ b/libs/agent-harness/infrastructure/compression/token-estimator.spec.ts
@@ -1,0 +1,70 @@
+/**
+ * token-estimator unit tests — tokenizer-backed counting (issue #1574).
+ *
+ * The whole point of the fix is that dense code does NOT tokenize at the old
+ * flat 4-chars/token rate. These tests pin the two properties the compressor
+ * relies on: (1) counts are non-trivial and (2) dense code counts materially
+ * higher than chars/4 (i.e. the estimate no longer under-counts).
+ */
+import {
+    estimateOverheadTokens,
+    estimateTextTokens,
+    estimateValueTokens,
+} from './token-estimator';
+
+describe('estimateTextTokens', () => {
+    it('returns 0 for empty input', () => {
+        expect(estimateTextTokens('')).toBe(0);
+    });
+
+    it('counts dense code well above the old flat chars/4 estimate', () => {
+        // i18n-ish dense JS: the failure mode from the issue (~2.6–2.8 chars/tok).
+        const dense = `const t = useTranslation();\nreturn t("some.very.deep.i18n.key.path.here");\n`.repeat(
+            50,
+        );
+        const flat4 = Math.ceil(dense.length / 4);
+        const real = estimateTextTokens(dense);
+        // Real tokenizer must count MORE tokens than the flat-4 undercount.
+        expect(real).toBeGreaterThan(flat4);
+    });
+
+    it('does not throw on special-token-like sequences in diffs', () => {
+        expect(() =>
+            estimateTextTokens('before <|endoftext|> after'),
+        ).not.toThrow();
+        expect(estimateTextTokens('before <|endoftext|> after')).toBeGreaterThan(
+            0,
+        );
+    });
+});
+
+describe('estimateValueTokens', () => {
+    it('serializes objects before counting', () => {
+        expect(estimateValueTokens({ a: 'hello', b: 'world' })).toBeGreaterThan(
+            0,
+        );
+    });
+
+    it('returns 0 for null/undefined', () => {
+        expect(estimateValueTokens(null)).toBe(0);
+        expect(estimateValueTokens(undefined)).toBe(0);
+    });
+});
+
+describe('estimateOverheadTokens', () => {
+    it('sums the system prompt and every tool schema', () => {
+        const system = 'You are a code reviewer. '.repeat(20);
+        const tools = [
+            { name: 'readFile', description: 'read', inputSchema: {} },
+            { name: 'grep', description: 'search', inputSchema: {} },
+        ];
+        const total = estimateOverheadTokens(system, tools);
+        const systemOnly = estimateOverheadTokens(system, []);
+        expect(systemOnly).toBeGreaterThan(0);
+        expect(total).toBeGreaterThan(systemOnly);
+    });
+
+    it('handles an undefined system prompt', () => {
+        expect(estimateOverheadTokens(undefined, [])).toBe(0);
+    });
+});

--- a/libs/agent-harness/infrastructure/compression/token-estimator.ts
+++ b/libs/agent-harness/infrastructure/compression/token-estimator.ts
@@ -1,0 +1,102 @@
+/**
+ * agent-harness — real-tokenizer token counting for the compression path.
+ *
+ * The compressor used to estimate tokens at a flat 4 chars/token. Dense code
+ * (JS/Vue + i18n JSON) tokenizes closer to ~2.6–2.8 chars/token, so that
+ * estimate under-counted the real request by ~1.6× — the exact factor behind
+ * the mid-loop context-window overflow (issue #1574): the compressor believed
+ * it was under budget while the provider already saw the request over the
+ * window (`requested: 421869` against a `262144` window ≈ 1.6×).
+ *
+ * We count with tiktoken's `o200k_base` encoding (the GPT-4o family
+ * vocabulary). It is NOT the exact tokenizer of every BYOK model, but it is a
+ * far tighter bound than chars/4 across the code + JSON we send, and being
+ * model-agnostic keeps this harness free of per-provider coupling. `encode_
+ * ordinary` is used so special-token-like sequences in diffs (e.g.
+ * `<|endoftext|>`) count as plain text instead of throwing. On any failure
+ * (WASM load, encode throw) we fall back to a conservative chars/token ratio so
+ * token counting never crashes the agent loop.
+ */
+import { get_encoding, type Tiktoken } from 'tiktoken';
+
+/**
+ * Conservative fallback ratio when the tokenizer is unavailable. Dense code is
+ * closer to ~3 chars/token than 4, so the fallback still doesn't systematically
+ * under-count the way the old flat-4 estimate did.
+ */
+export const FALLBACK_CHARS_PER_TOKEN = 3;
+
+let encoder: Tiktoken | null = null;
+let encoderFailed = false;
+
+function getEncoder(): Tiktoken | null {
+    if (encoder) {
+        return encoder;
+    }
+    if (encoderFailed) {
+        return null;
+    }
+    try {
+        encoder = get_encoding('o200k_base');
+        return encoder;
+    } catch {
+        // WASM unavailable / load failure — never retry, use the char fallback.
+        encoderFailed = true;
+        return null;
+    }
+}
+
+/** Token count of a single string, tokenizer-backed with a safe fallback. */
+export function estimateTextTokens(text: string): number {
+    if (!text) {
+        return 0;
+    }
+    const enc = getEncoder();
+    if (enc) {
+        try {
+            return enc.encode_ordinary(text).length;
+        } catch {
+            // fall through to the char estimate
+        }
+    }
+    return Math.ceil(text.length / FALLBACK_CHARS_PER_TOKEN);
+}
+
+/**
+ * Token count of a message-like value. Objects are JSON-serialized first so the
+ * structured `tool` / `tool-call` parts are counted the same way the provider
+ * sees them on the wire.
+ */
+export function estimateValueTokens(value: unknown): number {
+    if (value == null) {
+        return 0;
+    }
+    if (typeof value === 'string') {
+        return estimateTextTokens(value);
+    }
+    let serialized: string;
+    try {
+        serialized = JSON.stringify(value);
+    } catch {
+        serialized = String(value);
+    }
+    return estimateTextTokens(serialized);
+}
+
+/**
+ * Fixed per-request overhead the provider adds on top of the conversation
+ * messages: the system prompt plus the tool-schema block the AI SDK re-sends on
+ * every step. Counting this (the old estimator ignored it) is what lets the
+ * compressor reserve a real budget for the messages instead of over-committing
+ * the window (issue #1574).
+ */
+export function estimateOverheadTokens(
+    systemPrompt: string | undefined,
+    toolDefs: readonly unknown[],
+): number {
+    let total = estimateTextTokens(systemPrompt ?? '');
+    for (const def of toolDefs) {
+        total += estimateValueTokens(def);
+    }
+    return total;
+}

--- a/libs/code-review/infrastructure/agents/core/core-agent-loop.adapter.ts
+++ b/libs/code-review/infrastructure/agents/core/core-agent-loop.adapter.ts
@@ -33,6 +33,7 @@ import {
     buildFinderAgentSpec,
     runFinderWithVerify,
     recoverFindingsFromProse,
+    submitResultTool,
 } from '@libs/code-review/infrastructure/agents/core/finder.agent';
 import {
     buildFindingsFromVerify,
@@ -124,8 +125,14 @@ export async function runAgentLoopViaCore(
     // re-sends on EVERY step. Counting it lets the compressor reserve a real
     // budget for the accumulating tool-loop messages instead of over-committing
     // the window — the miss behind the mid-loop overflow (issue #1574).
+    // buildFinderAgentSpec adds submitResultTool to the model's tool set, so its
+    // schema (~210 tokens) is part of the real overhead and must be counted too
+    // — it matters on small windows where the safety margin is tight.
     const overheadTokens = contextWindowTokens
-        ? estimateOverheadTokens(input.systemPrompt, tools.list())
+        ? estimateOverheadTokens(input.systemPrompt, [
+              ...tools.list(),
+              submitResultTool,
+          ])
         : 0;
     // The AgentSpec.modelId is NOT used to resolve the model (the runner's
     // resolver above ignores it and always returns `model`). It IS used to

--- a/libs/code-review/infrastructure/agents/core/core-agent-loop.adapter.ts
+++ b/libs/code-review/infrastructure/agents/core/core-agent-loop.adapter.ts
@@ -24,6 +24,7 @@
 import { AiSdkAgentRunner } from '@libs/agent-harness/infrastructure/ai-sdk/ai-sdk-agent-runner';
 
 import { ContextWindowCompressor } from '@libs/agent-harness/infrastructure/compression/context-window-compressor';
+import { estimateOverheadTokens } from '@libs/agent-harness/infrastructure/compression/token-estimator';
 import { DiffCoverageLedger } from '@libs/code-review/infrastructure/agents/adapters/diff-coverage-ledger.adapter';
 import { buildFinderToolRegistry } from '@libs/code-review/infrastructure/agents/adapters/finder-tools.adapter';
 import { wrapByokModel } from '@libs/llm/byok-model-wrapper';
@@ -119,6 +120,13 @@ export async function runAgentLoopViaCore(
     const skipSynthesisRescue = !!input.skipSynthesisRescue;
 
     const contextWindowTokens = input.contextWindowTokens;
+    // Fixed per-request overhead (system prompt + tool schemas) the provider
+    // re-sends on EVERY step. Counting it lets the compressor reserve a real
+    // budget for the accumulating tool-loop messages instead of over-committing
+    // the window — the miss behind the mid-loop overflow (issue #1574).
+    const overheadTokens = contextWindowTokens
+        ? estimateOverheadTokens(input.systemPrompt, tools.list())
+        : 0;
     // The AgentSpec.modelId is NOT used to resolve the model (the runner's
     // resolver above ignores it and always returns `model`). It IS used to
     // decide provider-native strict tool use (supportsStrictTools), so pass the
@@ -132,7 +140,9 @@ export async function runAgentLoopViaCore(
             tools,
             coverageLedger: ledger,
             compressor: contextWindowTokens
-                ? new ContextWindowCompressor(contextWindowTokens)
+                ? new ContextWindowCompressor(contextWindowTokens, {
+                      overheadTokens,
+                  })
                 : undefined,
             maxSteps: input.maxSteps ?? 20,
             providerOptions,

--- a/libs/code-review/infrastructure/agents/core/finder.agent.ts
+++ b/libs/code-review/infrastructure/agents/core/finder.agent.ts
@@ -124,8 +124,11 @@ const SUBMIT_RESULT_SCHEMA: JSONSchema = {
 };
 
 /** The done tool. No-op execute: it is a finalize SIGNAL the CompletionGatePolicy
- *  detects by name; its input (the findings) is captured in the RunState. */
-const submitResultTool: AgentTool = {
+ *  detects by name; its input (the findings) is captured in the RunState.
+ *  Exported so the overhead estimator (core-agent-loop.adapter) counts its
+ *  schema — buildFinderAgentSpec always adds it to the model's tool set, so it
+ *  is real per-request overhead. */
+export const submitResultTool: AgentTool = {
     name: FINDER_DONE_TOOL,
     description:
         'Submit your final findings and end the review. Call this once you have investigated the changed code.',


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Fixes the mid-loop context-window overflow in the agent harness that caused provider 400 errors and failed code reviews (issue #1574).

## Root cause

The compression path had three gaps that let an oversized request reach the LLM:

1. **Token estimation under-counted dense code** — the old estimate assumed 1 token ≈ 4 characters, but real code + i18n JSON tokenizes closer to ~2.6–2.8 chars/token (~1.6× under-count).
2. **Fixed per-request overhead was ignored** — the system prompt and tool schemas are re-sent on every step but were not counted against the window budget.
3. **No hard guarantee** — the soft compression pass was best-effort; if it couldn't save enough tokens it returned the window unchanged, shipping an oversized request that overflowed the provider.

## Changes

- **Real tokenizer-backed counting** (`token-estimator.ts`): token counts now use tiktoken's `o200k_base` encoding, with a conservative fallback so counting never crashes the loop.
- **Overhead estimation**: system prompt + all tool schemas (including the `submitResult` tool) are counted once per request and subtracted from the window alongside a configurable safety margin.
- **Hard per-request clamp** (`clampMessagesToBudget`): guarantees the returned conversation window fits the real message budget via three escalating, structure-preserving phases:
  1. Aggressively truncate all tool-result text to a small cap.
  2. Evict whole oldest tool rounds (assistant call + its results) while preserving the initial diff and most-recent turns.
  3. Last resort: shrink remaining message content until it fits.
- **Structural safety**: clamping always keeps `tool` results paired with their assistant tool-calls and keeps tool content as arrays, so the AI SDK never crashes on orphaned results or flattened content.
- **Wired into the code-review agent loop**: `runAgentLoopViaCore` now computes the real overhead and passes it to `ContextWindowCompressor`.
- **Tests**: unit tests for the token estimator, clamp, and compressor behavior, plus an e2e regression test that drives an accumulating 12-step tool loop and verifies the run compresses, completes cleanly, and produces findings.
- **CI**: code-review evals now also trigger when `libs/agent-harness/**` changes.
<!-- kody-pr-summary:end -->