### PR TITLE
ci(e2e): Friday release train with cloud gate + Mon-Thu smoke heartbeat

### DIFF
--- a/.github/workflows/e2e-cloud.yml
+++ b/.github/workflows/e2e-cloud.yml
@@ -19,9 +19,13 @@ permissions:
 #
 # Trigger:
 #   - workflow_call from qa-build-push-and-pr-green.yml after the GitOps
-#     PR for the QA deploy is opened.
-#   - schedule nightly 05:17 UTC — catch-all for drift / provider
-#     regressions / flaky cells that don't reproduce per-deploy.
+#     PR for the QA deploy is opened, and from selfhosted-build-push.yml
+#     as the Friday release train's cloud gate (full fast.yml).
+#   - schedule Mon–Thu 03:00 UTC (00:00 BRT) — midweek-smoke.yml only, a
+#     ~20-min two-PR heartbeat on github×paid that catches systemic
+#     breakage (dead LLM key, webhook delivery, stuck pipeline) early so
+#     Friday's release train doesn't discover a week of damage at once.
+#     Full-matrix coverage now lives on the Friday train, not nightly.
 #   - workflow_dispatch for manual runs.
 
 on:
@@ -38,10 +42,11 @@ on:
                 default: matrix/fast.yml
                 type: string
     schedule:
-        # 05:17 UTC = ~02:17 BRT. Off-peak; offset from the benchmark
-        # cron (which lives at 04:17 UTC) so they don't share a runner
-        # spike.
-        - cron: "17 5 * * *"
+        # Mon–Thu 03:00 UTC = 00:00 BRT. Runs midweek-smoke.yml (see
+        # MATRIX_FILE resolution below) — Friday full coverage happens via
+        # the selfhosted-build-push release train's cloud gate instead, so
+        # no Friday cron here.
+        - cron: "0 3 * * 1-4"
     workflow_dispatch:
         inputs:
             image_tag:
@@ -251,7 +256,11 @@ jobs:
                   # target.sh requires it set, so we still export it.
                   TARGET_BASE_URL: ${{ vars.CLOUD_QA_API_URL || 'https://qa.api.kodus.io' }}
                   TARGET_WEB_URL: ${{ vars.CLOUD_QA_WEB_URL || 'https://qa.web.kodus.io' }}
-                  MATRIX_FILE: ${{ inputs.matrix_file || 'matrix/fast.yml' }}
+                  # Scheduled runs (Mon–Thu) are the cheap heartbeat and use
+                  # midweek-smoke.yml; everything else (workflow_call from the
+                  # release train / QA deploy, manual dispatch) defaults to
+                  # the full fast.yml unless the caller overrides it.
+                  MATRIX_FILE: ${{ inputs.matrix_file || (github.event_name == 'schedule' && 'matrix/midweek-smoke.yml') || 'matrix/fast.yml' }}
 
                   # Provider tokens — cells without the right token are
                   # skipped (target.sh passes --skip-missing-tokens).

--- a/.github/workflows/selfhosted-build-push.yml
+++ b/.github/workflows/selfhosted-build-push.yml
@@ -30,7 +30,11 @@ on:
     # minor/major/custom releases, hotfixes, or out-of-band runs,
     # dispatch manually via workflow_dispatch.
     schedule:
-        - cron: "0 6 * * 5"
+        # Friday 03:00 UTC = 00:00 BRT. The release train starts with the
+        # cloud-gate job (full cloud matrix against QA, ~2h); the RC is
+        # only built if that gate is green, so a broken product never
+        # burns the droplet build + self-hosted matrix cost.
+        - cron: "0 3 * * 5"
     workflow_dispatch:
         inputs:
             version_type:
@@ -61,6 +65,25 @@ concurrency:
 
 jobs:
     # ----------------------------------------------------------------
+    # Cloud gate (scheduled Friday train only): run the FULL cloud matrix
+    # against QA before spending anything on the self-hosted release.
+    # The cloud matrix exercises the same product review paths with no
+    # droplets and no image build — historically most release-breaking
+    # regressions (LLM key, webhook delivery, review pipeline) trip here
+    # first. Red gate -> the whole train stops at ~zero cost and the
+    # failure IS the to-fix list. Manual dispatches skip the gate: a
+    # human asking for a release is deliberate (and may be iterating on
+    # a fix the gate would re-block for 2h).
+    # ----------------------------------------------------------------
+    cloud-gate:
+        name: Cloud gate (full matrix vs QA)
+        if: ${{ github.event_name == 'schedule' }}
+        uses: ./.github/workflows/e2e-cloud.yml
+        with:
+            matrix_file: matrix/fast.yml
+        secrets: inherit
+
+    # ----------------------------------------------------------------
     # Freeze main while the release is in flight. The repo ruleset
     # `release-freeze` lives in this repo's settings (id 17004627);
     # default state is enforcement=disabled. We flip it to active here
