### PR TITLE
chore(observability): restore Langfuse child generations for AI SDK 7

### DIFF
--- a/apps/api/src/instrument.ts
+++ b/apps/api/src/instrument.ts
@@ -1,10 +1,14 @@
 import 'dotenv/config';
 
 import { setupSentry } from '@libs/core/infrastructure/config/log/sentry';
-import { registerLangfuseStandalone } from '@libs/core/log/langfuse';
+import {
+    registerLangfuseAiSdkTelemetry,
+    registerLangfuseStandalone,
+} from '@libs/core/log/langfuse';
 
 // Sentry runs with `skipOpenTelemetrySetup: true` so it doesn't claim the
 // global TracerProvider — Sentry keeps capturing errors via its own API,
 // and Langfuse owns the OTel side here. Order doesn't matter anymore.
 setupSentry('api');
 registerLangfuseStandalone();
+registerLangfuseAiSdkTelemetry();

--- a/apps/webhooks/src/instrument.ts
+++ b/apps/webhooks/src/instrument.ts
@@ -1,7 +1,11 @@
 import 'dotenv/config';
 
 import { setupSentry } from '@libs/core/infrastructure/config/log/sentry';
-import { registerLangfuseStandalone } from '@libs/core/log/langfuse';
+import {
+    registerLangfuseAiSdkTelemetry,
+    registerLangfuseStandalone,
+} from '@libs/core/log/langfuse';
 
 setupSentry('webhook');
 registerLangfuseStandalone();
+registerLangfuseAiSdkTelemetry();

--- a/apps/worker/src/instrument.ts
+++ b/apps/worker/src/instrument.ts
@@ -1,7 +1,11 @@
 import 'dotenv/config';
 
 import { setupSentry } from '@libs/core/infrastructure/config/log/sentry';
-import { registerLangfuseStandalone } from '@libs/core/log/langfuse';
+import {
+    registerLangfuseAiSdkTelemetry,
+    registerLangfuseStandalone,
+} from '@libs/core/log/langfuse';
 
 setupSentry('worker');
 registerLangfuseStandalone();
+registerLangfuseAiSdkTelemetry();

--- a/libs/agent-harness/README.md
+++ b/libs/agent-harness/README.md
@@ -64,7 +64,7 @@ diferentes — **verify não é policy.**
 - **Tools**: 2 caminhos — `AgentTool → aiTool()`, ou passthrough nativo via `AiSdkToolRegistry`.
 - **System prompt**: string, ou com `systemProviderOptions` (cache Anthropic).
 - **Config de chamada**: `temperature`, `maxOutputTokens`, `providerOptions`.
-- **Telemetria**: `input.telemetry` → `experimental_telemetry` (Langfuse).
+- **Telemetria**: `input.telemetry` → AI SDK `telemetry` (+ `runtimeContext` when metadata is present; Langfuse).
 - **Cancelamento**: `ctx.signal` → `abortSignal`.
 - **Parada**: `policy.shouldStop` (OR) + `stepCountIs(maxSteps)` fail-open.
 - **Steer por step**: diretivas de `policy.prepareStep` mescladas; `sanitizeNoSystem`.

--- a/libs/agent-harness/domain/contracts/agent.contract.ts
+++ b/libs/agent-harness/domain/contracts/agent.contract.ts
@@ -66,9 +66,10 @@ export interface AgentRunInput {
     /** Optional seed messages (prior context). */
     readonly seedMessages?: readonly { role: 'user' | 'assistant'; content: string }[];
     /** Opaque per-run telemetry forwarded to the model call as the AI SDK's
-     *  `experimental_telemetry` (the harness does not interpret it). Per-RUN so
-     *  each call — finder, each recall pass, each per-finding verify — can carry
-     *  its own observation name; the domain builds it (e.g. Langfuse). */
+     *  `telemetry` (and optional `runtimeContext` when `metadata` is present).
+     *  The harness does not interpret it. Per-RUN so each call — finder, each
+     *  recall pass, each per-finding verify — can carry its own observation
+     *  name; the domain builds it (e.g. Langfuse). */
     readonly telemetry?: Readonly<Record<string, unknown>>;
 }
 

