### PR TITLE
test(e2e): fix both cloud-matrix failures (bot authorship + App-token expiry)

### DIFF
--- a/tests/e2e/providers/github.ts
+++ b/tests/e2e/providers/github.ts
@@ -81,6 +81,29 @@ export class GitHubProvider extends BaseProvider {
         };
     }
 
+    // Headers for writes that establish AUTHORSHIP of a product-visible
+    // event (creating a PR, posting a trigger comment). When the harness
+    // runs on a GitHub App installation token (cloud cells, for quota), the
+    // author of those events becomes the App's `[bot]` account — and the
+    // product correctly skips reviews for bot authors ("User is ignored,
+    // skipping automation"), which silently zeroed the whole cloud matrix
+    // since the App secrets landed. Route authorship writes through the
+    // durable PAT (a human-typed account) and keep every read/poll on the
+    // App token's own quota. On PAT-only runs this is identical to
+    // headers().
+    private authorHeaders(): Record<string, string> {
+        const pat = process.env.GH_TEST_TOKEN;
+        const token =
+            this.token.startsWith('ghs_') && pat && !pat.startsWith('ghs_')
+                ? pat
+                : this.token;
+        return {
+            'Authorization': `Bearer ${token}`,
+            'Accept': 'application/vnd.github+json',
+            'X-GitHub-Api-Version': '2022-11-28',
+        };
+    }
+
     private cloneUrl(): string {
         return `https://x-access-token:${this.token}@github.com/${this.repoFullName}.git`;
     }
@@ -170,7 +193,7 @@ export class GitHubProvider extends BaseProvider {
                 `${this.apiBase}/repos/${this.repoFullName}/pulls`,
                 {
                     method: 'POST',
-                    headers: this.headers(),
+                    headers: this.authorHeaders(),
                     body: {
                         title: args.title,
                         body: args.body,
@@ -271,7 +294,7 @@ export class GitHubProvider extends BaseProvider {
             `${this.apiBase}/repos/${this.repoFullName}/pulls`,
             {
                 method: 'POST',
-                headers: this.headers(),
+                headers: this.authorHeaders(),
                 body: {
                     title: args.title,
                     body: args.body,
@@ -371,7 +394,7 @@ export class GitHubProvider extends BaseProvider {
             `${this.apiBase}/repos/${this.repoFullName}/issues/${target}/comments`,
             {
                 method: 'POST',
-                headers: this.headers(),
+                headers: this.authorHeaders(),
                 body: { body: '@kody review' },
             },
         );
@@ -676,7 +699,7 @@ export class GitHubProvider extends BaseProvider {
             `${this.apiBase}/repos/${this.repoFullName}/issues/${prNumber}/comments`,
             {
                 method: 'POST',
-                headers: this.headers(),
+                headers: this.authorHeaders(),
                 body: { body },
             },
         );

--- a/tests/e2e/providers/github.ts
+++ b/tests/e2e/providers/github.ts
@@ -42,7 +42,9 @@ export class GitHubProvider extends BaseProvider {
     readonly integrationType = 'GITHUB';
     readonly webhookPath = '/github/webhook';
 
-    protected readonly token: string;
+    // Not readonly: refreshInstallationTokenIfNeeded() swaps in a re-minted
+    // GitHub App installation token when a long poll outlives the ~1h expiry.
+    protected token: string;
     protected readonly repoFullName: string;
     protected readonly apiBase = 'https://api.github.com';
     protected readonly existingPrNumber?: number;
@@ -380,6 +382,26 @@ export class GitHubProvider extends BaseProvider {
         };
     }
 
+    // GitHub App installation tokens (ghs_) expire after ~1h. The runner
+    // mints one per SCENARIO, but a scenario with two 25-min polls plus a
+    // retry settle outlives it — observed on the cloud matrix as an opaque
+    // HTTP 401 mid-poll after ~50min. githubAppToken() keeps a cache with a
+    // 30-min refresh margin, so re-resolving here is free until a re-mint is
+    // actually due. PATs (ghp_/github_pat_) never take this path.
+    private async refreshInstallationTokenIfNeeded(): Promise<void> {
+        if (!this.token.startsWith('ghs_')) return;
+        try {
+            const { githubAppToken } = await import(
+                '../lib/github-app-token.js'
+            );
+            const fresh = await githubAppToken();
+            if (fresh) this.token = fresh;
+        } catch {
+            // keep the current token — if it is truly expired the next
+            // request 401s loudly, which is the pre-existing behaviour
+        }
+    }
+
     // Conditional GET with an ETag cache. GitHub serves 304 Not Modified
     // when the resource didn't change since the cached ETag — and 304s DO
     // NOT count against the per-account rate limit. The poll loops below
@@ -452,6 +474,7 @@ export class GitHubProvider extends BaseProvider {
         const since = encodeURIComponent(opts.sinceIso);
         const result = await pollUntil(
             async () => {
+                await this.refreshInstallationTokenIfNeeded();
                 const [reviewComments, issueComments, reviews] =
                     await Promise.all([
                         this.conditionalGet<{ id: number; body: string }[]>(
@@ -622,6 +645,7 @@ export class GitHubProvider extends BaseProvider {
         const since = encodeURIComponent(opts.sinceIso);
         const result = await pollUntil<{ startedAt: string; sample: string }>(
             async () => {
+                await this.refreshInstallationTokenIfNeeded();
                 const resp = await this.conditionalGet<
                     { id: number; body: string; created_at: string }[]
                 >(


### PR DESCRIPTION
Fixes das **duas** falhas do run cloud agendado [30339726353](https://github.com/kodustech/kodus-ai/actions/runs/30339726353):

## 1. "review pipeline likely never started" — autoria bot (a principal)
Desde que as secrets do GitHub App entraram (08/jul), os cells cloud rodam o harness com installation token — então os PRs e os comentários `@kody review` são **autorados pelo `e2e-qa-ci[bot]`**, e o produto (corretamente) pula reviews de bots. Confirmado nos logs de observabilidade do QA para o PR#648:

```
ValidatePrerequisitesStage | User is ignored, skipping automation
```

**Fix:** só as escritas que estabelecem autoria (criar PR, comentar) passam pelo PAT durável; todas as leituras/polls continuam no token do App (cota própria). Runs só-PAT ficam idênticos.

## 2. HTTP 401 no meio do poll — token de App expira em ~1h
O runner minta o installation token 1× por cenário; cenários com 2 polls de 25min o sobrevivem. **Fix:** os polls re-resolvem o token a cada iteração quando rodam em `ghs_` — o cache de 30min do `githubAppToken()` torna isso no-op até o re-mint ser devido.

## Verificação
`tsc` limpo; specs rate-limit-hardening + token-pool verdes. Validação real: próximo run agendado do e2e-cloud (ou dispatch manual).

🤖 Generated with [Claude Code](https://claude.com/claude-code)