### PR TITLE
feat(kody-rules): unlock plan-locked rules when an org moves to a paid plan

### DIFF
--- a/libs/cli-review/application/use-cases/__tests__/execute-cli-review.use-case.spec.ts
+++ b/libs/cli-review/application/use-cases/__tests__/execute-cli-review.use-case.spec.ts
@@ -48,6 +48,8 @@ function createMocks() {
 
     const kodyRulesService = {
         findByOrganizationId: jest.fn().mockResolvedValue(null),
+        // Default: nothing to unlock (Free plan / no locked rules).
+        unlockRulesLockedByPlan: jest.fn().mockResolvedValue(null),
     };
 
     const kodyRulesValidationService = {
@@ -569,6 +571,63 @@ describe('ExecuteCliReviewUseCase', () => {
             expect(result.repositoryId).toBe('global');
             expect(result.repositoryName).toBeNull();
             expect(result.config).toBeDefined();
+        });
+
+        /**
+         * A CLI review is still a review: a paid org whose rules were parked as
+         * PAUSED + lockedByPlan:true on Free must have them reactivated and
+         * applied in this run, not left ignored.
+         */
+        it('unlocks plan-locked rules on a paid plan and applies them in this review', async () => {
+            const {
+                useCase,
+                parametersService,
+                kodyRulesService,
+                kodyRulesValidationService,
+            } = createMocks();
+
+            const lockedRule = makeRule({
+                uuid: 'r-locked',
+                repositoryId: 'global',
+                status: KodyRulesStatus.PAUSED,
+                lockedByPlan: true,
+            });
+            const unlockedRule = {
+                ...lockedRule,
+                status: KodyRulesStatus.ACTIVE,
+                lockedByPlan: false,
+            };
+
+            parametersService.findByKey.mockResolvedValue({
+                toObject: () => ({
+                    configValue: { configs: {}, repositories: [] },
+                }),
+            });
+
+            kodyRulesService.findByOrganizationId.mockResolvedValue({
+                toObject: () => ({ rules: [lockedRule] }),
+            });
+
+            // Paid plan → unlock flips the rule to ACTIVE and returns the doc.
+            kodyRulesService.unlockRulesLockedByPlan.mockResolvedValue({
+                toObject: () => ({ rules: [unlockedRule] }),
+            });
+
+            kodyRulesValidationService.filterKodyRules.mockReturnValue({
+                standardRules: [unlockedRule],
+                memoryRules: [],
+            });
+
+            await (useCase as any).loadUserConfigWithRules(orgAndTeam, undefined);
+
+            expect(
+                kodyRulesService.unlockRulesLockedByPlan,
+            ).toHaveBeenCalledWith(orgAndTeam, { rules: [lockedRule] });
+            // filterKodyRules must see the UNLOCKED (ACTIVE) rule, not the
+            // parked one — otherwise the review ignores it.
+            expect(
+                kodyRulesValidationService.filterKodyRules,
+            ).toHaveBeenCalledWith([unlockedRule], 'global');
         });
     });
 

--- a/libs/cli-review/application/use-cases/execute-cli-review.use-case.ts
+++ b/libs/cli-review/application/use-cases/execute-cli-review.use-case.ts
@@ -467,9 +467,22 @@ export class ExecuteCliReviewUseCase implements IUseCase {
                     paramObj.configValue?.repositories,
                 );
 
+            // Lazy reconciliation of the free-plan quota lock: on a paid plan,
+            // reactivate any rule parked as PAUSED + lockedByPlan:true so this
+            // CLI review already applies it. Self-guarded (resolves the plan
+            // internally) and a no-op when nothing is locked.
+            const loadedRules = kodyRulesEntity?.toObject()?.rules || [];
+            const unlockedEntity =
+                await this.kodyRulesService.unlockRulesLockedByPlan(
+                    organizationAndTeamData,
+                    { rules: loadedRules },
+                );
+            const effectiveRules =
+                unlockedEntity?.toObject()?.rules ?? loadedRules;
+
             const { standardRules, memoryRules } =
                 this.kodyRulesValidationService.filterKodyRules(
-                    kodyRulesEntity?.toObject()?.rules || [],
+                    effectiveRules,
                     repositoryId,
                 );
 

--- a/libs/ee/codeBase/codeBaseConfig.service.ts
+++ b/libs/ee/codeBase/codeBaseConfig.service.ts
@@ -156,9 +156,21 @@ export default class CodeBaseConfigService implements ICodeBaseConfigService {
                     CodeBaseConfigService.name,
                 );
 
