### PR TITLE
fix(ci): stop the skipped cloud-gate from cascading through the release

### DIFF
--- a/.github/workflows/selfhosted-build-push.yml
+++ b/.github/workflows/selfhosted-build-push.yml
@@ -277,6 +277,18 @@ jobs:
     create-rc-tag:
         name: Create RC git tag at current SHA
         needs: plan-release
+        # Explicit `if` required, NOT decoration. `cloud-gate` is skipped on
+        # every non-schedule run (manual dispatch, hotfix), and GitHub's
+        # implicit `success()` walks the TRANSITIVE needs graph — so a skip
+        # upstream skips this job even though `plan-release` succeeded, and
+        # every job below it cascades. `freeze-main` / `plan-release` already
+        # tolerate the skipped gate; the rest of the chain did not, which
+        # silently no-op'd every manual release from 2026-07-29 (79b3d401c)
+        # onward: run green, nothing built, nothing shipped, no alert (a skip
+        # is not a failure, so notify-discord-failure never fires).
+        # Depend on the DIRECT predecessor's result so a genuine failure still
+        # stops the train.
+        if: ${{ !cancelled() && needs.plan-release.result == 'success' }}
         runs-on: ubuntu-latest
         permissions:
             contents: write
@@ -307,6 +319,9 @@ jobs:
         needs:
             - plan-release
             - create-rc-tag
+        # See create-rc-tag: explicit condition so the skipped cloud-gate does
+        # not cascade down the chain.
+        if: ${{ !cancelled() && needs.create-rc-tag.result == 'success' }}
         runs-on: ubuntu-latest
         # No environment: production here on purpose. The gate is at PROMOTE,
         # not at build — the Friday-morning flow dispatches at 9h and lets
@@ -443,6 +458,9 @@ jobs:
         needs:
             - plan-release
             - build-and-push
+        # See create-rc-tag: without this the matrix is skipped on every
+        # manual dispatch — the exact symptom that surfaced this bug.
+        if: ${{ !cancelled() && needs.build-and-push.result == 'success' }}
         permissions:
             contents: read
             packages: read
@@ -466,6 +484,10 @@ jobs:
         needs:
             - plan-release
             - e2e-matrix
+        # See create-rc-tag. Note this keeps promote strictly gated on a GREEN
+        # matrix — the point of the chain — while letting a skipped cloud-gate
+        # through.
+        if: ${{ !cancelled() && needs.e2e-matrix.result == 'success' }}
         permissions:
             contents: write
             packages: write


### PR DESCRIPTION
## Symptom

[Run 30664226072](https://github.com/kodustech/kodus-ai/actions/runs/30664226072) (manual dispatch, 2026-07-31) reported **success** but shipped nothing: it planned `selfhosted-2.1.28` / `rc.112` and then skipped **every** remaining job — RC tag, image build, **E2E matrix**, promote, changelog, CLI, env-sync.

## Cause

`cloud-gate` is `if: github.event_name == 'schedule'`, so it is skipped on every manual dispatch and hotfix — that part is deliberate and documented in the workflow.

The problem is what happens downstream. GitHub's implicit `success()` walks the **transitive** needs graph, so the skipped gate propagated past `plan-release` (which succeeded) into `create-rc-tag` and cascaded from there.

`freeze-main` and `plan-release` already anticipated this and tolerate it explicitly:

```yaml
needs.cloud-gate.result == 'success' || needs.cloud-gate.result == 'skipped'
```

The four jobs after them had **no `if:` at all**, so they inherited the poisoned chain.

Introduced in 79b3d401c (2026-07-29). **Every manual release since then has been a no-op.** The last dispatch that worked was 30477791708, on 2026-07-29, before that commit — it has no `Cloud gate` job at all.

Worse, it fails silently: a skip is not a failure, so the run is green and `notify-discord-failure` (`always() && contains(needs.*.result, 'failure')`) never fires. `unfreeze-main` is `if: always()`, so at least main was never left frozen.

## Fix

Give each job in the chain an explicit condition keyed on its **direct** predecessor:

| job | condition |
|---|---|
| `create-rc-tag` | `needs.plan-release.result == 'success'` |
| `build-and-push` | `needs.create-rc-tag.result == 'success'` |
| `e2e-matrix` | `needs.build-and-push.result == 'success'` |
| `promote` | `needs.e2e-matrix.result == 'success'` |

All wrapped in `!cancelled()`, matching the style already used by `freeze-main` / `plan-release`.

A skipped gate now passes through, while a genuine failure still stops the train — and `promote` remains strictly gated on a **green** e2e matrix, which is the whole point of the chain. The jobs below `promote` already had explicit `if: needs.promote.result == 'success'`, so they were never part of the problem.

## Verification

- `actionlint` — only pre-existing `SC2086` findings in steps this PR does not touch
- YAML parses; every job in the chain now carries an explicit `if`
- Full graph reviewed job by job, not just the four edited

## Follow-up (not in this PR)

A release that skips everything still reports green. `notify-discord-failure` only reacts to `failure`, never to "the train did nothing". Worth a guard that fails the run when `promote` neither succeeded nor was legitimately skipped — happy to open it separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)