### PR TITLE
test(e2e): health-check re-poll (kills the command-review skipped-row race)

### DIFF
--- a/tests/e2e/lib/execution-health.ts
+++ b/tests/e2e/lib/execution-health.ts
@@ -19,6 +19,17 @@ export async function assertHealthyExecution(
 ): Promise<string> {
     // The execution row settles shortly after the completion comment is
     // delivered; poll briefly rather than racing it.
+    //
+    // A non-success terminal status must NOT end the poll early: a PR can
+    // grow execution rows one at a time, and the row the scenario cares
+    // about can land AFTER an incidental one. Observed live (2026-07-29,
+    // cloud command-review PR#672): the auto-review row — `skipped` BY
+    // DESIGN, the scenario disables auto-review to test the command — was
+    // visible 3s before the command's `success` row landed, and the old
+    // first-terminal-wins read failed the cell against a perfectly healthy
+    // review. Keep polling on non-success; only the timeout turns the
+    // last-seen status into the verdict.
+    let lastSeen: string | null = null;
     const status = await pollUntil<string>(
         async () => {
             const resp = await http<any>(
@@ -46,23 +57,29 @@ export async function assertHealthyExecution(
             if (!found || found === 'pending' || found === 'in_progress') {
                 return null;
             }
+            if (found !== 'success') {
+                lastSeen = found;
+                return null;
+            }
             return found;
         },
         { intervalSec: 5, timeoutSec: 90 },
     );
 
+    const finalStatus = status ?? lastSeen;
     ctx.assert(
-        status !== null,
+        finalStatus !== null,
         `No settled automation execution found for PR #${prNumber} within 90s — cannot verify review health`,
     );
     ctx.assert(
-        status === 'success',
-        `Review of PR #${prNumber} completed UNHEALTHY: execution status is "${status}" ` +
+        finalStatus === 'success',
+        `Review of PR #${prNumber} completed UNHEALTHY: execution status stayed "${finalStatus}" ` +
+            `through the full 90s window with no success row ` +
             `(partial_error = an agent or auxiliary stage crashed and its work was silently dropped — ` +
             `the review may still have posted findings from the surviving agents). ` +
             `Check the worker logs for the failing stage/agent.`,
     );
-    return status!;
+    return finalStatus!;
 }
 
 /**

--- a/tests/e2e/matrix/cloud-reflake-3.yml
+++ b/tests/e2e/matrix/cloud-reflake-3.yml
@@ -1,0 +1,24 @@
+id: cloud-reflake-3
+description: |
+    Re-run the two cloud cells that flaked on the 2026-07-29 manual run
+    (30456334055), now with the execution-health re-poll hardening:
+
+    - command-review × cloud × github × paid: health assert read the
+      auto-review's by-design `skipped` row 3s before the command's
+      `success` row landed (first-terminal-wins race, fixed alongside
+      this file)
+    - kody-rules-create-and-apply × cloud × gitlab × paid: "No review
+      activity within timeout" — provider-side latency, re-run to
+      confirm transient
+
+scenarios:
+    - command-review
+    - kody-rules-create-and-apply
+
+cells:
+    - target: cloud
+      provider: github
+      license: paid
+    - target: cloud
+      provider: gitlab
+      license: paid


### PR DESCRIPTION
Hardening for flake #1 of run [30456334055](https://github.com/kodustech/kodus-ai/actions/runs/30456334055) (`command-review × cloud × github`).

**The race, proven in QA logs (PR#672):** the scenario disables auto-review to test the `@kody review` command path. The PR-opened event therefore produces an execution row that is `skipped` **by design**; the command's `success` row lands a few seconds later. `assertHealthyExecution` returned on the **first** terminal status it saw — it read the `skipped` row 3s before the `success` row appeared and failed the cell against a perfectly healthy review.

**Fix:** a non-success terminal status no longer ends the poll — it keeps polling until a `success` row appears or the 90s budget expires, at which point the last-seen status becomes the verdict. A genuinely broken review still fails — just after the window instead of via a race.

**Bonus:** `matrix/cloud-reflake-3.yml` to re-run only the two flaked cells via the `matrix_file` dispatch input (same pattern already used in the repo).

Verification: e2e `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)