+            // Lazy reconciliation of the free-plan quota lock: on a paid plan,
+            // reactivate any rule parked as PAUSED + lockedByPlan:true so this
+            // review already applies it. Self-guarded + no-op when nothing is
+            // locked; returns the refreshed doc when an unlock happened.
+            const loadedRules = kodyRulesEntity?.toObject()?.rules || [];
+            const unlockedEntity =
+                await this.kodyRulesService.unlockRulesLockedByPlan(
+                    organizationAndTeamData,
+                    { limited, rules: loadedRules },
+                );
+            const effectiveRules = unlockedEntity?.toObject()?.rules ?? loadedRules;
+
             const { standardRules, memoryRules } =
                 this.kodyRulesValidationService.filterKodyRules(
-                    kodyRulesEntity?.toObject()?.rules || [],
+                    effectiveRules,
                     repository.id,
                     mergedConfigs.directoryId,
                     limited,

--- a/libs/ee/kodyRules/repository/kodyRules.repository.spec.ts
+++ b/libs/ee/kodyRules/repository/kodyRules.repository.spec.ts
@@ -91,3 +91,56 @@ describe('KodyRulesRepository.updateRulesStatusByFilter', () => {
         );
     });
 });
+
+/**
+ * When an org upgrades off Free, rules parked as PAUSED + lockedByPlan:true
+ * must reactivate. The Mongo write matches ONLY `lockedByPlan: true` (leaving
+ * manual pauses untouched) and flips both fields atomically: status → ACTIVE
+ * and lockedByPlan → false.
+ */
+describe('KodyRulesRepository.bulkUnlockPlanLockedRules', () => {
+    let model: any;
+    let repo: KodyRulesRepository;
+    let findOneAndUpdate: jest.Mock;
+    let exec: jest.Mock;
+
+    beforeEach(() => {
+        exec = jest.fn().mockResolvedValue(null);
+        findOneAndUpdate = jest.fn().mockReturnValue({ exec });
+        model = { findOneAndUpdate };
+
+        repo = new KodyRulesRepository(model as any, {} as any);
+    });
+
+    it('scopes the doc filter to the org and to docs holding a plan-locked rule', async () => {
+        await repo.bulkUnlockPlanLockedRules('org-1');
+
+        const [filter] = findOneAndUpdate.mock.calls[0];
+        expect(filter.organizationId).toBe('org-1');
+        expect(filter['rules.lockedByPlan']).toBe(true);
+    });
+
+    it('targets only lockedByPlan:true elements in arrayFilters', async () => {
+        await repo.bulkUnlockPlanLockedRules('org-1');
+
+        const [, , options] = findOneAndUpdate.mock.calls[0];
+        const [arrayFilter] = options.arrayFilters;
+        expect(arrayFilter['elem.lockedByPlan']).toBe(true);
+    });
+
+    it('flips status → ACTIVE and lockedByPlan → false atomically', async () => {
+        await repo.bulkUnlockPlanLockedRules('org-1');
+
+        const [, update] = findOneAndUpdate.mock.calls[0];
+        expect(update.$set['rules.$[elem].status']).toBe(
+            KodyRulesStatus.ACTIVE,
+        );
+        expect(update.$set['rules.$[elem].lockedByPlan']).toBe(false);
+        expect(update.$set['rules.$[elem].updatedAt']).toBeInstanceOf(Date);
+    });
+
+    it('returns null when no document matched (nothing to unlock)', async () => {
+        const result = await repo.bulkUnlockPlanLockedRules('org-1');
+        expect(result).toBeNull();
+    });
+});

--- a/libs/ee/kodyRules/repository/kodyRules.repository.ts
+++ b/libs/ee/kodyRules/repository/kodyRules.repository.ts
@@ -385,5 +385,30 @@ export class KodyRulesRepository implements IKodyRulesRepository {
             ? mapSimpleModelToEntity(updated, KodyRulesEntity)
             : null;
     }
+
+    async bulkUnlockPlanLockedRules(
+        organizationId: string,
+    ): Promise<KodyRulesEntity | null> {
+        const updated = await this.kodyRulesModel
+            .findOneAndUpdate(
+                { organizationId, 'rules.lockedByPlan': true },
+                {
+                    $set: {
+                        'rules.$[elem].status': KodyRulesStatus.ACTIVE,
+                        'rules.$[elem].lockedByPlan': false,
+                        'rules.$[elem].updatedAt': new Date(),
+                    },
+                },
+                {
+                    new: true,
+                    arrayFilters: [{ 'elem.lockedByPlan': true }],
+                },
+            )
+            .exec();
+
+        return updated
+            ? mapSimpleModelToEntity(updated, KodyRulesEntity)
+            : null;
+    }
     //#endregion
 }

--- a/libs/ee/kodyRules/service/kodyRules.service.ts
+++ b/libs/ee/kodyRules/service/kodyRules.service.ts
@@ -1006,6 +1006,87 @@ export class KodyRulesService implements IKodyRulesService {
         }
     }
 
