### PR TITLE
fix(kody-rules): trace the sharded judge in Langfuse

### DIFF
--- a/libs/code-review/infrastructure/agents/providers/kody-rules-agent.langfuse-trace.spec.ts
+++ b/libs/code-review/infrastructure/agents/providers/kody-rules-agent.langfuse-trace.spec.ts
@@ -1,0 +1,118 @@
+import { KodyRulesAgentProvider } from '@libs/code-review/infrastructure/agents/providers/kody-rules-agent.provider';
+import { runStructuredReviewCall } from '@libs/llm/structured-review-call';
+import * as reviewObs from '@libs/code-review/infrastructure/agents/collaborators/review-observability';
+
+// The sharded judge runs the LLM at this boundary — mock it so the test never
+// hits a real model, and so we can prove the judge executed INSIDE the trace.
+jest.mock('@libs/llm/structured-review-call', () => ({
+    runStructuredReviewCall: jest.fn(),
+}));
+
+// Spy on runAgentWithTrace but keep executing `fn` so the rest of execute()
+// (the judge + merge) still runs. This is the seam that opens the Langfuse
+// root observation every OTHER review agent uses (base provider). The sharded
+// kody-rules execute() override must go through it too, or its Vercel AI SDK
+// generateText spans emit detached — no named trace, no org/PR/session tags —
+// which is exactly why the agent shows ZERO traces in Langfuse today.
+jest.mock(
+    '@libs/code-review/infrastructure/agents/collaborators/review-observability',
+    () => {
+        const actual = jest.requireActual(
+            '@libs/code-review/infrastructure/agents/collaborators/review-observability',
+        );
+        return {
+            ...actual,
+            runAgentWithTrace: jest.fn((_meta: any, _input: any, fn: any) =>
+                fn(),
+            ),
+        };
+    },
+);
+
+const mockJudge = runStructuredReviewCall as jest.Mock;
+const mockRunAgentWithTrace = reviewObs.runAgentWithTrace as jest.Mock;
+
+describe('KodyRulesAgentProvider.execute — Langfuse trace wrapping (#sharded-no-trace)', () => {
+    function makeProvider(responses: any[]) {
+        let i = 0;
+        mockJudge.mockReset();
+        mockJudge.mockImplementation(
+            async () => responses[i++] ?? { violations: [] },
+        );
+        mockRunAgentWithTrace.mockClear();
+        return new KodyRulesAgentProvider(
+            {} as any, // promptRunnerService (unused — local stack)
+            { getBYOKConfig: jest.fn(async () => null) } as any, // system model
+            {} as any, // observability (judge mocked)
+        );
+    }
+
+    const input = (over: any = {}) => ({
+        prNumber: 4242,
+        organizationAndTeamData: {
+            organizationId: 'org-abc',
+            teamId: 'team-xyz',
+        },
+        repositoryId: 'repo-123',
+        changedFiles: [
+            {
+                filename: 'src/a.ts',
+                patchWithLinesStr: '11 +const x: any = 2',
+                patch: '11 +const x: any = 2',
+            },
+        ],
+        prTitle: 'test',
+        prBody: '',
+        kodyRules: [
+            {
+                uuid: 'no-any',
+                title: 'no any',
+                rule: 'do not use any',
+                status: 'active',
+                severity: 'high',
+                path: '**/*.ts',
+            },
+        ],
+        ...over,
+    });
+
+    it('runs the semantic judge INSIDE runAgentWithTrace, tagged with the agent identity + org/team/PR/repo', async () => {
+        const provider = makeProvider([
+            {
+                violations: [
+                    {
+                        ruleId: 1,
+                        relevantLinesStart: 11,
+                        relevantLinesEnd: 11,
+                        existingCode: 'const x: any = 2',
+                        suggestionContent: 'avoid any',
+                        oneSentenceSummary: 'no any',
+                    },
+                ],
+            },
+        ]);
+
+        const out = await provider.execute(input() as any);
+
+        // The judge produced its finding — proves the wrapped `fn` actually ran.
+        expect(out.suggestions).toHaveLength(1);
+
+        // The LLM shards ran inside a Langfuse trace, not detached.
+        expect(mockRunAgentWithTrace).toHaveBeenCalledTimes(1);
+
+        // Trace is identifiable and filterable the same way every other agent is.
+        const meta = mockRunAgentWithTrace.mock.calls[0][0];
+        expect(meta).toMatchObject({
+            traceName: 'kodus-rules-review-agent',
+            organizationId: 'org-abc',
+            teamId: 'team-xyz',
+            prNumber: 4242,
+            repositoryId: 'repo-123',
+        });
+
+        // The shard LLM call happened within the trace wrapper (order proof).
+        const traceOrder = mockRunAgentWithTrace.mock.invocationCallOrder[0];
+        const judgeOrder = mockJudge.mock.invocationCallOrder[0];
+        expect(traceOrder).toBeLessThan(judgeOrder);
+    });
+});

