### PR TITLE
ci(e2e): fix self-hosted matrix rate-limit cascade (bot-token pool + preflight)

### DIFF
--- a/.github/workflows/e2e-self-hosted-matrix.yml
+++ b/.github/workflows/e2e-self-hosted-matrix.yml
@@ -154,7 +154,18 @@ jobs:
 
                   DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
 
+                  # GitHub bot-account token POOL. The runner round-robins
+                  # every github scenario across GH_TEST_TOKEN + GH_TEST_TOKEN_2..N
+                  # (see lib/github-token-pool.ts), so the ~26-scenario
+                  # license-paid cell spreads its polling/content-creation load
+                  # across multiple accounts instead of draining one account's
+                  # 5,000 req/hr primary quota and cascading into ~19 misleading
+                  # rate-limit SKIPs. GH_TEST_TOKEN_2 is a second dedicated bot
+                  # (Admin on the fixture repo). Empty siblings are dropped, so
+                  # this stays a single-token pool — identical to before — until
+                  # the secret is set.
                   GH_TEST_TOKEN: ${{ secrets.GH_TEST_TOKEN }}
+                  GH_TEST_TOKEN_2: ${{ secrets.GH_TEST_TOKEN_FREE }}
                   GH_TEST_REPO: ${{ secrets.GH_TEST_REPO }}
                   GH_TEST_PR_NUMBER: ${{ secrets.GH_TEST_PR_NUMBER }}
 

--- a/tests/e2e/lib/github-token-pool.ts
+++ b/tests/e2e/lib/github-token-pool.ts
@@ -70,3 +70,123 @@ export function makeGithubTokenPicker(
         return { token: pool[slot], slot: slot + 1, size: pool.length };
     };
 }
+
+// Below this fraction of the primary budget a bot account can't carry a full
+// github cell (~200-270 requests/scenario × several scenarios), so the run is
+// likely to trip mid-cell and cascade into rate-limit SKIPs.
+const LOW_QUOTA_FRACTION = 0.1;
+
+interface RateLimitInfo {
+    slot: number;
+    remaining: number;
+    limit: number;
+    resetIso: string;
+    ok: boolean;
+    note?: string;
+}
+
+/**
+ * Preflight the GitHub bot-account pool: report each account's remaining
+ * primary REST budget BEFORE the cells run, so an already-drained account
+ * (a prior run in the same hour, or one bad/expired token) is visible up
+ * front instead of surfacing as an opaque mid-run 403 cascade.
+ *
+ * GET /rate_limit does NOT itself count against the budget, so this is free.
+ * Best-effort: a network/parse error on one token never poisons the run —
+ * the per-scenario paths still throw their own specific errors.
+ */
+export async function preflightGithubRateLimits(
+    log: { info: (m: string) => void; warn: (m: string) => void },
+    env: NodeJS.ProcessEnv = process.env,
+): Promise<RateLimitInfo[]> {
+    const pool = githubTokenPool(env);
+    if (!pool.length) return [];
+
+    const infos = await Promise.all(
+        pool.map(async (token, idx): Promise<RateLimitInfo> => {
+            const slot = idx + 1;
+            try {
+                const resp = await fetch('https://api.github.com/rate_limit', {
+                    headers: {
+                        Authorization: `Bearer ${token}`,
+                        Accept: 'application/vnd.github+json',
+                        'X-GitHub-Api-Version': '2022-11-28',
+                    },
+                });
+                if (resp.status === 401) {
+                    return {
+                        slot,
+                        remaining: 0,
+                        limit: 0,
+                        resetIso: '',
+                        ok: false,
+                        note: 'token rejected (HTTP 401 — expired/revoked?)',
+                    };
+                }
+                const body = (await resp.json()) as {
+                    resources?: {
+                        core?: {
+                            remaining: number;
+                            limit: number;
+                            reset: number;
+                        };
+                    };
+                };
+                const core = body.resources?.core;
+                if (!core) {
+                    return {
+                        slot,
+                        remaining: 0,
+                        limit: 0,
+                        resetIso: '',
+                        ok: false,
+                        note: `unexpected /rate_limit shape (HTTP ${resp.status})`,
+                    };
+                }
+                return {
+                    slot,
+                    remaining: core.remaining,
+                    limit: core.limit,
+                    resetIso: new Date(core.reset * 1000).toISOString(),
+                    ok: true,
+                };
+            } catch (err) {
+                return {
+                    slot,
+                    remaining: 0,
+                    limit: 0,
+                    resetIso: '',
+                    ok: false,
+                    note: err instanceof Error ? err.message : String(err),
+                };
+            }
+        }),
+    );
+
+    for (const info of infos) {
+        if (!info.ok) {
+            log.warn(
+                `[preflight] github token slot ${info.slot}/${pool.length}: ${info.note}`,
+            );
+            continue;
+        }
+        const line =
+            `[preflight] github token slot ${info.slot}/${pool.length}: ` +
+            `${info.remaining}/${info.limit} core requests remaining ` +
+            `(resets ${info.resetIso})`;
+        if (info.remaining < info.limit * LOW_QUOTA_FRACTION) {
+            log.warn(`${line} — LOW, cell may trip the rate limit`);
+        } else {
+            log.info(line);
+        }
+    }
+
+    if (infos.every((i) => !i.ok || i.remaining < i.limit * LOW_QUOTA_FRACTION)) {
+        log.warn(
+            `[preflight] every github bot account is exhausted or unusable — ` +
+                `github cells will almost certainly SKIP on rate limits this run`,
+        );
+    }
+
+    return infos;
+}