+    bulkUnlockPlanLockedRules(
+        organizationId: string,
+    ): Promise<KodyRulesEntity | null> {
+        return this.kodyRulesRepository.bulkUnlockPlanLockedRules(
+            organizationId,
+        );
+    }
+
+    /**
+     * Lazy reconciliation of the free-plan quota lock. When an org upgrades to
+     * a paid plan the 10-rule cap disappears, but rules parked as PAUSED +
+     * `lockedByPlan: true` while on Free stay parked and the review keeps
+     * ignoring them. This flips every plan-locked rule back to ACTIVE.
+     *
+     * Self-extinguishing: after the first unlock no rule carries
+     * `lockedByPlan: true`, so the in-memory guard skips every subsequent call
+     * with zero DB work — no "already reconciled" flag needed. A later
+     * downgrade→upgrade that re-locks rules reconciles again on its own.
+     *
+     * Fails open: an unlock error never blocks the calling review/list.
+     */
+    async unlockRulesLockedByPlan(
+        organizationAndTeamData: OrganizationAndTeamData,
+        opts: { limited?: boolean; rules?: Partial<IKodyRule>[] } = {},
+    ): Promise<KodyRulesEntity | null> {
+        const organizationId = organizationAndTeamData?.organizationId;
+        if (!organizationId) {
+            return null;
+        }
+
+        // Cheap in-memory guard on the already-loaded rules: nothing plan-locked
+        // → skip the plan lookup and the write entirely. This is what makes the
+        // reconciliation free on the common (post-unlock) path.
+        if (
+            opts.rules &&
+            !opts.rules.some((rule) => rule?.lockedByPlan === true)
+        ) {
+            return null;
+        }
+
+        // Plan gate: only paid plans unlock. Reuse the caller's `limited` when
+        // it already computed it (review path) to avoid a redundant license
+        // lookup; otherwise resolve it here (front/CLI).
+        const limited =
+            opts.limited ??
+            (await this.permissionValidationService.shouldLimitResources(
+                organizationAndTeamData,
+                KodyRulesService.name,
+            ));
+        if (limited) {
+            return null;
+        }
+
+        try {
+            const updated =
+                await this.kodyRulesRepository.bulkUnlockPlanLockedRules(
+                    organizationId,
+                );
+
+            if (updated) {
+                this.logger.log({
+                    message: 'Reactivated plan-locked Kody rules after upgrade',
+                    context: KodyRulesService.name,
+                    metadata: { organizationId },
+                });
+            }
+
+            return updated;
+        } catch (error) {
+            this.logger.error({
+                message: 'Error unlocking plan-locked Kody rules',
+                context: KodyRulesService.name,
+                error: error,
+                metadata: { organizationId },
+            });
+            // Fail open: never block a review or the rules list because the
+            // reconciliation write failed. Next call retries.
+            return null;
+        }
+    }
+
     async deleteRuleLogically(
         uuid: string,
         ruleId: string,

--- a/libs/kodyRules/application/use-cases/find-by-organization-id.use-case.spec.ts
+++ b/libs/kodyRules/application/use-cases/find-by-organization-id.use-case.spec.ts
@@ -30,7 +30,11 @@ describe('FindByOrganizationIdKodyRulesUseCase', () => {
     let request: any;
 
     beforeEach(() => {
-        kodyRulesService = { findByOrganizationId: jest.fn() };
+        kodyRulesService = {
+            findByOrganizationId: jest.fn(),
+            // Default: nothing to unlock (Free plan / no locked rules).
+            unlockRulesLockedByPlan: jest.fn().mockResolvedValue(null),
+        };
         contextReferenceService = {};
         request = { user: { organization: { uuid: ORG_ID } } };
 
@@ -100,5 +104,58 @@ describe('FindByOrganizationIdKodyRulesUseCase', () => {
         const result = (await useCase.execute()) as { rules: any[] };
 
         expect(result.rules).toEqual([]);
+    });
+
+    /**
+     * Opening the Kody Rules screen after upgrading off Free must self-heal the
+     * plan-locked rules so the UI reflects the paid state without waiting for a
+     * review to run.
+     */
+    it('unlocks plan-locked rules and returns them ACTIVE when the org is paid', async () => {
+        const lockedRule = {
+            uuid: 'r-locked',
+            status: KodyRulesStatus.PAUSED,
+            lockedByPlan: true,
+        };
+        kodyRulesService.findByOrganizationId.mockResolvedValueOnce({
+            organizationId: ORG_ID,
+            rules: [lockedRule],
+        });
+        // Paid plan → the unlock flips it to ACTIVE and returns the fresh doc.
+        kodyRulesService.unlockRulesLockedByPlan.mockResolvedValueOnce({
+            toObject: () => ({
+                organizationId: ORG_ID,
+                rules: [
+                    {
+                        ...lockedRule,
+                        status: KodyRulesStatus.ACTIVE,
+                        lockedByPlan: false,
+                    },
+                ],
+            }),
+        });
+
+        const result = (await useCase.execute()) as { rules: any[] };
+
+        expect(kodyRulesService.unlockRulesLockedByPlan).toHaveBeenCalledWith(
+            { organizationId: ORG_ID },
+            { rules: [lockedRule] },
+        );
+        expect(result.rules).toHaveLength(1);
+        expect(result.rules[0].status).toBe(KodyRulesStatus.ACTIVE);
+        expect(result.rules[0].lockedByPlan).toBe(false);
+    });
+
+    it('keeps the original rules when there is nothing to unlock (Free plan)', async () => {
+        kodyRulesService.findByOrganizationId.mockResolvedValueOnce({
+            organizationId: ORG_ID,
+            rules: [{ uuid: 'r-active', status: KodyRulesStatus.ACTIVE }],
+        });
+        kodyRulesService.unlockRulesLockedByPlan.mockResolvedValueOnce(null);
+
+        const result = (await useCase.execute()) as { rules: any[] };
+
+        expect(kodyRulesService.unlockRulesLockedByPlan).toHaveBeenCalled();
+        expect(result.rules.map((r) => r.uuid)).toEqual(['r-active']);
     });
 });

--- a/libs/kodyRules/application/use-cases/find-by-organization-id.use-case.ts
+++ b/libs/kodyRules/application/use-cases/find-by-organization-id.use-case.ts
@@ -46,11 +46,21 @@ export class FindByOrganizationIdKodyRulesUseCase {
                 );
             }
 
+            // Opening the Kody Rules screen after upgrading off Free self-heals
+            // the plan-locked rules (PAUSED + lockedByPlan:true → ACTIVE), so
+            // the UI reflects the paid state without waiting for a review to
+            // run. Self-guarded + no-op when nothing is locked.
+            const unlocked = await this.kodyRulesService.unlockRulesLockedByPlan(
+                { organizationId: this.request.user.organization.uuid },
+                { rules: existing.rules || [] },
+            );
+            const source = unlocked ? unlocked.toObject() : existing;
+
             // Soft-deleted rules stay in the document for audit/history but
             // must not surface on the Kody Rules screen. APPLIED is also
             // hidden to match find-rules-in-organization-by-filter, which is
             // the other listing endpoint the UI uses.
-            const visibleRules = (existing.rules || []).filter(
+            const visibleRules = (source.rules || []).filter(
                 (rule) =>
                     rule.status !== KodyRulesStatus.DELETED &&
                     rule.status !== KodyRulesStatus.APPLIED,
@@ -63,7 +73,7 @@ export class FindByOrganizationIdKodyRulesUseCase {
             );
 
             return {
-                ...existing,
+                ...source,
                 rules: enrichedRulesArray,
             };
         } catch (error) {

--- a/libs/kodyRules/application/use-cases/find-rules-in-organization-by-filter.use-case.spec.ts
+++ b/libs/kodyRules/application/use-cases/find-rules-in-organization-by-filter.use-case.spec.ts
@@ -1,0 +1,114 @@
+jest.mock('@libs/core/log/logger', () => ({
+    createLogger: () => ({
+        log: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+        debug: jest.fn(),
+        info: jest.fn(),
+    }),
+}));
+
+jest.mock('./utils/enrich-rules-with-context-references.util', () => ({
+    enrichRulesWithContextReferences: jest.fn(async (rules) => rules),
+}));
+
+import { FindRulesInOrganizationByRuleFilterKodyRulesUseCase } from './find-rules-in-organization-by-filter.use-case';
+import { KodyRulesStatus } from '@libs/kodyRules/domain/interfaces/kodyRules.interface';
+
+/**
+ * This is the endpoint the Kody Rules screen actually renders from
+ * (find-rules-in-organization-by-filter). Opening it on a paid plan must
+ * self-heal rules parked as PAUSED + lockedByPlan:true so the UI reflects the
+ * paid state (rules ACTIVE, no "locked" banner) without waiting for a review.
+ */
+describe('FindRulesInOrganizationByRuleFilterKodyRulesUseCase — plan unlock', () => {
+    const ORG_ID = 'org-1';
+    let useCase: FindRulesInOrganizationByRuleFilterKodyRulesUseCase;
+    let kodyRulesService: {
+        find: jest.Mock;
+        unlockRulesLockedByPlan: jest.Mock;
+    };
+
+    const build = () => {
+        kodyRulesService = {
+            find: jest.fn(),
+            unlockRulesLockedByPlan: jest.fn().mockResolvedValue(null),
+        };
+        // No request.user → authorization scoping is skipped.
+        const request = {};
+        const contextReferenceService = {};
+        const authorizationService = {};
+
+        useCase = new (FindRulesInOrganizationByRuleFilterKodyRulesUseCase as any)(
+            kodyRulesService,
+            request,
+            contextReferenceService,
+            authorizationService,
+        );
+    };
+
+    beforeEach(build);
+
+    it('unlocks plan-locked rules and returns them ACTIVE on a paid plan', async () => {
+        const lockedRule = {
+            uuid: 'r-locked',
+            status: KodyRulesStatus.PAUSED,
+            lockedByPlan: true,
+        };
+        const activeRule = {
+            uuid: 'r-active',
+            status: KodyRulesStatus.ACTIVE,
+            lockedByPlan: false,
+        };
+        kodyRulesService.find.mockResolvedValueOnce([
+            { rules: [lockedRule, activeRule] },
+        ]);
+        // Paid plan → unlock persists and returns a (truthy) refreshed doc.
+        kodyRulesService.unlockRulesLockedByPlan.mockResolvedValueOnce({
+            toObject: () => ({ rules: [] }),
+        });
+
+        const result = (await useCase.execute(ORG_ID, {})) as any[];
+
+        expect(kodyRulesService.unlockRulesLockedByPlan).toHaveBeenCalledTimes(1);
+        expect(
+            kodyRulesService.unlockRulesLockedByPlan.mock.calls[0][0],
+        ).toEqual({ organizationId: ORG_ID });
+
+        const unlockedInResult = result.find((r) => r.uuid === 'r-locked');
+        expect(unlockedInResult.status).toBe(KodyRulesStatus.ACTIVE);
+        expect(unlockedInResult.lockedByPlan).toBe(false);
+    });
+
+    it('does not call unlock when no rule is plan-locked', async () => {
+        kodyRulesService.find.mockResolvedValueOnce([
+            {
+                rules: [
+                    { uuid: 'r-active', status: KodyRulesStatus.ACTIVE },
+                    { uuid: 'r-paused', status: KodyRulesStatus.PAUSED },
+                ],
+            },
+        ]);
+
+        await useCase.execute(ORG_ID, {});
+
+        expect(kodyRulesService.unlockRulesLockedByPlan).not.toHaveBeenCalled();
+    });
+
+    it('keeps rules parked when the unlock no-ops (Free plan)', async () => {
+        const lockedRule = {
+            uuid: 'r-locked',
+            status: KodyRulesStatus.PAUSED,
+            lockedByPlan: true,
+        };
+        kodyRulesService.find.mockResolvedValueOnce([{ rules: [lockedRule] }]);
+        // Free plan → unlock returns null, nothing changes.
+        kodyRulesService.unlockRulesLockedByPlan.mockResolvedValueOnce(null);
+
+        const result = (await useCase.execute(ORG_ID, {})) as any[];
+
+        const stillLocked = result.find((r) => r.uuid === 'r-locked');
+        expect(stillLocked.status).toBe(KodyRulesStatus.PAUSED);
+        expect(stillLocked.lockedByPlan).toBe(true);
+    });
+});

--- a/libs/kodyRules/application/use-cases/find-rules-in-organization-by-filter.use-case.ts
+++ b/libs/kodyRules/application/use-cases/find-rules-in-organization-by-filter.use-case.ts
@@ -95,6 +95,29 @@ export class FindRulesInOrganizationByRuleFilterKodyRulesUseCase implements IUse
                 return [...acc, ...entity.rules];
             }, []);
 
+            // Self-heal the free-plan quota lock when the org is on a paid plan:
+            // opening the Kody Rules screen reactivates rules parked as
+            // PAUSED + lockedByPlan:true, so the UI reflects the paid state
+            // without waiting for a review. Guarded so the plan lookup + write
+            // only run when something is actually locked; the returned doc is
+            // persisted, so we mirror the flip on the in-memory copies too.
+            if (allRules.some((rule) => rule?.lockedByPlan === true)) {
+                const unlocked =
+                    await this.kodyRulesService.unlockRulesLockedByPlan(
+                        { organizationId },
+                        { rules: allRules },
+                    );
+
+                if (unlocked) {
+                    for (const rule of allRules) {
+                        if (rule.lockedByPlan === true) {
+                            rule.status = KodyRulesStatus.ACTIVE;
+                            rule.lockedByPlan = false;
+                        }
+                    }
+                }
+            }
+
             let filteredRules = allRules;
 
             if (Array.isArray(allowedRepoScope)) {

--- a/libs/kodyRules/domain/contracts/kodyRules.repository.contract.ts
+++ b/libs/kodyRules/domain/contracts/kodyRules.repository.contract.ts
@@ -78,4 +78,14 @@ export interface IKodyRulesRepository {
         directoryId?: string,
         newStatus?: KodyRulesStatus,
     ): Promise<KodyRulesEntity | null>;
+
+    /**
+     * Bulk-reactivate every rule parked as PAUSED + `lockedByPlan: true` (the
+     * free-plan quota lock). Flips `status → ACTIVE` and `lockedByPlan → false`
+     * atomically, matching ONLY `lockedByPlan: true` so manual pauses are left
+     * untouched. Returns null when the org has no plan-locked rule to unlock.
+     */
+    bulkUnlockPlanLockedRules(
+        organizationId: string,
+    ): Promise<KodyRulesEntity | null>;
 }

--- a/libs/kodyRules/domain/contracts/kodyRules.service.contract.ts
+++ b/libs/kodyRules/domain/contracts/kodyRules.service.contract.ts
@@ -58,6 +58,18 @@ export interface IKodyRulesService extends IKodyRulesRepository {
         newStatus?: KodyRulesStatus,
     ): Promise<KodyRulesEntity | null>;
 
+    /**
+     * Reconcile the free-plan quota lock: on a paid plan, reactivate every rule
+     * parked as PAUSED + `lockedByPlan: true`. No-op (returns null) while the
+     * org is still resource-limited or when nothing is plan-locked. Callers that
+     * already loaded the rules / computed `limited` pass them via `opts` to skip
+     * redundant work. Returns the refreshed document when an unlock happened.
+     */
+    unlockRulesLockedByPlan(
+        organizationAndTeamData: OrganizationAndTeamData,
+        opts?: { limited?: boolean; rules?: Partial<IKodyRule>[] },
+    ): Promise<KodyRulesEntity | null>;
+
     deleteRuleWithLogging(
         organizationAndTeamData: OrganizationAndTeamData,
         ruleId: string,

--- a/test/unit/ee/codeBase/codeBaseConfig.unlockRules.spec.ts
+++ b/test/unit/ee/codeBase/codeBaseConfig.unlockRules.spec.ts
@@ -1,0 +1,116 @@
+import CodeBaseConfigService from '@libs/ee/codeBase/codeBaseConfig.service';
+import { KodyRulesStatus } from '@libs/kodyRules/domain/interfaces/kodyRules.interface';
+
+/**
+ * The server review path (getConfig) must self-heal plan-locked rules: on a
+ * paid org (shouldLimitResources === false) every rule parked as
+ * PAUSED + lockedByPlan:true is reactivated and applied in THIS review, so the
+ * unlocked rules are what `filterKodyRules` receives — not the parked ones.
+ */
+describe('CodeBaseConfigService.getConfig — unlock plan-locked rules', () => {
+    const organizationAndTeamData = {
+        organizationId: 'org-1',
+        teamId: 'team-1',
+    };
+    const repository = { id: 'repo-1', name: 'my-repo' };
+
+    const lockedRule = {
+        uuid: 'r-locked',
+        status: KodyRulesStatus.PAUSED,
+        lockedByPlan: true,
+        repositoryId: 'repo-1',
+    };
+    const unlockedRule = {
+        ...lockedRule,
+        status: KodyRulesStatus.ACTIVE,
+        lockedByPlan: false,
+    };
+
+    const buildService = (limited: boolean) => {
+        const parametersService = {
+            findOne: jest.fn().mockResolvedValue({ configValue: {} }),
+            findByKey: jest.fn().mockResolvedValue({ configValue: 'en-US' }),
+        };
+        const kodyRulesService = {
+            findByOrganizationId: jest.fn().mockResolvedValue({
+                toObject: () => ({ rules: [lockedRule] }),
+            }),
+            unlockRulesLockedByPlan: jest.fn().mockResolvedValue({
+                toObject: () => ({ rules: [unlockedRule] }),
+            }),
+        };
+        const filterKodyRules = jest
+            .fn()
+            .mockReturnValue({ standardRules: [unlockedRule], memoryRules: [] });
+        const kodyRulesValidationService = { filterKodyRules };
+        const permissionValidationService = {
+            shouldLimitResources: jest.fn().mockResolvedValue(limited),
+        };
+        const codeManagementService = {
+            verifyConnection: jest
+                .fn()
+                .mockResolvedValue({ hasConnection: true, isSetupComplete: true }),
+        };
+
+        const service = new CodeBaseConfigService(
+            {} as any, // integrationService
+            {} as any, // integrationConfigService
+            {} as any, // organizationParametersService
+            parametersService as any,
+            kodyRulesService as any,
+            {} as any, // globalParametersService
+            codeManagementService as any,
+            kodyRulesValidationService as any,
+            permissionValidationService as any,
+            {} as any, // cacheService
+        );
+
+        // Stub the heavy helpers so the test isolates the unlock+filter seam.
+        jest.spyOn(service as any, 'getDefaultBranch').mockResolvedValue('main');
+        jest
+            .spyOn(service as any, 'getReviewModeConfigParameter')
+            .mockResolvedValue({});
+        jest
+            .spyOn(service as any, 'getKodyFineTuningConfigParameter')
+            .mockResolvedValue({});
+        jest
+            .spyOn(service as any, 'getMergedCodeReviewConfigs')
+            .mockResolvedValue({
+                directoryId: undefined,
+                ignorePaths: [],
+                v2PromptOverrides: {},
+            });
+        jest.spyOn(service as any, 'getGlobalIgnorePaths').mockResolvedValue([]);
+        jest
+            .spyOn(service as any, 'sanitizeV2PromptOverrides')
+            .mockReturnValue({});
+
+        return { service, kodyRulesService, filterKodyRules };
+    };
+
+    it('unlocks and applies plan-locked rules on a paid plan', async () => {
+        const { service, kodyRulesService, filterKodyRules } =
+            buildService(false);
+
+        await service.getConfig(organizationAndTeamData, repository);
+
+        expect(kodyRulesService.unlockRulesLockedByPlan).toHaveBeenCalledWith(
+            organizationAndTeamData,
+            { limited: false, rules: [lockedRule] },
+        );
+        // filterKodyRules must receive the UNLOCKED (ACTIVE) rule.
+        expect(filterKodyRules.mock.calls[0][0]).toEqual([unlockedRule]);
+    });
+
+    it('does not unlock on a still-limited (Free) plan', async () => {
+        const { service, kodyRulesService, filterKodyRules } =
+            buildService(true);
+        kodyRulesService.unlockRulesLockedByPlan.mockResolvedValue(null);
+
+        await service.getConfig(organizationAndTeamData, repository);
+
+        // With limited=true the unlock no-ops (returns null) and the parked
+        // rule is what flows into filterKodyRules unchanged.
+        expect(filterKodyRules.mock.calls[0][0]).toEqual([lockedRule]);
+    });
+});

--- a/test/unit/ee/kodyRules/service/kodyRules.service.unlockRulesLockedByPlan.spec.ts
+++ b/test/unit/ee/kodyRules/service/kodyRules.service.unlockRulesLockedByPlan.spec.ts
@@ -1,0 +1,136 @@
+import { OrganizationAndTeamData } from '@libs/core/infrastructure/config/types/general/organizationAndTeamData';
+import { KodyRulesService } from '@libs/ee/kodyRules/service/kodyRules.service';
+import { KodyRulesStatus } from '@libs/kodyRules/domain/interfaces/kodyRules.interface';
+
+/**
+ * When an org upgrades from Free to a paid plan the rule quota disappears, but
+ * the rules that were parked as `PAUSED` + `lockedByPlan: true` while on Free
+ * stayed parked — the review kept ignoring them forever. `unlockRulesLockedByPlan`
+ * reconciles that lazily: on a paid plan every plan-locked rule flips back to
+ * ACTIVE. Manual pauses (`lockedByPlan` false/absent) must never be touched.
+ */
+describe('KodyRulesService.unlockRulesLockedByPlan', () => {
+    const organizationAndTeamData: OrganizationAndTeamData = {
+        organizationId: 'org-1',
+        teamId: 'team-1',
+    };
+
+    const buildService = (opts?: {
+        limited?: boolean;
+        unlockResult?: any;
+    }) => {
+        const bulkUnlockPlanLockedRules = jest
+            .fn()
+            .mockResolvedValue(opts?.unlockResult ?? null);
+        const repositoryMock = { bulkUnlockPlanLockedRules };
+
+        const shouldLimitResources = jest
+            .fn()
+            .mockResolvedValue(opts?.limited ?? false);
+        const permissionValidationServiceMock = { shouldLimitResources };
+
+        const service = new KodyRulesService(
+            repositoryMock as any,
+            { emit: jest.fn() } as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            {} as any,
+            permissionValidationServiceMock as any,
+            {} as any,
+            {} as any,
+        );
+
+        return {
+            service,
+            bulkUnlockPlanLockedRules,
+            shouldLimitResources,
+        };
+    };
+
+    const lockedRule = {
+        uuid: 'r-locked',
+        status: KodyRulesStatus.PAUSED,
+        lockedByPlan: true,
+    };
+    const activeRule = {
+        uuid: 'r-active',
+        status: KodyRulesStatus.ACTIVE,
+        lockedByPlan: false,
+    };
+
+    it('unlocks plan-locked rules on a paid plan (limited=false)', async () => {
+        const unlockedEntity = {
+            toObject: () => ({
+                rules: [
+                    activeRule,
+                    { ...lockedRule, status: KodyRulesStatus.ACTIVE, lockedByPlan: false },
+                ],
+            }),
+        };
+        const { service, bulkUnlockPlanLockedRules, shouldLimitResources } =
+            buildService({ limited: false, unlockResult: unlockedEntity });
+
+        const result = await service.unlockRulesLockedByPlan(
+            organizationAndTeamData,
+            { rules: [activeRule, lockedRule] },
+        );
+
+        expect(shouldLimitResources).toHaveBeenCalled();
+        expect(bulkUnlockPlanLockedRules).toHaveBeenCalledWith('org-1');
+        expect(result).toBe(unlockedEntity);
+    });
+
+    it('reuses a caller-supplied `limited` and skips the plan lookup', async () => {
+        const { service, bulkUnlockPlanLockedRules, shouldLimitResources } =
+            buildService();
+
+        await service.unlockRulesLockedByPlan(organizationAndTeamData, {
+            limited: false,
+            rules: [lockedRule],
+        });
+
+        expect(shouldLimitResources).not.toHaveBeenCalled();
+        expect(bulkUnlockPlanLockedRules).toHaveBeenCalledWith('org-1');
+    });
+
+    it('is a no-op on a still-limited (Free) plan', async () => {
+        const { service, bulkUnlockPlanLockedRules } = buildService();
+
+        const result = await service.unlockRulesLockedByPlan(
+            organizationAndTeamData,
+            { limited: true, rules: [lockedRule] },
+        );
+
+        expect(result).toBeNull();
+        expect(bulkUnlockPlanLockedRules).not.toHaveBeenCalled();
+    });
+
+    it('short-circuits (no plan lookup, no write) when nothing is plan-locked', async () => {
+        const { service, bulkUnlockPlanLockedRules, shouldLimitResources } =
+            buildService();
+
+        const result = await service.unlockRulesLockedByPlan(
+            organizationAndTeamData,
+            { rules: [activeRule] },
+        );
+
+        expect(result).toBeNull();
+        expect(shouldLimitResources).not.toHaveBeenCalled();
+        expect(bulkUnlockPlanLockedRules).not.toHaveBeenCalled();
+    });
+
+    it('fails open (returns null) when the bulk update throws', async () => {
+        const { service, bulkUnlockPlanLockedRules } = buildService();
+        bulkUnlockPlanLockedRules.mockRejectedValueOnce(new Error('mongo down'));
+
+        const result = await service.unlockRulesLockedByPlan(
+            organizationAndTeamData,
+            { limited: false, rules: [lockedRule] },
+        );
+
+        expect(result).toBeNull();
+    });
+});


### PR DESCRIPTION
## What & why

On the Free plan Kody Rules are capped at 10 active rules. Rules past the cap are parked as `status: PAUSED` + `lockedByPlan: true` and excluded from review. Nothing cleared that lock when an org upgraded to a paid plan (e.g. `teams_byok`), so paying customers kept running reviews with a ~10-rule cap while the rest of their rules were silently ignored on every PR.

Root cause: subscription state lives in the external billing service; the API only polls `validate-org-license`. There is no event that reacts to a plan upgrade, so `lockedByPlan` was written once at create/reactivate time and never cleared.

Fixes the bug reported in #1626.

## Approach — lazy, self-healing reconciliation

Whenever we already know the org is no longer resource-limited (`shouldLimitResources === false`), flip every rule with `lockedByPlan: true` back to `status: ACTIVE` + `lockedByPlan: false`, atomically. Manual pauses (`lockedByPlan` false/absent) are never touched.

The guard is **self-extinguishing**: after the first unlock no rule carries `lockedByPlan: true`, so subsequent calls short-circuit on an in-memory `some(lockedByPlan)` check with zero DB work — no "already reconciled" flag needed. A later downgrade→upgrade that re-locks rules reconciles again on its own.

**Fails open:** an unlock error never blocks a review or the rules list.

## Trigger points (unlock applies immediately, in the same request)

- **Server code review** — `CodeBaseConfigService.getConfig` (reuses the `limited` it already computes, so no extra license lookup).
- **CLI review** — `ExecuteCliReviewUseCase.loadUserConfigWithRules`.
- **Web rules list** — `FindRulesInOrganizationByRuleFilterKodyRulesUseCase` (the endpoint the Kody Rules screen actually renders from). `FindByOrganizationIdKodyRulesUseCase` also gets the hook as a defensive measure.

## Code

- Repository (EE): `bulkUnlockPlanLockedRules(organizationId)` — one `findOneAndUpdate` with `arrayFilters: [{ 'elem.lockedByPlan': true }]`, `$set` status→ACTIVE + lockedByPlan→false.
- Service (EE): `unlockRulesLockedByPlan(orgData, opts?)` — plan gate + in-memory guard + fail-open. All enforcement stays behind the EE license boundary.

## Not in scope

- Recompute-on-every-read (superseded by persisting the correction once).
- Frontend banner gating on current plan (separate follow-up).
- Legacy rules locked before the `lockedByPlan` flag existed (flag absent) are indistinguishable from manual pauses and are intentionally **not** auto-unlocked; those rare cases are corrected directly in the DB if they surface.

## Tests (RED → GREEN)

- Service: paid unlocks / Free no-op / nothing-locked short-circuit / caller-supplied `limited` reuse / fail-open on write error.
- Repository: Mongo filter + arrayFilters + atomic `$set` shape.
- Web (`find-rules-in-organization-by-filter` + `find-by-organization-id`), CLI, and server `getConfig`: paid org with a locked rule → rule reactivated and applied in the same request.

71 tests passing across the touched suites. No new type errors introduced.
