### PR TITLE
fix(platform): rethrow transient fetch failures swallowed in getCommits

### DIFF
--- a/libs/core/infrastructure/http/rate-limit-retry.ts
+++ b/libs/core/infrastructure/http/rate-limit-retry.ts
@@ -118,16 +118,29 @@ export function is429Error(err: unknown): boolean {
 // while reporting success (observed 2026-07-29, bitbucket cloud cell).
 export function isTransientFetchError(err: unknown): boolean {
     if (!err || typeof err !== 'object') return false;
-    const anyErr = err as { message?: unknown; cause?: unknown };
-    const message =
-        typeof anyErr.message === 'string' ? anyErr.message : '';
-    const causeMessage =
-        anyErr.cause &&
-        typeof (anyErr.cause as { message?: unknown }).message === 'string'
-            ? String((anyErr.cause as { message: string }).message)
-            : '';
-    return /fetch failed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|socket hang ?up|network error|Recv failure|operation was aborted|UND_ERR/i.test(
-        `${message} ${causeMessage}`,
+    const anyErr = err as {
+        message?: unknown;
+        code?: unknown;
+        cause?: unknown;
+    };
+    const cause = (anyErr.cause ?? {}) as {
+        message?: unknown;
+        code?: unknown;
+    };
+    // Test messages AND codes: undici's timeout errors carry their
+    // UND_ERR_* identifier in `.code` while the message is prose
+    // ("Headers Timeout Error"), and when thrown through fetch() the
+    // useful detail lives on `.cause`.
+    const haystack = [
+        anyErr.message,
+        anyErr.code,
+        cause.message,
+        cause.code,
+    ]
+        .filter((v): v is string => typeof v === 'string')
+        .join(' ');
+    return /fetch failed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|socket hang ?up|network error|Recv failure|operation was aborted|UND_ERR|HeadersTimeout|BodyTimeout|ConnectTimeout|TimeoutError|Timeout Error/i.test(
+        haystack,
     );
 }
 

--- a/libs/core/infrastructure/http/rate-limit-retry.ts
+++ b/libs/core/infrastructure/http/rate-limit-retry.ts
@@ -109,6 +109,28 @@ export function is429Error(err: unknown): boolean {
     return false;
 }
 
+// Transport-level failures where the request never produced an HTTP
+// response: undici's bare `fetch failed`, connection resets, DNS blips,
+// timeouts. Like a 429, they mean "we could not fetch", NOT "the resource
+// is empty" — callers that swallow errors into an empty result must treat
+// these as fetch failures and rethrow, or a transient network hiccup
+// silently masquerades as "PR has no commits" and the review posts nothing
+// while reporting success (observed 2026-07-29, bitbucket cloud cell).
+export function isTransientFetchError(err: unknown): boolean {
+    if (!err || typeof err !== 'object') return false;
+    const anyErr = err as { message?: unknown; cause?: unknown };
+    const message =
+        typeof anyErr.message === 'string' ? anyErr.message : '';
+    const causeMessage =
+        anyErr.cause &&
+        typeof (anyErr.cause as { message?: unknown }).message === 'string'
+            ? String((anyErr.cause as { message: string }).message)
+            : '';
+    return /fetch failed|ECONNRESET|ECONNREFUSED|ETIMEDOUT|EAI_AGAIN|socket hang ?up|network error|Recv failure|operation was aborted|UND_ERR/i.test(
+        `${message} ${causeMessage}`,
+    );
+}
+
 function resolveDelayMs(
     err: unknown,
     attempt: number,

--- a/libs/platform/infrastructure/adapters/services/azureRepos/azureRepos.service.ts
+++ b/libs/platform/infrastructure/adapters/services/azureRepos/azureRepos.service.ts
@@ -1,3 +1,7 @@
+import {
+    is429Error,
+    isTransientFetchError,
+} from '@libs/core/infrastructure/http/rate-limit-retry';
 import { BadRequestException, Inject, NotFoundException } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
 import { createTwoFilesPatch } from 'diff';
@@ -1848,6 +1852,15 @@ export class AzureReposService implements Omit<
                 error,
                 metadata: { params },
             });
+            // A 429 or a transport failure means "we couldn't fetch the
+            // commits", NOT "the PR has no commits" — swallowing it as null
+            // makes createLineComments anchor nothing and the review ships
+            // with zero inline comments while reporting success (same class
+            // observed live on the bitbucket path, 2026-07-29). Re-throw so
+            // callers can tell an empty list apart from a failed fetch.
+            if (is429Error(error) || isTransientFetchError(error)) {
+                throw error;
+            }
             return null;
         }
     }

