### PR TITLE
fix: add orphaned job reaper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -857,6 +857,20 @@ API_CRON_SSO_TEST_SESSION_CLEANUP="0 1 * * *"
 # (type: cron)
 API_CRON_STALE_REVIEW_WATCHDOG="*/30 * * * *"
 
+# Cadence of the workflow-jobs stale-PROCESSING reaper, which fails jobs
+# left in PROCESSING when a worker was killed mid-processing (OOM/eviction).
+# The eligibility threshold (WORKFLOW_STALE_JOB_TIMEOUT_MINUTES) still bounds
+# what can be reaped, so cadence only affects how quickly orphans are caught.
+# (type: cron)
+WORKFLOW_STALE_JOB_REAPER_CRON="0 */10 * * * *"
+
+# Minutes a workflow job may sit in PROCESSING before the reaper marks it
+# FAILED. Must exceed the longest legitimate run — the 105min job-abort
+# timeout and the 150min inbox claim timeout — so live jobs are never reaped;
+# 180 leaves margin.
+# (type: number)
+WORKFLOW_STALE_JOB_TIMEOUT_MINUTES=180
+
 # Per-handler prefetch (in-flight messages) for the check-implementation
 # workflow handler.
 # (type: number)

--- a/.env.schema
+++ b/.env.schema
@@ -1239,6 +1239,22 @@ API_CRON_SSO_TEST_SESSION_CLEANUP=0 1 * * *
 # kodus: audience=both
 API_CRON_STALE_REVIEW_WATCHDOG=*/30 * * * *
 
+# Cadence of the workflow-jobs stale-PROCESSING reaper, which fails jobs
+# left in PROCESSING when a worker was killed mid-processing (OOM/eviction).
+# The eligibility threshold (WORKFLOW_STALE_JOB_TIMEOUT_MINUTES) still bounds
+# what can be reaped, so cadence only affects how quickly orphans are caught.
+# @type=cron
+# kodus: audience=both
+WORKFLOW_STALE_JOB_REAPER_CRON=0 */10 * * * *
+
+# Minutes a workflow job may sit in PROCESSING before the reaper marks it
+# FAILED. Must exceed the longest legitimate run — the 105min job-abort
+# timeout and the 150min inbox claim timeout — so live jobs are never reaped;
+# 180 leaves margin.
+# @type=number
+# kodus: audience=both
+WORKFLOW_STALE_JOB_TIMEOUT_MINUTES=180
+
 # ============================================================
 # Workflow queue — autoscale + circuit breaker (advanced tuning)
 # Defaults are baked into the loader; override only when scaling needs.

--- a/.env.template
+++ b/.env.template
@@ -867,6 +867,20 @@ API_CRON_SSO_TEST_SESSION_CLEANUP="0 1 * * *"
 # (type: cron)
 API_CRON_STALE_REVIEW_WATCHDOG="*/30 * * * *"
 
+# Cadence of the workflow-jobs stale-PROCESSING reaper, which fails jobs
+# left in PROCESSING when a worker was killed mid-processing (OOM/eviction).
+# The eligibility threshold (WORKFLOW_STALE_JOB_TIMEOUT_MINUTES) still bounds
+# what can be reaped, so cadence only affects how quickly orphans are caught.
+# (type: cron)
+WORKFLOW_STALE_JOB_REAPER_CRON="0 */10 * * * *"
+
+# Minutes a workflow job may sit in PROCESSING before the reaper marks it
+# FAILED. Must exceed the longest legitimate run — the 105min job-abort
+# timeout and the 150min inbox claim timeout — so live jobs are never reaped;
+# 180 leaves margin.
+# (type: number)
+WORKFLOW_STALE_JOB_TIMEOUT_MINUTES=180
+
 # Per-handler prefetch (in-flight messages) for the check-implementation
 # workflow handler.
 # (type: number)

