### PR TITLE
fix(gitlab): adding validation to avoid comment suggestion in context line

### DIFF
--- a/libs/code-review/pipeline/stages/create-file-comments.stage.ts
+++ b/libs/code-review/pipeline/stages/create-file-comments.stage.ts
@@ -11,11 +11,13 @@ import {
     calculateCommentEndLine,
     calculateCommentStartLine,
 } from '@libs/common/utils/comment-builder.utils';
+import { resolveAddedLineAnchor } from '@libs/common/utils/resolve-added-line-anchor';
 import { PlatformType } from '@libs/core/domain/enums';
 import {
     ClusteringType,
     CodeReviewConfig,
     CodeSuggestion,
+    Comment,
     CommentResult,
     FileChange,
     FallbackSuggestionsBySeverity,
@@ -302,6 +304,7 @@ export class CreateFileCommentsStage extends BasePipelineStage<CodeReviewPipelin
                 fallbackSuggestionsBySeverity,
                 allDiscardedSuggestions,
                 changedFiles,
+                platformType,
             );
 
         // Save pull request suggestions — comments already posted at this point
@@ -378,6 +381,7 @@ export class CreateFileCommentsStage extends BasePipelineStage<CodeReviewPipelin
         fallbackSuggestionsBySeverity?: FallbackSuggestionsBySeverity,
         allDiscardedSuggestions?: Partial<CodeSuggestion>[],
         changedFiles: FileChange[] = [],