--- a/libs/platform/infrastructure/adapters/services/bitbucket/bitbucket-cloud.service.ts
+++ b/libs/platform/infrastructure/adapters/services/bitbucket/bitbucket-cloud.service.ts
@@ -2,7 +2,10 @@ import { createLogger } from '@libs/core/log/logger';
 
 import { fitPRDescription } from '@libs/code-review/utils/fit-pr-description';
 import { INTEGRATION_REQUEST_TIMEOUT_MS } from '@libs/core/infrastructure/http/integration-timeouts';
-import { is429Error } from '@libs/core/infrastructure/http/rate-limit-retry';
+import {
+    is429Error,
+    isTransientFetchError,
+} from '@libs/core/infrastructure/http/rate-limit-retry';
 import {
     parkRateGate,
     rateGateKey,
@@ -2513,13 +2516,16 @@ export class BitbucketCloudService implements Omit<
                     params,
                 },
             });
-            // A 429 means "we couldn't fetch the commits", NOT "the PR has no
-            // commits". Swallowing it as null lets it collapse to [] upstream,
-            // where ValidateNewCommitsStage misreads it as "PR has 0 commits"
-            // and silently SKIPs the review. Re-throw so callers can tell a
-            // genuine empty list apart from a throttled fetch. Non-429 errors
-            // keep the historical null contract.
-            if (is429Error(error)) {
+            // A 429 or a transport failure (undici `fetch failed`, resets,
+            // timeouts) means "we couldn't fetch the commits", NOT "the PR
+            // has no commits". Swallowing them as null lets it collapse to []
+            // upstream, where createLineComments reads it as "nothing to
+            // anchor" and posts ZERO inline comments while the stage reports
+            // success — the review ships with sent=0 and the error never
+            // surfaces (observed 2026-07-29, cloud bitbucket cell). Re-throw
+            // so callers can tell a genuine empty list apart from a failed
+            // fetch. Other errors keep the historical null contract.
+            if (is429Error(error) || isTransientFetchError(error)) {
                 throw error;
             }
             return null;


### PR DESCRIPTION
Investigation of the single failure in the nightly cloud run [30433724433](https://github.com/kodustech/kodus-ai/actions/runs/30433724433) (`code-review-basic × bitbucket × paid`, "posted findings but PERSISTED 0 suggestions").

## What the QA logs showed (PR#525)

```
08:14:52  [DEDUP] 2 → 1                                  ← healthy review
08:14:55  ERROR BitbucketCloudService getCommits: HTTPError: fetch failed   ← transient, SWALLOWED
08:14:55  CreateFileCommentsStage: Successfully processed ← 0 comments posted
08:14:58  summary updated (this is what the harness saw as "findings")
```

**It is not the Immer class** (#1522/#1523) the assert suggests: it is a transient undici `fetch failed` while listing commits, swallowed in `getCommitsForPullRequestForCodeReview` → `null` → upstream reads it as "PR has no commits" → **zero inline comments, review "successful", sent=0**. Real product impact: the customer sees only the summary, no inline comments, and no error anywhere.

## Fix
`isTransientFetchError` (transport-level failures: `fetch failed`, ECONNRESET, ETIMEDOUT, DNS, socket) rethrown alongside the existing `is429Error` — same rationale as the 429 comment: a failed fetch ≠ an empty list. GitLab already rethrows everything and GitHub propagates naturally; **bitbucket and azure** now match. With the throw, the stage records the error (partial_error) and the scenario/product retry covers the transient.

Verification: `tsc` clean on touched files (the only project error is a pre-existing spec with a broken import path, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)