--- a/docs/_snippets/env-vars-generated.mdx
+++ b/docs/_snippets/env-vars-generated.mdx
@@ -347,6 +347,8 @@
 | `API_CRON_CLASSIFY_ORPHANED_SESSIONS` | – | cron | ⚙️ Both | Reclassifies orphaned (no-PR) review sessions every 15 minutes. Cloud-only feature. |
 | `API_CRON_SSO_TEST_SESSION_CLEANUP` | – | cron | ☁️ Cloud | Daily cleanup of expired SSO test sessions (1 AM UTC). |
 | `API_CRON_STALE_REVIEW_WATCHDOG` | – | cron | ⚙️ Both | Reaps code review executions stuck IN_PROGRESS (process died mid-review) and finalizes their orphaned platform check runs. |
+| `WORKFLOW_STALE_JOB_REAPER_CRON` | – | cron | ⚙️ Both | Cadence of the workflow-jobs stale-PROCESSING reaper, which fails jobs left in PROCESSING when a worker was killed mid-processing (OOM/eviction). The eligibility threshold (WORKFLOW_STALE_JOB_TIMEOUT_MINUTES) still bounds what can be reaped, so cadence only affects how quickly orphans are caught. |
+| `WORKFLOW_STALE_JOB_TIMEOUT_MINUTES` | – | number | ⚙️ Both | Minutes a workflow job may sit in PROCESSING before the reaper marks it FAILED. Must exceed the longest legitimate run — the 105min job-abort timeout and the 150min inbox claim timeout — so live jobs are never reaped; 180 leaves margin. |
 | `WORKFLOW_QUEUE_CHECK_IMPLEMENTATION_PREFETCH` | – | number | ⚙️ Both (opt-in) | Per-handler prefetch (in-flight messages) for the check-implementation workflow handler. |
 | `WORKFLOW_QUEUE_CHECK_IMPLEMENTATION_TIMEOUT_MS` | – | number | ⚙️ Both (opt-in) | Hard timeout (ms) for a check-implementation handler invocation. |
 | `WORKFLOW_QUEUE_FEEDBACK_PREFETCH` | – | number | ⚙️ Both (opt-in) | Per-handler prefetch for the feedback workflow handler. |

--- a/libs/core/workflow/domain/contracts/workflow-job.repository.contract.ts
+++ b/libs/core/workflow/domain/contracts/workflow-job.repository.contract.ts
@@ -1,3 +1,10 @@
+export interface StaleWorkflowJobReapResult {
+    uuid: string;
+    workflowType: string;
+    organizationId: string | null;
+    startedAt: Date | null;
+}
+
 export interface IWorkflowJobRepository {
     create(job: any, transactionManager?: unknown): Promise<any>;
     update(id: string, data: any): Promise<any>;
@@ -7,6 +14,16 @@ export interface IWorkflowJobRepository {
         olderThan: Date;
         limit?: number;
     }): Promise<number>;