--- a/tests/e2e/lib/runner.ts
+++ b/tests/e2e/lib/runner.ts
@@ -14,7 +14,10 @@ import type {
 } from "./types.js";
 import { ScenarioSkipError } from "./types.js";
 import { makeProvider } from "../providers/index.js";
-import { makeGithubTokenPicker } from "./github-token-pool.js";
+import {
+    makeGithubTokenPicker,
+    preflightGithubRateLimits,
+} from "./github-token-pool.js";
 import { githubAppToken } from "./github-app-token.js";
 import {
     finishOnboarding,
@@ -445,6 +448,13 @@ export async function runMatrix(opts: RunOptions): Promise<RunOutcome> {
     // Round-robins GitHub cells across the bot-account token pool so no single
     // account's rate limit caps the run (no-op with a single token).
     const pickGithubToken = makeGithubTokenPicker();
+
+    // Report each bot account's remaining GitHub budget up front (free — GET
+    // /rate_limit doesn't count) so an already-drained or expired token is
+    // visible before the cells run instead of as an opaque mid-run 403 cascade.
+    if (!opts.dryRun && opts.cells.some((c) => c.provider === "github")) {
+        await preflightGithubRateLimits(log);
+    }
 
     for (const cell of opts.cells) {
         if (cell.target !== opts.target) continue;


### PR DESCRIPTION
## Contexto

O scheduled run da matriz e2e self-hosted ([30078797761](https://github.com/kodustech/kodus-ai/actions/runs/30078797761)) falhou. Investigando as evidências, achamos **três problemas independentes**:

1. **API key da OpenAI inválida** (`sk-svcacct-…` rejeitada) — o `kodus-generalist-review-agent` morria em **todos** os providers → review terminava `partial_error` → `code-review-basic`/`command-review` FAIL. **Já resolvido fora deste PR** (rotação da secret `BYOK_OPENAI_API_KEY`).
2. **Rate limit da API do GitHub** — só no cell github. Endereçado aqui.
3. Flakes de provisão nos re-runs manuais foram só **tag de imagem RC expirada** (não é bug).

## O que este PR corrige (problema 2)

O runner já faz round-robin de cada cenário github sobre um **pool de contas-bot** (`lib/github-token-pool.ts`), mas o workflow só exportava `GH_TEST_TOKEN` → em CI o pool tinha **1 conta só**. O cell `license-paid` (~26 cenários) drenava os 5.000 req/h primários daquela conta e cascateava ~19 cenários em SKIPs enganosos de rate limit.

- **`e2e-self-hosted-matrix.yml`**: exporta um segundo bot dedicado (`GH_TEST_TOKEN_2`, Admin no fixture repo) → cenários espalham entre 2 contas. Siblings vazios são descartados, então continua pool de 1 token até a secret existir.
- **`preflightGithubRateLimits`**: no início do run, loga a cota restante de cada conta via `GET /rate_limit` (que é grátis) → uma conta já drenada (run anterior na mesma hora) ou token expirado fica visível de cara, em vez de virar um 403 opaco no meio do run. Best-effort, nunca derruba o run.

## Verificação

- `tsc --noEmit` limpo.
- 11/11 testes passam (`github-token-pool.test.ts` + `rate-limit-hardening.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)