### PR TITLE
fix(onboarding): time-bound telemetry member lookup (finish-onboarding hang)

### DIFF
--- a/libs/platform/application/use-cases/codeManagement/finish-onboarding.use-case.ts
+++ b/libs/platform/application/use-cases/codeManagement/finish-onboarding.use-case.ts
@@ -225,11 +225,36 @@ export class FinishOnboardingUseCase {
                 // Real engineering team size from the just-connected git org.
                 // Best-effort lead-scoring signal for the onboarding Discord
                 // card — never blocks onboarding if the git lookup fails.
+                //
+                // MUST be time-bounded: the try/catch only covers rejections,
+                // not hangs. When the git provider is rate-limited, octokit's
+                // throttling plugin parks the request until the quota resets
+                // (up to ~1h) — and this await held the entire
+                // finish-onboarding response hostage to a Discord-card member
+                // count (observed live: client retried the POST 6× at ~6min
+                // each while the server "worked" on telemetry). 10s is
+                // generous for a healthy member list; past that, ship the
+                // telemetry without the count.
                 let orgMemberCount: number | undefined;
                 try {
-                    const members = await this.codeManagement.getListMembers({
-                        organizationAndTeamData: { organizationId, teamId },
-                    });
+                    let timeoutHandle: NodeJS.Timeout | undefined;
+                    const members = await Promise.race([
+                        this.codeManagement.getListMembers({
+                            organizationAndTeamData: { organizationId, teamId },
+                        }),
+                        new Promise<never>((_, reject) => {
+                            timeoutHandle = setTimeout(
+                                () =>
+                                    reject(
+                                        new Error(
+                                            'getListMembers timed out after 10s (time-bounded telemetry; likely provider rate-limit throttling)',
+                                        ),
+                                    ),
+                                10_000,
+                            );
+                            timeoutHandle.unref?.();
+                        }),
+                    ]).finally(() => clearTimeout(timeoutHandle));
                     orgMemberCount = Array.isArray(members)
                         ? members.length
                         : undefined;

--- a/libs/platform/infrastructure/adapters/services/github/github.service.ts
+++ b/libs/platform/infrastructure/adapters/services/github/github.service.ts
@@ -1359,6 +1359,13 @@ export class GithubService
         });
     }
 
