### PR TITLE
fix(e2e/platform): bitbucket webhook cap, RabbitMQ queue races, github webhook owner

### DIFF
--- a/libs/core/infrastructure/queue/rabbitmq-dlq.initializer.ts
+++ b/libs/core/infrastructure/queue/rabbitmq-dlq.initializer.ts
@@ -1,5 +1,6 @@
 import { AmqpConnection } from '@golevelup/nestjs-rabbitmq';
 import { createLogger } from '@libs/core/log/logger';
+import { WORKFLOW_JOB_QUEUE_ARGUMENTS } from '@libs/core/workflow/infrastructure/workflow-queue-arguments';
 import {
     Injectable,
     OnApplicationBootstrap,
@@ -9,63 +10,37 @@ import {
 type QueueBinding = {
     queue: string;
     routingKey: string;
-    queueArgs?: Record<string, any>;
 };
 
+// Queue ARGUMENTS deliberately live in WORKFLOW_JOB_QUEUE_ARGUMENTS (shared
+// with the @RabbitSubscribe consumers) — a local copy here drifted from the
+// consumers' args once already, and asserting a queue with divergent args
+// closes the channel with 406 PRECONDITION_FAILED in an endless
+// reconnect loop that unregisters every consumer.
 const WORKFLOW_JOB_QUEUES: QueueBinding[] = [
     {
         queue: 'workflow.jobs.code_review.queue',
         routingKey: 'workflow.jobs.*.CODE_REVIEW',
-        queueArgs: {
-            'x-queue-type': 'quorum',
-            'x-dead-letter-exchange': 'workflow.exchange.dlx',
-            'x-dead-letter-routing-key': 'workflow.job.failed',
-        },
     },
     {
         queue: 'workflow.jobs.cli_code_review.queue',
         routingKey: 'workflow.jobs.*.CLI_CODE_REVIEW',
-        queueArgs: {
-            'x-queue-type': 'quorum',
-            'x-dead-letter-exchange': 'workflow.exchange.dlx',
-            'x-dead-letter-routing-key': 'workflow.job.failed',
-        },
     },
     {
         queue: 'workflow.jobs.webhook.queue',
         routingKey: 'workflow.jobs.*.WEBHOOK_PROCESSING',
-        queueArgs: {
-            'x-queue-type': 'quorum',
-            'x-dead-letter-exchange': 'workflow.exchange.dlx',
-            'x-dead-letter-routing-key': 'workflow.job.failed',
-        },
     },
     {
         queue: 'workflow.jobs.check_implementation.queue',
         routingKey: 'workflow.jobs.*.CHECK_SUGGESTION_IMPLEMENTATION',
-        queueArgs: {
-            'x-queue-type': 'quorum',
-            'x-dead-letter-exchange': 'workflow.exchange.dlx',
-            'x-dead-letter-routing-key': 'workflow.job.failed',
-        },
     },
     {
         queue: 'workflow.jobs.ast_graph_build.queue',
         routingKey: 'workflow.jobs.*.AST_GRAPH_BUILD',
-        queueArgs: {
-            'x-queue-type': 'quorum',
-            'x-dead-letter-exchange': 'workflow.exchange.dlx',
-            'x-dead-letter-routing-key': 'workflow.job.failed',
-        },
     },
     {
         queue: 'workflow.jobs.ast_graph_incremental.queue',
         routingKey: 'workflow.jobs.*.AST_GRAPH_INCREMENTAL',
-        queueArgs: {
-            'x-queue-type': 'quorum',
-            'x-dead-letter-exchange': 'workflow.exchange.dlx',
-            'x-dead-letter-routing-key': 'workflow.job.failed',
-        },
     },
 ];
 
@@ -258,22 +233,23 @@ export class RabbitMQDLQInitializer implements OnApplicationBootstrap {
     private async bindQueuesToDelayedExchange(channel: any): Promise<void> {
         for (const qb of WORKFLOW_JOB_QUEUES) {
             // Assert the queue with the SAME arguments @RabbitSubscribe uses
-            // (single-sourced in WORKFLOW_JOB_QUEUES) BEFORE binding. A
-            // bind-only call assumes the @RabbitSubscribe consumer already
-            // declared the queue on this channel — but on a fresh RabbitMQ
-            // volume or a reconnect where the consumers haven't re-declared
-            // yet, that race makes bindQueue fail with 404 NOT_FOUND. The
-            // binding is then silently lost (and in the addSetup path the
-            // throw aborts consumer registration), so CODE_REVIEW jobs are
-            // published to an unbound/absent queue and the review never runs.
-            // Because the args match exactly, assertQueue is idempotent — it
-            // creates the queue when missing and is a no-op when the consumer
-            // already made it, WITHOUT the PRECONDITION_FAILED that a
-            // divergent redeclare would cause. This makes the initializer
-            // self-sufficient instead of ordering-dependent.
+            // (single-sourced in WORKFLOW_JOB_QUEUE_ARGUMENTS) BEFORE
+            // binding. A bind-only call assumes the @RabbitSubscribe consumer
+            // already declared the queue on this channel — but on a fresh
+            // RabbitMQ volume or a reconnect where the consumers haven't
+            // re-declared yet, that race makes bindQueue fail with 404
+            // NOT_FOUND. The binding is then silently lost (and in the
+            // addSetup path the throw aborts consumer registration), so
+            // CODE_REVIEW jobs are published to an unbound/absent queue and
+            // the review never runs. Because the args are shared with the
+            // consumers, assertQueue is idempotent — it creates the queue
+            // when missing and is a no-op when the consumer already made it,
+            // WITHOUT the PRECONDITION_FAILED that a divergent redeclare
+            // would cause. This makes the initializer self-sufficient instead
+            // of ordering-dependent.
             await channel.assertQueue(qb.queue, {
                 durable: true,
-                arguments: qb.queueArgs,
+                arguments: { ...WORKFLOW_JOB_QUEUE_ARGUMENTS[qb.queue] },
             });
             await channel.bindQueue(
                 qb.queue,

--- a/libs/core/infrastructure/queue/rabbitmq-dlq.initializer.ts
+++ b/libs/core/infrastructure/queue/rabbitmq-dlq.initializer.ts
@@ -257,10 +257,24 @@ export class RabbitMQDLQInitializer implements OnApplicationBootstrap {
 
     private async bindQueuesToDelayedExchange(channel: any): Promise<void> {
         for (const qb of WORKFLOW_JOB_QUEUES) {
-            // Only bind — do NOT assertQueue here because the queues are already
-            // declared by @RabbitSubscribe with specific arguments (x-dead-letter-exchange,
-            // x-queue-type, etc.). Re-declaring with different args closes the channel
-            // with PRECONDITION_FAILED.
+            // Assert the queue with the SAME arguments @RabbitSubscribe uses
+            // (single-sourced in WORKFLOW_JOB_QUEUES) BEFORE binding. A
+            // bind-only call assumes the @RabbitSubscribe consumer already
+            // declared the queue on this channel — but on a fresh RabbitMQ
+            // volume or a reconnect where the consumers haven't re-declared
+            // yet, that race makes bindQueue fail with 404 NOT_FOUND. The
+            // binding is then silently lost (and in the addSetup path the
+            // throw aborts consumer registration), so CODE_REVIEW jobs are
+            // published to an unbound/absent queue and the review never runs.
+            // Because the args match exactly, assertQueue is idempotent — it
+            // creates the queue when missing and is a no-op when the consumer
+            // already made it, WITHOUT the PRECONDITION_FAILED that a
+            // divergent redeclare would cause. This makes the initializer
+            // self-sufficient instead of ordering-dependent.
+            await channel.assertQueue(qb.queue, {
+                durable: true,
+                arguments: qb.queueArgs,
+            });
             await channel.bindQueue(
                 qb.queue,
                 'workflow.exchange.delayed',

--- a/libs/core/workflow/infrastructure/workflow-job-consumer.service.ts
+++ b/libs/core/workflow/infrastructure/workflow-job-consumer.service.ts
@@ -24,6 +24,7 @@ import {
 } from '@libs/core/workflow/domain/contracts/inbox-message.repository.contract';
 import { InboxStatus } from './repositories/schemas/inbox-message.model';
 import { createRabbitMQErrorHandlerWithFallback } from '@libs/core/infrastructure/queue/rabbitmq-error.handler';
+import { WORKFLOW_JOB_QUEUE_ARGUMENTS } from './workflow-queue-arguments';
 import { runWithBoundedTimeout } from './run-with-bounded-timeout';
 import {
     ITaskProtectionService,
@@ -70,11 +71,8 @@ export class WorkflowJobConsumer implements OnApplicationShutdown {
         ),
         queueOptions: {
             channel: 'channel-webhook',
-            arguments: {
-                'x-queue-type': 'quorum',
-                'x-dead-letter-exchange': 'workflow.exchange.dlx',
-                'x-dead-letter-routing-key': 'workflow.job.failed',
-            },
+            arguments:
+                WORKFLOW_JOB_QUEUE_ARGUMENTS['workflow.jobs.webhook.queue'],
         },
     })
     async handleWebhookProcessingJob(
@@ -103,11 +101,8 @@ export class WorkflowJobConsumer implements OnApplicationShutdown {
         ),
         queueOptions: {
             channel: 'channel-code-review',
-            arguments: {
-                'x-queue-type': 'quorum',
-                'x-dead-letter-exchange': 'workflow.exchange.dlx',
-                'x-dead-letter-routing-key': 'workflow.job.failed',
-            },
+            arguments:
+                WORKFLOW_JOB_QUEUE_ARGUMENTS['workflow.jobs.code_review.queue'],
         },
     })
     async handleCodeReviewJob(
@@ -137,11 +132,8 @@ export class WorkflowJobConsumer implements OnApplicationShutdown {
         ),
         queueOptions: {
             channel: 'channel-cli-code-review',
-            arguments: {
-                'x-queue-type': 'quorum',
-                'x-dead-letter-exchange': 'workflow.exchange.dlx',
-                'x-dead-letter-routing-key': 'workflow.job.failed',
-            },
+            arguments:
+                WORKFLOW_JOB_QUEUE_ARGUMENTS['workflow.jobs.cli_code_review.queue'],
         },
     })
     async handleCliCodeReviewJob(
@@ -170,11 +162,8 @@ export class WorkflowJobConsumer implements OnApplicationShutdown {
         ),
         queueOptions: {
             channel: 'channel-check-implementation',
-            arguments: {
-                'x-queue-type': 'quorum',
-                'x-dead-letter-exchange': 'workflow.exchange.dlx',
-                'x-dead-letter-routing-key': 'workflow.job.failed',
-            },
+            arguments:
+                WORKFLOW_JOB_QUEUE_ARGUMENTS['workflow.jobs.check_implementation.queue'],
         },
     })
     async handleImplementationCheckJob(
@@ -221,13 +210,8 @@ export class WorkflowJobConsumer implements OnApplicationShutdown {
         ),
         queueOptions: {
             channel: 'channel-ast-graph-build',
-            arguments: {
-                'x-queue-type': 'quorum',
-                'x-single-active-consumer': true,
-                'x-consumer-timeout': 25 * 60 * 1000,
-                'x-dead-letter-exchange': 'workflow.exchange.dlx',
-                'x-dead-letter-routing-key': 'workflow.job.failed',
-            },
+            arguments:
+                WORKFLOW_JOB_QUEUE_ARGUMENTS['workflow.jobs.ast_graph_build.queue'],
         },
     })
     async handleAstGraphBuildJob(
@@ -262,13 +246,8 @@ export class WorkflowJobConsumer implements OnApplicationShutdown {
         ),
         queueOptions: {
             channel: 'channel-ast-graph-incremental',
-            arguments: {
-                'x-queue-type': 'quorum',
-                'x-single-active-consumer': true,
-                'x-consumer-timeout': 15 * 60 * 1000,
-                'x-dead-letter-exchange': 'workflow.exchange.dlx',
-                'x-dead-letter-routing-key': 'workflow.job.failed',
-            },
+            arguments:
+                WORKFLOW_JOB_QUEUE_ARGUMENTS['workflow.jobs.ast_graph_incremental.queue'],
         },
     })
     async handleAstGraphIncrementalJob(

--- a/libs/core/workflow/infrastructure/workflow-queue-arguments.ts
+++ b/libs/core/workflow/infrastructure/workflow-queue-arguments.ts
@@ -1,0 +1,55 @@
+/**
+ * Single source of truth for workflow.jobs.*.queue AMQP queue arguments.
+ *
+ * RabbitMQ rejects a queue (re)declaration whose arguments differ from the
+ * live queue's by closing the channel with 406 PRECONDITION_FAILED — and
+ * amqp-connection-manager then tears the whole connection down and retries,
+ * producing an infinite reconnect loop where NO consumer stays registered.
+ * That is exactly what happened when RabbitMQDLQInitializer asserted these
+ * queues from its own (stale) copy of the arguments that lacked the AST
+ * queues' `x-single-active-consumer`/`x-consumer-timeout`.
+ *
+ * Both declaration sites — the @RabbitSubscribe decorators in
+ * workflow-job-consumer.service.ts and the eager assert in
+ * rabbitmq-dlq.initializer.ts — MUST reference this module so they can never
+ * drift apart again. Do not inline queue arguments at either site.
+ */
+export const WORKFLOW_JOB_QUEUE_ARGUMENTS: Record<
+    string,
+    Record<string, unknown>
+> = {
+    'workflow.jobs.webhook.queue': {
+        'x-queue-type': 'quorum',
+        'x-dead-letter-exchange': 'workflow.exchange.dlx',
+        'x-dead-letter-routing-key': 'workflow.job.failed',
+    },
+    'workflow.jobs.code_review.queue': {
+        'x-queue-type': 'quorum',
+        'x-dead-letter-exchange': 'workflow.exchange.dlx',
+        'x-dead-letter-routing-key': 'workflow.job.failed',
+    },
+    'workflow.jobs.cli_code_review.queue': {
+        'x-queue-type': 'quorum',
+        'x-dead-letter-exchange': 'workflow.exchange.dlx',
+        'x-dead-letter-routing-key': 'workflow.job.failed',
+    },
+    'workflow.jobs.check_implementation.queue': {
+        'x-queue-type': 'quorum',
+        'x-dead-letter-exchange': 'workflow.exchange.dlx',
+        'x-dead-letter-routing-key': 'workflow.job.failed',
+    },
+    'workflow.jobs.ast_graph_build.queue': {
+        'x-queue-type': 'quorum',
+        'x-single-active-consumer': true,
+        'x-consumer-timeout': 25 * 60 * 1000,
+        'x-dead-letter-exchange': 'workflow.exchange.dlx',
+        'x-dead-letter-routing-key': 'workflow.job.failed',
+    },
+    'workflow.jobs.ast_graph_incremental.queue': {
+        'x-queue-type': 'quorum',
+        'x-single-active-consumer': true,
+        'x-consumer-timeout': 15 * 60 * 1000,
+        'x-dead-letter-exchange': 'workflow.exchange.dlx',
+        'x-dead-letter-routing-key': 'workflow.job.failed',
+    },
+};

--- a/libs/platform/infrastructure/adapters/services/bitbucket/bitbucket-cloud.service.ts
+++ b/libs/platform/infrastructure/adapters/services/bitbucket/bitbucket-cloud.service.ts
@@ -3179,7 +3179,16 @@ export class BitbucketCloudService implements Omit<
                 params.type,
             );
 
-            this.createWebhook(params.organizationAndTeamData);
+            // Deliberately not awaited (webhook creation must not block the
+            // integration-config save) — but the promise MUST be caught:
+            // createWebhook rethrows on failure (e.g. Bitbucket's 50-hook
+            // per-repo cap rejecting the create), and an orphaned rejection
+            // here escalated to an unhandledRejection that crashed the whole
+            // API process. The failure still gets a loud error log from
+            // createWebhook's own catch; this catch only stops the crash.
+            void this.createWebhook(params.organizationAndTeamData).catch(
+                () => undefined,
+            );
         } catch (error) {
             this.logger.error({
                 message: 'Error to create or update integration config',

--- a/libs/platform/infrastructure/adapters/services/github/github.service.ts
+++ b/libs/platform/infrastructure/adapters/services/github/github.service.ts
@@ -5350,8 +5350,20 @@ This is an experimental feature that generates committable changes. Review the d
 
         try {
             for (const repo of repositories) {
+                // The hook lives under the REPO's namespace, not the
+                // integration account's. getCorrectOwner resolves personal
+                // PAT integrations to the authenticated user's login, which
+                // 404s ("Not Found - list-repository-webhooks") for every
+                // repo the account merely collaborates on — the whole
+                // registerRepo call then fails. Prefer the owner recorded on
+                // the repository itself; keep getCorrectOwner as a fallback
+                // for legacy configs missing both fields.
+                const repoOwner =
+                    repo.full_name?.split('/')[0] ||
+                    repo.organizationName ||
+                    owner;
                 const { data: webhooks } = await octokit.repos.listWebhooks({
-                    owner: owner,
+                    owner: repoOwner,
                     repo: repo.name,
                 });
 
@@ -5362,14 +5374,14 @@ This is an experimental feature that generates committable changes. Review the d
 
                 if (webhookToDelete) {
                     await octokit.repos.deleteWebhook({
-                        owner: owner,
+                        owner: repoOwner,
                         repo: repo.name,
                         hook_id: webhookToDelete.id,
                     });
                 }
 
                 const response = await octokit.repos.createWebhook({
-                    owner: owner,
+                    owner: repoOwner,
                     repo: repo.name,
                     config: {
                         url: webhookUrl,
@@ -5387,11 +5399,11 @@ This is an experimental feature that generates committable changes. Review the d
                 });
 
                 this.logger.log({
-                    message: `Webhook adicionado ao repositório ${repo.name} (owner: ${owner})`,
+                    message: `Webhook adicionado ao repositório ${repo.name} (owner: ${repoOwner})`,
                     context: GithubService.name,
                     metadata: {
                         ...params,
-                        owner,
+                        owner: repoOwner,
                         repositoryName: repo.name,
                         webhookId: response?.data?.id,
                     },

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -870,9 +870,16 @@ export class GitlabService implements Omit<
                 params.type,
             );
 
-            this.createMergeRequestWebhook({
+            // Deliberately not awaited (webhook creation must not block the
+            // integration-config save) — but the promise MUST be caught:
+            // createMergeRequestWebhook rethrows on failure, and an orphaned
+            // rejection escalates to an unhandledRejection that can crash the
+            // API process (observed on the Bitbucket twin of this call). The
+            // failure still gets a loud error log from the method's own
+            // catch; this catch only stops the crash.
+            void this.createMergeRequestWebhook({
                 organizationAndTeamData: params.organizationAndTeamData,
-            });
+            }).catch(() => undefined);
         } catch (err) {
             throw new BadRequestException(err);
         }

--- a/test/unit/core/rabbitmq-dlq.initializer.spec.ts
+++ b/test/unit/core/rabbitmq-dlq.initializer.spec.ts
@@ -3,11 +3,15 @@ import { RabbitMQDLQInitializer } from "@libs/core/infrastructure/queue/rabbitmq
 /**
  * Guards against the race-condition fix in rabbitmq-dlq.initializer.ts:
  * - Must implement `onApplicationBootstrap` (runs AFTER every module's
- *   onModuleInit, so the @RabbitSubscribe consumers have already
- *   declared workflow.jobs.*.queue).
+ *   onModuleInit).
  * - Must NOT implement `onModuleInit` (used to, which caused bind
  *   attempts on queues that didn't exist yet — silently dropping
  *   delayed retries on first boot with a fresh rabbit volume).
+ * - Must assertQueue each workflow.jobs.*.queue (with the same args as
+ *   @RabbitSubscribe) BEFORE binding it. Bind-only raced the consumers
+ *   and failed with 404 NOT_FOUND on a fresh volume / reconnect, silently
+ *   dropping the binding so CODE_REVIEW jobs were published to a queue no
+ *   one consumed and the review never ran.
  */
 
 describe("RabbitMQDLQInitializer lifecycle", () => {
@@ -41,7 +45,7 @@ describe("RabbitMQDLQInitializer lifecycle", () => {
             });
 
         const amqp = {
-            channel: { assertExchange, bindQueue },
+            channel: { assertExchange, bindQueue, assertQueue },
             managedChannel: { addSetup },
         } as any;
 
@@ -85,24 +89,45 @@ describe("RabbitMQDLQInitializer lifecycle", () => {
         expect(addSetup).toHaveBeenCalledTimes(1);
     });
 
-    it("does not assertQueue for workflow.jobs.*.queue (they come from @RabbitSubscribe)", async () => {
+    it("assertQueues each workflow.jobs.*.queue before binding, with @RabbitSubscribe's args", async () => {
         const assertExchange = jest.fn().mockResolvedValue(undefined);
         const bindQueue = jest.fn().mockResolvedValue(undefined);
         const assertQueue = jest.fn().mockResolvedValue(undefined);
         const addSetup = jest.fn();
         const amqp = {
-            channel: { assertExchange, bindQueue },
+            channel: { assertExchange, bindQueue, assertQueue },
             managedChannel: { addSetup },
         } as any;
 
         const instance = new RabbitMQDLQInitializer(amqp);
         await instance.onApplicationBootstrap();
 
+        // Each workflow job queue is asserted (so bind never races a
+        // not-yet-declared queue into a 404) with the SAME args as the
+        // @RabbitSubscribe consumer — otherwise a divergent redeclare would
+        // close the channel with PRECONDITION_FAILED.
         const assertedQueues = assertQueue.mock.calls.map((c) => c[0]);
-        expect(assertedQueues).not.toContain(
+        expect(assertedQueues).toContain("workflow.jobs.code_review.queue");
+        expect(assertedQueues).toContain("workflow.jobs.webhook.queue");
+        expect(assertQueue).toHaveBeenCalledWith(
             "workflow.jobs.code_review.queue",
+            expect.objectContaining({
+                durable: true,
+                arguments: expect.objectContaining({
+                    "x-queue-type": "quorum",
+                    "x-dead-letter-exchange": "workflow.exchange.dlx",
+                    "x-dead-letter-routing-key": "workflow.job.failed",
+                }),
+            }),
         );
-        expect(assertedQueues).not.toContain("workflow.jobs.webhook.queue");
+
+        // assertQueue must precede bindQueue for the same queue.
+        const firstAssert = assertQueue.mock.invocationCallOrder[0];
+        const firstBind = bindQueue.mock.invocationCallOrder.find(
+            (_, i) =>
+                bindQueue.mock.calls[i][0] === "workflow.jobs.code_review.queue",
+        );
+        expect(firstAssert).toBeLessThan(firstBind as number);
     });
 
     // Regression: `this.amqpConnection.channel` is a getter that throws

--- a/tests/e2e/lib/server-evidence.ts
+++ b/tests/e2e/lib/server-evidence.ts
@@ -42,11 +42,37 @@ export async function collectServerEvidence(
     const key = process.env.TARGET_SSH_KEY;
     if (!host || !key) return;
 
-    const containers = [
-        'kodus-api',
-        'kodus-worker-prod',
-        'kodus-webhooks-prod',
-    ];
+    // Resolve container names from the droplet instead of hardcoding them —
+    // the API container is NOT named `kodus-api` on the installer compose
+    // (every prior artifact's server-kodus-api-*.log held only "No such
+    // container: kodus-api", which is how the registerRepo-400 runs shipped
+    // with no API log at all). Fall back to the known worker/webhook names
+    // if discovery fails.
+    let containers = ['kodus-worker-prod', 'kodus-webhooks-prod'];
+    try {
+        const { stdout } = await execFileAsync(
+            'ssh',
+            [
+                '-i',
+                key,
+                '-o',
+                'StrictHostKeyChecking=no',
+                '-o',
+                'ConnectTimeout=10',
+                `root@${host}`,
+                `docker ps --format '{{.Names}}' | grep -ai kodus || true`,
+            ],
+            { timeout: 20_000, maxBuffer: 1024 * 1024 },
+        );
+        const found = stdout
+            .split('\n')
+            .map((s) => s.trim())
+            .filter(Boolean);
+        if (found.length) containers = found;
+    } catch {
+        // discovery is best-effort; the fallback list still covers the
+        // worker/webhook logs that have always resolved
+    }
     // Covers both kody-rules scenarios and the code-review pipeline: the
     // review path (webhook received → automation → pipeline stages → comment
     // posting) is what a code-review-basic timeout needs to explain whether

--- a/tests/e2e/lib/server-evidence.ts
+++ b/tests/e2e/lib/server-evidence.ts
@@ -47,8 +47,15 @@ export async function collectServerEvidence(
         'kodus-worker-prod',
         'kodus-webhooks-prod',
     ];
+    // Covers both kody-rules scenarios and the code-review pipeline: the
+    // review path (webhook received → automation → pipeline stages → comment
+    // posting) is what a code-review-basic timeout needs to explain whether
+    // the product ran at all and where it stopped. Bitbucket/webhook terms
+    // surface a webhook that never arrived vs a pipeline that crashed.
     const grepFilter =
-        'kody-rules-sync|kody-rules-eval|KodyRulesSync|CrossProcess|ERROR|error -|Failed';
+        'kody-rules-sync|kody-rules-eval|KodyRulesSync|CrossProcess|ERROR|error -|Failed|' +
+        'CodeReview|ReviewOrchestrator|CommentManager|CodeReviewPipeline|CodeReviewAgent|' +
+        'Webhook|webhook|Automation|automation|Bitbucket|bitbucket';
 
     for (const container of containers) {
         try {
@@ -62,7 +69,7 @@ export async function collectServerEvidence(
                     '-o',
                     'ConnectTimeout=10',
                     `root@${host}`,
-                    `docker logs --since 20m ${container} 2>&1 | grep -aE "${grepFilter}" | grep -av Mongoose | tail -120; echo '--- tail ---'; docker logs --tail 40 ${container} 2>&1 | grep -av Mongoose`,
+                    `docker logs --since 60m ${container} 2>&1 | grep -aE "${grepFilter}" | grep -av Mongoose | tail -200; echo '--- tail ---'; docker logs --tail 40 ${container} 2>&1 | grep -av Mongoose`,
                 ],
                 { timeout: 30_000, maxBuffer: 4 * 1024 * 1024 },
             );

--- a/tests/e2e/lib/server-evidence.ts
+++ b/tests/e2e/lib/server-evidence.ts
@@ -69,9 +69,14 @@ export async function collectServerEvidence(
                     '-o',
                     'ConnectTimeout=10',
                     `root@${host}`,
-                    `docker logs --since 60m ${container} 2>&1 | grep -aE "${grepFilter}" | grep -av Mongoose | tail -200; echo '--- tail ---'; docker logs --tail 40 ${container} 2>&1 | grep -av Mongoose`,
+                    // Three sections: (1) grep-filtered highlights, (2) the
+                    // FULL ungrepped window (a review that skips/aborts logs at
+                    // a level the filter misses AND scrolls off a small tail —
+                    // the only way to see the pipeline's actual decision), (3)
+                    // the last 40 lines for the crash-at-exit case.
+                    `docker logs --since 60m ${container} 2>&1 | grep -aE "${grepFilter}" | grep -av Mongoose | tail -200; echo '--- full (ungrepped, since 60m) ---'; docker logs --since 60m ${container} 2>&1 | grep -av Mongoose | tail -6000; echo '--- tail ---'; docker logs --tail 40 ${container} 2>&1 | grep -av Mongoose`,
                 ],
-                { timeout: 30_000, maxBuffer: 4 * 1024 * 1024 },
+                { timeout: 45_000, maxBuffer: 24 * 1024 * 1024 },
             );
             writeFileSync(
                 join(artifactDir, `server-${container}-${label}.log`),

--- a/tests/e2e/providers/bitbucket.ts
+++ b/tests/e2e/providers/bitbucket.ts
@@ -16,6 +16,9 @@ import {
 } from "./base.js";
 import { ensureOk, http } from "../lib/http.js";
 import { prepareBranch } from "../lib/git.js";
+import { logger } from "../lib/log.js";
+
+const log = logger("bitbucket");
 
 interface BitbucketComment {
     id: number;
@@ -362,10 +365,67 @@ export class BitbucketProvider extends BaseProvider {
         };
     }
 
+    // Classify a PR comment against the "is this a real Kody review finding?"
+    // rules, returning WHY it was dropped so a timeout can dump the reasons
+    // (product-posted-nothing vs detector-rejected-a-real-review). Keep the
+    // predicate here single-sourced so the diagnostic can't drift from the
+    // live filter.
+    private classifyReviewComment(
+        c: BitbucketComment,
+        opts: { sinceIso: string; triggerId?: string },
+    ): { keep: boolean; reason: string } {
+        if (c.created_on <= opts.sinceIso)
+            return { keep: false, reason: "before sinceIso" };
+        if (opts.triggerId && String(c.id) === opts.triggerId)
+            return { keep: false, reason: "the @kody trigger comment itself" };
+        const raw = c.content?.raw ?? "";
+        if (raw.toLowerCase().startsWith("@kody"))
+            return { keep: false, reason: "@kody command echo" };
+        // Drop "Started!" placeholder but keep "Complete!" — the latter is a
+        // valid mechanics signal even when Kody found no inline findings.
+        // Bitbucket-specific: Kody does NOT inject the `<!-- kody-codereview -->`
+        // HTML marker into Bitbucket comments (it does on github/gitlab), so
+        // the marker check alone matches nothing. Fall back to detecting the
+        // visible heading text Kody renders into the placeholder.
+        if (
+            raw.includes("<!-- kody-codereview") &&
+            !raw.includes("kody-codereview-completed")
+        ) {
+            return { keep: false, reason: "in-progress kody-codereview marker" };
+        }
+        if (raw.includes("Code Review Started!")) {
+            return { keep: false, reason: "'Code Review Started!' placeholder" };
+        }
+        // Bitbucket-only leftover: when the gate skips the pipeline mid-flow,
+        // Kody overwrites its "Code Review Started!" placeholder so only the
+        // docs.kodus.io feedback footer remains (~80 chars of just the 👎
+        // link, no review content) — easy to confuse with a real "No issues
+        // found" outcome. Drop it.
+        const trimmed = raw.trim();
+        // Regex (not String.includes) so CodeQL doesn't read this as URL-host
+        // sanitization — `trimmed` is a review-comment body and we're plain
+        // text-matching the footer's docs link, not validating a URL.
+        if (
+            trimmed.length < 200 &&
+            /docs\.kodus\.io/.test(trimmed) &&
+            !trimmed.includes("Kody Review Complete") &&
+            !trimmed.includes("Kody Guide")
+        ) {
+            return {
+                keep: false,
+                reason: "footer-only placeholder (<200 chars, docs link)",
+            };
+        }
+        return { keep: true, reason: "real finding" };
+    }
+
     async pollForReview(
         pr: { number: number },
         opts: { sinceIso: string; triggerId?: string; timeoutSec?: number },
     ): Promise<ReviewSignal> {
+        // Last page of comments the poll actually saw, so a timeout can report
+        // what WAS on the PR instead of a bare "no findings".
+        let lastSeen: BitbucketComment[] = [];
         const result = await pollUntil(
             async () => {
                 const resp = await http<{ values: BitbucketComment[] }>(
@@ -373,50 +433,10 @@ export class BitbucketProvider extends BaseProvider {
                     { headers: this.headers() },
                 );
                 ensureOk(resp, "bitbucket:pollForReview");
-                const filtered = (resp.body.values ?? []).filter((c) => {
-                    if (c.created_on <= opts.sinceIso) return false;
-                    if (opts.triggerId && String(c.id) === opts.triggerId) return false;
-                    const raw = c.content?.raw ?? "";
-                    if (raw.toLowerCase().startsWith("@kody")) return false;
-                    // Drop "Started!" placeholder but keep "Complete!" — the
-                    // latter is a valid mechanics signal even when Kody
-                    // found no inline findings. Bitbucket-specific: Kody
-                    // does NOT inject the `<!-- kody-codereview -->` HTML
-                    // marker into Bitbucket comments (it does on github/
-                    // gitlab), so the marker check alone matches nothing.
-                    // Fall back to detecting the visible heading text
-                    // Kody renders into the placeholder.
-                    if (
-                        raw.includes("<!-- kody-codereview") &&
-                        !raw.includes("kody-codereview-completed")
-                    ) {
-                        return false;
-                    }
-                    if (raw.includes("Code Review Started!")) {
-                        return false;
-                    }
-                    // Bitbucket-only leftover: when the gate skips the pipeline
-                    // mid-flow, Kody overwrites its "Code Review Started!"
-                    // placeholder comment so only the docs.kodus.io feedback
-                    // footer remains. The comment is then ~80 chars of just
-                    // the 👎 link with no actual review content — meaningless
-                    // for the per-seat scenario and easy to confuse with a
-                    // real "No issues found" outcome. Drop it.
-                    const trimmed = raw.trim();
-                    // Regex (not String.includes) so CodeQL doesn't read this
-                    // as URL-host sanitization — `trimmed` is a review-comment
-                    // body and we're plain text-matching the footer's docs
-                    // link, not validating a URL.
-                    if (
-                        trimmed.length < 200 &&
-                        /docs\.kodus\.io/.test(trimmed) &&
-                        !trimmed.includes("Kody Review Complete") &&
-                        !trimmed.includes("Kody Guide")
-                    ) {
-                        return false;
-                    }
-                    return true;
-                });
+                lastSeen = resp.body.values ?? [];
+                const filtered = lastSeen.filter(
+                    (c) => this.classifyReviewComment(c, opts).keep,
+                );
                 if (filtered.length) {
                     return {
                         reviewComments: filtered.length,
@@ -429,7 +449,42 @@ export class BitbucketProvider extends BaseProvider {
             },
             { timeoutSec: opts.timeoutSec ?? 600, intervalSec: 10 },
         );
+        if (!result) {
+            this.dumpNoFindingsDiagnostic(pr.number, opts, lastSeen);
+        }
         return result ?? { reviewComments: 0, issueComments: 0, reviews: 0 };
+    }
+
+    // On a pollForReview timeout, dump every comment posted after the trigger
+    // with the reason the detector dropped it. Zero comments after sinceIso ⇒
+    // the PRODUCT never posted (webhook/pipeline problem); comments present but
+    // all dropped ⇒ a DETECTOR filter is rejecting a real review. This is the
+    // one signal the fail-log tails don't carry.
+    private dumpNoFindingsDiagnostic(
+        prNumber: number,
+        opts: { sinceIso: string; triggerId?: string },
+        lastSeen: BitbucketComment[],
+    ): void {
+        const afterSince = lastSeen.filter((c) => c.created_on > opts.sinceIso);
+        log.warn(
+            `bitbucket:pollForReview TIMEOUT on PR#${prNumber} — ${afterSince.length} comment(s) after the trigger, none accepted as a real finding:`,
+        );
+        for (const c of afterSince) {
+            const { reason } = this.classifyReviewComment(c, opts);
+            const raw = c.content?.raw ?? "";
+            log.warn(
+                `  - #${c.id} by ${c.user?.display_name ?? "?"} @${c.created_on} ` +
+                    `[dropped: ${reason}] len=${raw.length}: ` +
+                    JSON.stringify(raw.slice(0, 200)),
+            );
+        }
+        if (afterSince.length === 0) {
+            log.warn(
+                `  → ZERO comments after the trigger: the PRODUCT posted no review ` +
+                    `(webhook not delivered / pipeline crashed / review skipped) — ` +
+                    `NOT a detector-filter problem. Check the worker's code-review pipeline logs.`,
+            );
+        }
     }
 
     async postComment(

--- a/tests/e2e/providers/bitbucket.ts
+++ b/tests/e2e/providers/bitbucket.ts
@@ -317,6 +317,57 @@ export class BitbucketProvider extends BaseProvider {
             }
             url = resp.body.next ?? null;
         }
+
+        // Also purge webhooks left behind by prior runs. Every run's
+        // registerRepo makes the product create a webhook pointing at that
+        // run's ephemeral trycloudflare tunnel, and nothing ever deleted
+        // them — the fixture accumulated 50 (Bitbucket's per-repo cap), at
+        // which point the CURRENT run's webhook registration fails
+        // silently, the droplet never receives a single PR event, and the
+        // review never runs (the root cause of the standing bitbucket ×
+        // code-review-basic timeout). Delete every hook aimed at a dead
+        // ephemeral tunnel; leave non-tunnel hooks (e.g. the QA instance)
+        // alone. Requires the app password to carry the
+        // `delete:webhook:bitbucket` scope — without it Bitbucket 403s,
+        // which we surface loudly instead of silently re-hitting the cap.
+        try {
+            const hooksResp = await http<{
+                values?: Array<{ uuid: string; url: string }>;
+            }>(
+                `${this.apiBase}/repositories/${this.workspaceSlug}/hooks?pagelen=100`,
+                { headers: this.headers() },
+            );
+            ensureOk(hooksResp, "bitbucket:cleanupStale:listHooks");
+            const stale = (hooksResp.body.values ?? []).filter(
+                (h) =>
+                    /trycloudflare\.com|localhost|127\.0\.0\.1/.test(
+                        h.url ?? "",
+                    ),
+            );
+            let hooksDeleted = 0;
+            for (const h of stale) {
+                const del = await http(
+                    `${this.apiBase}/repositories/${this.workspaceSlug}/hooks/${encodeURIComponent(h.uuid)}`,
+                    { method: "DELETE", headers: this.headers() },
+                );
+                if (del.status === 403) {
+                    log.warn(
+                        `bitbucket:cleanupStale: cannot delete stale webhook ${h.url} — app password lacks the delete:webhook:bitbucket scope. ` +
+                            `${stale.length} dead tunnel webhook(s) remain; at Bitbucket's 50-hook cap NEW webhook registration fails silently and reviews never trigger.`,
+                    );
+                    break;
+                }
+                if (del.status >= 200 && del.status < 300) hooksDeleted += 1;
+            }
+            if (hooksDeleted > 0) {
+                log.info(
+                    `bitbucket:cleanupStale: deleted ${hooksDeleted} stale tunnel webhook(s)`,
+                );
+            }
+        } catch {
+            // Best-effort — webhook cleanup failing must not block the run;
+            // the loud 403 warn above is the actionable signal.
+        }
         return { closed };
     }
 


### PR DESCRIPTION
Continuação do #1603/#1607 — os fixes que fecharam a investigação da matriz e2e. Com eles (+ limpeza manual dos 50 webhooks do fixture bitbucket), o run [30287800304](https://github.com/kodustech/kodus-ai/actions/runs/30287800304) ficou **4/5 verde** — bitbucket passou pela primeira vez em semanas (code-review-basic em 124s; era timeout de 50min). O 5º cell (github-paid) fica verde com o fix daqui (provado localmente: 400 → 201).

## Produto
- **fix(rabbitmq): assert-before-bind + args single-sourced** — o DLQ initializer bindava filas sem assertQueue (race → `QueueBind 404` → jobs de review perdidos); a primeira correção expôs cópia divergente dos args (filas AST têm `x-single-active-consumer`/`x-consumer-timeout`) causando `PRECONDITION_FAILED` em loop. Agora `workflow-queue-arguments.ts` é a fonte única usada pelos consumers e pelo initializer.
- **fix(github): owner do webhook derivado do repo** — `createPullRequestWebhook` usava `getCorrectOwner` (org/login da **conta** da integração) → `GET /repos/<owner-errado>/<repo>/hooks` → 404 → `registerRepo` 400 em todos os cenários do cell github-paid. Agora usa `full_name`/`organizationName` do próprio repo. Reproduzido e validado no stack local (antes: 400; depois: 201 + hook criado em `kodus-e2e/tiny-url`).
- **fix(platform): catch nas criações de webhook fire-and-forget** (bitbucket + gitlab) — falha na criação (ex.: cap de 50 hooks do Bitbucket) virava `unhandledRejection` e **derrubava a API** (observado ao vivo).

## Harness (tests/e2e)
- **Cleanup de webhooks bitbucket** — deleta hooks de tunnels efêmeros mortos a cada run; era o acúmulo deles (50 = cap do BB Cloud) que impedia o registro do webhook do run e matava a review silenciosamente. Warn alto se faltar o escopo `delete:webhook`.
- **Diagnóstico de pollForReview** — no timeout, dumpa cada comentário pós-trigger com o motivo exato do descarte (foi o que revelou o footer-stub do webhook fantasma do QA).
- **Evidence com janela completa do worker** + descoberta dinâmica de containers (o log da API nunca era coletado: o container chama `kodus_api`, não `kodus-api`).

## Verificação
- Run 30287800304: gitlab ✅ azure ✅ github-free ✅ **bitbucket ✅** (boot sem `QueueBind 404`/`PRECONDITION_FAILED`).
- Owner fix: validado end-to-end no stack dev local.
- `tsc` limpo nos arquivos tocados; specs atualizados (9/9 initializer, 5/5 consumer, 294 core).

🤖 Generated with [Claude Code](https://claude.com/claude-code)