### PR TITLE
fix(gitlab): treat work_in_progress as draft signal on older GitLab (#1514)

### DIFF
--- a/libs/common/utils/webhooks/gitlab.spec.ts
+++ b/libs/common/utils/webhooks/gitlab.spec.ts
@@ -1,0 +1,57 @@
+import { GitlabMappedPlatform, resolveGitlabIsDraft } from './gitlab';
+
+describe('resolveGitlabIsDraft', () => {
+    it('treats draft:null + work_in_progress:true as draft (old GitLab, issue #1514)', () => {
+        expect(
+            resolveGitlabIsDraft({ draft: null, work_in_progress: true }),
+        ).toBe(true);
+    });
+
+    it('returns true when draft is true', () => {
+        expect(resolveGitlabIsDraft({ draft: true })).toBe(true);
+    });
+
+    it('lets an explicit draft:false win over work_in_progress:true', () => {
+        expect(
+            resolveGitlabIsDraft({ draft: false, work_in_progress: true }),
+        ).toBe(false);
+    });
+
+    it('falls back to work_in_progress:false when draft is null', () => {
+        expect(
+            resolveGitlabIsDraft({ draft: null, work_in_progress: false }),
+        ).toBe(false);
+    });
+
+    it('returns false when both fields are absent', () => {
+        expect(resolveGitlabIsDraft({})).toBe(false);
+    });
+
+    it.each([[null], [undefined]])('returns false for %p', (mr) => {
+        expect(resolveGitlabIsDraft(mr as any)).toBe(false);
+    });
+});
+
+describe('GitlabMappedPlatform.mapPullRequest — draft detection', () => {
+    it('maps a Draft MR reported with draft:null + work_in_progress:true as isDraft=true', () => {
+        const payload: any = {
+            object_kind: 'merge_request',
+            event_type: 'merge_request',
+            object_attributes: {
+                iid: 8423,
+                title: 'Draft: something',
+                state: 'opened',
+                draft: null,
+                work_in_progress: true,
+                source_branch: 'feature',
+                target_branch: 'main',
+                labels: [],
+            },
+            repository: { name: 'repo' },
+        };
+
+        const result = new GitlabMappedPlatform().mapPullRequest({ payload });
+
+        expect(result?.isDraft).toBe(true);
+    });
+});

--- a/libs/common/utils/webhooks/gitlab.ts
+++ b/libs/common/utils/webhooks/gitlab.ts
@@ -13,6 +13,24 @@ import {
 
 import { extractRepoFullName } from './webhooks.utils';
 
+/**
+ * Resolves whether a GitLab merge request is a draft.
+ *
+ * GitLab renamed "WIP" to "Draft" in 13.2. On older self-managed instances a
+ * Draft MR can be returned with `draft: null` and `work_in_progress: true`, so
+ * reading `draft` alone maps such MRs as non-draft. We treat `draft` as
+ * canonical when present (an explicit `draft: false` wins) and only fall back to
+ * the deprecated `work_in_progress` when `draft` is null/undefined.
+ */
+export function resolveGitlabIsDraft(
+    mr:
+        | { draft?: boolean | null; work_in_progress?: boolean | null }
+        | null
+        | undefined,
+): boolean {
+    return Boolean(mr?.draft ?? mr?.work_in_progress ?? false);
+}
+
 export class GitlabMappedPlatform implements IMappedPlatform {
     mapUsers(params: {
         payload: IWebhookGitlabMergeRequestEvent;
@@ -73,10 +91,7 @@ export class GitlabMappedPlatform implements IMappedPlatform {
                 },
                 ref: mergeRequest?.target_branch,
             },
-            isDraft:
-                'draft' in mergeRequest
-                    ? (mergeRequest?.draft ?? false)
-                    : false,
+            isDraft: resolveGitlabIsDraft(mergeRequest),
             tags: mergeRequest?.labels?.map((label) => label.title) ?? [],
         };
     }

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -12,6 +12,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { Reaction } from '@libs/code-review/domain/codeReviewFeedback/enums/codeReviewCommentReaction.enum';
 import { decrypt, encrypt } from '@libs/common/utils/crypto';
+import { resolveGitlabIsDraft } from '@libs/common/utils/webhooks/gitlab';
 import { fitPRDescription } from '@libs/code-review/utils/fit-pr-description';
 import { IntegrationServiceDecorator } from '@libs/common/utils/decorators/integration-service.decorator';
 import { CacheService } from '@libs/core/cache/cache.service';
@@ -4834,7 +4835,7 @@ export class GitlabService implements Omit<
                 name: mergeRequest?.author?.name ?? '',
                 id: mergeRequest?.author?.id?.toString() ?? '',
             },
-            isDraft: mergeRequest?.draft ?? false,
+            isDraft: resolveGitlabIsDraft(mergeRequest),
         };
     }
 