@@ -79,7 +102,11 @@ jobs:
         # Freeze on every release path EXCEPT hotfix. Schedule (Friday
         # cron) has no inputs, so `inputs.hotfix != true` resolves to
         # "freeze" — exactly what we want for the weekly train.
-        if: ${{ inputs.hotfix != true }}
+        # needs+if: on the scheduled train the freeze (and the whole
+        # release behind it) only starts when the cloud gate is green;
+        # on manual dispatch the gate is skipped and we proceed.
+        needs: [cloud-gate]
+        if: ${{ !cancelled() && inputs.hotfix != true && (needs.cloud-gate.result == 'success' || needs.cloud-gate.result == 'skipped') }}
         runs-on: ubuntu-latest
         environment: ci
         permissions:
@@ -159,11 +186,16 @@ jobs:
 
     plan-release:
         name: Plan release (compute version and RC version)
-        needs: freeze-main
+        needs: [freeze-main, cloud-gate]
         # Run on freeze success (normal release) OR skip (hotfix path).
         # Don't run if freeze failed — that indicates an admin / token /
         # ruleset bug and we shouldn't ship with main potentially open.
-        if: ${{ needs.freeze-main.result == 'success' || needs.freeze-main.result == 'skipped' }}
+        #
+        # The cloud-gate condition must be checked HERE too, not only on
+        # freeze-main: a red gate leaves freeze-main `skipped`, which is
+        # indistinguishable from the legitimate hotfix skip — without this
+        # guard the release would sail on through a failed gate.
+        if: ${{ !cancelled() && (needs.freeze-main.result == 'success' || needs.freeze-main.result == 'skipped') && (needs.cloud-gate.result == 'success' || needs.cloud-gate.result == 'skipped') }}
         runs-on: ubuntu-latest
         outputs:
             release_version: ${{ steps.bump.outputs.release_version }}

--- a/tests/e2e/matrix/midweek-smoke.yml
+++ b/tests/e2e/matrix/midweek-smoke.yml
@@ -1,0 +1,24 @@
+id: midweek-smoke
+description: |
+    Mon–Thu heartbeat (00:00 BRT cron on e2e-cloud): is the review engine
+    alive? Two PRs on a single provider (github × paid, the BYOK
+    gpt-5.4-mini tenant) catch the SYSTEMIC breakage classes early —
+    rotated/dead LLM key, webhook delivery, review pipeline stuck, broken
+    tenant — so the Friday release train doesn't discover a week of
+    accumulated damage at once (the exact pathology of the jul/2026
+    outage, where every root cause would have tripped one of these three
+    scenarios within a day).
+
+    NOT coverage: gitlab/bitbucket/azure, trial/free licensing,
+    kody-rules, rbac etc. stay on Friday's fast.yml, which gates the
+    self-hosted release build.
+
+scenarios:
+    - onboarding-webhook-registration
+    - code-review-basic
+    - command-review
+
+cells:
+    - target: cloud
+      provider: github
+      license: paid


### PR DESCRIPTION
Reshapes the scheduled e2e spend around Release Friday, cutting the recurring cost to a fraction while keeping daily systemic-breakage detection.

## Before → After

| Schedule (BRT) | Before | After |
|---|---|---|
| Mon–Thu 00:00 | full cloud matrix nightly (~2h, ~15 LLM reviews) | **midweek-smoke.yml**: 2 PRs on github×paid, single model (gpt-5.4-mini), ~20min |
| Fri 00:00 | — (cloud ran nightly; release ran 03:00 BRT independently) | **release train**: full cloud matrix (gate) → green? → freeze + RC build + self-hosted matrix → promote gate |
| Manual dispatch | unchanged | unchanged (no gate — a human asking for a release is deliberate) |

## Why the gate works
The cloud matrix exercises the same product review paths with no droplets and no image build. Historically (jul/2026 outage) every release-breaking regression — LLM key, webhook delivery, review pipeline, provider auth — would have tripped the cloud matrix first. Red gate → the train stops at ~zero cost and the failure is the to-fix list.

## Why the smoke exists
Friday-only coverage means a Monday regression is discovered with 4 days of merges stacked on top — the exact pathology that made the July outage a 10-layer onion. The smoke is a ~20min "is the heart beating" check: dead key, broken webhook, stuck pipeline all surface within a day.

## Guard detail
`plan-release` checks the gate result directly: a red gate leaves `freeze-main` *skipped*, which is otherwise indistinguishable from the legitimate hotfix skip — without the extra guard the release would sail through a failed gate.

## Verification
- Both workflows parse as valid YAML
- `midweek-smoke.yml` dry-run: 3/3 scenarios resolve on the intended cell

🤖 Generated with [Claude Code](https://claude.com/claude-code)