--- a/libs/agent-harness/infrastructure/ai-sdk/ai-sdk-agent-runner.ts
+++ b/libs/agent-harness/infrastructure/ai-sdk/ai-sdk-agent-runner.ts
@@ -148,10 +148,12 @@ export class AiSdkAgentRunner implements AgentRunner {
                 ...(spec.providerOptions
                     ? { providerOptions: spec.providerOptions as any }
                     : {}),
-                // Opaque per-run telemetry (e.g. Langfuse experimental_telemetry)
-                // — domain-built, forwarded verbatim. Self-disables when off.
+                // Opaque per-run telemetry → AI SDK 7 `telemetry` (+ optional
+                // `runtimeContext` when the payload includes `metadata`).
+                // Domain builds the shape (e.g. buildLangfuseTelemetry); the
+                // harness only forwards / remaps, never interprets.
                 ...(input.telemetry
-                    ? { experimental_telemetry: input.telemetry as any }
+                    ? expandAiSdkTelemetry(input.telemetry)
                     : {}),
                 // shouldStop seam: stop if ANY policy says so; hard fail-open at maxSteps.
                 stopWhen: [
@@ -495,6 +497,35 @@ function readAiSdkUsage(usage: any): TokenUsage {
         cacheReadTokens:
             usage?.inputTokenDetails?.cacheReadTokens ??
             usage?.cachedInputTokens,
+    };
+}
+
+/**
+ * Map opaque domain telemetry into AI SDK 7 call options.
+ * `metadata` (Langfuse-style) becomes `runtimeContext` + `includeRuntimeContext`
+ * so observation attributes still attach after the AI SDK 7 telemetry redesign.
+ */
+function expandAiSdkTelemetry(
+    raw: Readonly<Record<string, unknown>>,
+): {
+    telemetry: Record<string, unknown>;
+    runtimeContext?: Record<string, unknown>;
+} {
+    const { metadata, ...telemetry } = raw as {
+        metadata?: Record<string, unknown>;
+        [key: string]: unknown;
+    };
+    if (!metadata || Object.keys(metadata).length === 0) {
+        return { telemetry };
+    }
+    return {
+        telemetry: {
+            ...telemetry,
+            includeRuntimeContext: Object.fromEntries(
+                Object.keys(metadata).map((k) => [k, true]),
+            ),
+        },
+        runtimeContext: metadata,
     };
 }
 

--- a/libs/agents/skills/runtime/ai-sdk-fetcher.adapter.ts
+++ b/libs/agents/skills/runtime/ai-sdk-fetcher.adapter.ts
@@ -102,7 +102,7 @@ export interface FetcherRunResult {
  *
  * The result is the LAST assistant step's text — matching the legacy fetcher
  * contract of returning a JSON string the capabilities parse. Langfuse parity
- * is via `input.telemetry` (forwarded to `experimental_telemetry`); Mongo
+ * is via `input.telemetry` (forwarded as AI SDK `telemetry`); Mongo
  * billing is emitted by the caller from `state.usage`.
  */
 export async function runMcpFetcherAgent(params: {
@@ -179,6 +179,9 @@ export async function runMcpFetcherAgent(params: {
         { runId: params.runId, signal: params.signal },
     );
 
+    // `state.usage` is harness TokenUsage (AiSdkAgentRunner already maps
+    // ai@7 `outputTokenDetails.reasoningTokens` / `inputTokenDetails.cacheReadTokens`
+    // via readAiSdkUsage) — not raw LanguageModelUsage.
     const inputTokens = state.usage?.inputTokens;
     const outputTokens = state.usage?.outputTokens;
 

--- a/libs/ai-engine/infrastructure/adapters/services/reference-detector.service.ts
+++ b/libs/ai-engine/infrastructure/adapters/services/reference-detector.service.ts
@@ -9,7 +9,10 @@ import {
 } from '@libs/ai-engine/domain/prompt/interfaces/promptExternalReference.interface';
 import { OrganizationAndTeamData } from '@libs/core/infrastructure/config/types/general/organizationAndTeamData';
 
-import { buildLangfuseTelemetry } from '@libs/core/log/langfuse';
+import {
+    buildLangfuseTelemetry,
+    toAiSdkTelemetryArgs,
+} from '@libs/core/log/langfuse';
 import {
     prompt_detect_external_references_system,
     prompt_detect_external_references_user,
@@ -169,12 +172,11 @@ export class ReferenceDetectorService {
             model,
             system: systemPrompt,
             prompt: userPrompt,
-            experimental_telemetry: buildLangfuseTelemetry(
-                'detectExternalReferences',
-                {
+            ...toAiSdkTelemetryArgs(
+                buildLangfuseTelemetry('detectExternalReferences', {
                     organizationId: organizationAndTeamData.organizationId,
                     teamId: organizationAndTeamData.teamId,
-                },
+                }),
             ),
         });
 

--- a/libs/code-review/infrastructure/adapters/services/commentAnalysis.service.ts
+++ b/libs/code-review/infrastructure/adapters/services/commentAnalysis.service.ts
@@ -13,7 +13,10 @@ import {
     timeoutSignal,
     tracedGenerateText,
 } from '@libs/llm/llm-call';
-import { buildLangfuseTelemetry } from '@libs/core/log/langfuse';
+import {
+    buildLangfuseTelemetry,
+    toAiSdkTelemetryArgs,
+} from '@libs/core/log/langfuse';
 
 import { SUPPORTED_LANGUAGES } from '@libs/code-review/domain/contracts/SupportedLanguages';
 import { isKodyAuthoredBody } from '@libs/common/utils/kody-identifiers';
@@ -130,11 +133,13 @@ export class CommentAnalysisService {
                     prompt: user,
                     output: Output.object({ schema: schema as any }),
                     abortSignal: timeoutSignal(LLM_CALL_TIMEOUT_MS),
-                    experimental_telemetry: buildLangfuseTelemetry(runName, {
-                        organizationId:
-                            organizationAndTeamData.organizationId,
-                        teamId: organizationAndTeamData.teamId,
-                    }),
+                    ...toAiSdkTelemetryArgs(
+                        buildLangfuseTelemetry(runName, {
+                            organizationId:
+                                organizationAndTeamData.organizationId,
+                            teamId: organizationAndTeamData.teamId,
+                        }),
+                    ),
                 } as any),
         });
 

--- a/libs/code-review/infrastructure/adapters/services/commentManager.service.spec.ts
+++ b/libs/code-review/infrastructure/adapters/services/commentManager.service.spec.ts
@@ -64,6 +64,7 @@ jest.mock('@libs/llm/llm-call', () => ({
 }));
 jest.mock('@libs/core/log/langfuse', () => ({
     buildLangfuseTelemetry: () => ({ isEnabled: false, functionId: 'test' }),
+    toAiSdkTelemetryArgs: (cfg: any) => ({ telemetry: cfg }),
 }));
 
 import { getClassification } from '@libs/llm/error-classifier';

--- a/libs/code-review/infrastructure/adapters/services/commentManager.service.ts
+++ b/libs/code-review/infrastructure/adapters/services/commentManager.service.ts
@@ -47,7 +47,10 @@ import {
     classifyLLMError,
 } from '@libs/llm/error-classifier';
 import { tracedGenerateText } from '@libs/llm/llm-call';
-import { buildLangfuseTelemetry } from '@libs/core/log/langfuse';
+import {
+    buildLangfuseTelemetry,
+    toAiSdkTelemetryArgs,
+} from '@libs/core/log/langfuse';
 import {
     getTranslationsForLanguageByCategory,
     TranslationsCategory,
@@ -143,9 +146,8 @@ export class CommentManagerService implements ICommentManagerService {
                     ...(configuredTemperature !== undefined
                         ? { temperature: configuredTemperature }
                         : {}),
-                    experimental_telemetry: buildLangfuseTelemetry(
-                        runName,
-                        metadata,
+                    ...toAiSdkTelemetryArgs(
+                        buildLangfuseTelemetry(runName, metadata),
                     ),
                 });
             },

--- a/libs/code-review/infrastructure/agents/engine/classify-severity.ts
+++ b/libs/code-review/infrastructure/agents/engine/classify-severity.ts
@@ -13,7 +13,10 @@ import type { BYOKConfig } from '@kodus/kodus-common/llm';
 import type { CodeReviewConfig } from '@libs/core/infrastructure/config/types/general/codeReview.type';
 import { resolveSecondaryPassModel } from './secondary-pass-model';
 import { tracedGenerateText as generateText } from '@libs/llm/llm-call';
-import { buildLangfuseTelemetry } from '@libs/core/log/langfuse';
+import {
+    buildLangfuseTelemetry,
+    toAiSdkTelemetryArgs,
+} from '@libs/core/log/langfuse';
 import {
     DEFAULT_SEVERITY_FLAGS,
     buildSeverityPrompt,
@@ -64,8 +67,8 @@ export async function classifySeverity(
         const result: any = await generateText({
             model: model as any,
             abortSignal: controller.signal,
-            experimental_telemetry: buildLangfuseTelemetry(
-                'severity-classifier',
+            ...toAiSdkTelemetryArgs(
+                buildLangfuseTelemetry('severity-classifier'),
             ),
             prompt: buildSeverityPrompt(suggestions, flags),
         });

--- a/libs/code-review/infrastructure/agents/engine/format-suggestion-content.ts
+++ b/libs/code-review/infrastructure/agents/engine/format-suggestion-content.ts
@@ -1,7 +1,10 @@
 import { createLogger } from '@libs/core/log/logger';
 import { BYOKConfig } from '@kodus/kodus-common/llm';
 import { tracedGenerateText as generateText } from '@libs/llm/llm-call';
-import { buildLangfuseTelemetry } from '@libs/core/log/langfuse';
+import {
+    buildLangfuseTelemetry,
+    toAiSdkTelemetryArgs,
+} from '@libs/core/log/langfuse';
 import { resolveSecondaryPassModel } from './secondary-pass-model';
 import {
     buildFormatPrompt,
@@ -71,8 +74,8 @@ export async function formatSuggestionContent(
         const result: any = await generateText({
             model: model as any,
             abortSignal: controller.signal,
-            experimental_telemetry: buildLangfuseTelemetry(
-                'suggestion-formatter',
+            ...toAiSdkTelemetryArgs(
+                buildLangfuseTelemetry('suggestion-formatter'),
             ),
             prompt: buildFormatPrompt(suggestions, {
                 customWritingGuidelines: options?.customWritingGuidelines,

--- a/libs/code-review/pipeline/stages/agent-review.stage.ts
+++ b/libs/code-review/pipeline/stages/agent-review.stage.ts
@@ -24,6 +24,7 @@ import {
 import { buildKodyRuleLink } from '@libs/code-review/utils/build-kody-rule-link';
 import {
     buildLangfuseTelemetry,
+    toAiSdkTelemetryArgs,
     type LangfuseTelemetryMetadata,
 } from '@libs/core/log/langfuse';
 
@@ -1530,9 +1531,11 @@ export class AgentReviewStage extends BasePipelineStage<CodeReviewPipelineContex
             const runDedup = (model: any) =>
                 tracedGenerateText({
                     model: model as any,
-                    experimental_telemetry: buildLangfuseTelemetry(
-                        'dedup-suggestions',
-                        telemetryMeta,
+                    ...toAiSdkTelemetryArgs(
+                        buildLangfuseTelemetry(
+                            'dedup-suggestions',
+                            telemetryMeta,
+                        ),
                     ),
                     output: Output.object({
                         schema: jsonSchema(DEDUP_SCHEMA as any),

--- a/libs/core/log/langfuse.ts
+++ b/libs/core/log/langfuse.ts
@@ -1,10 +1,13 @@
 import { LangfuseSpanProcessor } from '@langfuse/otel';
+import { LangfuseVercelAiSdkIntegration } from '@langfuse/vercel-ai-sdk';
 import { NodeTracerProvider } from '@opentelemetry/sdk-trace-node';
 import type { AttributeValue } from '@opentelemetry/api';
+import { registerTelemetry } from 'ai';
 
 let spanProcessor: LangfuseSpanProcessor | null = null;
 let ownTracerProvider: NodeTracerProvider | null = null;
 let beforeExitInstalled = false;
+let aiSdkTelemetryRegistered = false;
 
 export function shouldTrace(): boolean {
     return (
@@ -86,6 +89,24 @@ export function registerLangfuseStandalone(): void {
     ownTracerProvider.register();
 }
 
+/**
+ * Register Langfuse's AI SDK 7 telemetry integration once at process start.
+ * AI SDK 7 uses a callback-based telemetry registry (`registerTelemetry`);
+ * without this, `telemetry` / `experimental_telemetry` on generateText never
+ * emit OTEL spans — only manual `@langfuse/tracing` observations show up.
+ *
+ * Call after `registerLangfuseStandalone()` (or Sentry OTel wiring) so the
+ * global TracerProvider already has the Langfuse span processor.
+ * Idempotent; no-op when tracing is disabled.
+ */
+export function registerLangfuseAiSdkTelemetry(): void {
+    if (aiSdkTelemetryRegistered) return;
+    if (!shouldTrace()) return;
+
+    registerTelemetry(new LangfuseVercelAiSdkIntegration());
+    aiSdkTelemetryRegistered = true;
+}
+
 export async function flushLangfuse(): Promise<void> {
     if (!spanProcessor) return;
     try {
@@ -115,20 +136,24 @@ export interface LangfuseTelemetryMetadata {
     provider?: string;
 }
 
+export interface LangfuseTelemetryConfig {
+    isEnabled: boolean;
+    functionId: string;
+    /** Carried for AI SDK 7 via `runtimeContext` (see `toAiSdkTelemetryArgs`). */
+    metadata?: Record<string, AttributeValue>;
+}
+
 /**
- * Build the `experimental_telemetry` config for a Vercel AI SDK call.
- * `functionId` sets the observation name in Langfuse; `metadata` shows up
- * in the Metadata tab. Safe to call when tracing is disabled — the AI SDK
- * reads `isEnabled` and skips span emission.
+ * Build Langfuse telemetry knobs for a Vercel AI SDK call.
+ * `functionId` sets the observation name; optional `metadata` is applied as
+ * AI SDK 7 `runtimeContext` via `toAiSdkTelemetryArgs` (not the removed
+ * `telemetry.metadata` field). Safe when tracing is disabled — `isEnabled`
+ * opts the call out.
  */
 export function buildLangfuseTelemetry(
     functionId: string,
     metadata?: LangfuseTelemetryMetadata,
-): {
-    isEnabled: boolean;
-    functionId: string;
-    metadata?: Record<string, AttributeValue>;
-} {
+): LangfuseTelemetryConfig {
     const attrs: Record<string, AttributeValue> = {};
     if (metadata?.organizationId) attrs.organizationId = metadata.organizationId;
     if (metadata?.teamId) attrs.teamId = metadata.teamId;
@@ -140,5 +165,34 @@ export function buildLangfuseTelemetry(
         isEnabled: shouldTrace(),
         functionId,
         ...(Object.keys(attrs).length > 0 && { metadata: attrs }),
+    };
+}
+
+/**
+ * Expand `buildLangfuseTelemetry()` into AI SDK 7 `generateText` fields.
+ * Spreads as `{ telemetry, runtimeContext? }` — metadata keys become
+ * observation metadata via `includeRuntimeContext`.
+ */
+export function toAiSdkTelemetryArgs(config: LangfuseTelemetryConfig): {
+    telemetry: {
+        isEnabled: boolean;
+        functionId: string;
+        includeRuntimeContext?: Record<string, true>;
+    };
+    runtimeContext?: Record<string, AttributeValue>;
+} {
+    const { isEnabled, functionId, metadata } = config;
+    if (!metadata || Object.keys(metadata).length === 0) {
+        return { telemetry: { isEnabled, functionId } };
+    }
+    return {
+        telemetry: {
+            isEnabled,
+            functionId,
+            includeRuntimeContext: Object.fromEntries(
+                Object.keys(metadata).map((k) => [k, true as const]),
+            ),
+        },
+        runtimeContext: metadata,
     };
 }

--- a/libs/core/log/observability.service.ts
+++ b/libs/core/log/observability.service.ts
@@ -422,7 +422,7 @@ export class ObservabilityService implements OnModuleInit {
      * span so its token usage lands in `observability_telemetry` — the Mongo
      * billing dataset keyed by org/team/PR. This is the parity bridge for agents
      * migrated off the legacy flow-engine LLM adapter: the AI SDK's
-     * `experimental_telemetry` feeds Langfuse, while this feeds the internal
+     * `telemetry` feeds Langfuse, while this feeds the internal
      * cost pipeline. A span carrying `gen_ai.usage.total_tokens` is treated as
      * billing-critical (synchronously flushed) by the telemetry engine.
      *

--- a/libs/llm/llm-call.ts
+++ b/libs/llm/llm-call.ts
@@ -5,7 +5,7 @@
  * ignore AbortSignal and hang forever; `hardTimeout` is the safety net that
  * guarantees every model call has a maximum wall-clock time. `tracedGenerateText`
  * is the AI SDK `generateText` with that net applied — Langfuse tracing is
- * consumed via `experimental_telemetry` on each call by the caller.
+ * consumed via `telemetry` on each call by the caller.
  */
 import { generateText as _aiSdkGenerateText } from 'ai';
 
@@ -66,7 +66,10 @@ const generateText: typeof _aiSdkGenerateText = (async (
         (opts?.abortSignal
             ? LLM_CALL_TIMEOUT_MS // secondary calls already set timeoutSignal
             : AGENT_TIMEOUT_MS); // main call uses agent-level timeout
-    const label = opts?.experimental_telemetry?.functionId || 'generateText';
+    const label =
+        opts?.telemetry?.functionId ||
+        opts?.experimental_telemetry?.functionId ||
+        'generateText';
     return hardTimeout(_aiSdkGenerateText(...args), ms, label);
 }) as typeof _aiSdkGenerateText;
 

--- a/libs/llm/reasoning-options.spec.ts
+++ b/libs/llm/reasoning-options.spec.ts
@@ -370,4 +370,31 @@ describe('buildLangfuseTelemetry', () => {
         const result = buildLangfuseTelemetry('my-run');
         expect(result.metadata).toBeUndefined();
     });
+
+    it('toAiSdkTelemetryArgs maps metadata into runtimeContext', () => {
+        process.env.LANGFUSE_TRACING = 'true';
+        process.env.LANGFUSE_PUBLIC_KEY = 'pk-test';
+        process.env.LANGFUSE_SECRET_KEY = 'sk-test';
+        jest.resetModules();
+         
+        const {
+            buildLangfuseTelemetry,
+            toAiSdkTelemetryArgs,
+        } = require('@libs/core/log/langfuse');
+        const args = toAiSdkTelemetryArgs(
+            buildLangfuseTelemetry('my-run', {
+                organizationId: 'org-1',
+                teamId: 'team-1',
+            }),
+        );
+        expect(args.telemetry.functionId).toBe('my-run');
+        expect(args.telemetry.includeRuntimeContext).toEqual({
+            organizationId: true,
+            teamId: true,
+        });
+        expect(args.runtimeContext).toMatchObject({
+            organizationId: 'org-1',
+            teamId: 'team-1',
+        });
+    });
 });

--- a/libs/llm/reasoning-options.ts
+++ b/libs/llm/reasoning-options.ts
@@ -24,7 +24,7 @@ export const EFFORT_TO_BUDGET: Record<ReasoningEffort, number> = {
 /**
  * Build provider-specific reasoning `providerOptions` for a generateText call.
  * Telemetry metadata is no longer merged here — callers pass
- * `experimental_telemetry: buildLangfuseTelemetry(runName, meta)` separately.
+ * `telemetry: buildLangfuseTelemetry(runName, meta)` separately.
  */
 export function buildProviderOptions(
     runName: string,

--- a/libs/llm/structured-review-call.spec.ts
+++ b/libs/llm/structured-review-call.spec.ts
@@ -19,6 +19,9 @@ jest.mock('@libs/llm/llm-call', () => ({
 }));
 jest.mock('@libs/core/log/langfuse', () => ({
     buildLangfuseTelemetry: jest.fn(() => ({ isEnabled: false })),
+    toAiSdkTelemetryArgs: jest.fn(() => ({
+        telemetry: { isEnabled: false },
+    })),
 }));
 jest.mock('@ai-sdk/openai-compatible', () => ({
     createOpenAICompatible: jest.fn(

--- a/libs/llm/structured-review-call.ts
+++ b/libs/llm/structured-review-call.ts
@@ -26,7 +26,10 @@ import {
     timeoutSignal,
     LLM_CALL_TIMEOUT_MS,
 } from '@libs/llm/llm-call';
-import { buildLangfuseTelemetry } from '@libs/core/log/langfuse';
+import {
+    buildLangfuseTelemetry,
+    toAiSdkTelemetryArgs,
+} from '@libs/core/log/langfuse';
 import { createLogger } from '@libs/core/log/logger';
 import { zodToStrictWireSchema } from '@libs/llm/strict-wire-schema';
 import { ObservabilityService } from '@libs/core/log/observability.service';
@@ -148,9 +151,11 @@ export async function runStructuredReviewCall<S extends z.ZodType | Schema>(
                         // pipeline slot for the full agent budget. Also feeds the
                         // BYOK limiter cancellation. Matches peer AI-SDK callers.
                         abortSignal: timeoutSignal(LLM_CALL_TIMEOUT_MS),
-                        experimental_telemetry: buildLangfuseTelemetry(runName, {
-                            organizationId,
-                        }),
+                        ...toAiSdkTelemetryArgs(
+                            buildLangfuseTelemetry(runName, {
+                                organizationId,
+                            }),
+                        ),
                     } as any),
             })
             .then(

--- a/package.json
+++ b/package.json
@@ -282,6 +282,7 @@
         "@langfuse/langchain": "^5.9.1",
         "@langfuse/otel": "^5.9.1",
         "@langfuse/tracing": "^5.9.1",
+        "@langfuse/vercel-ai-sdk": "^5.9.1",
         "@llamaduck/forgejo-ts": "15.0.3",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "@morphllm/morphsdk": "^0.2.189",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@langfuse/tracing':
         specifier: ^5.9.1
         version: 5.9.1(@opentelemetry/api@1.9.1)
+      '@langfuse/vercel-ai-sdk':
+        specifier: ^5.9.1
+        version: 5.9.1(@opentelemetry/api@1.9.1)(ai@7.0.16(zod@4.4.3))(zod@4.4.3)
       '@llamaduck/forgejo-ts':
         specifier: 15.0.3
         version: 15.0.3
@@ -595,6 +598,12 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/gateway@4.0.2':
+    resolution: {integrity: sha512-Jz1BiiTSvhDsCBJrkFRSqLHDRMVjFtYk9GdbSi3UOqY+/epza+oIESMDzfN4m+YHT/1IYmNEmxaMfjXOvxKDjQ==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/google-vertex@5.0.11':
     resolution: {integrity: sha512-+UUYbO8syQRmfmCiLTEcUijJXCz3c2Ekx04z08PnHousFnspdy8L6zhK0UoQLTZ8oO+mc/clCDVK2VOYmLcXLA==}
     engines: {node: '>=22'}
@@ -619,11 +628,25 @@ packages:
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
 
+  '@ai-sdk/otel@1.0.2':
+    resolution: {integrity: sha512-vmuuwOxJ5OuwMYDktABTLb9V33hwR2k77QIDPZ8mSHSo04seT88IXCmzZwLjTskHfIa5C9IRizzNy6sr2qOQWQ==}
+    engines: {node: '>=22'}
+
+  '@ai-sdk/provider-utils@5.0.0':
+    resolution: {integrity: sha512-zj66M02jc6ASYwIgWZowsooDUwaVngeNZQ3H10GwcPMZ+KR6gHMhcUuKl6tkai+JPXTKDyHY1pnszuxRtw2D4A==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
   '@ai-sdk/provider-utils@5.0.5':
     resolution: {integrity: sha512-oI0t3dvCoqWNV1I8o1Rybi2DXDvHES5r/TrwtJW90tuFLVepgJlftPxrcjh8vaSvjqC2diTuA2vXyjKAyHJm4A==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
+
+  '@ai-sdk/provider@4.0.0':
+    resolution: {integrity: sha512-fr9Gs89prDWiuox/T+kCA+i2cJkHpxU5S+tr4megjTzRC27ZsvFhwjU/+XrqqMbvBUlfmXxTOYWy8ng45dsjIg==}
+    engines: {node: '>=22'}
 
   '@ai-sdk/provider@4.0.2':
     resolution: {integrity: sha512-pfPoy9J1B1xV7cqJ8MYHOsDYrMv5tR3+EMNfI249OhkD2uRakvav3Fo7XpD2luuN/YNCBY7KfEQc7vEV7KEtyw==}
@@ -2434,6 +2457,13 @@ packages:
     engines: {node: '>=20'}
     peerDependencies:
       '@opentelemetry/api': ^1.9.0
+
+  '@langfuse/vercel-ai-sdk@5.9.1':
+    resolution: {integrity: sha512-gZPZJ3JXYTkT7W61VhbNHXgn/88+laoAQGMc082ESeXBwfuMVVPKDueZzM0xy6s0BTtPLW5WmbJ5NkLNCtR3Nw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      '@opentelemetry/api': ^1.9.0
+      ai: '>=7.0.0 <8'
 
   '@llamaduck/forgejo-ts@15.0.3':
     resolution: {integrity: sha512-bwJknz4Wlp+N6iv5IHQ3ZR8gtQUuEW+zp5+LRafEDyP/cy/peL15woK6Adn/NhcgBx8lbJeNl/0Yw3V/MvuL1w==}
@@ -4494,6 +4524,12 @@ packages:
 
   ai@7.0.16:
     resolution: {integrity: sha512-OuA+uz6ZUVId+SVeB5bThi25Ofee/FmLvffAA368tlgqYCe2qAhqZUpfHL0dd9QC/iPiszdvCQYENJavSo/0gw==}
+    engines: {node: '>=22'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+
+  ai@7.0.2:
+    resolution: {integrity: sha512-VMU08jHIDJnnKDrbC9AFa5ZsPpOTfAPRLvTRHtJk4FGAoeldmJROMxvZ2ak5lCjEJ2GP2OLPQbMRyEK8w0+S4A==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -9570,6 +9606,13 @@ snapshots:
       '@vercel/oidc': 3.2.0
       zod: 4.4.3
 
+  '@ai-sdk/gateway@4.0.2(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.0(zod@4.4.3)
+      '@vercel/oidc': 3.2.0
+      zod: 4.4.3
+
   '@ai-sdk/google-vertex@5.0.11(zod@4.4.3)':
     dependencies:
       '@ai-sdk/anthropic': 4.0.8(zod@4.4.3)
@@ -9600,6 +9643,22 @@ snapshots:
       '@ai-sdk/provider-utils': 5.0.5(zod@4.4.3)
       zod: 4.4.3
 
+  '@ai-sdk/otel@1.0.2(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.0
+      '@opentelemetry/api': 1.9.1
+      ai: 7.0.2(zod@4.4.3)
+    transitivePeerDependencies:
+      - zod
+
+  '@ai-sdk/provider-utils@5.0.0(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/provider': 4.0.0
+      '@standard-schema/spec': 1.1.0
+      '@workflow/serde': 4.1.0
+      eventsource-parser: 3.0.8
+      zod: 4.4.3
+
   '@ai-sdk/provider-utils@5.0.5(zod@4.4.3)':
     dependencies:
       '@ai-sdk/provider': 4.0.2
@@ -9607,6 +9666,10 @@ snapshots:
       '@workflow/serde': 4.1.0
       eventsource-parser: 3.0.8
       zod: 4.4.3
+
+  '@ai-sdk/provider@4.0.0':
+    dependencies:
+      json-schema: 0.4.0
 
   '@ai-sdk/provider@4.0.2':
     dependencies:
@@ -11204,6 +11267,15 @@ snapshots:
     dependencies:
       '@langfuse/core': 5.9.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/api': 1.9.1
+
+  '@langfuse/vercel-ai-sdk@5.9.1(@opentelemetry/api@1.9.1)(ai@7.0.16(zod@4.4.3))(zod@4.4.3)':
+    dependencies:
+      '@ai-sdk/otel': 1.0.2(zod@4.4.3)
+      '@langfuse/core': 5.9.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/api': 1.9.1
+      ai: 7.0.16(zod@4.4.3)
+    transitivePeerDependencies:
+      - zod
 
   '@llamaduck/forgejo-ts@15.0.3':
     dependencies:
@@ -13791,6 +13863,13 @@ snapshots:
       '@ai-sdk/gateway': 4.0.12(zod@4.4.3)
       '@ai-sdk/provider': 4.0.2
       '@ai-sdk/provider-utils': 5.0.5(zod@4.4.3)
+      zod: 4.4.3
+
+  ai@7.0.2(zod@4.4.3):
+    dependencies:
+      '@ai-sdk/gateway': 4.0.2(zod@4.4.3)
+      '@ai-sdk/provider': 4.0.0
+      '@ai-sdk/provider-utils': 5.0.0(zod@4.4.3)
       zod: 4.4.3
 
   ajv-draft-04@1.0.0(ajv@8.20.0):

--- a/test/unit/ai-engine/reference-detector-markers.spec.ts
+++ b/test/unit/ai-engine/reference-detector-markers.spec.ts
@@ -111,6 +111,7 @@ jest.mock('@libs/llm/byok-to-vercel', () => ({
 }));
 jest.mock('@libs/core/log/langfuse', () => ({
     buildLangfuseTelemetry: jest.fn().mockReturnValue({}),
+    toAiSdkTelemetryArgs: jest.fn().mockReturnValue({ telemetry: {} }),
 }));
 
 describe('ReferenceDetectorService.detectReferences (LLM path)', () => {


### PR DESCRIPTION
## Summary

Restores Langfuse child generations for AI SDK 7 (`ai@7`) paths by registering `@langfuse/vercel-ai-sdk` at process startup and mapping call-site telemetry to the v7 `telemetry` + `runtimeContext` shape.

Fixes https://github.com/kodustech/kodus-ai/issues/1590

After `ai@7`, `experimental_telemetry: { isEnabled: true }` alone no longer emits OTEL spans. Without `registerTelemetry(new LangfuseVercelAiSdkIntegration())`, only coarse `@langfuse/tracing` parent observations appear — finder / verifier / tool-loop generations stay missing. LangChain callbacks and Mongo usage tracking were already fine; this is specifically the AI SDK → Langfuse gap.