### PR TITLE
ci(e2e): isolate product GitHub quota + rate-limit circuit breaker

### DIFF
--- a/.github/workflows/e2e-self-hosted-matrix.yml
+++ b/.github/workflows/e2e-self-hosted-matrix.yml
@@ -166,6 +166,14 @@ jobs:
                   # the secret is set.
                   GH_TEST_TOKEN: ${{ secrets.GH_TEST_TOKEN }}
                   GH_TEST_TOKEN_2: ${{ secrets.GH_TEST_TOKEN_FREE }}
+                  # Dedicated account for the PRODUCT's stored GitHub
+                  # integration credential, separate from the harness driver
+                  # pool above. The self-hosted product uses this for all its
+                  # own GitHub calls (read diff/files, post comments) — pinning
+                  # it to GH_TEST_TOKEN meant product + harness drained one
+                  # account and tripped the rate limit mid-cell. Falls back to
+                  # GH_TEST_TOKEN when unset (see github.ts authToken()).
+                  GH_INTEGRATION_TOKEN: ${{ secrets.GH_INTEGRATION_TOKEN }}
                   GH_TEST_REPO: ${{ secrets.GH_TEST_REPO }}
                   GH_TEST_PR_NUMBER: ${{ secrets.GH_TEST_PR_NUMBER }}
 

--- a/tests/e2e/lib/runner.ts
+++ b/tests/e2e/lib/runner.ts
@@ -476,12 +476,33 @@ export async function runMatrix(opts: RunOptions): Promise<RunOutcome> {
                   opts.runId,
               );
 
+        // Circuit breaker: once a github bot account's quota is exhausted,
+        // every remaining scenario in the cell would either re-hit the 403 or
+        // hang polling for a product action the (also rate-limited) product
+        // can't take — draining the whole 60-min job budget on retries. The
+        // hour-long reset can't clear mid-cell, so short-circuit the rest to a
+        // fast, honest SKIP instead. Resets per cell.
+        let githubRateLimited = false;
+
         for (const scenario of opts.scenarios) {
             const cellLabel = `${scenario.id} × ${cell.target} × ${cell.provider} × ${cell.license}`;
 
             if (!appliesToCell(scenario, cell)) {
                 log.info(`SKIP  ${cellLabel}`);
                 results.push(makeResult(scenario, cell, 'skipped', 0, {}));
+                continue;
+            }
+
+            if (githubRateLimited) {
+                log.err(
+                    `SKIP  ${cellLabel}: GitHub rate limit already tripped this cell — short-circuiting (quota resets hourly, NOT a product pass)`,
+                );
+                results.push(
+                    makeResult(scenario, cell, 'skipped', 0, {
+                        skipReason:
+                            'github-rate-limit: cell circuit breaker (a prior scenario exhausted the account quota)',
+                    }),
+                );
                 continue;
             }
 
@@ -653,6 +674,10 @@ export async function runMatrix(opts: RunOptions): Promise<RunOutcome> {
                     // of failing the release red. Logged loudly so a wall of
                     // these reads as "out of quota / spread load", not a pass.
                     if (isGithubRateLimit(e.message)) {
+                        // Trip the per-cell breaker so the remaining scenarios
+                        // fast-SKIP instead of each re-hitting the 403 or
+                        // hanging on the rate-limited product until timeout.
+                        githubRateLimited = true;
                         log.err(
                             `SKIP  ${cellLabel}: GitHub rate limit — quota exhausted, NOT a product pass (${e.message.slice(0, 160)})`,
                         );

--- a/tests/e2e/providers/github.ts
+++ b/tests/e2e/providers/github.ts
@@ -821,16 +821,25 @@ export class GitHubProvider extends BaseProvider {
     // the product's credential mid-run. Always hand the backend the
     // long-lived base PAT; the assigned token keeps serving the harness's
     // own API calls (clone, PRs, polling).
+    //
+    // Prefer a DEDICATED integration account (GH_INTEGRATION_TOKEN) so the
+    // product's own GitHub calls (read diff/files, post comments, resolve
+    // threads) draw on a separate 5,000 req/hr budget from the harness
+    // driver pool. Without it, the product and the harness both hammer
+    // GH_TEST_TOKEN — that single account's quota was tripping mid-cell and
+    // cascading scenarios into rate-limit SKIPs. Falls back to GH_TEST_TOKEN
+    // when the dedicated secret is unset, so this is a no-op until wired.
     authToken(): string {
         // Installation tokens are prefixed ghs_ and die in ~1h. NOTHING with
         // that prefix may become the stored integration credential — not the
-        // runner-assigned token, and not a misconfigured GH_TEST_TOKEN secret
-        // either (a silent 1h credential in CI config would fail mid-run).
-        const durable = process.env.GH_TEST_TOKEN;
+        // runner-assigned token, and not a misconfigured secret either (a
+        // silent 1h credential in CI config would fail mid-run).
+        const durable =
+            process.env.GH_INTEGRATION_TOKEN || process.env.GH_TEST_TOKEN;
         if (durable) {
             if (durable.startsWith('ghs_')) {
                 throw new Error(
-                    'GH_TEST_TOKEN is a GitHub App installation token (ghs_) — the integration credential must be a durable PAT',
+                    'The GitHub integration credential (GH_INTEGRATION_TOKEN / GH_TEST_TOKEN) is a GitHub App installation token (ghs_) — it must be a durable PAT',
                 );
             }
             return durable;


### PR DESCRIPTION
Follow-up to #1603. That PR gave the **harness** its own bot-token pool, but the RC validation run ([30160345619](https://github.com/kodustech/kodus-ai/actions/runs/30160345619)) surfaced two more issues that timed out the github-paid and bitbucket-paid cells at the 60-min job ceiling.

## ✅ First, the good news
The OpenAI-key fix holds: gitlab + azure cells passed fully green, and github reviews (`code-review-basic`, `command-review-focus`, `kody-rules-create-and-apply`, `kody-rules-file-sync`) all PASSED before the cell timed out.

## Problem 1 — product & harness share one GitHub account
`github.ts authToken()` stored `GH_TEST_TOKEN` (account `kozman31`, also slot 1 of the harness pool) as the **product's** integration credential. The product can't rotate — it uses that one account for every review call. So `kozman31` took load from both product and harness and tripped its 5,000 req/hr mid-cell (preflight confirmed both accounts full at start, then only slot 1 exhausted).

**Fix:** prefer a dedicated `GH_INTEGRATION_TOKEN` for the stored credential; fall back to `GH_TEST_TOKEN` when unset (no-op until the secret exists).

## Problem 2 — a rate-limited scenario hangs to timeout
After the 403, `rule-file-detection` kept polling for a product action the (rate-limited) product couldn't take, burned its full ~20min budget, retried, burned another ~20min, and pushed the cell past the 60-min job timeout → **cancelled**.

**Fix:** a **per-cell circuit breaker** — the first github rate-limit SKIP trips a flag and the remaining scenarios in the cell fast-SKIP (the hourly quota can't reset mid-cell anyway) instead of draining the job budget on retries.

## Ops step to activate Problem 1's fix
Create a **third dedicated bot** (Admin on `kodus-e2e/tiny-url`), then:
```
gh secret set GH_INTEGRATION_TOKEN --repo kodustech/kodus-ai
```
Until then, behaviour is unchanged (falls back to GH_TEST_TOKEN).

## Verification
- `tsc --noEmit` clean; 11/11 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)