--- a/libs/platform/infrastructure/webhooks/gitlab/gitlabPullRequest.handler.spec.ts
+++ b/libs/platform/infrastructure/webhooks/gitlab/gitlabPullRequest.handler.spec.ts
@@ -1,4 +1,7 @@
-import { extractGitlabHost } from './gitlabPullRequest.handler';
+import {
+    extractGitlabHost,
+    isGitlabDraftToReadyTransition,
+} from './gitlabPullRequest.handler';
 
 describe('extractGitlabHost', () => {
     it('extracts host from project.git_http_url (real Ikatec payload shape)', () => {
@@ -140,5 +143,39 @@ describe('extractGitlabHost', () => {
         // URL.hostname does not include the port — covers the case where a
         // self-hosted GitLab listens on a non-standard port.
         expect(extractGitlabHost(payload)).toBe('gitlab.example.com');
+    });
+});
+
+describe('isGitlabDraftToReadyTransition', () => {
+    it('detects a Draft->Ready flip via changes.draft (modern GitLab)', () => {
+        expect(
+            isGitlabDraftToReadyTransition({
+                draft: { previous: true, current: false },
+            }),
+        ).toBe(true);
+    });
+
+    it('detects a Draft->Ready flip via changes.work_in_progress (old GitLab, issue #1514)', () => {
+        expect(
+            isGitlabDraftToReadyTransition({
+                work_in_progress: { previous: true, current: false },
+            }),
+        ).toBe(true);
+    });
+
+    it('ignores a Ready->Draft flip', () => {
+        expect(
+            isGitlabDraftToReadyTransition({
+                draft: { previous: false, current: true },
+            }),
+        ).toBe(false);
+    });
+
+    it('returns false when no draft/wip change is present', () => {
+        expect(isGitlabDraftToReadyTransition({})).toBe(false);
+    });
+
+    it.each([[null], [undefined]])('returns false for %p changes', (changes) => {
+        expect(isGitlabDraftToReadyTransition(changes)).toBe(false);
     });
 });

--- a/libs/platform/infrastructure/webhooks/gitlab/gitlabPullRequest.handler.ts
+++ b/libs/platform/infrastructure/webhooks/gitlab/gitlabPullRequest.handler.ts
@@ -581,9 +581,7 @@ export class GitLabMergeRequestHandler implements IWebhookEventHandler {
 
         if (
             objectAttributes.action === 'update' &&
-            changes?.draft &&
-            changes.draft.previous === true &&
-            changes.draft.current === false
+            isGitlabDraftToReadyTransition(changes)
         ) {
             return true;
         }
@@ -604,6 +602,25 @@ export class GitLabMergeRequestHandler implements IWebhookEventHandler {
 
         return !!(lastCommitId && oldRev && lastCommitId !== oldRev);
     }
+}
+
+/**
+ * Detects a GitLab MR update that flips the MR from Draft to Ready.
+ *
+ * New GitLab reports this via `changes.draft`; older self-managed instances
+ * (pre-13.2 naming) report it via the deprecated `changes.work_in_progress`.
+ * Either field going `previous: true -> current: false` counts as "marked
+ * ready", which should trigger a review.
+ *
+ * Note: the `changes.work_in_progress` payload shape on old GitLab is assumed,
+ * not confirmed. The check is safe regardless — if the field is absent the
+ * branch never fires, and the result is idempotent (no double-trigger).
+ */
+export function isGitlabDraftToReadyTransition(changes: any): boolean {
+    const wentReady = (change: any): boolean =>
+        change?.previous === true && change?.current === false;
+
+    return wentReady(changes?.draft) || wentReady(changes?.work_in_progress);
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes #1514.

On GitLab self-managed 13.x, a **Draft** merge request can be returned by the API/webhook with `draft: null` **and** `work_in_progress: true`. Kodus decided draft state by reading only `draft`, so such MRs were mapped as `isDraft = false`. The `runOnDraft=false` guard was then bypassed and an automatic review ran on a Draft MR.

GitLab renamed "WIP" to "Draft" in 13.2. `work_in_progress` is deprecated but is still the reliable draft signal on those older instances, so the fix is **field-compatible** rather than version-gated.

## Root cause

Three sites keyed draft state off `draft` alone:

1. Webhook mapping — `libs/common/utils/webhooks/gitlab.ts` (`mapPullRequest`)
2. API transform — `libs/platform/infrastructure/adapters/services/gitlab.service.ts`
3. Draft→Ready transition detection — `libs/platform/infrastructure/webhooks/gitlab/gitlabPullRequest.handler.ts` (watched only `changes.draft`)

The `isDraft` set by (1)/(2) flows into the review gate at `libs/code-review/pipeline/stages/validate-config.stage.ts` (`if (isDraft && !runOnDraft) { skip }`), which is exactly the guard the issue reports as bypassed.

## Fix

Resolve draft state as `draft ?? work_in_progress ?? false`. This trusts an explicit `draft: false` when GitLab sends it (draft is canonical when present) and only falls back to the deprecated `work_in_progress` when `draft` is `null`/`undefined`.

- New shared helper `resolveGitlabIsDraft()` in `libs/common/utils/webhooks/gitlab.ts`, used by both the webhook mapping and the API transform. It takes a self-contained structural param (`{ draft?; work_in_progress? }`) so it stays assignable from `@gitbeaker`'s `MergeRequestSchema` without depending on that type declaring `work_in_progress`.
- New helper `isGitlabDraftToReadyTransition()` in the webhook handler: the Draft→Ready trigger now fires when **either** `changes.draft` **or** `changes.work_in_progress` goes `previous: true → current: false`.

## Assumption (please sanity-check)

The issue documents the MR **object** carrying `work_in_progress: true`, but does **not** prove the webhook `changes` payload carries `changes.work_in_progress: { previous, current }` on old GitLab. The added OR-branch is safe regardless: if that field never appears the branch never fires, and the return is idempotent (no double-trigger). Happy to adjust if maintainers know the real old-GitLab `changes` shape.

## Tests

Added unit tests following the repo's existing pattern of testing exported pure functions:

- `libs/common/utils/webhooks/gitlab.spec.ts` — `resolveGitlabIsDraft` truth table (including the `draft:null, work_in_progress:true` bug case) + a `mapPullRequest` integration case.
- Extended `libs/platform/infrastructure/webhooks/gitlab/gitlabPullRequest.handler.spec.ts` — `isGitlabDraftToReadyTransition` cases for both fields and the reverse (Ready→Draft) direction.

```
npx jest libs/common/utils/webhooks/gitlab.spec.ts
npx jest libs/platform/infrastructure/webhooks/gitlab/gitlabPullRequest.handler.spec.ts
```

> Note: I could not run the local jest suite in my environment (dependencies not installed), so I am relying on CI to run these. The pure-helper logic was verified directly. Please let CI validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