+        platformType?: PlatformType,
     ) {
         try {
             // Children in a cluster are merged into their parent's
@@ -416,30 +420,70 @@ export class CreateFileCommentsStage extends BasePipelineStage<CodeReviewPipelin
                     .map((f) => f.filename),
             );
 
-            const lineComments = sortedPrioritizedSuggestions
-                .filter(
-                    (suggestion) =>
-                        suggestion.clusteringInformation?.type !==
-                            ClusteringType.RELATED &&
-                        !removedFiles.has(suggestion.relevantFile),
-                )
-                .map((suggestion) => {
-                    return {
-                        path: suggestion.relevantFile,
-                        body: {
-                            language: repository?.language,
-                            improvedCode: suggestion?.improvedCode,
-                            suggestionContent: suggestion?.suggestionContent,
-                            actionStatement:
-                                suggestion?.clusteringInformation
-                                    ?.actionStatement || '',
-                        },
-                        start_line: calculateCommentStartLine(suggestion),
-                        line: calculateCommentEndLine(suggestion),
-                        side: 'RIGHT',
-                        suggestion,
-                    };
+            const candidateSuggestions = sortedPrioritizedSuggestions.filter(
+                (suggestion) =>
+                    suggestion.clusteringInformation?.type !==
+                        ClusteringType.RELATED &&
+                    !removedFiles.has(suggestion.relevantFile),
+            );
+
+            // GitLab only: a discussion anchored on a context (unchanged) line
+            // loses its "Resolve" control once its diff version is superseded by
+            // a rebase/force-push, while an added-line anchor survives. Snap each
+            // comment onto an added line within the span it already covers; if the
+            // span has no added line, the comment is about unchanged code — discard
+            // it (as `discarded-by-code-diff`) rather than post a fragile note.
+            // Other providers are left untouched: GitHub already rejects
+            // non-added-line comments, and Bitbucket/Azure have no such reports.
+            const isGitlab = platformType === PlatformType.GITLAB;
+            const patchByFile = new Map(
+                changedFiles.map((file) => [file.filename, file.patch]),
+            );
+
+            const lineComments: Comment[] = [];
+            for (const suggestion of candidateSuggestions) {
+                let startLine = calculateCommentStartLine(suggestion);
+                let line = calculateCommentEndLine(suggestion);
+
+                if (isGitlab && typeof line === 'number') {
+                    const patch = patchByFile.get(suggestion.relevantFile);
+                    if (patch) {
+                        const anchor = resolveAddedLineAnchor(
+                            patch,
+                            suggestion.relevantFile,
+                            { startLine, line },
+                        );
+
+                        if (!anchor) {
+                            allDiscardedSuggestions?.push({
+                                ...suggestion,
+                                priorityStatus:
+                                    PriorityStatus.DISCARDED_BY_CODE_DIFF,
+                            });
+                            continue;
+                        }
+
+                        startLine = anchor.startLine;
+                        line = anchor.line;
+                    }
+                }
+
+                lineComments.push({
+                    path: suggestion.relevantFile,
+                    body: {
+                        language: repository?.language,
+                        improvedCode: suggestion?.improvedCode,
+                        suggestionContent: suggestion?.suggestionContent,
+                        actionStatement:
+                            suggestion?.clusteringInformation?.actionStatement ||
+                            '',
+                    },
+                    start_line: startLine,
+                    line,
+                    side: 'RIGHT',
+                    suggestion,
                 });
+            }
 
             const { lastAnalyzedCommit, commentResults } =
                 await this.commentManagerService.createLineComments(

--- a/libs/code-review/pipeline/stages/create-file-comments.stage.ts
+++ b/libs/code-review/pipeline/stages/create-file-comments.stage.ts
@@ -460,6 +460,20 @@ export class CreateFileCommentsStage extends BasePipelineStage<CodeReviewPipelin
                                 priorityStatus:
                                     PriorityStatus.DISCARDED_BY_CODE_DIFF,
                             });
+                            // Remove it from the prioritized list too, so it isn't
+                            // persisted a second time as a phantom `failed` (it's
+                            // never posted, so verifyIfSuggestionsWereSent would
+                            // otherwise stamp it FAILED). Safe to splice: this array
+                            // is a fresh copy built in finalizeReviewProcessing; we
+                            // drop the entry, we don't mutate the frozen suggestion.
+                            const prioritizedIndex =
+                                sortedPrioritizedSuggestions.indexOf(suggestion);
+                            if (prioritizedIndex !== -1) {
+                                sortedPrioritizedSuggestions.splice(
+                                    prioritizedIndex,
+                                    1,
+                                );
+                            }
                             continue;
                         }
 

--- a/libs/common/utils/resolve-added-line-anchor.ts
+++ b/libs/common/utils/resolve-added-line-anchor.ts
@@ -1,0 +1,90 @@
+import {
+    convertToUnifiedDiffWithLineNumbers,
+    extractLinesFromUnifiedDiff,
+} from './patch';
+
+/**
+ * Deterministically resolves a review-comment anchor onto an ADDED (`+`) diff line.
+ *
+ * Context (why this exists):
+ * On GitLab, a discussion `position` that lands on an *added* line stores only
+ * `new_line` and survives a branch rewrite (rebase/force-push). A position that
+ * lands on a *context* (unchanged) line gets both `old_line` and `new_line`
+ * filled by GitLab, and that anchor loses its "Resolve thread" control once its
+ * diff version is superseded (the docblock/rebase repro from the field report).
+ *
+ * The AI-provided target line is only a hint — it may point at a context line.
+ * This helper validates that hint against the real diff and either keeps it,
+ * relocates it onto an added line *within the span the comment already covers*,
+ * or reports that the comment cannot be anchored on added code.
+ *
+ * Model (in-range only — no distance cap, no cross-hunk jump):
+ * - The anchor GitLab actually uses as `new_line` is `startLine ?? line`
+ *   (see gitlab.service.ts createReviewComment). The covered span is
+ *   `[startLine ?? line, line]`.
+ * - If the anchor is already an added line → keep it (`snapped: false`),
+ *   preserving the original multi-line range.
+ * - Else if the covered span contains an added line → snap to the added line
+ *   nearest the anchor, collapsing to a single-line anchor (`snapped: true`).
+ * - Else → return `null`: the comment is about unchanged code and must not be
+ *   posted (the caller discards it as `discarded-by-code-diff`). This mirrors
+ *   how GitHub already rejects non-added-line comments.
+ */
+export interface AddedLineAnchor {
+    /** New-side line the comment should be anchored to (an added line). */
+    line: number;
+    /** Start of a multi-line anchor, when preserved; `undefined` for single-line. */
+    startLine?: number;
+    /** True when the original target was moved off a context line. */
+    snapped: boolean;
+}
+
+export function resolveAddedLineAnchor(
+    patch: string,
+    filename: string,
+    target: { startLine?: number; line: number },
+): AddedLineAnchor | null {
+    const anchor = target.startLine ?? target.line;
+    const spanStart = Math.min(anchor, target.line);
+    const spanEnd = Math.max(anchor, target.line);
+
+    const addedRanges = extractLinesFromUnifiedDiff(
+        convertToUnifiedDiffWithLineNumbers(patch, { filename }),
+    );
+
+    const isAdded = (n: number): boolean =>
+        addedRanges.some((r) => n >= r.start && n <= r.end);
+
+    // Anchor already lands on an added line — keep it as-is.
+    if (isAdded(anchor)) {
+        return {
+            line: target.line,
+            startLine: target.startLine,
+            snapped: false,
+        };
+    }
+
+    // Collect the added lines that fall within the span the comment covers.
+    const inSpanAdded: number[] = [];
+    for (const range of addedRanges) {
+        const from = Math.max(range.start, spanStart);
+        const to = Math.min(range.end, spanEnd);
+        for (let n = from; n <= to; n++) {
+            inSpanAdded.push(n);
+        }
+    }
+
+    // No added line inside the covered span — the comment targets unchanged
+    // code and cannot be safely anchored. Caller discards it.
+    if (inSpanAdded.length === 0) {
+        return null;
+    }
+
+    // Snap to the added line nearest the anchor (ties resolve to the lower line),
+    // collapsing to a single-line anchor.
+    inSpanAdded.sort(
+        (a, b) => Math.abs(a - anchor) - Math.abs(b - anchor) || a - b,
+    );
+
+    return { line: inSpanAdded[0], startLine: undefined, snapped: true };
+}

--- a/test/unit/code-review/pipeline/stages/create-file-comments.stage.spec.ts
+++ b/test/unit/code-review/pipeline/stages/create-file-comments.stage.spec.ts
@@ -1072,6 +1072,55 @@ describe('CreateFileCommentsStage', () => {
             expect(discarded.priorityStatus).toBe('discarded-by-code-diff');
         });
 
+        it('does not double-persist a discarded suggestion — it is removed from the prioritized list (no phantom failed)', async () => {
+            const validSuggestions = [
+                // kept: anchor on the added line.
+                { id: 'added', relevantFile: 'Invoice.php', severity: 'high', relevantLinesStart: 1032, relevantLinesEnd: 1032 },
+                // discarded: single context line, no added line in span.
+                { id: 'context', relevantFile: 'Invoice.php', severity: 'high', relevantLinesStart: 1035, relevantLinesEnd: 1035 },
+            ] as any[];
+
+            wireHappyPathMocks();
+            // Passthrough so we can inspect exactly which suggestions reach
+            // persistence as prioritized (the ones that would get a delivery status).
+            mockSuggestionService.verifyIfSuggestionsWereSent.mockImplementation(
+                (_o: any, _pr: any, prioritized: any) => prioritized,
+            );
+
+            const context = createBaseContext({
+                platformType: PlatformType.GITLAB,
+                validSuggestions,
+                changedFiles: [
+                    { filename: 'Invoice.php', status: 'modified', patch: DOCBLOCK_PATCH } as any,
+                ],
+            });
+
+            await (stage as any).executeStage(context);
+
+            const saveArgs =
+                mockPullRequestService.aggregateAndSaveDataStructure.mock
+                    .calls[0];
+            const prioritized = saveArgs[3];
+            const unused = saveArgs[4];
+
+            // The discarded suggestion must NOT be persisted as prioritized
+            // (that path would stamp it FAILED — the duplicate bug).
+            expect(
+                prioritized.some((s: any) => s.id === 'context'),
+            ).toBe(false);
+            // The kept one stays prioritized.
+            expect(prioritized.some((s: any) => s.id === 'added')).toBe(true);
+
+            // It appears exactly once overall, only as discarded-by-code-diff.
+            const contextInUnused = unused.filter(
+                (s: any) => s.id === 'context',
+            );
+            expect(contextInUnused).toHaveLength(1);
+            expect(contextInUnused[0].priorityStatus).toBe(
+                'discarded-by-code-diff',
+            );
+        });
+
         it('leaves GitHub untouched — a context-line comment is still posted as-is', async () => {
             const validSuggestions = [
                 { id: 'context', relevantFile: 'Invoice.php', severity: 'high', relevantLinesStart: 1035, relevantLinesEnd: 1035 },

--- a/test/unit/code-review/pipeline/stages/create-file-comments.stage.spec.ts
+++ b/test/unit/code-review/pipeline/stages/create-file-comments.stage.spec.ts
@@ -989,6 +989,115 @@ describe('CreateFileCommentsStage', () => {
             ).toBe(true);
         });
 
+    });
+
+    // Docblock hunk with a single inserted line: added line 1032, context
+    // lines 1030/1031/1033/1034/1035 (mirrors the field report).
+    const DOCBLOCK_PATCH = `@@ -1030,5 +1030,6 @@ class InvoiceRenderer
+      * Render the invoice header.
+      *
++     * @param array $meta additional metadata
+      * @param int $id
+      * @return void
+      */`;
+
+    describe('GitLab added-line anchoring gate', () => {
+        const wireHappyPathMocks = () => {
+            mockCommentManagerService.createLineComments.mockResolvedValue({
+                lastAnalyzedCommit: 'abc123',
+                commentResults: [],
+            });
+            mockSuggestionService.verifyIfSuggestionsWereSent.mockResolvedValue(
+                [],
+            );
+            mockSuggestionService.extractRepriorizedSuggestions.mockImplementation(
+                (_commentResults: any, discarded: any) => ({
+                    repriorizedSuggestions: [],
+                    filteredDiscardedSuggestions: discarded,
+                }),
+            );
+            mockCodeManagementService.getCommitsForPullRequestForCodeReview.mockResolvedValue(
+                [{ sha: 'abc123' }],
+            );
+            mockPullRequestService.findByNumberAndRepositoryName.mockResolvedValue(
+                { number: 123, files: [] },
+            );
+        };
+
+        it('keeps added-line comments, snaps context-in-span onto the added line, discards context-only', async () => {
+            const validSuggestions = [
+                // anchor already on the added line → kept as-is.
+                { id: 'added', relevantFile: 'Invoice.php', severity: 'high', relevantLinesStart: 1032, relevantLinesEnd: 1032 },
+                // single context line, added line outside its span → discarded.
+                { id: 'context', relevantFile: 'Invoice.php', severity: 'high', relevantLinesStart: 1035, relevantLinesEnd: 1035 },
+                // multi-line span [1030,1034] covering the added line → snapped to 1032.
+                { id: 'snap', relevantFile: 'Invoice.php', severity: 'high', relevantLinesStart: 1030, relevantLinesEnd: 1034 },
+            ] as any[];
+
+            wireHappyPathMocks();
+
+            const context = createBaseContext({
+                platformType: PlatformType.GITLAB,
+                validSuggestions,
+                changedFiles: [
+                    { filename: 'Invoice.php', status: 'modified', patch: DOCBLOCK_PATCH } as any,
+                ],
+            });
+
+            await (stage as any).executeStage(context);
+
+            const posted =
+                mockCommentManagerService.createLineComments.mock.calls[0][3];
+            expect(posted.map((c: any) => c.suggestion.id)).toEqual([
+                'added',
+                'snap',
+            ]);
+
+            const added = posted.find((c: any) => c.suggestion.id === 'added');
+            expect(added.line).toBe(1032);
+            expect(added.start_line).toBeUndefined();
+
+            const snap = posted.find((c: any) => c.suggestion.id === 'snap');
+            expect(snap.line).toBe(1032);
+            expect(snap.start_line).toBeUndefined();
+
+            // The context-only comment reaches Mongo as discarded-by-code-diff.
+            const saveArgs =
+                mockPullRequestService.aggregateAndSaveDataStructure.mock
+                    .calls[0];
+            const unusedSuggestions = saveArgs[4];
+            const discarded = unusedSuggestions.find(
+                (s: any) => s.id === 'context',
+            );
+            expect(discarded.priorityStatus).toBe('discarded-by-code-diff');
+        });
+
+        it('leaves GitHub untouched — a context-line comment is still posted as-is', async () => {
+            const validSuggestions = [
+                { id: 'context', relevantFile: 'Invoice.php', severity: 'high', relevantLinesStart: 1035, relevantLinesEnd: 1035 },
+            ] as any[];
+
+            wireHappyPathMocks();
+
+            const context = createBaseContext({
+                platformType: PlatformType.GITHUB,
+                validSuggestions,
+                changedFiles: [
+                    { filename: 'Invoice.php', status: 'modified', patch: DOCBLOCK_PATCH } as any,
+                ],
+            });
+
+            await (stage as any).executeStage(context);
+
+            const posted =
+                mockCommentManagerService.createLineComments.mock.calls[0][3];
+            expect(posted).toHaveLength(1);
+            expect(posted[0].suggestion.id).toBe('context');
+            expect(posted[0].line).toBe(1035);
+        });
+    });
+
+    describe('saving discarded suggestions to database (extra reasons)', () => {
         it('should save mixed discarded suggestions to database when all are discarded by different reasons', async () => {
             const discardedSuggestions = [
                 {

--- a/test/unit/shared/utils/resolve-added-line-anchor.spec.ts
+++ b/test/unit/shared/utils/resolve-added-line-anchor.spec.ts
@@ -1,0 +1,273 @@
+import {
+    convertToUnifiedDiffWithLineNumbers,
+    extractLinesFromUnifiedDiff,
+} from '@/shared/utils/patch';
+import {
+    resolveAddedLineAnchor,
+    AddedLineAnchor,
+} from '@/shared/utils/resolve-added-line-anchor';
+
+/**
+ * Fixtures reproduce the field report: a docblock region where one line was
+ * inserted, so the hunk holds a single added (`+`) line surrounded by context
+ * lines. The customer's two Kody notes landed on:
+ *   - new_line 1032 (the added line)   → survived rebase (control)
+ *   - new_line 1035 (a context line)   → lost its Resolve control (bug)
+ * Content is generic; only the diff shape mirrors the real case.
+ */
+
+// Added line = 1032. Context lines = 1030, 1031, 1033, 1034, 1035.
+const DOCBLOCK_PATCH = `@@ -1030,5 +1030,6 @@ class InvoiceRenderer
+      * Render the invoice header.
+      *
++     * @param array $meta additional metadata
+      * @param int $id
+      * @return void
+      */`;
+
+// Added lines = 11 and 14 (non-contiguous), context = 10, 12, 13, 15.
+const TWO_ADDS_PATCH = `@@ -10,4 +10,6 @@ function build()
+   const a = ctx();
++  const b = added();
+   const c = ctx();
+   const d = ctx();
++  const e = added();
+   const f = ctx();`;
+
+// No added lines at all — a pure deletion hunk. Context = 5, 6, 7.
+const DELETION_ONLY_PATCH = `@@ -5,4 +5,3 @@ function shrink()
+   keepA();
+-  removeMe();
+   keepC();
+   keepD();`;
+
+// Contiguous added lines 21 and 22, context = 20, 23.
+const MULTILINE_ADD_PATCH = `@@ -20,2 +20,4 @@ function grow()
+   before();
++  addedP();
++  addedQ();
+   after();`;
+
+// Two separate hunks in one file. Hunk 1: added line 11 (context 10/12/13).
+// Hunk 2 (far away): added line 101 (context 100/102/103).
+const TWO_HUNKS_PATCH = `@@ -10,4 +10,5 @@ function alpha()
+   const a = ctx();
++  const inserted1 = added();
+   const b = ctx();
+   const c = ctx();
+@@ -100,4 +100,5 @@ function beta()
+   const d = ctx();
++  const inserted2 = added();
+   const e = ctx();
+   const f = ctx();`;
+
+const covers = (ranges: { start: number; end: number }[], line: number) =>
+    ranges.some((r) => line >= r.start && line <= r.end);
+
+describe('resolve-added-line-anchor', () => {
+    /**
+     * PRECONDITION — runs GREEN today. Proves, using only the existing patch
+     * utilities, that each fixture really does place the "suspect" target on a
+     * context line and the "control" target on an added line. This documents the
+     * bug independently of the not-yet-written resolver.
+     */
+    describe('fixtures reproduce context-vs-added anchors (precondition)', () => {
+        it('docblock hunk: 1032 is added, 1035 is context', () => {
+            const ranges = extractLinesFromUnifiedDiff(
+                convertToUnifiedDiffWithLineNumbers(DOCBLOCK_PATCH, {
+                    filename: 'InvoiceRenderer.php',
+                }),
+            );
+
+            expect(ranges).toEqual([{ start: 1032, end: 1032 }]);
+            expect(covers(ranges, 1032)).toBe(true); // control (added)
+            expect(covers(ranges, 1035)).toBe(false); // suspect (context)
+            expect(covers(ranges, 1030)).toBe(false); // suspect (context)
+        });
+
+        it('two-adds hunk: 11 and 14 added, 12/13/15 context', () => {
+            const ranges = extractLinesFromUnifiedDiff(
+                convertToUnifiedDiffWithLineNumbers(TWO_ADDS_PATCH, {
+                    filename: 'build.ts',
+                }),
+            );
+
+            expect(ranges).toEqual([
+                { start: 11, end: 11 },
+                { start: 14, end: 14 },
+            ]);
+            expect(covers(ranges, 12)).toBe(false);
+            expect(covers(ranges, 13)).toBe(false);
+        });
+
+        it('deletion-only hunk: no added lines exist', () => {
+            const ranges = extractLinesFromUnifiedDiff(
+                convertToUnifiedDiffWithLineNumbers(DELETION_ONLY_PATCH, {
+                    filename: 'shrink.ts',
+                }),
+            );
+
+            expect(ranges).toEqual([]);
+        });
+
+        it('multiline-add hunk: 21 and 22 form a contiguous added range', () => {
+            const ranges = extractLinesFromUnifiedDiff(
+                convertToUnifiedDiffWithLineNumbers(MULTILINE_ADD_PATCH, {
+                    filename: 'grow.ts',
+                }),
+            );
+
+            expect(ranges).toEqual([{ start: 21, end: 22 }]);
+        });
+
+        it('two-hunks patch: added lines 11 and 101 sit in separate hunks', () => {
+            const ranges = extractLinesFromUnifiedDiff(
+                convertToUnifiedDiffWithLineNumbers(TWO_HUNKS_PATCH, {
+                    filename: 'twohunks.ts',
+                }),
+            );
+
+            expect(ranges).toEqual([
+                { start: 11, end: 11 },
+                { start: 101, end: 101 },
+            ]);
+        });
+    });
+
+    /**
+     * BEHAVIOR — the spec of the fix (in-range only, no distance cap).
+     * The anchor GitLab uses is `startLine ?? line`; the covered span is
+     * `[startLine ?? line, line]`. Snap only ever lands inside that span;
+     * otherwise the comment is discarded.
+     * RED until resolveAddedLineAnchor is implemented; GREEN when the fix lands.
+     */
+    describe('resolveAddedLineAnchor', () => {
+        it('leaves a single-line added target untouched (control note stays healthy)', () => {
+            const result = resolveAddedLineAnchor(
+                DOCBLOCK_PATCH,
+                'InvoiceRenderer.php',
+                { line: 1032 },
+            );
+
+            expect(result).toEqual<AddedLineAnchor>({
+                line: 1032,
+                startLine: undefined,
+                snapped: false,
+            });
+        });
+
+        it('preserves a multi-line anchor whose start is already an added line', () => {
+            // anchor = startLine = 1032 (added) → kept, range preserved,
+            // even though the end line 1035 is a context line.
+            const result = resolveAddedLineAnchor(
+                DOCBLOCK_PATCH,
+                'InvoiceRenderer.php',
+                { startLine: 1032, line: 1035 },
+            );
+
+            expect(result).toEqual<AddedLineAnchor>({
+                line: 1035,
+                startLine: 1032,
+                snapped: false,
+            });
+        });
+
+        it('preserves a multi-line anchor whose endpoints are both added', () => {
+            const result = resolveAddedLineAnchor(
+                MULTILINE_ADD_PATCH,
+                'grow.ts',
+                { startLine: 21, line: 22 },
+            );
+
+            expect(result).toEqual<AddedLineAnchor>({
+                line: 22,
+                startLine: 21,
+                snapped: false,
+            });
+        });
+
+        it('snaps a context-anchored multi-line comment onto the added line inside its span', () => {
+            // span [1030,1034] covers the added line 1032; anchor 1030 is context.
+            const result = resolveAddedLineAnchor(
+                DOCBLOCK_PATCH,
+                'InvoiceRenderer.php',
+                { startLine: 1030, line: 1034 },
+            );
+
+            expect(result).toEqual<AddedLineAnchor>({
+                line: 1032,
+                startLine: undefined,
+                snapped: true,
+            });
+        });
+
+        it('snaps to the added line nearest the anchor when several sit in the span', () => {
+            // span [10,15] covers added lines 11 and 14; anchor 10 → nearest is 11.
+            expect(
+                resolveAddedLineAnchor(TWO_ADDS_PATCH, 'build.ts', {
+                    startLine: 10,
+                    line: 15,
+                })?.line,
+            ).toBe(11);
+
+            // anchor 13 (context), span [13,15] covers only 14 → snaps to 14.
+            expect(
+                resolveAddedLineAnchor(TWO_ADDS_PATCH, 'build.ts', {
+                    startLine: 13,
+                    line: 15,
+                })?.line,
+            ).toBe(14);
+        });
+
+        it('discards a single-line context comment whose added line is OUTSIDE its span (the customer note)', () => {
+            // 1035 context, span [1035,1035]; the added line 1032 is outside it.
+            // GitHub already drops this kind of comment — GitLab now matches.
+            const result = resolveAddedLineAnchor(
+                DOCBLOCK_PATCH,
+                'InvoiceRenderer.php',
+                { line: 1035 },
+            );
+
+            expect(result).toBeNull();
+        });
+
+        it('discards a comment whose span contains no added line at all', () => {
+            const result = resolveAddedLineAnchor(
+                DELETION_ONLY_PATCH,
+                'shrink.ts',
+                { startLine: 5, line: 7 },
+            );
+
+            expect(result).toBeNull();
+        });
+
+        it('snaps within the comment span and never borrows an added line from another hunk', () => {
+            // span [10,13] lives in hunk 1 and covers its added line 11.
+            // Hunk 2's added line 101 must be ignored entirely.
+            const result = resolveAddedLineAnchor(
+                TWO_HUNKS_PATCH,
+                'twohunks.ts',
+                { startLine: 10, line: 13 },
+            );
+
+            expect(result).toEqual<AddedLineAnchor>({
+                line: 11,
+                startLine: undefined,
+                snapped: true,
+            });
+        });
+
+        it('discards rather than jumping to another hunk when the span has no added line', () => {
+            // 13 is context; its span [13,13] has no added line. The nearest
+            // added lines (11 in this hunk, 101 in the other) are both out of
+            // span, so the comment is discarded — never relocated across hunks.
+            const result = resolveAddedLineAnchor(
+                TWO_HUNKS_PATCH,
+                'twohunks.ts',
+                { line: 13 },
+            );
+
+            expect(result).toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
<!-- kody-pr-summary:start -->
## Description

This PR fixes a GitLab-specific issue where code review comments/suggestions anchored on unchanged (“context”) lines in a diff could lose their “Resolve thread” control after the branch is rebased or force-pushed. On GitLab, only comments anchored on **added lines** remain stable across diff version updates.

### What changed

- Added validation for GitLab comments in the `CreateFileCommentsStage`:
  - If a suggestion is already anchored on an **added line**, it is posted as-is.
  - If the suggestion’s covered line span contains an added line, the comment is “snapped” to the nearest added line within that span.
  - If the suggestion targets only unchanged/context lines (no added line in the covered span), the comment is **discarded** as `discarded-by-code-diff` instead of being posted as a fragile note.
- Added a new utility `resolveAddedLineAnchor` to determine, from the actual diff patch, whether a target line is an added line, to find added lines within the covered span, and to snap/discard accordingly.
- Removed discarded suggestions from the prioritized list before persistence so they are not later recorded as failed comments (avoiding a duplicate/“phantom failed” state).
- Added unit tests covering:
  - Added-line comments kept intact.
  - Context-line comments discarded when no added line is in the span.
  - Multi-line comments snapped to an added line within their span.
  - No cross-hunk jumping when no added line exists in the span.
  - Other platforms (GitHub, Bitbucket, Azure) remain unchanged — only GitLab is affected.

### Why

On GitLab, a discussion position placed on a context line stores both `old_line` and `new_line` and becomes invalid once the diff version is superseded by a rebase/force-push. Anchoring on an added line keeps the comment stable and fully functional. This makes GitLab behavior consistent with GitHub, which already rejects non-added-line comments.
<!-- kody-pr-summary:end -->