### PR TITLE
fix: DLQ initializer crash-loops app on setup failure

### DIFF
--- a/libs/core/infrastructure/queue/rabbitmq-dlq.initializer.ts
+++ b/libs/core/infrastructure/queue/rabbitmq-dlq.initializer.ts
@@ -72,6 +72,8 @@ const WORKFLOW_JOB_QUEUES: QueueBinding[] = [
 @Injectable()
 export class RabbitMQDLQInitializer implements OnApplicationBootstrap {
     private readonly logger = createLogger(RabbitMQDLQInitializer.name);
+    /** True once delayed-exchanges / DLQ queues were asserted successfully. */
+    private dlqReady = false;
 
     constructor(@Optional() private readonly amqpConnection?: AmqpConnection) {}
 
@@ -143,10 +145,12 @@ export class RabbitMQDLQInitializer implements OnApplicationBootstrap {
                 await this.declareDLQQueues(setupChannel);
                 await this.bindQueuesToDelayedExchange(setupChannel);
 
+                this.dlqReady = true;
                 this.logger.log({
                     message:
                         'DLQ queues/bindings and delayed exchanges asserted',
                     context: RabbitMQDLQInitializer.name,
+                    metadata: { dlqReady: this.dlqReady },
                 });
             } catch (err) {
                 // amqp-connection-manager silently swallows setup errors. When
@@ -154,6 +158,7 @@ export class RabbitMQDLQInitializer implements OnApplicationBootstrap {
                 // handlers after this setup never register their consumers —
                 // producing "channel connected, consumers=0" zombies. Root
                 // cause of the 2026-04-24 incident.
+                this.dlqReady = false;
                 this.logger.error({
                     message:
                         'DLQ setup failed during (re)connect — consumers may NOT re-register',
@@ -162,9 +167,14 @@ export class RabbitMQDLQInitializer implements OnApplicationBootstrap {
                     metadata: {
                         errorMessage:
                             err instanceof Error ? err.message : String(err),
+                        dlqReady: this.dlqReady,
                     },
                 });
-                throw err;
+                // Deliberately do NOT re-throw: an unhandledRejection here
+                // aborts bootstrap before the HTTP server installs, turning a
+                // recoverable DLQ-setup failure into a hard crash loop. The
+                // dlqReady flag + error log above preserve visibility; the
+                // next connection re-establishment retries the setup.
             }
         });
 


### PR DESCRIPTION
## Problem

`RabbitMQDLQInitializer` registers a `managedChannel.addSetup(...)` callback
that asserts delayed exchanges, DLQ queues, and bindings. On any setup
failure the callback re-threw the error, producing an `unhandledRejection`
during bootstrap — **before the HTTP server handler is installed**. The
process crash-looped on every boot, so the app never came up.

## Fix

Catch the setup error instead of re-throwing:

- Log the full error (message + stack preserved, unchanged).
- Set an internal `dlqReady = false` flag so callers can distinguish
  "setup skipped/failed" from "setup succeeded".
- Set `dlqReady = true` on successful assertion and include the flag in
  log metadata for observability.
- Do **not** re-throw — the connection manager retries the setup on the
  next channel re-establishment, so a transient failure is recoverable
  instead of fatal.

Diff: `libs/core/infrastructure/queue/rabbitmq-dlq.initializer.ts` (+11/-1).

## Verification (real, not just "boots without crash")

- App boot completes with RabbitMQ enabled: HTTP 200 on `/health`,
  container healthy.
- Log shows the actual success path: `DLQ queues/bindings and delayed
  exchanges asserted … dlqReady: true`.
- Broker-side artifacts confirmed (vhost `kodus-ai`): 3×
  `x-delayed-message` exchanges (`workflow.exchange.delayed`,
  `workflow.events.delayed`, `orchestrator.exchange.delayed`), 3× DLX
  exchanges, 3 DLQ queues (`workflow.jobs.dlq`, `workflow.events.dlq`,
  `orchestrator.dlq`), 7 delayed-exchange bindings.
- End-to-end message flow: published a real message to
  `workflow.exchange.dlx` → routed into `workflow.jobs.dlq` (depth 1),
  then purged.
- Worker process unaffected; api connection to broker persists.
- The broker already has `rabbitmq_delayed_message_exchange` enabled —
  no second config issue hiding behind the code bug.

## Related finding (not fixed here — recommended follow-up)

Four `@Cron()` decorators in the API read env vars with **no code
fallback**: `API_CRON_CHECK_IF_PR_SHOULD_BE_APPROVED`,
`API_CRON_SYNC_CODE_REVIEW_REACTIONS`, `API_CRON_KODY_LEARNING`,
`API_CRON_SSO_TEST_SESSION_CLEANUP`. When undefined they crash
`CronTime._parse` at `onApplicationBootstrap`. We set the canonical
values from `.env.example` in our deployment, but upstream should add
sane defaults (or explicit startup validation errors) so a missing var
fails loudly with a clear message instead of a parse crash.