+    // `User.suspendedAt` only exists on GitHub Enterprise schemas — on
+    // github.com every batch fails with "Field 'suspendedAt' doesn't exist"
+    // and we were re-issuing (and error-logging) the doomed query on every
+    // member listing. Remember the schema verdict per process and skip
+    // straight to the all-active fallback afterwards.
+    private suspendedAtUnsupported = false;
+
     private async getSuspendedStatusBatch(
         octokit: Octokit,
         logins: string[],
@@ -1367,6 +1374,12 @@ export class GithubService
         if (logins.length === 0) return new Map();
 
         const statusMap = new Map<string, boolean>();
+
+        if (this.suspendedAtUnsupported) {
+            logins.forEach((login) => statusMap.set(login, true));
+            return statusMap;
+        }
+
         let aliasCounter = 0;
 
         for (let i = 0; i < logins.length; i += batchSize) {
@@ -1394,6 +1407,18 @@ export class GithubService
                     statusMap.set(login, userData?.suspendedAt === null);
                 });
             } catch (error) {
+                const message =
+                    error instanceof Error ? error.message : String(error);
+                if (/'suspendedAt' doesn't exist/.test(message)) {
+                    this.suspendedAtUnsupported = true;
+                    this.logger.warn({
+                        message:
+                            "GraphQL schema has no User.suspendedAt (github.com) — treating all members as active and skipping future suspended-status batches",
+                        context: GithubService.name,
+                    });
+                    logins.forEach((login) => statusMap.set(login, true));
+                    return statusMap;
+                }
                 this.logger.error({
                     message: 'GraphQL batch query failed for suspended status',
                     context: GithubService.name,

--- a/libs/platform/infrastructure/adapters/services/github/github.service.ts
+++ b/libs/platform/infrastructure/adapters/services/github/github.service.ts
@@ -1362,9 +1362,18 @@ export class GithubService
     // `User.suspendedAt` only exists on GitHub Enterprise schemas — on
     // github.com every batch fails with "Field 'suspendedAt' doesn't exist"
     // and we were re-issuing (and error-logging) the doomed query on every
-    // member listing. Remember the schema verdict per process and skip
-    // straight to the all-active fallback afterwards.
-    private suspendedAtUnsupported = false;
+    // member listing. Remember the schema verdict PER API BASE URL: the
+    // schema is a property of the GitHub instance, and a process-wide flag
+    // would let a github.com org disable the (real) suspension check for a
+    // GHE org served by the same service instance.
+    private suspendedAtUnsupportedByBaseUrl = new Map<string, boolean>();
+
+    private graphqlBaseUrlOf(octokit: Octokit): string {
+        return (
+            (octokit as any)?.request?.endpoint?.DEFAULTS?.baseUrl ??
+            'https://api.github.com'
+        );
+    }
 
     private async getSuspendedStatusBatch(
         octokit: Octokit,
@@ -1375,7 +1384,8 @@ export class GithubService
 
         const statusMap = new Map<string, boolean>();
 
-        if (this.suspendedAtUnsupported) {
+        const baseUrl = this.graphqlBaseUrlOf(octokit);
+        if (this.suspendedAtUnsupportedByBaseUrl.get(baseUrl)) {
             logins.forEach((login) => statusMap.set(login, true));
             return statusMap;
         }
@@ -1410,11 +1420,12 @@ export class GithubService
                 const message =
                     error instanceof Error ? error.message : String(error);
                 if (/'suspendedAt' doesn't exist/.test(message)) {
-                    this.suspendedAtUnsupported = true;
+                    this.suspendedAtUnsupportedByBaseUrl.set(baseUrl, true);
                     this.logger.warn({
                         message:
-                            "GraphQL schema has no User.suspendedAt (github.com) — treating all members as active and skipping future suspended-status batches",
+                            "GraphQL schema has no User.suspendedAt (github.com) — treating all members as active and skipping future suspended-status batches for this API base URL",
                         context: GithubService.name,
+                        metadata: { baseUrl },
                     });
                     logins.forEach((login) => statusMap.set(login, true));
                     return statusMap;


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Summary

This PR addresses the `finish-onboarding` endpoint hanging when GitHub is rate-limited, and also reduces repeated failing GraphQL queries for member suspension status.

### Changes

1. **Time-bounded telemetry member lookup** (`finish-onboarding.use-case.ts`)
   - The onboarding flow performs a best-effort member count lookup for Discord lead-scoring telemetry. This lookup was previously wrapped in a `try/catch`, but that only caught rejections — not hangs. When the git provider is rate-limited, Octokit's throttling plugin can park the request until the quota resets (up to ~1 hour), holding the entire `finish-onboarding` response hostage.
   - A 10-second timeout has been added via `Promise.race`. If the member list request doesn't complete within 10 seconds, the telemetry is shipped without the member count, and onboarding continues normally.

2. **Cache unsupported `User.suspendedAt` schema per GitHub API base URL** (`github.service.ts`)
   - The `User.suspendedAt` field only exists on GitHub Enterprise schemas. On github.com, every batch member query fails with `"Field 'suspendedAt' doesn't exist"`, causing the same doomed query to be re-issued (and error-logged) on every member listing.
   - The service now detects this schema error and records that `suspendedAt` is unsupported for that specific API base URL. Future suspended-status batches for that instance treat all members as active and skip the GraphQL query entirely, eliminating repeated failures and reducing overhead.

### Impact

- Prevents `finish-onboarding` from hanging for extended periods during GitHub rate-limit throttling.
- Reduces error log noise and redundant API calls when the GitHub instance doesn't support the `suspendedAt` field.
- Both changes are defensive/best-effort: onboarding and telemetry continue even if the member lookup or suspension check cannot complete.
<!-- kody-pr-summary:end -->