### PR TITLE
feat(organization): persist code host member count

### DIFF
--- a/libs/core/infrastructure/database/typeorm/migrations/2026072800000000-addCodeHostMemberCountToOrganizations.ts
+++ b/libs/core/infrastructure/database/typeorm/migrations/2026072800000000-addCodeHostMemberCountToOrganizations.ts
@@ -1,0 +1,34 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Persists the latest organization-member snapshot obtained from the connected
+ * code host. For GitHub integrations this is the GitHub organization developer
+ * count previously sent only to PostHog at the end of onboarding.
+ */
+export class AddCodeHostMemberCountToOrganizations2026072800000000
+    implements MigrationInterface
+{
+    name = 'AddCodeHostMemberCountToOrganizations2026072800000000';
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "organizations"
+            ADD COLUMN IF NOT EXISTS "code_host_member_count" integer
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "organizations"
+            ADD COLUMN IF NOT EXISTS "code_host_member_count_updated_at" TIMESTAMPTZ
+        `);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`
+            ALTER TABLE "organizations"
+            DROP COLUMN IF EXISTS "code_host_member_count_updated_at"
+        `);
+        await queryRunner.query(`
+            ALTER TABLE "organizations"
+            DROP COLUMN IF EXISTS "code_host_member_count"
+        `);
+    }
+}

--- a/libs/organization/domain/organization/entities/organization.entity.ts
+++ b/libs/organization/domain/organization/entities/organization.entity.ts
@@ -13,6 +13,8 @@ export class OrganizationEntity implements Entity<IOrganization> {
     private _name: string;
     private _tenantName: string;
     private _status: boolean;
+    private _codeHostMemberCount?: number;
+    private _codeHostMemberCountUpdatedAt?: Date;
     private _releaseTrack: ReleaseTrack;
     private _users?: Partial<IUser>[];
     private _teams?: Partial<ITeam>[];
@@ -22,6 +24,9 @@ export class OrganizationEntity implements Entity<IOrganization> {
         this._name = organization.name;
         this._tenantName = organization.tenantName || this.generateTenantName();
         this._status = organization.status;
+        this._codeHostMemberCount = organization.codeHostMemberCount;
+        this._codeHostMemberCountUpdatedAt =
+            organization.codeHostMemberCountUpdatedAt;
         this._releaseTrack =
             organization.releaseTrack ?? DEFAULT_RELEASE_TRACK;
         this._users = organization.users;
@@ -54,6 +59,14 @@ export class OrganizationEntity implements Entity<IOrganization> {
         return this._status;
     }
 
+    public get codeHostMemberCount() {
+        return this._codeHostMemberCount;
+    }
+
+    public get codeHostMemberCountUpdatedAt() {
+        return this._codeHostMemberCountUpdatedAt;
+    }
+
     public get releaseTrack(): ReleaseTrack {
         return this._releaseTrack;
     }
@@ -72,6 +85,8 @@ export class OrganizationEntity implements Entity<IOrganization> {
             name: this._name,
             tenantName: this._tenantName,
             status: this._status,
+            codeHostMemberCount: this._codeHostMemberCount,
+            codeHostMemberCountUpdatedAt: this._codeHostMemberCountUpdatedAt,
             releaseTrack: this._releaseTrack,
             users: this._users,
             teams: this._teams,
@@ -84,6 +99,8 @@ export class OrganizationEntity implements Entity<IOrganization> {
             name: this._name,
             tenantName: this._tenantName,
             status: this._status,
+            codeHostMemberCount: this._codeHostMemberCount,
+            codeHostMemberCountUpdatedAt: this._codeHostMemberCountUpdatedAt,
             releaseTrack: this._releaseTrack,
             users: this._users,
             teams: this._teams,

--- a/libs/organization/domain/organization/interfaces/organization.interface.ts
+++ b/libs/organization/domain/organization/interfaces/organization.interface.ts
@@ -5,6 +5,8 @@ export interface IOrganization<TUser = any, TTeam = any> {
     name: string;
     tenantName: string;
     status: boolean;
+    codeHostMemberCount?: number;
+    codeHostMemberCountUpdatedAt?: Date;
     releaseTrack?: ReleaseTrack;
     users?: Partial<TUser>[] | null;
     teams?: Partial<TTeam>[] | null;

--- a/libs/organization/infrastructure/adapters/repositories/schemas/organization.model.ts
+++ b/libs/organization/infrastructure/adapters/repositories/schemas/organization.model.ts
@@ -31,6 +31,21 @@ export class OrganizationModel extends CoreModel {
     @Column({ default: true })
     public status: boolean;
 
+    /**
+     * Most recent member count obtained from the organization's connected
+     * code-host organization (GitHub for GitHub integrations).
+     */
+    @Column({ name: 'code_host_member_count', type: 'integer', nullable: true })
+    codeHostMemberCount?: number;
+
+    /** Timestamp of the snapshot in `codeHostMemberCount`. */
+    @Column({
+        name: 'code_host_member_count_updated_at',
+        type: 'timestamptz',
+        nullable: true,
+    })
+    codeHostMemberCountUpdatedAt?: Date;
+
     @Column({
         name: 'release_track',
         type: 'enum',

--- a/libs/platform/application/use-cases/codeManagement/finish-onboarding.use-case.spec.ts
+++ b/libs/platform/application/use-cases/codeManagement/finish-onboarding.use-case.spec.ts
@@ -13,7 +13,7 @@ jest.mock('@libs/ee/configs/environment', () => {
 });
 
 describe('FinishOnboardingUseCase', () => {
-    const buildUseCase = () => {
+    const buildUseCase = (user: { uuid?: string; email?: string } = {}) => {
         const parametersService = {
             findByKey: jest
                 .fn()
@@ -28,8 +28,18 @@ describe('FinishOnboardingUseCase', () => {
         const generateKodyRulesUseCase = {
             execute: jest.fn().mockResolvedValue([]),
         };
-        // No `uuid` on the user → the telemetry block is skipped.
-        const request = { user: { organization: { uuid: 'org-1' } } };
+        const request = {
+            user: { organization: { uuid: 'org-1' }, ...user },
+        };
+        const teamService = {
+            findById: jest.fn().mockResolvedValue({
+                name: 'Platform',
+                organization: { name: 'Acme' },
+            }),
+        };
+        const codeManagement = {
+            getListMembers: jest.fn().mockResolvedValue([]),
+        };
 
         const licenseService = {
             startTrial: jest.fn().mockResolvedValue(true),
@@ -37,16 +47,20 @@ describe('FinishOnboardingUseCase', () => {
         const permissionValidationService = {
             getBYOKConfig: jest.fn().mockResolvedValue(null),
         };
+        const organizationService = {
+            update: jest.fn().mockResolvedValue(undefined),
+        };
 
         const useCase = new FinishOnboardingUseCase(
             parametersService as any,
-            {} as any, // teamService
+            teamService as any,
+            organizationService as any,
             {} as any, // reviewPRUseCase
             request as any,
             syncSelectedReposKodyRulesUseCase as any,
             createOrUpdateParametersUseCase as any,
             {} as any, // telemetry
-            {} as any, // codeManagement
+            codeManagement as any,
             generateKodyRulesUseCase as any,
             licenseService as any,
             permissionValidationService as any,
@@ -59,6 +73,8 @@ describe('FinishOnboardingUseCase', () => {
             generateKodyRulesUseCase,
             licenseService,
             permissionValidationService,
+            organizationService,
+            codeManagement,
         };
     };
 
@@ -121,5 +137,26 @@ describe('FinishOnboardingUseCase', () => {
         expect(
             syncSelectedReposKodyRulesUseCase.execute,
         ).toHaveBeenCalledWith({ teamId: 'team-1', organizationId: 'org-1' });
+    });
+
+    it('persists the connected GitHub organization member-count snapshot', async () => {
+        const { useCase, codeManagement, organizationService } = buildUseCase({
+            uuid: 'user-1',
+        });
+        codeManagement.getListMembers.mockResolvedValue([
+            { id: 1 },
+            { id: 2 },
+            { id: 3 },
+        ]);
+
+        await useCase.execute({ teamId: 'team-1', reviewPR: false } as any);
+
+        expect(organizationService.update).toHaveBeenCalledWith(
+            { uuid: 'org-1' },
+            expect.objectContaining({
+                codeHostMemberCount: 3,
+                codeHostMemberCountUpdatedAt: expect.any(Date),
+            }),
+        );
     });
 });

--- a/libs/platform/application/use-cases/codeManagement/finish-onboarding.use-case.spec.ts
+++ b/libs/platform/application/use-cases/codeManagement/finish-onboarding.use-case.spec.ts
@@ -50,6 +50,11 @@ describe('FinishOnboardingUseCase', () => {
         const organizationService = {
             update: jest.fn().mockResolvedValue(undefined),
         };
+        const telemetry = {
+            onboardingCompleted: jest.fn(),
+            onboardingReviewTriggered: jest.fn(),
+            onboardingReviewSkipped: jest.fn(),
+        };
 
         const useCase = new FinishOnboardingUseCase(
             parametersService as any,
@@ -59,7 +64,7 @@ describe('FinishOnboardingUseCase', () => {
             request as any,
             syncSelectedReposKodyRulesUseCase as any,
             createOrUpdateParametersUseCase as any,
-            {} as any, // telemetry
+            telemetry as any,
             codeManagement as any,
             generateKodyRulesUseCase as any,
             licenseService as any,

--- a/libs/platform/application/use-cases/codeManagement/finish-onboarding.use-case.ts
+++ b/libs/platform/application/use-cases/codeManagement/finish-onboarding.use-case.ts
@@ -12,6 +12,10 @@ import {
     ITeamService,
     TEAM_SERVICE_TOKEN,
 } from '@libs/organization/domain/team/contracts/team.service.contract';
+import {
+    IOrganizationService,
+    ORGANIZATION_SERVICE_TOKEN,
+} from '@libs/organization/domain/organization/contracts/organization.service.contract';
 
 import { CreatePRCodeReviewUseCase } from './create-prs-code-review.use-case';
 import { SyncSelectedRepositoriesKodyRulesUseCase } from '@libs/kodyRules/application/use-cases/sync-selected-repositories.use-case';
@@ -34,6 +38,8 @@ export class FinishOnboardingUseCase {
         private readonly parametersService: IParametersService,
         @Inject(TEAM_SERVICE_TOKEN)
         private readonly teamService: ITeamService,
+        @Inject(ORGANIZATION_SERVICE_TOKEN)
+        private readonly organizationService: IOrganizationService,
         private readonly reviewPRUseCase: CreatePRCodeReviewUseCase,
         @Inject(REQUEST)
         private readonly request: Request & {
@@ -258,10 +264,20 @@ export class FinishOnboardingUseCase {
                     orgMemberCount = Array.isArray(members)
                         ? members.length
                         : undefined;
+
+                    if (orgMemberCount !== undefined) {
+                        await this.organizationService.update(
+                            { uuid: organizationId },
+                            {
+                                codeHostMemberCount: orgMemberCount,
+                                codeHostMemberCountUpdatedAt: new Date(),
+                            },
+                        );
+                    }
                 } catch (error) {
                     this.logger.warn({
                         message:
-                            'Failed to resolve org member count for onboarding telemetry',
+                            'Failed to resolve or persist org member count during onboarding',
                         context: FinishOnboardingUseCase.name,
                         metadata: {
                             teamId,

--- a/libs/platform/modules/platform.module.ts
+++ b/libs/platform/modules/platform.module.ts
@@ -16,6 +16,7 @@ import { PermissionsModule } from '@libs/identity/modules/permissions.module';
 import { OrganizationParametersModule } from '@libs/organization/modules/organizationParameters.module';
 import { ParametersModule } from '@libs/organization/modules/parameters.module';
 import { TeamModule } from '@libs/organization/modules/team.module';
+import { OrganizationModule } from '@libs/organization/modules/organization.module';
 import { PlatformDataModule } from '@libs/platformData/platformData.module';
 import CodeManagementUseCases from '../application/use-cases/codeManagement';
 import { AzureReposPullRequestHandler } from '../infrastructure/webhooks/azure/azureReposPullRequest.handler';
@@ -53,6 +54,7 @@ import { SandboxModule } from '@libs/sandbox/modules/sandbox.module';
         forwardRef(() => AgentsModule),
         forwardRef(() => OrganizationParametersModule),
         forwardRef(() => TeamModule),
+        forwardRef(() => OrganizationModule),
         forwardRef(() => ParametersModule),
         forwardRef(() => PlatformDataModule),
         PermissionsModule,


### PR DESCRIPTION
## What changed
- Persist the connected code-host organization member count and its snapshot timestamp on `organizations`.
- Reuse the existing onboarding member lookup that already feeds PostHog.
- Add a PostgreSQL migration and coverage for the persistence path.

## Why
The GitHub organization developer-count signal was previously sent only to PostHog and was unavailable to product and backend queries.

## Validation
- `git diff --cached --check`
- Targeted Jest could not run because this checkout has no installed dependencies and package download is blocked by network/DNS access.