--- a/libs/code-review/infrastructure/agents/providers/kody-rules-agent.provider.ts
+++ b/libs/code-review/infrastructure/agents/providers/kody-rules-agent.provider.ts
@@ -10,6 +10,7 @@ import { runStructuredReviewCall } from '@libs/llm/structured-review-call';
 import { BaseCodeReviewAgentProvider } from '@libs/code-review/infrastructure/agents/providers/base-code-review-agent.provider';
 import { resolveAgentModel } from '@libs/code-review/infrastructure/agents/collaborators/model-factory';
 import { mapAgentFindings } from '@libs/code-review/infrastructure/agents/collaborators/finding-mapper';
+import { runAgentWithTrace } from '@libs/code-review/infrastructure/agents/collaborators/review-observability';
 import {
     judgeKodyRulesSharded,
     inlineRuleReferences,
@@ -223,14 +224,40 @@ export class KodyRulesAgentProvider extends BaseCodeReviewAgentProvider {
                 input,
             );
 
-            const result = await judgeKodyRulesSharded({
-                changedFiles: input.changedFiles,
-                rules: rulesForJudge,
-                runJudge,
-                prTitle: input.prTitle,
-                prBody: input.prBody,
-                logger: this.shardLogger,
-            });
+            // Open the Langfuse root observation the sharded judge runs under.
+            // Every OTHER review agent runs inside runAgentWithTrace (via the
+            // base provider's agentic loop); this override bypassed super.execute
+            // and with it that wrapper, so the shard `generateText` spans emitted
+            // detached — no named trace, no org/team/PR/session tags — and the
+            // agent showed ZERO traces in Langfuse. Wrapping the judge here nests
+            // every shard span under a `kodus-rules-review-agent` trace, tagged
+            // like the generalist. No-op passthrough when tracing is disabled.
+            const result = await runAgentWithTrace(
+                {
+                    traceName: this.getIdentity().name,
+                    organizationId:
+                        input.organizationAndTeamData?.organizationId,
+                    teamId: input.organizationAndTeamData?.teamId,
+                    prNumber: input.prNumber,
+                    repositoryId: input.repositoryId,
+                },
+                // Sanitized span input: shape only, never the file patches.
+                {
+                    prNumber: input.prNumber,
+                    semanticRules: rulesForJudge.length,
+                    mechanicalRules: mechanicalRules.length,
+                    changedFiles: input.changedFiles?.length ?? 0,
+                },
+                () =>
+                    judgeKodyRulesSharded({
+                        changedFiles: input.changedFiles,
+                        rules: rulesForJudge,
+                        runJudge,
+                        prTitle: input.prTitle,
+                        prBody: input.prBody,
+                        logger: this.shardLogger,
+                    }),
+            );
             judgeViolations = result.violations;
             shardsRun = result.shardsRun;
             shardsErrored = result.shardsErrored;


### PR DESCRIPTION
## Problem

The kody-rules review agent (deterministic **sharded** path, #1449) produces **zero traces in Langfuse**, while every other review agent traces normally.

**Root cause:** the agent's `execute()` override bypasses `super.execute()` and, with it, the `runAgentWithTrace()` wrapper that every other review agent runs inside (`base-code-review-agent.provider.ts`). That wrapper opens the Langfuse root observation — named after the agent and tagged with `organizationId` / `teamId` / `prNumber` / `sessionId` via `propagateAttributes` — that the Vercel AI SDK `generateText` spans nest under.

Without it, the shard LLM calls emit **detached** spans: no named trace, no org/team/PR/session tags, unfilterable — so nothing identifiable as kody-rules reaches Langfuse.

**Confirmed against production Langfuse (7d, `env=production`):**

| Trace name | Count |
|---|---|
| `kodus-generalist-review-agent` (goes through `runAgentWithTrace`) | 11,623 |
| `kodus-rules-review-agent` | **0** |
| observations `kodus-rules-review-agent.shard` | **0** |

(The generalist trace carries `userId`, `sessionId=org:repo:pr` and `organizationId/teamId/prNumber/repositoryId` metadata, with `chat <model>` / `step` / `readFile` spans nested under it — exactly what the kody-rules trace should look like.)

## Fix

Wrap the `judgeKodyRulesSharded` call in `runAgentWithTrace`, mirroring the base provider. Every shard `generateText` span now nests under a `kodus-rules-review-agent` trace, tagged like the generalist.

- No-op passthrough when tracing is disabled (`shouldTrace()` false).
- Span input is **shape-only** (rule/file counts, PR number) — never the file patches.

## Tests

- New red/green spec `kody-rules-agent.langfuse-trace.spec.ts`: drives the real `execute()` (LLM mocked at the `runStructuredReviewCall` boundary) and asserts the sharded judge runs **inside** `runAgentWithTrace`, tagged with the agent identity + org/team/PR/repo, in the correct order.
  - Verified **red** before the fix (`runAgentWithTrace` called 0 times) and **green** after.
- Full suite green: 608 suites / 5,601 tests, no regressions.

## Verification note

The `LANGFUSE_BASE_URL` in the local env templates points to the EU host (`cloud.langfuse.com`), but the project is on the **US** region (`us.cloud.langfuse.com`). Not changed here, but worth aligning in local configs to avoid `401 Invalid credentials` when querying from a dev machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)