### PR TITLE
fix(kody-rules): recompute and sync plan-locked rules on upgrade

### DIFF
--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/kody-rules/_components/_page.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/kody-rules/_components/_page.tsx
@@ -33,6 +33,7 @@ import { PlusIcon } from "lucide-react";
 import { PageBoundary } from "src/core/components/page-boundary";
 import { useSelectedTeamId } from "src/core/providers/selected-team-context";
 import { captureGateHit } from "src/core/utils/gate-hit";
+import { useSubscriptionStatus } from "src/features/ee/subscription/_hooks/use-subscription-status";
 import {
     compareRules,
     EMPTY_LIST_FILTERS,
@@ -130,6 +131,8 @@ const KodyRulesPageContent = () => {
         ResourceType.KodyRules,
         repositoryId,
     );
+    const subscription = useSubscriptionStatus();
+    const isFreePlan = subscription.status === "free";
 
     // Scope rules and inherited rules are loaded in parallel (single
     // suspense boundary, both requests fired at once) to avoid the waterfall
@@ -903,7 +906,7 @@ const KodyRulesPageContent = () => {
             <Page.Content>
                 <CentralizedConfigReadOnlyAlert />
 
-                {lockedRulesCount > 0 && (
+                {lockedRulesCount > 0 && isFreePlan && (
                     <Card
                         color="lv1"
                         className="flex flex-row items-center justify-between gap-6 p-5">

--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/kody-rules/_components/item.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/kody-rules/_components/item.tsx
@@ -39,6 +39,7 @@ import { KodyRulesStatus } from "@services/kodyRules/types";
 import { toast } from "@components/ui/toaster/use-toast";
 import { useAsyncAction } from "@hooks/use-async-action";
 import { resolveKodyRuleBadgeState } from "src/core/utils/kody-rules/resolve-badge-state";
+import { useSubscriptionStatus } from "src/features/ee/subscription/_hooks/use-subscription-status";
 
 function showLastPaths(path: string, max = 3): string {
     const items = path.split(",").map((g) => g.trim()).filter((g) => g.length > 0);
@@ -80,6 +81,8 @@ export const KodyRuleItem = ({
         ResourceType.KodyRules,
         repositoryId,
     );
+    const subscription = useSubscriptionStatus();
+    const isFreePlan = subscription.status === "free";
 
     const isInherited = !!rule.inherited;
     const isExcluded = isInherited && !!rule.excluded;
@@ -97,7 +100,7 @@ export const KodyRuleItem = ({
                 : null;
     const entityLabel = isMemory ? "memory" : "rule";
     const isPaused = rule.status === KodyRulesStatus.PAUSED;
-    const badgeState = resolveKodyRuleBadgeState(rule);
+    const badgeState = resolveKodyRuleBadgeState(rule, isFreePlan);
     const isLockedByPlan = badgeState === "locked";
 
     // Opens the edit/view modal in place — same pattern Delete and "New

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,4 +1,3 @@
-import type { Metadata } from "next";
 import { DM_Sans, Overpass_Mono } from "next/font/google";
 import { Toaster } from "@components/ui/toaster/toaster";
 import { TooltipProvider } from "@components/ui/tooltip";

--- a/apps/web/src/core/utils/kody-rules/resolve-badge-state.spec.ts
+++ b/apps/web/src/core/utils/kody-rules/resolve-badge-state.spec.ts
@@ -9,13 +9,31 @@ describe("resolveKodyRuleBadgeState", () => {
         ).toBeNull();
     });
 
-    it("returns 'locked' for a rule paused by the plan limit", () => {
+    it("returns 'locked' for a rule paused by the plan limit on free plan", () => {
+        expect(
+            resolveKodyRuleBadgeState({
+                status: KodyRulesStatus.PAUSED,
+                lockedByPlan: true,
+            }, true),
+        ).toBe("locked");
+    });
+
+    it("returns 'locked' by default when isFreePlan not provided (backward compat)", () => {
         expect(
             resolveKodyRuleBadgeState({
                 status: KodyRulesStatus.PAUSED,
                 lockedByPlan: true,
             }),
         ).toBe("locked");
+    });
+
+    it("returns 'paused' even with lockedByPlan on a paid plan", () => {
+        expect(
+            resolveKodyRuleBadgeState({
+                status: KodyRulesStatus.PAUSED,
+                lockedByPlan: true,
+            }, false),
+        ).toBe("paused");
     });
 
     it("returns 'paused' for a rule the user paused themselves", () => {

--- a/apps/web/src/core/utils/kody-rules/resolve-badge-state.ts
+++ b/apps/web/src/core/utils/kody-rules/resolve-badge-state.ts
@@ -13,10 +13,19 @@ export type KodyRuleBadgeState = "locked" | "paused" | null;
  * "Locked" with an upgrade CTA; a rule the user paused themselves renders
  * as the plain "Paused" badge. Both share the same underlying PAUSED status,
  * so this is the single place that decides which one the user sees.
+ *
+ * Accepts an optional `isFreePlan` flag as a second line of defense: on paid
+ * plans with stale cached data (`lockedByPlan` still true from before an
+ * upgrade) the badge correctly shows "paused" instead of "locked".
  */
 export function resolveKodyRuleBadgeState(
     rule: RuleBadgeInput,
+    isFreePlan?: boolean,
 ): KodyRuleBadgeState {
     if (rule.status !== KodyRulesStatus.PAUSED) return null;
-    return rule.lockedByPlan === true ? "locked" : "paused";
+
+    // Only show "locked" badge on FREE plans when rule was auto-paused by quota.
+    // On a paid plan (or user-paused), show the plain "paused" badge.
+    const showLocked = rule.lockedByPlan === true && isFreePlan !== false;
+    return showLocked ? "locked" : "paused";
 }

--- a/apps/web/src/features/ee/subscription/choose-plan/_components/token-projection.tsx
+++ b/apps/web/src/features/ee/subscription/choose-plan/_components/token-projection.tsx
@@ -28,16 +28,26 @@ function getUsageDateRange(
 ) {
     const now = new Date();
 
-    if (license?.valid && license.subscriptionStatus === "trial") {
+    // Guard: some trial licenses carry subscriptionStatus="trial" without a
+    // trialEnd (e.g. legacy rows / plan-reset via SQL). new Date(undefined)
+    // is Invalid Date and format() then throws RangeError. Fall back to the
+    // default lookback window instead of crashing the choose-plan page.
+    if (
+        license?.valid &&
+        license.subscriptionStatus === "trial" &&
+        license.trialEnd
+    ) {
         const trialEndDate = new Date(license.trialEnd);
-        const trialStartDate = subDays(trialEndDate, TRIAL_DURATION_DAYS);
-        const daysUsed = Math.max(1, differenceInDays(now, trialStartDate));
+        if (!isNaN(trialEndDate?.getTime())) {
+            const trialStartDate = subDays(trialEndDate, TRIAL_DURATION_DAYS);
+            const daysUsed = Math.max(1,differenceInDays(now, trialStartDate));
 
-        return {
-            startDate: format(trialStartDate, "yyyy-MM-dd"),
-            endDate: format(now, "yyyy-MM-dd"),
-            daysUsed,
-        };
+            return {
+                startDate: format(trialStartDate, "yyyy-MM-dd"),
+                endDate: format(now, "yyyy-MM-dd"),
+                daysUsed,
+            };
+        }
     }
 
     const startDate = subDays(now, USAGE_LOOKBACK_DAYS);

--- a/apps/webhooks/src/controllers/billing.controller.spec.ts
+++ b/apps/webhooks/src/controllers/billing.controller.spec.ts
@@ -6,6 +6,7 @@ import { Response } from 'express';
 
 import { NotificationService } from '@libs/notifications/application/notification.service';
 import { NotificationEvent } from '@libs/notifications/domain/catalog/events';
+import { KODY_RULES_SERVICE_TOKEN } from '@libs/kodyRules/domain/contracts/kodyRules.service.contract';
 
 import { BillingController } from './billing.controller';
 
@@ -66,6 +67,14 @@ describe('BillingController', () => {
             providers: [
                 { provide: NotificationService, useValue: notify },
                 { provide: ConfigService, useValue: config },
+                {
+                    provide: KODY_RULES_SERVICE_TOKEN,
+                    useValue: {
+                        syncRulesWithPlanLimit: jest
+                            .fn()
+                            .mockResolvedValue(null),
+                    },
+                },
             ],
         }).compile();
 

--- a/apps/webhooks/src/controllers/billing.controller.ts
+++ b/apps/webhooks/src/controllers/billing.controller.ts
@@ -8,6 +8,11 @@ import { Request, Response } from 'express';
 import { Public } from '@libs/identity/infrastructure/adapters/services/auth/public.decorator';
 import { NotificationService } from '@libs/notifications/application/notification.service';
 import { NotificationEvent } from '@libs/notifications/domain/catalog/events';
+import {
+    IKodyRulesService,
+    KODY_RULES_SERVICE_TOKEN,
+} from '@libs/kodyRules/domain/contracts/kodyRules.service.contract';
+import { Inject } from '@nestjs/common';
 
 /**
  * Express request shape with the raw-body capture from
@@ -36,6 +41,13 @@ interface TrialExpiringBody {
     upgradeUrl?: string;
 }
 
+interface PlanChangedBody {
+    organizationId?: string;
+    teamId?: string;
+    planType?: string;
+    subscriptionStatus?: string;
+}
+
 /**
  * Receives outbound notifications from kodus-service-billing.
  *
@@ -58,6 +70,8 @@ export class BillingController {
     constructor(
         private readonly notificationService: NotificationService,
         private readonly configService: ConfigService,
+        @Inject(KODY_RULES_SERVICE_TOKEN)
+        private readonly kodyRulesService: IKodyRulesService,
     ) {}
 
     @Post('/payment-failed')
@@ -123,6 +137,45 @@ export class BillingController {
                 organizationId: body.organizationId,
             }),
         );
+
+        return res.status(HttpStatus.OK).send('ok');
+    }
+
+    @Post('/plan-changed')
+    async planChanged(
+        @Req() req: WebhookRequest,
+        @Res() res: Response,
+    ): Promise<Response> {
+        const verification = this.verifySignature(req);
+        if (verification.status !== 'ok') {
+            return res.status(verification.status).send(verification.reason);
+        }
+
+        const body = req.body as PlanChangedBody;
+        if (!body?.organizationId) {
+            return res
+                .status(HttpStatus.BAD_REQUEST)
+                .send('Missing organizationId');
+        }
+
+        try {
+            await this.kodyRulesService.syncRulesWithPlanLimit({
+                organizationId: body.organizationId,
+                teamId: body.teamId,
+            });
+            this.logger.log({
+                message: 'Kody Rules synced after billing plan-changed webhook',
+                context: BillingController.name,
+                metadata: { organizationId: body.organizationId },
+            });
+        } catch (error) {
+            this.logger.error({
+                message: 'Failed to sync Kody Rules after billing plan-changed webhook',
+                context: BillingController.name,
+                error,
+                metadata: { organizationId: body.organizationId },
+            });
+        }
 
         return res.status(HttpStatus.OK).send('ok');
     }

--- a/apps/webhooks/src/modules/webhook-handler.module.ts
+++ b/apps/webhooks/src/modules/webhook-handler.module.ts
@@ -5,6 +5,7 @@ import { EmailModule } from '@libs/common/email/email.module';
 import { SharedCoreModule } from '@libs/shared/infrastructure/shared-core.module';
 import { RabbitMQWrapperModule } from '@libs/core/infrastructure/queue/rabbitmq.module';
 import { SharedPostgresModule } from '@libs/shared/database/shared-postgres.module';
+import { SharedMongoModule } from '@libs/shared/database/shared-mongo.module';
 import { SharedConfigModule } from '@libs/shared/infrastructure/shared-config.module';
 import { SharedLogModule } from '@libs/shared/infrastructure/shared-log.module';
 import { SharedObservabilityModule } from '@libs/shared/infrastructure/shared-observability.module';
@@ -14,6 +15,9 @@ import { LangfuseShutdownProvider } from '@libs/core/log/langfuse-shutdown.provi
 import { WebhookEnqueueModule } from './webhook-enqueue.module';
 
 import { NotificationModule } from '@libs/notifications/modules/notification.module';
+import { KodyRulesModule } from '@libs/kodyRules/modules/kodyRules.module';
+import { LLMModule } from '@kodus/kodus-common/llm';
+import { LoggerWrapperService } from '@libs/core/log/loggerWrapper.service';
 
 import { AzureReposController } from '../controllers/azureRepos.controller';
 import { BillingController } from '../controllers/billing.controller';
@@ -32,12 +36,17 @@ import { WebhookHealthController } from '../controllers/webhook-health.controlle
         TelemetryModule,
         FeatureGateModule,
         SharedPostgresModule.forRoot({ poolSize: 8 }),
+        SharedMongoModule.forRoot(),
+        LLMModule.forRoot({
+            logger: LoggerWrapperService,
+        }),
 
         EventEmitterModule.forRoot(),
         RabbitMQWrapperModule.register({ enableConsumers: false }),
         WebhookEnqueueModule,
         EmailModule,
         NotificationModule,
+        KodyRulesModule,
     ],
     controllers: [
         GithubController,

--- a/libs/cli-review/application/use-cases/__tests__/execute-cli-review.use-case.spec.ts
+++ b/libs/cli-review/application/use-cases/__tests__/execute-cli-review.use-case.spec.ts
@@ -48,6 +48,8 @@ function createMocks() {
 
     const kodyRulesService = {
         findByOrganizationId: jest.fn().mockResolvedValue(null),
+        // Default: nothing to reconcile (returns null → caller keeps loaded rules).
+        syncRulesWithPlanLimit: jest.fn().mockResolvedValue(null),
     };
 
     const kodyRulesValidationService = {
@@ -569,6 +571,59 @@ describe('ExecuteCliReviewUseCase', () => {
             expect(result.repositoryId).toBe('global');
             expect(result.repositoryName).toBeNull();
             expect(result.config).toBeDefined();
+        });
+
+        // Fail-safe: a CLI review reconciles the plan lock before applying
+        // rules, so a paid org whose rules were left parked (webhook missed)
+        // still runs with them reactivated in this review.
+        it('reconciles plan-locked rules and applies the synced set', async () => {
+            const {
+                useCase,
+                parametersService,
+                kodyRulesService,
+                kodyRulesValidationService,
+            } = createMocks();
+
+            const lockedRule = makeRule({
+                uuid: 'r-locked',
+                repositoryId: 'global',
+                status: KodyRulesStatus.PAUSED,
+                lockedByPlan: true,
+            });
+            const unlockedRule = {
+                ...lockedRule,
+                status: KodyRulesStatus.ACTIVE,
+                lockedByPlan: false,
+            };
+
+            parametersService.findByKey.mockResolvedValue({
+                toObject: () => ({
+                    configValue: { configs: {}, repositories: [] },
+                }),
+            });
+            kodyRulesService.findByOrganizationId.mockResolvedValue({
+                toObject: () => ({ rules: [lockedRule] }),
+            });
+            // Paid plan → sync reactivates and returns the fresh doc.
+            kodyRulesService.syncRulesWithPlanLimit.mockResolvedValue({
+                toObject: () => ({ rules: [unlockedRule] }),
+            });
+            kodyRulesValidationService.filterKodyRules.mockReturnValue({
+                standardRules: [unlockedRule],
+                memoryRules: [],
+            });
+
+            await (useCase as any).loadUserConfigWithRules(orgAndTeam, undefined);
+
+            expect(
+                kodyRulesService.syncRulesWithPlanLimit,
+            ).toHaveBeenCalledWith(orgAndTeam, {
+                entity: expect.anything(),
+            });
+            // filterKodyRules must see the SYNCED (ACTIVE) rule, not the parked one.
+            expect(
+                kodyRulesValidationService.filterKodyRules,
+            ).toHaveBeenCalledWith([unlockedRule], 'global');
         });
     });
 

--- a/libs/cli-review/application/use-cases/execute-cli-review.use-case.ts
+++ b/libs/cli-review/application/use-cases/execute-cli-review.use-case.ts
@@ -467,9 +467,21 @@ export class ExecuteCliReviewUseCase implements IUseCase {
                     paramObj.configValue?.repositories,
                 );
 
+            // Fail-safe: a CLI review is still a review — reconcile the rules'
+            // lock state with the current plan before applying them, in case
+            // the plan-change webhook was missed. Reuses the entity already
+            // loaded above; no `limited` here, so the sync resolves the plan.
+            const syncedEntity =
+                await this.kodyRulesService.syncRulesWithPlanLimit(
+                    organizationAndTeamData,
+                    { entity: kodyRulesEntity },
+                );
+            const effectiveRules =
+                (syncedEntity ?? kodyRulesEntity)?.toObject()?.rules || [];
+
             const { standardRules, memoryRules } =
                 this.kodyRulesValidationService.filterKodyRules(
-                    kodyRulesEntity?.toObject()?.rules || [],
+                    effectiveRules,
                     repositoryId,
                 );
 

--- a/libs/code-review/modules/documentation-context.module.ts
+++ b/libs/code-review/modules/documentation-context.module.ts
@@ -17,11 +17,13 @@ import {
     DocumentationSearchExaService,
 } from '@libs/code-review/infrastructure/adapters/services/documentation-search-exa.service';
 import { CodebaseModule } from './codebase.module';
+import { LLMModule } from '@kodus/kodus-common/llm';
 
 @Module({
     imports: [
         MongooseModule.forFeature([DocumentationSearchCacheModelInstance]),
         forwardRef(() => CodebaseModule),
+        LLMModule,
     ],
     providers: [
         DocumentationPackageDiscoveryService,

--- a/libs/core/infrastructure/database/mongodb/mongoose.factory.ts
+++ b/libs/core/infrastructure/database/mongodb/mongoose.factory.ts
@@ -24,7 +24,7 @@ export class MongooseFactory implements MongooseOptionsFactory {
         const isProduction = !['development', 'test'].includes(env ?? '');
 
         if (!isProduction) {
-            mongoose.set('debug', true);
+            mongoose.set('debug', false);
         }
 
         let uri: string;

--- a/libs/ee/codeBase/codeBaseConfig.service.ts
+++ b/libs/ee/codeBase/codeBaseConfig.service.ts
@@ -156,9 +156,21 @@ export default class CodeBaseConfigService implements ICodeBaseConfigService {
                     CodeBaseConfigService.name,
                 );
 
+            // Fail-safe: reconcile the rules' lock state with the current plan
+            // before the review uses them, in case the plan-change webhook was
+            // missed. Reuses the entity + `limited` already resolved above so
+            // it's a no-op (no extra lookup, no write) when already in sync.
+            const syncedEntity =
+                await this.kodyRulesService.syncRulesWithPlanLimit(
+                    organizationAndTeamData,
+                    { entity: kodyRulesEntity, limited },
+                );
+            const effectiveRules =
+                (syncedEntity ?? kodyRulesEntity)?.toObject()?.rules || [];
+
             const { standardRules, memoryRules } =
                 this.kodyRulesValidationService.filterKodyRules(
-                    kodyRulesEntity?.toObject()?.rules || [],
+                    effectiveRules,
                     repository.id,
                     mergedConfigs.directoryId,
                     limited,

--- a/libs/ee/kodyRules/service/kody-rules-validation.service.ts
+++ b/libs/ee/kodyRules/service/kody-rules-validation.service.ts
@@ -113,7 +113,15 @@ export class KodyRulesValidationService {
         const globalRules: Partial<IKodyRule>[] = [];
 
         for (const rule of rules) {
-            if (rule.status !== KodyRulesStatus.ACTIVE) {
+            // A rule is enforced if it's ACTIVE, OR if the org is on a paid plan (!limited)
+            // and the rule was only auto-paused due to free plan quota (lockedByPlan).
+            const isEnforced =
+                rule.status === KodyRulesStatus.ACTIVE ||
+                (!limited &&
+                    rule.status === KodyRulesStatus.PAUSED &&
+                    rule.lockedByPlan === true);
+
+            if (!isEnforced) {
                 continue;
             }
 

--- a/libs/ee/kodyRules/service/kodyRules.service.ts
+++ b/libs/ee/kodyRules/service/kodyRules.service.ts
@@ -227,29 +227,44 @@ export class KodyRulesService implements IKodyRulesService {
 
         if (!entities?.length) return entities;
 
-        // If any entity has stale PAUSED+lockedByPlan rules, sync plan limits
-        // (updates MongoDB) then re-fetch so the UI returns corrected rules.
-        const hasStale = entities.some((entity) =>
-            entity
-                ?.toObject()
-                ?.rules?.some(
-                    (r) => r.status === KodyRulesStatus.PAUSED && r.lockedByPlan,
-                ),
+        const toObject = (e: any) =>
+            typeof e?.toObject === 'function' ? e.toObject() : e;
+
+        const staleOrgIds = new Set<string>();
+        entities.forEach((e) => {
+            const obj = toObject(e);
+            if (
+                obj?.rules?.some(
+                    (r: any) =>
+                        r.status === KodyRulesStatus.PAUSED && r.lockedByPlan,
+                ) &&
+                obj?.organizationId
+            ) {
+                staleOrgIds.add(obj.organizationId);
+            }
+        });
+
+        const orgIdArray = [...staleOrgIds];
+        const syncResults = await Promise.allSettled(
+            orgIdArray.map((orgId) =>
+                this.syncRulesWithPlanLimit({ organizationId: orgId }),
+            ),
         );
 
-        if (hasStale) {
-            try {
-                await this.syncRulesWithPlanLimit({
-                    organizationId: filter?.organizationId,
-                });
-                return await this.kodyRulesRepository.find(filter);
-            } catch (error) {
-                this.logger.warn({
+        syncResults.forEach((result, index) => {
+            if (result.status === 'rejected') {
+                const orgId = orgIdArray[index];
+                this.logger.error({
                     message: 'Failed self-healing stale rules in find()',
                     context: KodyRulesService.name,
-                    error,
+                    error: result.reason,
+                    metadata: { organizationId: orgId },
                 });
             }
+        });
+
+        if (staleOrgIds.size > 0) {
+            return await this.kodyRulesRepository.find(filter);
         }
 
         return entities;

--- a/libs/ee/kodyRules/service/kodyRules.service.ts
+++ b/libs/ee/kodyRules/service/kodyRules.service.ts
@@ -365,14 +365,27 @@ export class KodyRulesService implements IKodyRulesService {
 
         if (!changedRules.length) return entity;
 
-        // Targeted per-rule updates: prevents whole-array overwrite race conditions (#1626)
-        for (const { ruleId, patch } of changedRules) {
-            await this.kodyRulesRepository.updateRule(
-                entity.uuid,
-                ruleId,
-                patch,
-            );
-        }
+        // Targeted per-rule updates in parallel: prevents whole-array overwrite race conditions (#1626)
+        const updateResults = await Promise.allSettled(
+            changedRules.map(({ ruleId, patch }) =>
+                this.kodyRulesRepository.updateRule(
+                    entity.uuid,
+                    ruleId,
+                    patch,
+                ),
+            ),
+        );
+
+        updateResults.forEach((res, i) => {
+            if (res.status === 'rejected') {
+                this.logger.error({
+                    message: 'Failed per-rule update in syncRulesWithPlanLimit',
+                    context: KodyRulesService.name,
+                    error: res.reason,
+                    metadata: { organizationId, ruleId: changedRules[i].ruleId },
+                });
+            }
+        });
 
         this.logger.log({
             message: 'Synchronized Kody Rules with current plan limits in MongoDB',

--- a/libs/ee/kodyRules/service/kodyRules.service.ts
+++ b/libs/ee/kodyRules/service/kodyRules.service.ts
@@ -225,20 +225,137 @@ export class KodyRulesService implements IKodyRulesService {
     async find(filter?: Partial<IKodyRules>): Promise<KodyRulesEntity[]> {
         const entities = await this.kodyRulesRepository.find(filter);
 
-        return entities?.map((entity) => {
-            const normalized = entity.toObject();
-            normalized.rules = normalized.rules.map((rule) => ({
-                ...rule,
-                severity: rule.severity?.toLowerCase(),
-            }));
-            return KodyRulesEntity.create(normalized);
-        });
+        if (!entities?.length) return entities;
+
+        // If any entity has stale PAUSED+lockedByPlan rules, sync plan limits
+        // (updates MongoDB) then re-fetch so the UI returns corrected rules.
+        const hasStale = entities.some((entity) =>
+            entity
+                ?.toObject()
+                ?.rules?.some(
+                    (r) => r.status === KodyRulesStatus.PAUSED && r.lockedByPlan,
+                ),
+        );
+
+        if (hasStale) {
+            try {
+                await this.syncRulesWithPlanLimit({
+                    organizationId: filter?.organizationId,
+                });
+                return await this.kodyRulesRepository.find(filter);
+            } catch (error) {
+                this.logger.warn({
+                    message: 'Failed self-healing stale rules in find()',
+                    context: KodyRulesService.name,
+                    error,
+                });
+            }
+        }
+
+        return entities;
     }
 
     async findByOrganizationId(
         organizationId: string,
     ): Promise<KodyRulesEntity | null> {
         return this.kodyRulesRepository.findByOrganizationId(organizationId);
+    }
+
+    /**
+     * Synchronizes an organization's stored Kody Rules in MongoDB with its
+     * current plan resource limits (#1626).
+     *
+     * - On Paid plans (not limited): clears `lockedByPlan` and flips `PAUSED` → `ACTIVE`
+     *   for any rules that were previously locked by plan limits.
+     * - On Free plans (limited): enforces the 10-rule cap on active rules, stamping any
+     *   overflow rules as `PAUSED` with `lockedByPlan: true`.
+     */
+    async syncRulesWithPlanLimit(
+        organizationAndTeamData: OrganizationAndTeamData,
+    ): Promise<KodyRulesEntity | null> {
+        const organizationId = organizationAndTeamData.organizationId;
+        if (!organizationId) return null;
+
+        const entity =
+            await this.kodyRulesRepository.findByOrganizationId(
+                organizationId,
+            );
+        const existingRules = entity?.toObject()?.rules || [];
+
+        if (!existingRules?.length) return entity;
+
+        let isLimited = false;
+        try {
+            isLimited =
+                await this.permissionValidationService.shouldLimitResources(
+                    organizationAndTeamData,
+                    KodyRulesService.name,
+                );
+        } catch (error) {
+            this.logger.error({
+                message: 'Error checking resource limits for rules sync',
+                context: KodyRulesService.name,
+                error,
+            });
+            return entity;
+        }
+
+        let mutated = false;
+        const updatedRules = [...existingRules];
+
+        if (!isLimited) {
+            // Paid plan: unpause any rule that was auto-locked by a plan limit
+            for (let i = 0; i < updatedRules.length; i++) {
+                const r = updatedRules[i];
+                if (r.status === KodyRulesStatus.PAUSED && r.lockedByPlan) {
+                    updatedRules[i] = {
+                        ...r,
+                        status: KodyRulesStatus.ACTIVE,
+                        lockedByPlan: false,
+                        updatedAt: new Date(),
+                    };
+                    mutated = true;
+                }
+            }
+        } else {
+            // Free plan: enforce MAX_KODY_RULES (10) active ceiling
+            const MAX = this.kodyRulesValidationService.MAX_KODY_RULES;
+            let activeCount = 0;
+
+            for (let i = 0; i < updatedRules.length; i++) {
+                const r = updatedRules[i];
+                if (r.status === KodyRulesStatus.ACTIVE) {
+                    activeCount++;
+                    if (activeCount > MAX) {
+                        updatedRules[i] = {
+                            ...r,
+                            status: KodyRulesStatus.PAUSED,
+                            lockedByPlan: true,
+                            updatedAt: new Date(),
+                        };
+                        mutated = true;
+                    }
+                }
+            }
+        }
+
+        if (!mutated) return entity;
+
+        const updated = await this.kodyRulesRepository.update(entity.uuid, {
+            rules: updatedRules,
+        });
+
+        this.logger.log({
+            message: 'Synchronized Kody Rules with current plan limits in MongoDB',
+            context: KodyRulesService.name,
+            metadata: {
+                organizationId,
+                isLimited,
+                totalRules: updatedRules.length,
+            },
+        });
+
+        return updated;
     }
 
     async findOrganizationIdsWithRules(): Promise<string[]> {

--- a/libs/ee/kodyRules/service/kodyRules.service.ts
+++ b/libs/ee/kodyRules/service/kodyRules.service.ts
@@ -296,33 +296,43 @@ export class KodyRulesService implements IKodyRulesService {
      */
     async syncRulesWithPlanLimit(
         organizationAndTeamData: OrganizationAndTeamData,
+        opts: { entity?: KodyRulesEntity | null; limited?: boolean } = {},
     ): Promise<KodyRulesEntity | null> {
         const organizationId = organizationAndTeamData.organizationId;
         if (!organizationId) return null;
 
+        // The review pipeline already loaded the rules; it passes the entity in
+        // so this fail-safe doesn't repeat the round-trip.
         const entity =
-            await this.kodyRulesRepository.findByOrganizationId(
+            opts.entity ??
+            (await this.kodyRulesRepository.findByOrganizationId(
                 organizationId,
-            );
+            ));
         const existingRules = entity?.toObject()?.rules || [];
 
         if (!existingRules?.length) return entity;
 
-        let isLimited = false;
-        try {
-            isLimited =
-                await this.permissionValidationService.shouldLimitResources(
-                    organizationAndTeamData,
-                    KodyRulesService.name,
-                );
-        } catch (error) {
-            this.logger.error({
-                message: 'Error checking resource limits for rules sync',
-                context: KodyRulesService.name,
-                error,
-                metadata: { organizationAndTeamData },
-            });
-            return entity;
+        let isLimited: boolean;
+        if (typeof opts.limited === 'boolean') {
+            // codeBaseConfig already resolved the plan gate for the review —
+            // reuse it instead of a second license lookup.
+            isLimited = opts.limited;
+        } else {
+            try {
+                isLimited =
+                    await this.permissionValidationService.shouldLimitResources(
+                        organizationAndTeamData,
+                        KodyRulesService.name,
+                    );
+            } catch (error) {
+                this.logger.error({
+                    message: 'Error checking resource limits for rules sync',
+                    context: KodyRulesService.name,
+                    error,
+                    metadata: { organizationAndTeamData },
+                });
+                return entity;
+            }
         }
 
         const changedRules: Array<{ ruleId: string; patch: Partial<IKodyRule> }> = [];

--- a/libs/ee/kodyRules/service/kodyRules.service.ts
+++ b/libs/ee/kodyRules/service/kodyRules.service.ts
@@ -262,12 +262,21 @@ export class KodyRulesService implements IKodyRulesService {
                 });
             }
         });
+        const normalized = (entitiesResult: KodyRulesEntity[]) =>
+            entitiesResult?.map((entity) => {
+                const normalized = toObject(entity);
+                normalized.rules = normalized.rules.map((rule) => ({
+                    ...rule,
+                    severity: rule.severity?.toLowerCase(),
+                }));
+                return KodyRulesEntity.create(normalized);
+            });
 
         if (staleOrgIds.size > 0) {
-            return await this.kodyRulesRepository.find(filter);
+            return normalized(await this.kodyRulesRepository.find(filter));
         }
 
-        return entities;
+        return normalized(entities);
     }
 
     async findByOrganizationId(
@@ -311,25 +320,25 @@ export class KodyRulesService implements IKodyRulesService {
                 message: 'Error checking resource limits for rules sync',
                 context: KodyRulesService.name,
                 error,
+                metadata: { organizationAndTeamData },
             });
             return entity;
         }
 
-        let mutated = false;
-        const updatedRules = [...existingRules];
+        const changedRules: Array<{ ruleId: string; patch: Partial<IKodyRule> }> = [];
 
         if (!isLimited) {
             // Paid plan: unpause any rule that was auto-locked by a plan limit
-            for (let i = 0; i < updatedRules.length; i++) {
-                const r = updatedRules[i];
-                if (r.status === KodyRulesStatus.PAUSED && r.lockedByPlan) {
-                    updatedRules[i] = {
-                        ...r,
-                        status: KodyRulesStatus.ACTIVE,
-                        lockedByPlan: false,
-                        updatedAt: new Date(),
-                    };
-                    mutated = true;
+            for (const r of existingRules) {
+                if (r.uuid && r.status === KodyRulesStatus.PAUSED && r.lockedByPlan) {
+                    changedRules.push({
+                        ruleId: r.uuid,
+                        patch: {
+                            status: KodyRulesStatus.ACTIVE,
+                            lockedByPlan: false,
+                            updatedAt: new Date(),
+                        },
+                    });
                 }
             }
         } else {
@@ -337,28 +346,33 @@ export class KodyRulesService implements IKodyRulesService {
             const MAX = this.kodyRulesValidationService.MAX_KODY_RULES;
             let activeCount = 0;
 
-            for (let i = 0; i < updatedRules.length; i++) {
-                const r = updatedRules[i];
+            for (const r of existingRules) {
                 if (r.status === KodyRulesStatus.ACTIVE) {
                     activeCount++;
-                    if (activeCount > MAX) {
-                        updatedRules[i] = {
-                            ...r,
-                            status: KodyRulesStatus.PAUSED,
-                            lockedByPlan: true,
-                            updatedAt: new Date(),
-                        };
-                        mutated = true;
+                    if (activeCount > MAX && r.uuid) {
+                        changedRules.push({
+                            ruleId: r.uuid,
+                            patch: {
+                                status: KodyRulesStatus.PAUSED,
+                                lockedByPlan: true,
+                                updatedAt: new Date(),
+                            },
+                        });
                     }
                 }
             }
         }
 
-        if (!mutated) return entity;
+        if (!changedRules.length) return entity;
 
-        const updated = await this.kodyRulesRepository.update(entity.uuid, {
-            rules: updatedRules,
-        });
+        // Targeted per-rule updates: prevents whole-array overwrite race conditions (#1626)
+        for (const { ruleId, patch } of changedRules) {
+            await this.kodyRulesRepository.updateRule(
+                entity.uuid,
+                ruleId,
+                patch,
+            );
+        }
 
         this.logger.log({
             message: 'Synchronized Kody Rules with current plan limits in MongoDB',
@@ -366,11 +380,11 @@ export class KodyRulesService implements IKodyRulesService {
             metadata: {
                 organizationId,
                 isLimited,
-                totalRules: updatedRules.length,
+                updatedRuleCount: changedRules.length,
             },
         });
 
-        return updated;
+        return this.kodyRulesRepository.findByOrganizationId(organizationId);
     }
 
     async findOrganizationIdsWithRules(): Promise<string[]> {

--- a/libs/kodyRules/domain/contracts/kodyRules.service.contract.ts
+++ b/libs/kodyRules/domain/contracts/kodyRules.service.contract.ts
@@ -121,4 +121,8 @@ export interface IKodyRulesService extends IKodyRulesRepository {
         organizationAndTeamData: OrganizationAndTeamData,
         filters?: FindMemoriesFilters,
     ): Promise<FindMemoriesResult[]>;
+
+    syncRulesWithPlanLimit(
+        organizationAndTeamData: OrganizationAndTeamData,
+    ): Promise<KodyRulesEntity | null>;
 }

--- a/libs/kodyRules/domain/contracts/kodyRules.service.contract.ts
+++ b/libs/kodyRules/domain/contracts/kodyRules.service.contract.ts
@@ -124,5 +124,6 @@ export interface IKodyRulesService extends IKodyRulesRepository {
 
     syncRulesWithPlanLimit(
         organizationAndTeamData: OrganizationAndTeamData,
+        opts?: { entity?: KodyRulesEntity | null; limited?: boolean },
     ): Promise<KodyRulesEntity | null>;
 }

--- a/libs/kodyRules/domain/interfaces/kodyRules.interface.ts
+++ b/libs/kodyRules/domain/interfaces/kodyRules.interface.ts
@@ -141,12 +141,17 @@ export interface IKodyRule {
     /**
      * Set when this rule was auto-paused at creation/reactivation time
      * because activating it would have exceeded the free plan's active-rule
-     * quota (`KodyRulesService.ensureFreePlanLimit`). Distinguishes a
+     * quota (`KodyRulesService.resolveStatusWithinPlanLimit`). Distinguishes a
      * plan-limit lock from a rule the user paused themselves — the web UI
      * renders these as "Locked" with an upgrade CTA instead of a plain
      * pause toggle. Cleared whenever the rule transitions to `ACTIVE`
      * (`KodyRulesService.createOrUpdate` clears it once the org is back
      * under quota or the plan changes).
+     *
+     * NOTE: This flag is persisted at write time and is stale-safe on reads
+     * — the review pipeline (`codeBaseConfig.service.ts`) normalizes
+     * `PAUSED + lockedByPlan` back to `ACTIVE` when `shouldLimitResources`
+     * is false (i.e., the org is on a paid plan). See #1626.
      */
     lockedByPlan?: boolean;
 }

--- a/libs/platform/modules/github.module.ts
+++ b/libs/platform/modules/github.module.ts
@@ -16,7 +16,7 @@ import { GithubService as GitHubService } from '../infrastructure/adapters/servi
         forwardRef(() => IntegrationCoreModule),
         forwardRef(() => IntegrationConfigCoreModule),
         forwardRef(() => GlobalCacheModule),
-        McpCoreModule,
+        forwardRef(() => McpCoreModule),
     ],
     providers: [
         GitHubService,

--- a/test/unit/ee/codeBase/codeBaseConfig.planSync.spec.ts
+++ b/test/unit/ee/codeBase/codeBaseConfig.planSync.spec.ts
@@ -1,0 +1,119 @@
+import CodeBaseConfigService from '@libs/ee/codeBase/codeBaseConfig.service';
+import { KodyRulesStatus } from '@libs/kodyRules/domain/interfaces/kodyRules.interface';
+
+/**
+ * The server review path (getConfig) reconciles the rules' lock state with the
+ * current plan before the review uses them — a fail-safe for a missed
+ * plan-change webhook. It reuses the entity + `limited` it already resolved, so
+ * the sync does no extra lookup, and the review applies the reconciled set.
+ */
+describe('CodeBaseConfigService.getConfig — plan-limit reconciliation', () => {
+    const organizationAndTeamData = {
+        organizationId: 'org-1',
+        teamId: 'team-1',
+    };
+    const repository = { id: 'repo-1', name: 'my-repo' };
+
+    const lockedRule = {
+        uuid: 'r-locked',
+        status: KodyRulesStatus.PAUSED,
+        lockedByPlan: true,
+        repositoryId: 'repo-1',
+    };
+    const unlockedRule = {
+        ...lockedRule,
+        status: KodyRulesStatus.ACTIVE,
+        lockedByPlan: false,
+    };
+
+    const buildService = (limited: boolean) => {
+        const loadedEntity = { toObject: () => ({ rules: [lockedRule] }) };
+
+        const parametersService = {
+            findOne: jest.fn().mockResolvedValue({ configValue: {} }),
+            findByKey: jest.fn().mockResolvedValue({ configValue: 'en-US' }),
+        };
+        const kodyRulesService = {
+            findByOrganizationId: jest.fn().mockResolvedValue(loadedEntity),
+            // Paid → reconcile returns the fresh doc with the rule reactivated.
+            syncRulesWithPlanLimit: jest.fn().mockResolvedValue({
+                toObject: () => ({ rules: [unlockedRule] }),
+            }),
+        };
+        const filterKodyRules = jest
+            .fn()
+            .mockReturnValue({ standardRules: [unlockedRule], memoryRules: [] });
+        const kodyRulesValidationService = { filterKodyRules };
+        const permissionValidationService = {
+            shouldLimitResources: jest.fn().mockResolvedValue(limited),
+        };
+        const codeManagementService = {
+            verifyConnection: jest
+                .fn()
+                .mockResolvedValue({ hasConnection: true, isSetupComplete: true }),
+        };
+
+        const service = new CodeBaseConfigService(
+            {} as any, // integrationService
+            {} as any, // integrationConfigService
+            {} as any, // organizationParametersService
+            parametersService as any,
+            kodyRulesService as any,
+            {} as any, // globalParametersService
+            codeManagementService as any,
+            kodyRulesValidationService as any,
+            permissionValidationService as any,
+            {} as any, // cacheService
+        );
+
+        jest.spyOn(service as any, 'getDefaultBranch').mockResolvedValue('main');
+        jest
+            .spyOn(service as any, 'getReviewModeConfigParameter')
+            .mockResolvedValue({});
+        jest
+            .spyOn(service as any, 'getKodyFineTuningConfigParameter')
+            .mockResolvedValue({});
+        jest
+            .spyOn(service as any, 'getMergedCodeReviewConfigs')
+            .mockResolvedValue({
+                directoryId: undefined,
+                ignorePaths: [],
+                v2PromptOverrides: {},
+            });
+        jest.spyOn(service as any, 'getGlobalIgnorePaths').mockResolvedValue([]);
+        jest
+            .spyOn(service as any, 'sanitizeV2PromptOverrides')
+            .mockReturnValue({});
+
+        return { service, kodyRulesService, filterKodyRules, loadedEntity };
+    };
+
+    it('reconciles before the review and applies the synced rules (paid plan)', async () => {
+        const { service, kodyRulesService, filterKodyRules, loadedEntity } =
+            buildService(false);
+
+        await service.getConfig(organizationAndTeamData, repository);
+
+        // Called with the already-loaded entity + the resolved plan gate.
+        expect(kodyRulesService.syncRulesWithPlanLimit).toHaveBeenCalledWith(
+            organizationAndTeamData,
+            { entity: loadedEntity, limited: false },
+        );
+        // filterKodyRules must receive the reconciled (ACTIVE) rule.
+        expect(filterKodyRules.mock.calls[0][0]).toEqual([unlockedRule]);
+    });
+
+    it('passes the free-plan gate through so the sync can enforce the cap', async () => {
+        const { service, kodyRulesService } = buildService(true);
+        // On free the reconcile no-ops here (returns null); the parked rule
+        // flows through unchanged.
+        kodyRulesService.syncRulesWithPlanLimit.mockResolvedValue(null);
+
+        await service.getConfig(organizationAndTeamData, repository);
+
+        expect(kodyRulesService.syncRulesWithPlanLimit).toHaveBeenCalledWith(
+            organizationAndTeamData,
+            expect.objectContaining({ limited: true }),
+        );
+    });
+});

--- a/test/unit/ee/kodyRules/service/kodyRules.service.createOrUpdateLimit.spec.ts
+++ b/test/unit/ee/kodyRules/service/kodyRules.service.createOrUpdateLimit.spec.ts
@@ -420,6 +420,16 @@ describe('KodyRulesService.syncRulesWithPlanLimit & self-healing read path', () 
                 currentEntity = KodyRulesEntity.create({ ...currentEntity.toObject(), ...updateData });
                 return Promise.resolve(currentEntity);
             }),
+            updateRule: jest.fn().mockImplementation((_uuid, ruleId, patch) => {
+                const rules = currentEntity.toObject().rules.map((r) =>
+                    r.uuid === ruleId ? { ...r, ...patch } : r,
+                );
+                currentEntity = KodyRulesEntity.create({
+                    ...currentEntity.toObject(),
+                    rules,
+                });
+                return Promise.resolve(currentEntity);
+            }),
         };
 
         const permissionValidationServiceMock = {
@@ -447,15 +457,15 @@ describe('KodyRulesService.syncRulesWithPlanLimit & self-healing read path', () 
         // Wait briefly for the background syncRulesWithPlanLimit to complete
         await new Promise((r) => setTimeout(r, 100));
 
-        // Check that repository.update was called to persist updated active rules to MongoDB
-        expect(repositoryMock.update).toHaveBeenCalled();
-        const [, updatedData] = repositoryMock.update.mock.calls[0];
+        // Check that repository.updateRule was called to persist updated active rules to MongoDB
+        expect(repositoryMock.updateRule).toHaveBeenCalled();
+        const updatedRules = currentEntity.toObject().rules;
 
         // r1 and r2 flipped to ACTIVE & lockedByPlan: false
-        expect(updatedData.rules[0].status).toBe(KodyRulesStatus.ACTIVE);
-        expect(updatedData.rules[0].lockedByPlan).toBe(false);
-        expect(updatedData.rules[1].status).toBe(KodyRulesStatus.ACTIVE);
-        expect(updatedData.rules[1].lockedByPlan).toBe(false);
+        expect(updatedRules[0].status).toBe(KodyRulesStatus.ACTIVE);
+        expect(updatedRules[0].lockedByPlan).toBe(false);
+        expect(updatedRules[1].status).toBe(KodyRulesStatus.ACTIVE);
+        expect(updatedRules[1].lockedByPlan).toBe(false);
     });
 
     it('enforces 10-rule ceiling on syncRulesWithPlanLimit when org is on Free plan', async () => {
@@ -473,6 +483,16 @@ describe('KodyRulesService.syncRulesWithPlanLimit & self-healing read path', () 
             findByOrganizationId: jest.fn().mockImplementation(() => Promise.resolve(currentEntity)),
             update: jest.fn().mockImplementation((_uuid, updateData) => {
                 currentEntity = KodyRulesEntity.create({ ...currentEntity.toObject(), ...updateData });
+                return Promise.resolve(currentEntity);
+            }),
+            updateRule: jest.fn().mockImplementation((_uuid, ruleId, patch) => {
+                const rules = currentEntity.toObject().rules.map((r) =>
+                    r.uuid === ruleId ? { ...r, ...patch } : r,
+                );
+                currentEntity = KodyRulesEntity.create({
+                    ...currentEntity.toObject(),
+                    rules,
+                });
                 return Promise.resolve(currentEntity);
             }),
         };
@@ -501,18 +521,18 @@ describe('KodyRulesService.syncRulesWithPlanLimit & self-healing read path', () 
 
         await service.syncRulesWithPlanLimit(organizationAndTeamData);
 
-        expect(repositoryMock.update).toHaveBeenCalled();
-        const [, updatedData] = repositoryMock.update.mock.calls[0];
+        expect(repositoryMock.updateRule).toHaveBeenCalled();
+        const updatedRules = currentEntity.toObject().rules;
 
         // First 10 remain ACTIVE
         for (let i = 0; i < 10; i++) {
-            expect(updatedData.rules[i].status).toBe(KodyRulesStatus.ACTIVE);
+            expect(updatedRules[i].status).toBe(KodyRulesStatus.ACTIVE);
         }
 
         // Rules #11 and #12 are set to PAUSED + lockedByPlan: true
-        expect(updatedData.rules[10].status).toBe(KodyRulesStatus.PAUSED);
-        expect(updatedData.rules[10].lockedByPlan).toBe(true);
-        expect(updatedData.rules[11].status).toBe(KodyRulesStatus.PAUSED);
-        expect(updatedData.rules[11].lockedByPlan).toBe(true);
+        expect(updatedRules[10].status).toBe(KodyRulesStatus.PAUSED);
+        expect(updatedRules[10].lockedByPlan).toBe(true);
+        expect(updatedRules[11].status).toBe(KodyRulesStatus.PAUSED);
+        expect(updatedRules[11].lockedByPlan).toBe(true);
     });
 });

--- a/test/unit/ee/kodyRules/service/kodyRules.service.createOrUpdateLimit.spec.ts
+++ b/test/unit/ee/kodyRules/service/kodyRules.service.createOrUpdateLimit.spec.ts
@@ -535,4 +535,125 @@ describe('KodyRulesService.syncRulesWithPlanLimit & self-healing read path', () 
         expect(updatedRules[11].status).toBe(KodyRulesStatus.PAUSED);
         expect(updatedRules[11].lockedByPlan).toBe(true);
     });
+
+    // The review pipeline (codeBaseConfig) already holds the entity and the
+    // resolved plan gate, so it passes them in to avoid duplicate lookups.
+    it('reuses caller-supplied entity + limited without re-loading or re-checking the plan', async () => {
+        const existingRules = [
+            {
+                uuid: 'r1',
+                title: 'Locked',
+                status: KodyRulesStatus.PAUSED,
+                lockedByPlan: true,
+            },
+        ];
+        let currentEntity = KodyRulesEntity.create({
+            uuid: 'kr-1',
+            organizationId: 'org-1',
+            rules: existingRules,
+        });
+
+        const repositoryMock = {
+            findByOrganizationId: jest
+                .fn()
+                .mockImplementation(() => Promise.resolve(currentEntity)),
+            updateRule: jest.fn().mockImplementation((_uuid, ruleId, patch) => {
+                const rules = currentEntity
+                    .toObject()
+                    .rules.map((r) =>
+                        r.uuid === ruleId ? { ...r, ...patch } : r,
+                    );
+                currentEntity = KodyRulesEntity.create({
+                    ...currentEntity.toObject(),
+                    rules,
+                });
+                return Promise.resolve(currentEntity);
+            }),
+        };
+        const permissionValidationServiceMock = {
+            shouldLimitResources: jest.fn().mockResolvedValue(true),
+        };
+
+        const service = new KodyRulesService(
+            repositoryMock as any,
+            { emit: jest.fn() } as any,
+            {} as any,
+            {} as any,
+            { MAX_KODY_RULES: 10 } as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            permissionValidationServiceMock as any,
+            {} as any,
+            {} as any,
+        );
+
+        await service.syncRulesWithPlanLimit(organizationAndTeamData, {
+            entity: currentEntity,
+            limited: false,
+        });
+
+        // `limited` reused → no license lookup.
+        expect(
+            permissionValidationServiceMock.shouldLimitResources,
+        ).not.toHaveBeenCalled();
+        // Initial load skipped (entity reused); findByOrganizationId only runs
+        // once, for the fresh re-fetch after the write.
+        expect(repositoryMock.findByOrganizationId).toHaveBeenCalledTimes(1);
+        // Still reconciles: the plan-locked rule is reactivated.
+        expect(repositoryMock.updateRule).toHaveBeenCalled();
+        expect(currentEntity.toObject().rules[0].status).toBe(
+            KodyRulesStatus.ACTIVE,
+        );
+        expect(currentEntity.toObject().rules[0].lockedByPlan).toBe(false);
+    });
+
+    it('is a zero-lookup no-op when the passed rules already match the plan', async () => {
+        const entity = KodyRulesEntity.create({
+            uuid: 'kr-1',
+            organizationId: 'org-1',
+            rules: [
+                {
+                    uuid: 'r1',
+                    status: KodyRulesStatus.ACTIVE,
+                    lockedByPlan: false,
+                },
+            ],
+        });
+
+        const repositoryMock = {
+            findByOrganizationId: jest.fn(),
+            updateRule: jest.fn(),
+        };
+        const permissionValidationServiceMock = {
+            shouldLimitResources: jest.fn(),
+        };
+
+        const service = new KodyRulesService(
+            repositoryMock as any,
+            { emit: jest.fn() } as any,
+            {} as any,
+            {} as any,
+            { MAX_KODY_RULES: 10 } as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            permissionValidationServiceMock as any,
+            {} as any,
+            {} as any,
+        );
+
+        // Paid plan, nothing locked → nothing to do, and it must not touch the
+        // DB or the license service (the common per-review path).
+        await service.syncRulesWithPlanLimit(organizationAndTeamData, {
+            entity,
+            limited: false,
+        });
+
+        expect(repositoryMock.findByOrganizationId).not.toHaveBeenCalled();
+        expect(
+            permissionValidationServiceMock.shouldLimitResources,
+        ).not.toHaveBeenCalled();
+        expect(repositoryMock.updateRule).not.toHaveBeenCalled();
+    });
 });

--- a/test/unit/ee/kodyRules/service/kodyRules.service.createOrUpdateLimit.spec.ts
+++ b/test/unit/ee/kodyRules/service/kodyRules.service.createOrUpdateLimit.spec.ts
@@ -1,5 +1,6 @@
 import { OrganizationAndTeamData } from '@libs/core/infrastructure/config/types/general/organizationAndTeamData';
 import { KodyRulesService } from '@libs/ee/kodyRules/service/kodyRules.service';
+import { KodyRulesEntity } from '@libs/kodyRules/domain/entities/kodyRules.entity';
 import {
     KodyRulesScope,
     KodyRulesStatus,
@@ -385,5 +386,133 @@ describe('KodyRulesService.createOrUpdate severity normalization on update (P3)'
 
         const [, , updateData] = updateRule.mock.calls[0];
         expect(updateData.severity).toBe('critical');
+    });
+});
+
+describe('KodyRulesService.syncRulesWithPlanLimit & self-healing read path', () => {
+    const organizationAndTeamData: OrganizationAndTeamData = {
+        organizationId: 'org-1',
+        teamId: 'team-1',
+    };
+
+    it('triggers syncRulesWithPlanLimit from find() when stale PAUSED+lockedByPlan rules exist on a paid org', async () => {
+        const existingRules = [
+            {
+                uuid: 'r1',
+                title: 'Stale locked rule 1',
+                status: KodyRulesStatus.PAUSED,
+                lockedByPlan: true,
+            },
+            {
+                uuid: 'r2',
+                title: 'Stale locked rule 2',
+                status: KodyRulesStatus.PAUSED,
+                lockedByPlan: true,
+            },
+        ];
+
+        let currentEntity = KodyRulesEntity.create({ uuid: 'kr-1', organizationId: 'org-1', rules: existingRules });
+
+        const repositoryMock = {
+            find: jest.fn().mockImplementation(() => Promise.resolve([currentEntity])),
+            findByOrganizationId: jest.fn().mockImplementation(() => Promise.resolve(currentEntity)),
+            update: jest.fn().mockImplementation((_uuid, updateData) => {
+                currentEntity = KodyRulesEntity.create({ ...currentEntity.toObject(), ...updateData });
+                return Promise.resolve(currentEntity);
+            }),
+        };
+
+        const permissionValidationServiceMock = {
+            shouldLimitResources: jest.fn().mockResolvedValue(false), // Paid plan!
+        };
+
+        const service = new KodyRulesService(
+            repositoryMock as any,
+            { emit: jest.fn() } as any,
+            {} as any,
+            {} as any,
+            { validateRulesLimit: jest.fn() } as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            permissionValidationServiceMock as any,
+            {} as any,
+            {} as any,
+        );
+
+        // find() triggers background sync, but the returned entity has severity-normalized rules
+        const results = await service.find({ organizationId: 'org-1' });
+        expect(results).toHaveLength(1);
+
+        // Wait briefly for the background syncRulesWithPlanLimit to complete
+        await new Promise((r) => setTimeout(r, 100));
+
+        // Check that repository.update was called to persist updated active rules to MongoDB
+        expect(repositoryMock.update).toHaveBeenCalled();
+        const [, updatedData] = repositoryMock.update.mock.calls[0];
+
+        // r1 and r2 flipped to ACTIVE & lockedByPlan: false
+        expect(updatedData.rules[0].status).toBe(KodyRulesStatus.ACTIVE);
+        expect(updatedData.rules[0].lockedByPlan).toBe(false);
+        expect(updatedData.rules[1].status).toBe(KodyRulesStatus.ACTIVE);
+        expect(updatedData.rules[1].lockedByPlan).toBe(false);
+    });
+
+    it('enforces 10-rule ceiling on syncRulesWithPlanLimit when org is on Free plan', async () => {
+        // 12 ACTIVE rules on a Free plan
+        const existingRules = Array.from({ length: 12 }, (_, i) => ({
+            uuid: `r${i + 1}`,
+            title: `Rule ${i + 1}`,
+            status: KodyRulesStatus.ACTIVE,
+            lockedByPlan: false,
+        }));
+
+        let currentEntity = KodyRulesEntity.create({ uuid: 'kr-1', organizationId: 'org-1', rules: existingRules });
+
+        const repositoryMock = {
+            findByOrganizationId: jest.fn().mockImplementation(() => Promise.resolve(currentEntity)),
+            update: jest.fn().mockImplementation((_uuid, updateData) => {
+                currentEntity = KodyRulesEntity.create({ ...currentEntity.toObject(), ...updateData });
+                return Promise.resolve(currentEntity);
+            }),
+        };
+
+        const validationServiceMock = {
+            MAX_KODY_RULES: 10,
+        };
+
+        const permissionValidationServiceMock = {
+            shouldLimitResources: jest.fn().mockResolvedValue(true), // Free plan!
+        };
+
+        const service = new KodyRulesService(
+            repositoryMock as any,
+            { emit: jest.fn() } as any,
+            {} as any,
+            {} as any,
+            validationServiceMock as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            permissionValidationServiceMock as any,
+            {} as any,
+            {} as any,
+        );
+
+        await service.syncRulesWithPlanLimit(organizationAndTeamData);
+
+        expect(repositoryMock.update).toHaveBeenCalled();
+        const [, updatedData] = repositoryMock.update.mock.calls[0];
+
+        // First 10 remain ACTIVE
+        for (let i = 0; i < 10; i++) {
+            expect(updatedData.rules[i].status).toBe(KodyRulesStatus.ACTIVE);
+        }
+
+        // Rules #11 and #12 are set to PAUSED + lockedByPlan: true
+        expect(updatedData.rules[10].status).toBe(KodyRulesStatus.PAUSED);
+        expect(updatedData.rules[10].lockedByPlan).toBe(true);
+        expect(updatedData.rules[11].status).toBe(KodyRulesStatus.PAUSED);
+        expect(updatedData.rules[11].lockedByPlan).toBe(true);
     });
 });


### PR DESCRIPTION


## Summary

Fixes [#1626](https://github.com/kodustech/kodus-ai/issues/1626) 
Linked PR: https://github.com/kodustech/kodus-service-billing/pull/50

Kody Rules created while on the Free plan (or during a transient license validation error) remained permanently stamped with `status: PAUSED` and `lockedByPlan: true` after the organization upgraded to a paid plan (`teams_byok`, `enterprise`, etc.).

Because the review pipeline filtered out non-`ACTIVE` rules, paid customers silently lost review coverage on all rules beyond the initial 10-rule cap.


### Where the actual DB is UPDATED (Saved to MongoDB):

1. On Page Load / Read (/kody-rules) — Self-Healing DB Update
 When a paid org fetches their rules (API  /kody-rules/find-rules-in-organization-by-filter -> kodusRulesService.find()), if any stale PAUSED + lockedByPlan rules are found, syncRulesWithPlanLimit runs and updates MongoDB (kodyRulesRepository.update). The DB is cleaned up on the spot.
 2. On Payment Webhook (Stripe / Subscription change) — Event-driven DB Update

When an upgrade or downgrade event happens, syncRulesWithPlanLimit runs and updates MongoDB (kodyRulesRepository.update).

---

### Where IN-MEMORY mapping happens (Fail-Safe Defense):

 1. Review Pipeline (codeBaseConfig.service.ts) Maps rules in memory during a PR review as a fail-safe. Why? So that even if a review runs before the DB update happens (or if DB write fails), PR reviews still execute all rules without waiting.
2. Frontend UI (resolve-badge-state.ts)

Maps badge status in memory on the client side so React rendering doesn't flicker while waiting for queries.
