### PR TITLE
fix(observability): read ai@7 cache/reasoning usage fields

### DIFF
--- a/libs/agent-harness/infrastructure/ai-sdk/ai-sdk-agent-runner.ts
+++ b/libs/agent-harness/infrastructure/ai-sdk/ai-sdk-agent-runner.ts
@@ -223,13 +223,7 @@ export class AiSdkAgentRunner implements AgentRunner {
                         index: steps.length,
                         message: eventToMessage(event),
                         usage: event?.usage
-                            ? {
-                                  inputTokens: event.usage.inputTokens,
-                                  outputTokens: event.usage.outputTokens,
-                                  reasoningTokens: event.usage.reasoningTokens,
-                                  cacheReadTokens:
-                                      event.usage.cachedInputTokens,
-                              }
+                            ? readAiSdkUsage(event.usage)
                             : undefined,
                     };
                     steps.push(step);
@@ -328,14 +322,7 @@ export class AiSdkAgentRunner implements AgentRunner {
                 stopReason ?? 'result',
             ),
             stopReason,
-            usage: {
-                inputTokens: result.usage?.inputTokens,
-                outputTokens: result.usage?.outputTokens,
-                reasoningTokens: result.usage?.reasoningTokens,
-                cacheReadTokens: (
-                    result.usage as { cachedInputTokens?: number } | undefined
-                )?.cachedInputTokens,
-            },
+            usage: readAiSdkUsage(result.usage),
             trace,
         };
     }
@@ -490,16 +477,41 @@ function parseArtifactInput(input: unknown): unknown {
     return input;
 }
 
+/**
+ * Map AI SDK `LanguageModelUsage` onto our TokenUsage.
+ *
+ * ai@7 removed top-level `cachedInputTokens` / `reasoningTokens` in favour of
+ * `inputTokenDetails.cacheReadTokens` / `outputTokenDetails.reasoningTokens`.
+ * Keep the ai@6 field names as fallbacks so mixed-version / vendor shims still
+ * report cache hits.
+ */
+function readAiSdkUsage(usage: any): TokenUsage {
+    return {
+        inputTokens: usage?.inputTokens,
+        outputTokens: usage?.outputTokens,
+        reasoningTokens:
+            usage?.outputTokenDetails?.reasoningTokens ??
+            usage?.reasoningTokens,
+        cacheReadTokens:
+            usage?.inputTokenDetails?.cacheReadTokens ??
+            usage?.cachedInputTokens,
+    };
+}
+
 /** Best-effort token usage from the steps collected before a failure —
  *  the error path has no provider-level total to read. */
 function aggregateUsage(steps: readonly RunStep[]): TokenUsage {
     let inputTokens = 0;
     let outputTokens = 0;
+    let reasoningTokens = 0;
+    let cacheReadTokens = 0;
     for (const s of steps) {
         inputTokens += s.usage?.inputTokens ?? 0;
         outputTokens += s.usage?.outputTokens ?? 0;
+        reasoningTokens += s.usage?.reasoningTokens ?? 0;
+        cacheReadTokens += s.usage?.cacheReadTokens ?? 0;
     }
-    return { inputTokens, outputTokens };
+    return { inputTokens, outputTokens, reasoningTokens, cacheReadTokens };
 }
 
 // --- mappers (AI SDK <-> core contracts) ---

--- a/libs/core/log/observability.service.ts
+++ b/libs/core/log/observability.service.ts
@@ -465,12 +465,35 @@ export class ObservabilityService implements OnModuleInit {
                             inputTokens: usage?.inputTokens,
                             outputTokens: usage?.outputTokens,
                             totalTokens: usage?.totalTokens,
-                            reasoningTokens: usage?.reasoningTokens,
-                            cacheReadTokens: (
-                                usage as
-                                    | { cachedInputTokens?: number }
-                                    | undefined
-                            )?.cachedInputTokens,
+                            // ai@7: nested details; ai@6: top-level fields.
+                            reasoningTokens:
+                                (
+                                    usage as
+                                        | {
+                                              outputTokenDetails?: {
+                                                  reasoningTokens?: number;
+                                              };
+                                              reasoningTokens?: number;
+                                          }
+                                        | undefined
+                                )?.outputTokenDetails?.reasoningTokens ??
+                                usage?.reasoningTokens,
+                            cacheReadTokens:
+                                (
+                                    usage as
+                                        | {
+                                              inputTokenDetails?: {
+                                                  cacheReadTokens?: number;
+                                              };
+                                              cachedInputTokens?: number;
+                                          }
+                                        | undefined
+                                )?.inputTokenDetails?.cacheReadTokens ??
+                                (
+                                    usage as
+                                        | { cachedInputTokens?: number }
+                                        | undefined
+                                )?.cachedInputTokens,
                         },
                     }),
                 );


### PR DESCRIPTION
## Summary

Fixes #1591. AI SDK v7 moved cached/reasoning token counts into `inputTokenDetails` / `outputTokenDetails`, but the agent harness and `runAiSdkLLMInSpan` still read the old top-level fields — so BYOK cache hits were recorded as `cacheRead=0` and billed at the full input rate. Prefer the v7 paths with v6 fallbacks.