+    /**
+     * Reaps jobs orphaned in PROCESSING (worker SIGKILLed before any
+     * terminal update). Flips PROCESSING rows whose updatedAt is older than
+     * `olderThan` to FAILED and returns the reaped rows for logging.
+     */
+    failStaleProcessing?(params: {
+        olderThan: Date;
+        lastError: string;
+        errorClassification: unknown;
+    }): Promise<StaleWorkflowJobReapResult[]>;
 }
 
 export const WORKFLOW_JOB_REPOSITORY_TOKEN = Symbol.for(

--- a/libs/core/workflow/infrastructure/outbox-relay.service.spec.ts
+++ b/libs/core/workflow/infrastructure/outbox-relay.service.spec.ts
@@ -1,4 +1,18 @@
-import { INBOX_REAPER_CONSUMER_TIMEOUTS } from './outbox-relay.service';
+import { ErrorClassification } from '@libs/core/workflow/domain/enums/error-classification.enum';
+
+import {
+    INBOX_REAPER_CONSUMER_TIMEOUTS,
+    OutboxRelayService,
+} from './outbox-relay.service';
+
+jest.mock('@libs/core/log/logger', () => ({
+    createLogger: jest.fn().mockReturnValue({
+        log: jest.fn(),
+        debug: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    }),
+}));
 
 describe('INBOX_REAPER_CONSUMER_TIMEOUTS', () => {
     it('covers every workflow consumer that claims inbox messages', () => {
@@ -13,5 +27,136 @@ describe('INBOX_REAPER_CONSUMER_TIMEOUTS', () => {
                 'workflow-job-consumer.webhook',
             ].sort(),
         );
+    });
+});
+
+describe('OutboxRelayService.reapStaleProcessingJobs', () => {
+    const DEFAULT_TIMEOUT_MIN = 180;
+
+    let jobRepository: { failStaleProcessing: jest.Mock };
+    let lock: { release: jest.Mock };
+    let distributedLockService: { acquire: jest.Mock };
+    let incidentManager: { failHeartbeat: jest.Mock };
+
+    const build = () => {
+        jobRepository = {
+            failStaleProcessing: jest.fn().mockResolvedValue([]),
+        };
+        lock = { release: jest.fn().mockResolvedValue(undefined) };
+        distributedLockService = {
+            acquire: jest.fn().mockResolvedValue(lock),
+        };
+        incidentManager = {
+            failHeartbeat: jest.fn().mockResolvedValue(undefined),
+        };
+
+        const configService = { get: jest.fn() };
+
+        return new OutboxRelayService(
+            {} as any, // outboxRepository
+            {} as any, // inboxRepository
+            jobRepository as any, // jobRepository
+            {} as any, // messageBroker
+            {} as any, // observability
+            configService as any,
+            distributedLockService as any,
+            {} as any, // sandboxLeaseManager
+            incidentManager as any,
+        );
+    };
+
+    beforeEach(() => {
+        delete process.env.WORKFLOW_STALE_JOB_TIMEOUT_MINUTES;
+    });
+
+    it('reaps PROCESSING jobs older than the timeout as FAILED/PERMANENT', async () => {
+        const service = build();
+        const before = Date.now();
+
+        await service.reapStaleProcessingJobs();
+
+        expect(distributedLockService.acquire).toHaveBeenCalledTimes(1);
+        expect(jobRepository.failStaleProcessing).toHaveBeenCalledTimes(1);
+
+        const arg = jobRepository.failStaleProcessing.mock.calls[0][0];
+        expect(arg.errorClassification).toBe(ErrorClassification.PERMANENT);
+        expect(typeof arg.lastError).toBe('string');
+        expect(arg.lastError.length).toBeGreaterThan(0);
+
+        // cutoff ~ now - 180min (allow a generous window for test slowness)
+        const expected = before - DEFAULT_TIMEOUT_MIN * 60 * 1000;
+        expect(arg.olderThan.getTime()).toBeGreaterThanOrEqual(
+            expected - 5000,
+        );
+        expect(arg.olderThan.getTime()).toBeLessThanOrEqual(expected + 5000);
+
+        expect(lock.release).toHaveBeenCalledTimes(1);
+    });
+
+    it('does nothing when the distributed lock is not acquired', async () => {
+        const service = build();
+        distributedLockService.acquire.mockResolvedValue(null);
+
+        await service.reapStaleProcessingJobs();
+
+        expect(jobRepository.failStaleProcessing).not.toHaveBeenCalled();
+    });
+
+    it('honors WORKFLOW_STALE_JOB_TIMEOUT_MINUTES override', async () => {
+        process.env.WORKFLOW_STALE_JOB_TIMEOUT_MINUTES = '30';
+        const service = build();
+        const before = Date.now();
+
+        await service.reapStaleProcessingJobs();
+
+        const arg = jobRepository.failStaleProcessing.mock.calls[0][0];
+        const expected = before - 30 * 60 * 1000;
+        expect(arg.olderThan.getTime()).toBeGreaterThanOrEqual(
+            expected - 5000,
+        );
+        expect(arg.olderThan.getTime()).toBeLessThanOrEqual(expected + 5000);
+    });
+
+    it('raises a high-reap-rate incident when many jobs are orphaned', async () => {
+        const service = build();
+        jobRepository.failStaleProcessing.mockResolvedValue(
+            Array.from({ length: 6 }, (_, i) => ({
+                uuid: `job-${i}`,
+                workflowType: 'CODE_REVIEW',
+                organizationId: 'org-1',
+                startedAt: new Date(),
+            })),
+        );
+
+        await service.reapStaleProcessingJobs();
+
+        expect(incidentManager.failHeartbeat).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not raise an incident for a small reap batch', async () => {
+        const service = build();
+        jobRepository.failStaleProcessing.mockResolvedValue([
+            {
+                uuid: 'job-1',
+                workflowType: 'CODE_REVIEW',
+                organizationId: 'org-1',
+                startedAt: new Date(),
+            },
+        ]);
+
+        await service.reapStaleProcessingJobs();
+
+        expect(incidentManager.failHeartbeat).not.toHaveBeenCalled();
+    });
+
+    it('always releases the lock, even when the repository throws', async () => {
+        const service = build();
+        jobRepository.failStaleProcessing.mockRejectedValue(
+            new Error('db down'),
+        );
+
+        await service.reapStaleProcessingJobs();
+
+        expect(lock.release).toHaveBeenCalledTimes(1);
     });
 });

--- a/libs/core/workflow/infrastructure/outbox-relay.service.ts
+++ b/libs/core/workflow/infrastructure/outbox-relay.service.ts
@@ -65,6 +65,24 @@ const OUTBOX_BACKOFF: BackoffOptions = {
 const DEFAULT_OUTBOX_MAX_ATTEMPTS = 10;
 const DEFAULT_OUTBOX_PUBLISH_TIMEOUT_MS = 15000;
 
+// A job orphaned in PROCESSING beyond this is unrecoverable: the worker
+// that owned it died without a terminal update. Must sit above every
+// legitimate recovery window — the 105-min job abort timeout
+// (job-processor-router.service.ts) and the 150-min inbox claim timeout —
+// so an actively running or reclaimable job is never reaped.
+const DEFAULT_STALE_JOB_TIMEOUT_MINUTES = 180;
+
+// Above this many orphans reaped in a single pass, fire the incident
+// heartbeat — a spike means workers are crash-looping.
+const STALE_JOB_HIGH_REAP_THRESHOLD = 5;
+
+// Cadence of the stale-job reaper. Overridable for ops/testing; the
+// threshold (WORKFLOW_STALE_JOB_TIMEOUT_MINUTES) still bounds eligibility,
+// so a faster cadence only means quicker detection, never earlier reaping.
+const STALE_JOB_REAPER_CRON =
+    process.env.WORKFLOW_STALE_JOB_REAPER_CRON ||
+    CronExpression.EVERY_10_MINUTES;
+
 export const INBOX_REAPER_CONSUMER_TIMEOUTS = {
     'workflow-job-consumer.webhook': 20 * 60 * 1000,
     'workflow-job-consumer.check_implementation': 20 * 60 * 1000,
@@ -105,6 +123,10 @@ export class OutboxRelayService
     private readonly publishTimeoutMs = parsePositiveIntEnv(
         'WORKFLOW_OUTBOX_PUBLISH_TIMEOUT_MS',
         DEFAULT_OUTBOX_PUBLISH_TIMEOUT_MS,
+    );
+    private readonly staleJobTimeoutMinutes = parsePositiveIntEnv(
+        'WORKFLOW_STALE_JOB_TIMEOUT_MINUTES',
+        DEFAULT_STALE_JOB_TIMEOUT_MINUTES,
     );
 
     private readonly BATCH_SIZE = 50;
@@ -456,6 +478,110 @@ export class OutboxRelayService
                 'workflow.operation': 'reclaim_inbox',
             },
         );
+    }
+
+    /**
+     * Reaper for workflow jobs orphaned in PROCESSING.
+     *
+     * A worker SIGKILLed mid-job (OOM / node eviction / /tmp overflow) never
+     * runs the consumer's catch/finally, so its workflow_jobs row is left at
+     * PROCESSING forever: the inbox reaper frees the message lock, but the
+     * requeued RabbitMQ message is rejected as "already claimed" and DLQ'd
+     * (the DLX has no consumer) long before the 150-min claim can be
+     * reclaimed — so the job is never reprocessed and no other path resets
+     * its status. This flips such rows to FAILED so they stop reporting as
+     * running, are observable, and can be re-driven by a new review.
+     *
+     * The UI "in progress" badge is reaped separately by the automation
+     * execution watchdog (staleReviewWatchdog.cron); this closes the job
+     * layer, which also covers workflow types that have no automation
+     * execution row (check_implementation, AST graph builds).
+     */
+    @Cron(STALE_JOB_REAPER_CRON, { name: 'workflow-stale-job-reaper' })
+    async reapStaleProcessingJobs(): Promise<void> {
+        const lock = await this.acquireCronLock(
+            'CRON:WORKFLOW:STALE_JOB_REAPER',
+            4 * 60 * 1000,
+        );
+        if (!lock) {
+            return;
+        }
+
+        try {
+            const olderThan = new Date(
+                Date.now() - this.staleJobTimeoutMinutes * 60 * 1000,
+            );
+
+            const reaped = await this.jobRepository.failStaleProcessing?.({
+                olderThan,
+                lastError: `Orphaned: worker crashed/evicted while job was PROCESSING (no terminal update within ${this.staleJobTimeoutMinutes}min). Reaped by stale-job watchdog.`,
+                errorClassification: ErrorClassification.PERMANENT,
+            });
+
+            const reapedCount = reaped?.length ?? 0;
+            if (reapedCount === 0) {
+                return;
+            }
+
+            this.logger.warn({
+                message: `Reaped ${reapedCount} stale PROCESSING workflow jobs`,
+                context: OutboxRelayService.name,
+                metadata: {
+                    reapedCount,
+                    staleTimeoutMinutes: this.staleJobTimeoutMinutes,
+                    olderThan: olderThan.toISOString(),
+                    jobs: reaped.map((job) => ({
+                        jobId: job.uuid,
+                        workflowType: job.workflowType,
+                        organizationId: job.organizationId,
+                        startedAt: job.startedAt,
+                    })),
+                },
+            });
+
+            if (reapedCount > STALE_JOB_HIGH_REAP_THRESHOLD) {
+                this.logger.error({
+                    message: `HIGH REAP RATE: ${reapedCount} workflow jobs orphaned in PROCESSING!`,
+                    context: OutboxRelayService.name,
+                    metadata: {
+                        reapedCount,
+                        possibleCause:
+                            'Worker crashes/evictions (OOM, node pressure, restarts)',
+                    },
+                });
+
+                this.incidentManager
+                    ?.failHeartbeat(
+                        'API_BETTERSTACK_HEARTBEAT_OUTBOX_URL',
+                        `High stale-job reap rate: ${reapedCount} workflow jobs orphaned in PROCESSING. Possible cause: worker crashes/evictions (OOM, node pressure, restarts). ${this.formatContext(
+                            {
+                                monitor: 'stale_job_reap_rate',
+                                reapedCount,
+                            },
+                        )}`,
+                    )
+                    .catch((err) => {
+                        this.logger.error({
+                            message:
+                                'Failed to report stale-job reap heartbeat failure',
+                            context: OutboxRelayService.name,
+                            error: err instanceof Error ? err : undefined,
+                            metadata: { reapedCount },
+                        });
+                    });
+            }
+        } catch (error) {
+            this.logger.error({
+                message: 'Failed to reap stale PROCESSING workflow jobs',
+                context: OutboxRelayService.name,
+                error: error instanceof Error ? error : undefined,
+            });
+        } finally {
+            await this.releaseCronLock(
+                lock,
+                'Failed to release stale-job reaper lock',
+            );
+        }
     }
 
     /**

--- a/libs/core/workflow/infrastructure/repositories/workflow-job.repository.spec.ts
+++ b/libs/core/workflow/infrastructure/repositories/workflow-job.repository.spec.ts
@@ -1,0 +1,99 @@
+import { JobStatus } from '@libs/core/workflow/domain/enums/job-status.enum';
+import { ErrorClassification } from '@libs/core/workflow/domain/enums/error-classification.enum';
+
+import { WorkflowJobRepository } from './workflow-job.repository';
+import { WorkflowJobModel } from './schemas/workflow-job.model';
+
+jest.mock('@libs/core/log/logger', () => ({
+    createLogger: jest.fn().mockReturnValue({
+        log: jest.fn(),
+        debug: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    }),
+}));
+
+describe('WorkflowJobRepository.failStaleProcessing', () => {
+    let qb: {
+        update: jest.Mock;
+        set: jest.Mock;
+        where: jest.Mock;
+        andWhere: jest.Mock;
+        returning: jest.Mock;
+        execute: jest.Mock;
+    };
+    let repository: { createQueryBuilder: jest.Mock };
+    let repo: WorkflowJobRepository;
+
+    const olderThan = new Date('2026-07-01T00:00:00Z');
+    const lastError = 'Orphaned: worker crashed while PROCESSING';
+
+    beforeEach(() => {
+        qb = {
+            update: jest.fn().mockReturnThis(),
+            set: jest.fn().mockReturnThis(),
+            where: jest.fn().mockReturnThis(),
+            andWhere: jest.fn().mockReturnThis(),
+            returning: jest.fn().mockReturnThis(),
+            execute: jest.fn().mockResolvedValue({ raw: [], affected: 0 }),
+        };
+        repository = { createQueryBuilder: jest.fn().mockReturnValue(qb) };
+        repo = new WorkflowJobRepository(repository as any);
+    });
+
+    it('flips only PROCESSING rows older than the cutoff to FAILED/PERMANENT', async () => {
+        await repo.failStaleProcessing({
+            olderThan,
+            lastError,
+            errorClassification: ErrorClassification.PERMANENT,
+        });
+
+        expect(qb.update).toHaveBeenCalledWith(WorkflowJobModel);
+        expect(qb.set).toHaveBeenCalledWith(
+            expect.objectContaining({
+                status: JobStatus.FAILED,
+                errorClassification: ErrorClassification.PERMANENT,
+                lastError,
+            }),
+        );
+        // Only PROCESSING jobs are eligible — never PENDING / WAITING_FOR_EVENT.
+        expect(qb.where).toHaveBeenCalledWith('status = :status', {
+            status: JobStatus.PROCESSING,
+        });
+        // Actively-progressing jobs bump updatedAt and must be excluded.
+        expect(qb.andWhere).toHaveBeenCalledWith(
+            expect.stringContaining('updatedAt'),
+            { olderThan },
+        );
+    });
+
+    it('returns the reaped rows for logging', async () => {
+        const reaped = [
+            {
+                uuid: 'job-1',
+                workflowType: 'CODE_REVIEW',
+                organizationId: 'org-1',
+                startedAt: new Date('2026-06-26T14:00:00Z'),
+            },
+        ];
+        qb.execute.mockResolvedValue({ raw: reaped, affected: 1 });
+
+        const result = await repo.failStaleProcessing({
+            olderThan,
+            lastError,
+            errorClassification: ErrorClassification.PERMANENT,
+        });
+
+        expect(result).toEqual(reaped);
+    });
+
+    it('returns an empty array when nothing is stale', async () => {
+        const result = await repo.failStaleProcessing({
+            olderThan,
+            lastError,
+            errorClassification: ErrorClassification.PERMANENT,
+        });
+
+        expect(result).toEqual([]);
+    });
+});

--- a/libs/core/workflow/infrastructure/repositories/workflow-job.repository.ts
+++ b/libs/core/workflow/infrastructure/repositories/workflow-job.repository.ts
@@ -3,10 +3,14 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { FindOptionsWhere, Repository, EntityManager } from 'typeorm';
 
 import { createLogger } from '@libs/core/log/logger';
-import { IWorkflowJobRepository } from '@libs/core/workflow/domain/contracts/workflow-job.repository.contract';
+import {
+    IWorkflowJobRepository,
+    StaleWorkflowJobReapResult,
+} from '@libs/core/workflow/domain/contracts/workflow-job.repository.contract';
 import { IWorkflowJob } from '@libs/core/workflow/domain/interfaces/workflow-job.interface';
 import { JobStatus } from '@libs/core/workflow/domain/enums/job-status.enum';
 import { WorkflowType } from '@libs/core/workflow/domain/enums/workflow-type.enum';
+import { ErrorClassification } from '@libs/core/workflow/domain/enums/error-classification.enum';
 import { IJobExecutionHistory } from '@libs/core/workflow/domain/interfaces/job-execution-history.interface';
 
 import { WorkflowJobModel } from './schemas/workflow-job.model';
@@ -173,6 +177,54 @@ export class WorkflowJobRepository implements IWorkflowJobRepository {
                 context: WorkflowJobRepository.name,
                 error,
                 metadata: { query },
+            });
+            throw error;
+        }
+    }
+
+    /**
+     * Reaps jobs orphaned in PROCESSING by a crashed/evicted worker.
+     *
+     * Only `PROCESSING` rows are eligible (never `PENDING` or the
+     * legitimately-paused `WAITING_FOR_EVENT`), and only those whose
+     * `updatedAt` predates the cutoff — a job still making progress bumps
+     * `updatedAt` (currentStage/pipelineState updates) and is left alone.
+     * Single UPDATE ... RETURNING so the selection and mutation are atomic.
+     */
+    async failStaleProcessing(params: {
+        olderThan: Date;
+        lastError: string;
+        errorClassification: ErrorClassification;
+    }): Promise<StaleWorkflowJobReapResult[]> {
+        try {
+            const result = await this.repository
+                .createQueryBuilder()
+                .update(WorkflowJobModel)
+                .set({
+                    status: JobStatus.FAILED,
+                    errorClassification: params.errorClassification,
+                    lastError: params.lastError,
+                    completedAt: () => 'NOW()',
+                })
+                .where('status = :status', { status: JobStatus.PROCESSING })
+                .andWhere('"updatedAt" < :olderThan', {
+                    olderThan: params.olderThan,
+                })
+                .returning([
+                    'uuid',
+                    'workflowType',
+                    'organizationId',
+                    'startedAt',
+                ])
+                .execute();
+
+            return (result.raw ?? []) as StaleWorkflowJobReapResult[];
+        } catch (error) {
+            this.logger.error({
+                message: 'Failed to reap stale PROCESSING workflow jobs',
+                context: WorkflowJobRepository.name,
+                error,
+                metadata: { olderThan: params.olderThan },
             });
             throw error;
         }


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

Adds a periodic "stale job reaper" to the workflow engine that detects and cleans up workflow jobs stranded in a `PROCESSING` state after a worker dies mid-execution (e.g., OOM kill, node eviction, restart). These orphaned jobs previously stayed in `PROCESSING` indefinitely — they stopped being reported as running by the inbox reaper and were never retried — leaving the system and UI in a permanent "in progress" state with no path to recovery.

## Problem

- When a worker process is SIGKILLed while handling a job, the consumer's normal cleanup never runs, leaving the workflow job row stuck at `PROCESSING`.
- The existing inbox reaper frees the message lock, but the requeued RabbitMQ message is rejected as "already claimed" and sent to a DLQ, so the job is never reprocessed.
- No other mechanism reset the job status, causing jobs to remain stuck forever (covering both automation executions and workflow types without an automation row, like check-implementation and AST graph builds).

## Changes

- **New stale-job reaper cron** (`reapStaleProcessingJobs`): runs every 10 minutes by default, protected by a distributed lock, and flips eligible stuck jobs to `FAILED`.
- **Atomic status update** (`failStaleProcessing` in the workflow job repository): a single `UPDATE ... RETURNING` targets only `PROCESSING` rows whose `updatedAt` is older than the cutoff (180 minutes by default). Active jobs that are still progressing are never touched.
- **Configurable thresholds**:
  - `WORKFLOW_STALE_JOB_TIMEOUT_MINUTES` — how old a `PROCESSING` job must be before it's reaped (default 180, set above the 105-min job-abort and 150-min inbox claim timeouts so live/reclaimable jobs are safe).
  - `WORKFLOW_STALE_JOB_REAPER_CRON` — cadence override for ops/testing (faster cadence only speeds detection, never reaps sooner than the timeout allows).
- **Operational observability**:
  - Logs the details of every reaped job (ID, workflow type, organization, start time).
  - Triggers an incident heartbeat if more than 5 jobs are reaped in a single pass, flagging possible worker crash-loops (OOM, node pressure, restarts).
- **Comprehensive tests** for the reaper behavior, repository query, timeout overrides, and error handling (lock release even on failure).
<!-- kody-pr-summary:end -->