### PR TITLE
feat(cli): hunk 0.18, findings sidebar, readable notes, worktree fix

### DIFF
--- a/apps/cli/hunk-extension/kodus/findings.ts
+++ b/apps/cli/hunk-extension/kodus/findings.ts
@@ -1,0 +1,205 @@
+/**
+ * Pure matching/ordering logic for the Kodus hunk sidebar.
+ *
+ * Split out of `index.tsx` so it can be unit-tested without a React/OpenTUI
+ * runtime — the sidebar's real risk isn't the rendering, it's mapping a Kodus
+ * finding onto the right file and hunk. Kept dependency-free (types only) so
+ * `tsc` never needs to see it and hunk can import it as a plain helper module.
+ */
+
+export type KodusSeverity = 'critical' | 'error' | 'warning' | 'info';
+
+export interface KodusFinding {
+    id: string;
+    file: string;
+    line: number;
+    endLine: number;
+    severity: KodusSeverity;
+    title: string;
+    category?: string;
+    ruleId?: string;
+}
+
+export interface KodusFindings {
+    version: 1;
+    summary?: string;
+    findings: KodusFinding[];
+}
+
+/** The subset of `ExtensionDiffFile` this module needs. */
+export interface DiffFileLike {
+    id: string;
+    path: string;
+    hunks?: ReadonlyArray<{ index: number; newRange?: [number, number] }>;
+}
+
+export const SEVERITY_ORDER: KodusSeverity[] = [
+    'critical',
+    'error',
+    'warning',
+    'info',
+];
+
+export const SEVERITY_GLYPH: Record<KodusSeverity, string> = {
+    critical: '‼',
+    error: '✖',
+    warning: '⚠',
+    info: 'ℹ',
+};
+
+/**
+ * Coerce whatever severity the sidecar carries into one this pane can render.
+ *
+ * The CLI normalizes before writing, but the API's raw vocabulary is wider
+ * (`high` / `medium` / `low`) and the sidecar is a file on disk — an unknown
+ * value must degrade to `info`, not sort ahead of `critical` with an undefined
+ * glyph.
+ */
+export function coerceSeverity(value: unknown): KodusSeverity {
+    if (typeof value !== 'string') {
+        return 'info';
+    }
+    const normalized = value.toLowerCase();
+    if (normalized === 'critical') {
+        return 'critical';
+    }
+    if (normalized === 'error' || normalized === 'high') {
+        return 'error';
+    }
+    if (normalized === 'warning' || normalized === 'medium') {
+        return 'warning';
+    }
+    return 'info';
+}
+
+export function parseFindings(raw: unknown): KodusFindings {
+    const empty: KodusFindings = { version: 1, findings: [] };
+    if (!raw || typeof raw !== 'object') {
+        return empty;
+    }
+    const candidate = raw as Partial<KodusFindings>;
+    if (!Array.isArray(candidate.findings)) {
+        return empty;
+    }
+    return {
+        version: 1,
+        summary: candidate.summary,
+        findings: candidate.findings
+            .filter(
+                (finding): finding is KodusFinding =>
+                    Boolean(finding) &&
+                    typeof finding.file === 'string' &&
+                    typeof finding.line === 'number',
+            )
+            .map((finding) => ({
+                ...finding,
+                severity: coerceSeverity(finding.severity),
+            })),
+    };
+}
+
+/**
+ * Order findings the way a reviewer triages them: worst first, then by file and
+ * line so one file's findings stay together inside a severity band.
+ */
+export function orderFindings(findings: KodusFinding[]): KodusFinding[] {
+    return [...findings].sort((a, b) => {
+        const bySeverity =
+            SEVERITY_ORDER.indexOf(a.severity) -
+            SEVERITY_ORDER.indexOf(b.severity);
+        if (bySeverity !== 0) {
+            return bySeverity;
+        }
+        return a.file.localeCompare(b.file) || a.line - b.line;
+    });
+}
+
+/**
+ * Match a finding's path against the review's files.
+ *
+ * Both sides are normally repo-relative, but a review scoped to a subdirectory
+ * can leave the two spelled differently, so fall back to a path-segment suffix
+ * match rather than silently dropping the finding.
+ */
+export function findFile<T extends DiffFileLike>(
+    files: readonly T[],
+    findingPath: string,
+): T | undefined {
+    const exact = files.find((file) => file.path === findingPath);
+    if (exact) {
+        return exact;
+    }
+    return files.find(
+        (file) =>
+            file.path.endsWith(`/${findingPath}`) ||
+            findingPath.endsWith(`/${file.path}`),
+    );
+}
+
+/**
+ * The hunk whose new-side span covers the finding, or the nearest one.
+ *
+ * Kodus reviews whole files while hunk only renders changed spans, so a finding
+ * can legitimately land outside every hunk. Landing the reviewer on the closest
+ * hunk beats refusing to navigate.
+ */
+export function findHunkIndex(
+    file: DiffFileLike,
+    finding: Pick<KodusFinding, 'line'>,
+): number | null {
+    const hunks = file.hunks ?? [];
+    if (hunks.length === 0) {
+        return null;
+    }
+
+    const covering = hunks.find((hunk) => {
+        const range = hunk.newRange;
+        return range && finding.line >= range[0] && finding.line <= range[1];
+    });
+    if (covering) {
+        return covering.index;
+    }
+
+    let nearest: { index: number; distance: number } | null = null;
+    for (const hunk of hunks) {
+        const range = hunk.newRange;
+        if (!range) {
+            continue;
+        }
+        const distance =
+            finding.line < range[0]
+                ? range[0] - finding.line
+                : finding.line - range[1];
+        if (!nearest || distance < nearest.distance) {
+            nearest = { index: hunk.index, distance };
+        }
+    }
+    return nearest?.index ?? hunks[0].index;
+}
+
+/** `src/very/long/path/file.ts` → `…/path/file.ts` for a narrow pane. */
+export function shortenPath(path: string, budget: number): string {
+    if (path.length <= budget) {
+        return path;
+    }
+    const segments = path.split('/');
+    let out = segments[segments.length - 1] ?? path;
+    for (let i = segments.length - 2; i >= 0; i--) {
+        const next = `${segments[i]}/${out}`;
+        if (next.length + 2 > budget) {
+            return `…/${out}`;
+        }
+        out = next;
+    }
+    return out;
+}
+
+export function countBySeverity(
+    findings: readonly KodusFinding[],
+): Partial<Record<KodusSeverity, number>> {
+    const tally: Partial<Record<KodusSeverity, number>> = {};
+    for (const finding of findings) {
+        tally[finding.severity] = (tally[finding.severity] ?? 0) + 1;
+    }
+    return tally;
+}

--- a/apps/cli/hunk-extension/kodus/findings.ts
+++ b/apps/cli/hunk-extension/kodus/findings.ts
@@ -203,3 +203,24 @@ export function countBySeverity(
     }
     return tally;
 }
+
+/**
+ * Advance the severity-first finding cursor.
+ *
+ * `-1` means "nothing selected yet". Feeding that through the plain modulo
+ * lands on `length - 2` when stepping backwards, so the first `p` used to skip
+ * the last finding entirely; anchor each direction to its natural start instead.
+ */
+export function nextCursor(
+    cursor: number,
+    delta: number,
+    length: number,
+): number {
+    if (length === 0) {
+        return -1;
+    }
+    if (cursor === -1) {
+        return delta > 0 ? 0 : length - 1;
+    }
+    return (cursor + delta + length) % length;
+}

--- a/apps/cli/hunk-extension/kodus/index.tsx
+++ b/apps/cli/hunk-extension/kodus/index.tsx
@@ -1,0 +1,344 @@
+/**
+ * Kodus findings sidebar for Hunk.
+ *
+ * Loaded by `kodus review` with `--extension <this folder>` whenever it hands a
+ * review off to the hunk TUI. Findings arrive out-of-band through the
+ * `KODUS_HUNK_FINDINGS` env var — a JSON sidecar written by the CLI — because
+ * hunk's own `--agent-context` schema flattens severity into a glyph inside the
+ * note text, and this pane needs it back as data.
+ *
+ * The inline notes hunk already renders answer "what is wrong with this line?".
+ * This pane answers what a file-ordered diff cannot: "what are the worst things
+ * in this changeset, and where are they?" — so it sorts by severity, not path.
+ *
+ * NOTE: shipped as source and executed by hunk's own runtime. It lives outside
+ * `src/` so our `tsc` never compiles it. React is served by hunk at import
+ * time — never bundle or vendor a copy.
+ */
+import { useEffect, useMemo, useRef } from 'react';
+import type { ScrollBoxRenderable } from '@opentui/core';
+import type {
+    ExtensionCommandContext,
+    ExtensionDiffFile,
+    ExtensionSidebarViewProps,
+    HunkExtensionAPI,
+} from 'hunkdiff/extension';
+import {
+    SEVERITY_GLYPH,
+    SEVERITY_ORDER,
+    countBySeverity,
+    findFile,
+    findHunkIndex,
+    orderFindings,
+    parseFindings,
+    shortenPath,
+    type KodusFinding,
+    type KodusFindings,
+    type KodusSeverity,
+} from './findings.js';
+
+const VIEW_ID = 'findings';
+
+/**
+ * Read the sidecar. A missing or malformed file is not worth failing a review
+ * over — the pane just reports it has nothing.
+ */
+function loadFindings(): KodusFindings {
+    const sidecarPath = process.env.KODUS_HUNK_FINDINGS;
+    if (!sidecarPath) {
+        return { version: 1, findings: [] };
+    }
+
+    try {
+        const { readFileSync } = require('node:fs') as typeof import('node:fs');
+        return parseFindings(JSON.parse(readFileSync(sidecarPath, 'utf-8')));
+    } catch {
+        return { version: 1, findings: [] };
+    }
+}
+
+function severityColor(
+    severity: KodusSeverity,
+    theme: ExtensionSidebarViewProps['theme'],
+): string {
+    switch (severity) {
+        case 'critical':
+        case 'error':
+            return theme.badgeRemoved;
+        case 'warning':
+            return theme.accent;
+        default:
+            return theme.muted;
+    }
+}
+
+interface ResolvedFinding {
+    finding: KodusFinding;
+    file: ExtensionDiffFile | undefined;
+    hunkIndex: number | null;
+}
+
+function resolveFindings(
+    findings: readonly KodusFinding[],
+    files: ExtensionDiffFile[],
+): ResolvedFinding[] {
+    return findings.map((finding) => {
+        const file = findFile(files, finding.file);
+        return {
+            finding,
+            file,
+            hunkIndex: file ? findHunkIndex(file, finding) : null,
+        };
+    });
+}
+
+function KodusFindingsSidebar({
+    files,
+    selectedFileId,
+    selectedHunkIndex,
+    width,
+    theme,
+    actions,
+}: ExtensionSidebarViewProps) {
+    const ordered = useMemo(() => orderFindings(loadFindings().findings), []);
+    const resolved = useMemo(
+        () => resolveFindings(ordered, files),
+        [ordered, files],
+    );
+    const counts = useMemo(() => countBySeverity(ordered), [ordered]);
+    const scrollRef = useRef<ScrollBoxRenderable | null>(null);
+
+    // Follow the review stream: when the user navigates with the keyboard, keep
+    // the matching finding visible instead of making them hunt for it.
+    useEffect(() => {
+        if (!selectedFileId) {
+            return;
+        }
+        const match = resolved.find(
+            (entry) =>
+                entry.file?.id === selectedFileId &&
+                (selectedHunkIndex === null ||
+                    entry.hunkIndex === selectedHunkIndex),
+        );
+        if (match) {
+            scrollRef.current?.scrollChildIntoView(`row-${match.finding.id}`);
+        }
+    }, [selectedFileId, selectedHunkIndex, resolved]);
+
+    const headline =
+        ordered.length === 0
+            ? ' Kodus · no findings'
+            : ` Kodus · ${ordered.length} finding${ordered.length === 1 ? '' : 's'}`;
+
+    const breakdown = SEVERITY_ORDER.filter((severity) => counts[severity])
+        .map((severity) => `${SEVERITY_GLYPH[severity]}${counts[severity]}`)
+        .join('  ');
+
+    // Leave room for the leading glyph column and the `:123` line suffix.
+    const pathBudget = Math.max(12, width - 12);
+
+    return (
+        <scrollbox
+            ref={scrollRef}
+            width="100%"
+            height="100%"
+            focused={false}
+            scrollY={true}
+            rootOptions={{ backgroundColor: theme.panel }}
+            wrapperOptions={{ backgroundColor: theme.panel }}
+            viewportOptions={{ backgroundColor: theme.panel }}
+            contentOptions={{ backgroundColor: theme.panel }}
+            verticalScrollbarOptions={{ visible: false }}
+            horizontalScrollbarOptions={{ visible: false }}
+        >
+            <box
+                style={{
+                    width: '100%',
+                    flexDirection: 'column',
+                    backgroundColor: theme.panel,
+                }}
+            >
+                <text
+                    content={headline}
+                    style={{ fg: theme.accent, bg: theme.panel }}
+                />
+                {breakdown ? (
+                    <text
+                        content={` ${breakdown}`}
+                        style={{ fg: theme.muted, bg: theme.panel }}
+                    />
+                ) : null}
+                {ordered.length === 0 ? (
+                    <text
+                        content=" Nothing to review here."
+                        style={{ fg: theme.muted, bg: theme.panel }}
+                    />
+                ) : null}
+                {resolved.map(({ finding, file, hunkIndex }) => {
+                    const selected =
+                        file?.id === selectedFileId &&
+                        hunkIndex === selectedHunkIndex;
+                    const background = selected
+                        ? theme.selectedHunk
+                        : theme.panel;
+                    const reachable = Boolean(file);
+
+                    return (
+                        <box
+                            key={finding.id}
+                            id={`row-${finding.id}`}
+                            style={{
+                                width: '100%',
+                                flexDirection: 'column',
+                                backgroundColor: background,
+                            }}
+                            onMouseDown={() => {
+                                if (!file) {
+                                    actions.notify(
+                                        `${finding.file} is not in this review`,
+                                        'warning',
+                                    );
+                                    return;
+                                }
+                                if (hunkIndex === null) {
+                                    actions.selectFile(file.id);
+                                } else {
+                                    actions.selectHunk(file.id, hunkIndex);
+                                }
+                            }}
+                        >
+                            <text
+                                content={` ${SEVERITY_GLYPH[finding.severity]} ${shortenPath(finding.file, pathBudget)}:${finding.line}`}
+                                style={{
+                                    fg: reachable
+                                        ? severityColor(finding.severity, theme)
+                                        : theme.muted,
+                                    bg: background,
+                                }}
+                            />
+                            <text
+                                content={`   ${finding.title}`}
+                                style={{
+                                    fg: reachable ? theme.text : theme.muted,
+                                    bg: background,
+                                }}
+                            />
+                        </box>
+                    );
+                })}
+            </box>
+        </scrollbox>
+    );
+}
+
+export default function registerKodusFindings(hunk: HunkExtensionAPI): void {
+    const ordered = orderFindings(loadFindings().findings);
+
+    // Sidebar components get `files` as a prop; command handlers don't, so the
+    // changeset is mirrored here from the lifecycle events instead.
+    let visibleFiles: ExtensionDiffFile[] = [];
+    // Severity-first cursor. Deliberately not the same walk as hunk's `}`
+    // (next *annotated* hunk, in document order): a critical three files down
+    // should come before an info in the current file.
+    let cursor = -1;
+
+    hunk.registerSidebarView({
+        id: VIEW_ID,
+        title: 'Kodus findings',
+        placement: 'right',
+        // Only claim a pane when there is something to show; an empty panel
+        // stealing width from the diff is worse than no panel.
+        defaultOpen: ordered.length > 0,
+        component: KodusFindingsSidebar,
+    });
+
+    // Hunk drops the entire sidebar area — the built-in file navigation
+    // included — below roughly 220 columns, and no registered view can reopen
+    // it (`replacesDefault` doesn't lower the threshold; neither does `--mode`).
+    // On a normal-width terminal the findings would therefore be invisible with
+    // no hint that they exist, so announce them with a toast, which renders
+    // over the review regardless of pane layout.
+    hunk.on('startup', (_event, ctx) => {
+        if (ordered.length === 0) {
+            return;
+        }
+        const counts = countBySeverity(ordered);
+        const breakdown = SEVERITY_ORDER.filter((severity) => counts[severity])
+            .map((severity) => `${SEVERITY_GLYPH[severity]}${counts[severity]}`)
+            .join(' ');
+        ctx.notify(
+            `Kodus · ${ordered.length} finding${ordered.length === 1 ? '' : 's'} ${breakdown} · y panel · n/p next`,
+        );
+    });
+
+    hunk.on('changeset_loaded', ({ changeset }) => {
+        visibleFiles = changeset.files;
+    });
+    hunk.on('session_reload', ({ changeset }) => {
+        visibleFiles = changeset.files;
+        cursor = -1;
+    });
+
+    // `defaultOpen` marks the view open, but hunk drops the whole sidebar
+    // *area* on narrow terminals (or wide diffs) — and an extension cannot ask
+    // whether the area is visible. Toggling in that state would close a pane
+    // the user never saw, so the first press always opens: `sidebars.open`
+    // reveals the area too. Afterwards it toggles normally.
+    let revealed = false;
+    const reveal = (ctx: ExtensionCommandContext) => {
+        ctx.sidebars.open(VIEW_ID);
+        revealed = true;
+    };
+
+    hunk.registerCommand(
+        { id: 'toggle', title: 'Toggle Kodus findings', key: 'y' },
+        (ctx) => {
+            if (!revealed) {
+                reveal(ctx);
+                return;
+            }
+            ctx.sidebars.toggle(VIEW_ID);
+        },
+    );
+
+    const step = (delta: number) => (ctx: ExtensionCommandContext) => {
+        if (ordered.length === 0) {
+            ctx.notify('No Kodus findings in this review');
+            return;
+        }
+
+        cursor = (cursor + delta + ordered.length) % ordered.length;
+        const finding = ordered[cursor];
+
+        reveal(ctx);
+
+        const file = findFile(visibleFiles, finding.file);
+        if (!file) {
+            ctx.notify(
+                `${finding.file}:${finding.line} is not in this review`,
+                'warning',
+            );
+            return;
+        }
+
+        const hunkIndex = findHunkIndex(file, finding);
+        if (hunkIndex === null) {
+            ctx.navigation.selectFile(file.id);
+        } else {
+            ctx.navigation.selectHunk(file.id, hunkIndex);
+        }
+
+        ctx.notify(
+            `${SEVERITY_GLYPH[finding.severity]} ${cursor + 1}/${ordered.length} · ${finding.title}`,
+        );
+    };
+
+    hunk.registerCommand(
+        { id: 'next', title: 'Next Kodus finding', key: 'n' },
+        step(1),
+    );
+    hunk.registerCommand(
+        { id: 'previous', title: 'Previous Kodus finding', key: 'p' },
+        step(-1),
+    );
+}

--- a/apps/cli/hunk-extension/kodus/index.tsx
+++ b/apps/cli/hunk-extension/kodus/index.tsx
@@ -29,6 +29,7 @@ import {
     countBySeverity,
     findFile,
     findHunkIndex,
+    nextCursor,
     orderFindings,
     parseFindings,
     shortenPath,
@@ -307,7 +308,7 @@ export default function registerKodusFindings(hunk: HunkExtensionAPI): void {
             return;
         }
 
-        cursor = (cursor + delta + ordered.length) % ordered.length;
+        cursor = nextCursor(cursor, delta, ordered.length);
         const finding = ordered[cursor];
 
         reveal(ctx);

--- a/apps/cli/hunk-extension/kodus/package.json
+++ b/apps/cli/hunk-extension/kodus/package.json
@@ -1,0 +1,10 @@
+{
+    "name": "kodus-hunk-extension",
+    "private": true,
+    "description": "Kodus findings sidebar for the Hunk terminal diff viewer",
+    "hunk": {
+        "extensions": [
+            "./index.tsx"
+        ]
+    }
+}

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -56,7 +56,7 @@
         "execa": "^9.6.1",
         "figlet": "^1.11.0",
         "gradient-string": "^3.0.0",
-        "hunkdiff": "0.12.1",
+        "hunkdiff": "0.18.0-beta.0",
         "latest-version": "^9.0.0",
         "node-machine-id": "^1.1.12",
         "open": "^11.0.0",
@@ -85,6 +85,7 @@
     "packageManager": "pnpm@11.9.0",
     "files": [
         "dist",
-        "skills"
+        "skills",
+        "hunk-extension"
     ]
 }

--- a/apps/cli/pnpm-lock.yaml
+++ b/apps/cli/pnpm-lock.yaml
@@ -37,8 +37,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       hunkdiff:
-        specifier: 0.12.1
-        version: 0.12.1(@opentui/core@0.1.107(stage-js@1.0.2)(typescript@6.0.3)(web-tree-sitter@0.25.10))(@opentui/react@0.1.107(react-devtools-core@7.0.1)(react@19.2.7)(stage-js@1.0.2)(typescript@6.0.3)(web-tree-sitter@0.25.10)(ws@8.21.0))(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+        specifier: 0.18.0-beta.0
+        version: 0.18.0-beta.0(@opentui/core@0.1.107(stage-js@1.0.2)(typescript@6.0.3)(web-tree-sitter@0.25.10))(@opentui/react@0.1.107(react-devtools-core@7.0.1)(react@19.2.7)(stage-js@1.0.2)(typescript@6.0.3)(web-tree-sitter@0.25.10)(ws@8.21.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       latest-version:
         specifier: ^9.0.0
         version: 9.0.0
@@ -560,35 +560,15 @@ packages:
   '@oxc-project/types@0.138.0':
     resolution: {integrity: sha512-1a7ZKmrRTCoN1XMZ4L0PyyqrMnrNlLyPuOkdSX2MZg7IiIGRUyurNhAm73ptDOraoBcIordsIGKNPKUzy3ZmfA==}
 
-  '@pierre/diffs@1.2.12':
-    resolution: {integrity: sha512-pY/gmgWL03WnagqCyCnBi3QtRXUv4hCIY6FYqd5b1ZGaoI6a4Bsji8j+yRl2RfzPh/8Hf19rCl1GE80G6a1cLQ==}
+  '@pierre/diffs@1.2.2':
+    resolution: {integrity: sha512-MvWLv2oSOJOF8oYXWLdhicguHM11G/VNWu6OPR5ZETolp2NM2/KPQG3cZTnKpJ6ImqEHwvw6Gl6z2gmmy2FQmQ==}
     peerDependencies:
       react: ^18.3.1 || ^19.0.0
       react-dom: ^18.3.1 || ^19.0.0
 
-  '@pierre/theme@1.1.0':
-    resolution: {integrity: sha512-GC2OWTAfTIIWWYhPCygwG8t2EtePQkRfON4MI2rwIkJylmiyqIttJID2dCL8sUD8cNdEvYkEyfEHHKMeCiDLoQ==}
+  '@pierre/theme@1.0.3':
+    resolution: {integrity: sha512-sWHv11TMoqKxKDgTIk5VbhQjdPhs8DCcBxbjh3mRlS3YOM/OcrWoGX6MM8eBGn9cUu3M46Py0JnxsG2nJaFTuA==}
     engines: {vscode: ^1.0.0}
-
-  '@pierre/theming@0.0.2':
-    resolution: {integrity: sha512-QM1M4stXfnzfaE8I8YbjXSApV8c+2dBsXJj8eYg9WTpBR/cTmCZIcfGnN4p13iRrYu2Br/R/OJfEL7uR8Qjctw==}
-    peerDependencies:
-      '@pierre/theme': ^1.1.0
-      '@shikijs/themes': ^3.0.0 || ^4.0.0
-      react: ^18.3.1 || ^19.0.0
-      react-dom: ^18.3.1 || ^19.0.0
-      shiki: ^3.0.0 || ^4.0.0
-    peerDependenciesMeta:
-      '@pierre/theme':
-        optional: true
-      '@shikijs/themes':
-        optional: true
-      react:
-        optional: true
-      react-dom:
-        optional: true
-      shiki:
-        optional: true
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -703,37 +683,26 @@ packages:
   '@sec-ant/readable-stream@0.4.1':
     resolution: {integrity: sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==}
 
-  '@shikijs/core@4.3.1':
-    resolution: {integrity: sha512-ANMDxuaPsNMdDC1m4vfvhlDmJweMwkE5XitTwrq2rWHx5jM+dlm4MmHt2PP6t0uejfR77SuhrhJ0zEijIF/uhA==}
-    engines: {node: '>=20'}
+  '@shikijs/core@3.23.0':
+    resolution: {integrity: sha512-NSWQz0riNb67xthdm5br6lAkvpDJRTgB36fxlo37ZzM2yq0PQFFzbd8psqC2XMPgCzo1fW6cVi18+ArJ44wqgA==}
 
-  '@shikijs/engine-javascript@4.3.1':
-    resolution: {integrity: sha512-JBItcnPuYq7jVJdZo/vMj94r+szT7XEjHFX+mvFDGSEIbVAXAGyHAHzhbWzpGOwYidCZrErJLLgn2PVeiokHnQ==}
-    engines: {node: '>=20'}
+  '@shikijs/engine-javascript@3.23.0':
+    resolution: {integrity: sha512-aHt9eiGFobmWR5uqJUViySI1bHMqrAgamWE1TYSUoftkAeCCAiGawPMwM+VCadylQtF4V3VNOZ5LmfItH5f3yA==}
 
-  '@shikijs/engine-oniguruma@4.3.1':
-    resolution: {integrity: sha512-OXyNMzg0pews+msMj4cHeqT4xiYKKvbnn6VbdAXxfoFl3SSx4fJTc8FadECuc5/H9p3BzhNAoAUXKwAu9rWYhg==}
-    engines: {node: '>=20'}
+  '@shikijs/engine-oniguruma@3.23.0':
+    resolution: {integrity: sha512-1nWINwKXxKKLqPibT5f4pAFLej9oZzQTsby8942OTlsJzOBZ0MWKiwzMsd+jhzu8YPCHAswGnnN1YtQfirL35g==}
 
-  '@shikijs/langs@4.3.1':
-    resolution: {integrity: sha512-m0l9nsDqgBHvbZbk7A0/kXz/impK3uB/c6rAn6Gpg/uPtdZRQ+alsN/17MU5thb68XTj/4DxkZAotrM0GGSpDQ==}
-    engines: {node: '>=20'}
+  '@shikijs/langs@3.23.0':
+    resolution: {integrity: sha512-2Ep4W3Re5aB1/62RSYQInK9mM3HsLeB91cHqznAJMuylqjzNVAVCMnNWRHFtcNHXsoNRayP9z1qj4Sq3nMqYXg==}
 
-  '@shikijs/primitive@4.3.1':
-    resolution: {integrity: sha512-CXQRQOYy1leqQ8ceTeJdmXv/bsUY++6QyLpXJ94LZAAYj5X2SKRdc5ipguv4NPyGVKItB2PPwUpRNe0Sjh5S1A==}
-    engines: {node: '>=20'}
+  '@shikijs/themes@3.23.0':
+    resolution: {integrity: sha512-5qySYa1ZgAT18HR/ypENL9cUSGOeI2x+4IvYJu4JgVJdizn6kG4ia5Q1jDEOi7gTbN4RbuYtmHh0W3eccOrjMA==}
 
-  '@shikijs/themes@4.3.1':
-    resolution: {integrity: sha512-dgpoJ4WqNi2yTmizQHBJ5zcX6j2lE6icN/0yt4l1kkf16jrY/pwPLoTb1ETsWMz0OBLf9ZNvwmxft+cH+N9qSA==}
-    engines: {node: '>=20'}
+  '@shikijs/transformers@3.23.0':
+    resolution: {integrity: sha512-F9msZVxdF+krQNSdQ4V+Ja5QemeAoTQ2jxt7nJCwhDsdF1JWS3KxIQXA3lQbyKwS3J61oHRUSv4jYWv3CkaKTQ==}
 
-  '@shikijs/transformers@4.3.1':
-    resolution: {integrity: sha512-z6ir0bGDgWcF2FduktEfPgIsdOtIlDiLAjFBgBzE42Q9xHbkkIXZtORHzlLVB71iZP9elEcqKg6keajvOUwE2A==}
-    engines: {node: '>=20'}
-
-  '@shikijs/types@4.3.1':
-    resolution: {integrity: sha512-CHFxE0jztBIZRHH6gxXE7DXUCFXjReEGxZ/j0rfSLGKZuwp2xBYycEP14875DSa9KLL/6700oxIq6oO6ef9K2g==}
-    engines: {node: '>=20'}
+  '@shikijs/types@3.23.0':
+    resolution: {integrity: sha512-3JZ5HXOZfYjsYSk0yPwBrkupyYSLpAE26Qc0HLghhZNGTZg/SKxXIIgoxOpmmeQP0RRSDJTk1/vPfw9tbw+jSQ==}
 
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
@@ -1027,6 +996,10 @@ packages:
   chardet@2.2.0:
     resolution: {integrity: sha512-rddelWYNPRrXq6PtNEN2S3f6t9ILzvqaN5pVgi4kqt9jHQaXIial9PznB5iSPVlQSLNaaH22ItWz3EJtQ10+OA==}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
   cli-boxes@3.0.0:
     resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
     engines: {node: '>=10'}
@@ -1122,10 +1095,6 @@ packages:
 
   diff@8.0.4:
     resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
-    engines: {node: '>=0.3.1'}
-
-  diff@9.0.0:
-    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
 
   dot-prop@9.0.0:
@@ -1329,43 +1298,38 @@ packages:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
 
-  hunkdiff-darwin-arm64@0.12.1:
-    resolution: {integrity: sha512-ZDci4+rdLI2Lhu8eNtHz8Go5H+ovRl9hg1hjshpmbgXLtKB2/tpLkjbCSLaWPHlMAxjag9nGi1tRWJXsHip3Lg==}
+  hunkdiff-darwin-arm64@0.18.0-beta.0:
+    resolution: {integrity: sha512-mY9F/CGTqSxN5UbZnAiapwaXTrFQqqSNOxwxyGONy3Ut4ySJVain9fjvWjyghno12GV1T7CLXDHFBPleScT4eg==}
     cpu: [arm64]
     os: [darwin]
-    hasBin: true
 
-  hunkdiff-darwin-x64@0.12.1:
-    resolution: {integrity: sha512-joM9wXRTg6Tmd1pXL4nOHjmiLqOwBsJoIyoNOArtuolwyqK+TxeFbvH7z0iMPOQiAtoNIE8ltzvCPoM517Vm+g==}
+  hunkdiff-darwin-x64@0.18.0-beta.0:
+    resolution: {integrity: sha512-1xgbzofwa41lZJBeipB9N1H6qawiQzuYCdTHzWSQXP4yaMH135wIQYbPbcdbTUc51XGPX17bq3pMPt91R0K0lw==}
     cpu: [x64]
     os: [darwin]
-    hasBin: true
 
-  hunkdiff-linux-arm64@0.12.1:
-    resolution: {integrity: sha512-nnUG3hMbodR3fMxIG2DDscTRzlbO5nPlb9pbZ3Z8vYhztIHkNSn5Jc/gd7B4T0d+iLL4iCXK1EEvmIqNn2oigQ==}
+  hunkdiff-linux-arm64@0.18.0-beta.0:
+    resolution: {integrity: sha512-mN7vzGgusp1RZcMuxcIKzRGtC4/SysbiKIrqTNjBZHFslLtdokvi0g5l2FysADMD5pbVzV1txVk1uDM+g+6WlQ==}
     cpu: [arm64]
     os: [linux]
-    hasBin: true
 
-  hunkdiff-linux-x64@0.12.1:
-    resolution: {integrity: sha512-XsBRVQQsfH0SHhxk4wwo3QhuHV0FUmkfJuEJBf9/0E2PfrDXgLY+GvGY6bWlM4CNbyar14Plko/YOhPDW6QrZw==}
+  hunkdiff-linux-x64@0.18.0-beta.0:
+    resolution: {integrity: sha512-4vgxCkjGImKYI6LJyqPi0lVpqx7sWjdM0cOnLK9M4nRRFseUh57erzDNobL7441X49WTkqvkuVHi7ikCBKH4Lw==}
     cpu: [x64]
     os: [linux]
-    hasBin: true
 
-  hunkdiff-windows-x64@0.12.1:
-    resolution: {integrity: sha512-Xx7B9nUZeQMNFsdprF4ao+Z3GJPMb/aPi3NqNgUs4th6yxfGWWfEk1hFQ5e1oO4LiW2HiMoWvIhYUt96WNlh3w==}
+  hunkdiff-windows-x64@0.18.0-beta.0:
+    resolution: {integrity: sha512-+DvEw89phCfwZKa8i2D3AWll2xHp+jiwqd/rWJ7mivwKFiJ4yvlA1VHLMc0y59/rniBwGpUyUkeLvXe9EdeAbA==}
     cpu: [x64]
     os: [win32]
-    hasBin: true
 
-  hunkdiff@0.12.1:
-    resolution: {integrity: sha512-KUama+WAHtO3OZKKmZJBnQaE3e7upOW8YMWpq48EaZR4c1wpYew8sy6QxmtvgXWcmjgFFuamQa6/dgRd+1qkvw==}
+  hunkdiff@0.18.0-beta.0:
+    resolution: {integrity: sha512-REvVeT4R/spFbM/bMtXM5bW0WMdLiryWMhGqPmIbh6MvUS0bVmN4ZfiSay6SBpJo4FG1dVrGu1tz8zKNW3/8Rw==}
     engines: {node: '>=18'}
     hasBin: true
     peerDependencies:
-      '@opentui/core': ^0.1.88
-      '@opentui/react': ^0.1.88
+      '@opentui/core': ^0.4.3
+      '@opentui/react': ^0.4.3
       react: ^19.2.4
 
   iconv-lite@0.7.3:
@@ -1832,6 +1796,10 @@ packages:
     resolution: {integrity: sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==}
     engines: {node: '>=0.10.0'}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
   regex-recursion@6.0.2:
     resolution: {integrity: sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==}
 
@@ -1896,9 +1864,8 @@ packages:
     resolution: {integrity: sha512-Iov+JwFv/2HcTpcwNMKd8+IWNb8tboQJNQTkAY/LLVK7gGH9jy+LGkVqPxfekHl+yMmiqXszdGWXgkfml7hjqA==}
     engines: {node: '>= 0.4'}
 
-  shiki@4.3.1:
-    resolution: {integrity: sha512-oR+qDVi2OjX1tmDpyv+3KviX01KzO6Af+0NNnKnsp9491UEGz2YpxTuJboS/6VhYpTdqzmuJBuiTlrAWWJAssw==}
-    engines: {node: '>=20'}
+  shiki@3.23.0:
+    resolution: {integrity: sha512-55Dj73uq9ZXL5zyeRPzHQsK7Nbyt6Y10k5s7OjuFZGMhpp4r/rsLBH0o/0fstIzX1Lep9VxefWljK/SKCzygIA==}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -2842,29 +2809,18 @@ snapshots:
 
   '@oxc-project/types@0.138.0': {}
 
-  '@pierre/diffs@1.2.12(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+  '@pierre/diffs@1.2.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
     dependencies:
-      '@pierre/theme': 1.1.0
-      '@pierre/theming': 0.0.2(@pierre/theme@1.1.0)(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(shiki@4.3.1)
-      '@shikijs/transformers': 4.3.1
-      diff: 9.0.0
+      '@pierre/theme': 1.0.3
+      '@shikijs/transformers': 3.23.0
+      diff: 8.0.3
       hast-util-to-html: 9.0.5
       lru_map: 0.4.1
       react: 19.2.7
       react-dom: 19.2.7(react@19.2.7)
-      shiki: 4.3.1
-    transitivePeerDependencies:
-      - '@shikijs/themes'
+      shiki: 3.23.0
 
-  '@pierre/theme@1.1.0': {}
-
-  '@pierre/theming@0.0.2(@pierre/theme@1.1.0)(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(shiki@4.3.1)':
-    optionalDependencies:
-      '@pierre/theme': 1.1.0
-      '@shikijs/themes': 4.3.1
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
-      shiki: 4.3.1
+  '@pierre/theme@1.0.3': {}
 
   '@pnpm/config.env-replace@1.1.0': {}
 
@@ -2931,45 +2887,38 @@ snapshots:
 
   '@sec-ant/readable-stream@0.4.1': {}
 
-  '@shikijs/core@4.3.1':
+  '@shikijs/core@3.23.0':
     dependencies:
-      '@shikijs/primitive': 4.3.1
-      '@shikijs/types': 4.3.1
+      '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
       hast-util-to-html: 9.0.5
 
-  '@shikijs/engine-javascript@4.3.1':
+  '@shikijs/engine-javascript@3.23.0':
     dependencies:
-      '@shikijs/types': 4.3.1
+      '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
       oniguruma-to-es: 4.3.6
 
-  '@shikijs/engine-oniguruma@4.3.1':
+  '@shikijs/engine-oniguruma@3.23.0':
     dependencies:
-      '@shikijs/types': 4.3.1
+      '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
 
-  '@shikijs/langs@4.3.1':
+  '@shikijs/langs@3.23.0':
     dependencies:
-      '@shikijs/types': 4.3.1
+      '@shikijs/types': 3.23.0
 
-  '@shikijs/primitive@4.3.1':
+  '@shikijs/themes@3.23.0':
     dependencies:
-      '@shikijs/types': 4.3.1
-      '@shikijs/vscode-textmate': 10.0.2
-      '@types/hast': 3.0.4
+      '@shikijs/types': 3.23.0
 
-  '@shikijs/themes@4.3.1':
+  '@shikijs/transformers@3.23.0':
     dependencies:
-      '@shikijs/types': 4.3.1
+      '@shikijs/core': 3.23.0
+      '@shikijs/types': 3.23.0
 
-  '@shikijs/transformers@4.3.1':
-    dependencies:
-      '@shikijs/core': 4.3.1
-      '@shikijs/types': 4.3.1
-
-  '@shikijs/types@4.3.1':
+  '@shikijs/types@3.23.0':
     dependencies:
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
@@ -3310,6 +3259,10 @@ snapshots:
 
   chardet@2.2.0: {}
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   cli-boxes@3.0.0: {}
 
   cli-cursor@5.0.0:
@@ -3389,8 +3342,6 @@ snapshots:
   diff@8.0.3: {}
 
   diff@8.0.4: {}
-
-  diff@9.0.0: {}
 
   dot-prop@9.0.0:
     dependencies:
@@ -3622,39 +3573,42 @@ snapshots:
 
   human-signals@8.0.1: {}
 
-  hunkdiff-darwin-arm64@0.12.1:
+  hunkdiff-darwin-arm64@0.18.0-beta.0:
     optional: true
 
-  hunkdiff-darwin-x64@0.12.1:
+  hunkdiff-darwin-x64@0.18.0-beta.0:
     optional: true
 
-  hunkdiff-linux-arm64@0.12.1:
+  hunkdiff-linux-arm64@0.18.0-beta.0:
     optional: true
 
-  hunkdiff-linux-x64@0.12.1:
+  hunkdiff-linux-x64@0.18.0-beta.0:
     optional: true
 
-  hunkdiff-windows-x64@0.12.1:
+  hunkdiff-windows-x64@0.18.0-beta.0:
     optional: true
 
-  hunkdiff@0.12.1(@opentui/core@0.1.107(stage-js@1.0.2)(typescript@6.0.3)(web-tree-sitter@0.25.10))(@opentui/react@0.1.107(react-devtools-core@7.0.1)(react@19.2.7)(stage-js@1.0.2)(typescript@6.0.3)(web-tree-sitter@0.25.10)(ws@8.21.0))(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
+  hunkdiff@0.18.0-beta.0(@opentui/core@0.1.107(stage-js@1.0.2)(typescript@6.0.3)(web-tree-sitter@0.25.10))(@opentui/react@0.1.107(react-devtools-core@7.0.1)(react@19.2.7)(stage-js@1.0.2)(typescript@6.0.3)(web-tree-sitter@0.25.10)(ws@8.21.0))(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
     dependencies:
       '@opentui/core': 0.1.107(stage-js@1.0.2)(typescript@6.0.3)(web-tree-sitter@0.25.10)
       '@opentui/react': 0.1.107(react-devtools-core@7.0.1)(react@19.2.7)(stage-js@1.0.2)(typescript@6.0.3)(web-tree-sitter@0.25.10)(ws@8.21.0)
-      '@pierre/diffs': 1.2.12(@shikijs/themes@4.3.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@pierre/diffs': 1.2.2(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       bun: 1.3.14
+      chokidar: 4.0.3
       commander: 14.0.3
       diff: 8.0.4
+      get-east-asian-width: 1.6.0
       react: 19.2.7
+      shell-quote: 1.9.0
+      string-width: 8.2.1
       zod: 4.4.3
     optionalDependencies:
-      hunkdiff-darwin-arm64: 0.12.1
-      hunkdiff-darwin-x64: 0.12.1
-      hunkdiff-linux-arm64: 0.12.1
-      hunkdiff-linux-x64: 0.12.1
-      hunkdiff-windows-x64: 0.12.1
+      hunkdiff-darwin-arm64: 0.18.0-beta.0
+      hunkdiff-darwin-x64: 0.18.0-beta.0
+      hunkdiff-linux-arm64: 0.18.0-beta.0
+      hunkdiff-linux-x64: 0.18.0-beta.0
+      hunkdiff-windows-x64: 0.18.0-beta.0
     transitivePeerDependencies:
-      - '@shikijs/themes'
       - react-dom
 
   iconv-lite@0.7.3:
@@ -4070,6 +4024,8 @@ snapshots:
 
   react@19.2.7: {}
 
+  readdirp@4.1.2: {}
+
   regex-recursion@6.0.2:
     dependencies:
       regex-utilities: 2.3.0
@@ -4141,14 +4097,14 @@ snapshots:
 
   shell-quote@1.9.0: {}
 
-  shiki@4.3.1:
+  shiki@3.23.0:
     dependencies:
-      '@shikijs/core': 4.3.1
-      '@shikijs/engine-javascript': 4.3.1
-      '@shikijs/engine-oniguruma': 4.3.1
-      '@shikijs/langs': 4.3.1
-      '@shikijs/themes': 4.3.1
-      '@shikijs/types': 4.3.1
+      '@shikijs/core': 3.23.0
+      '@shikijs/engine-javascript': 3.23.0
+      '@shikijs/engine-oniguruma': 3.23.0
+      '@shikijs/langs': 3.23.0
+      '@shikijs/themes': 3.23.0
+      '@shikijs/types': 3.23.0
       '@shikijs/vscode-textmate': 10.0.2
       '@types/hast': 3.0.4
 

--- a/apps/cli/src/__tests__/worktree-e2e.test.ts
+++ b/apps/cli/src/__tests__/worktree-e2e.test.ts
@@ -25,7 +25,9 @@ function run(
     return new Promise((resolve, reject) => {
         const child = spawn(process.execPath, [cliEntryPoint, ...args], {
             cwd,
-            env: { ...process.env, KODUS_SKIP_UPDATE_CHECK: '1' },
+            // Without this the CLI reaches the network on every invocation and
+            // the test hangs when that call is slow.
+            env: { ...process.env, KODUS_DISABLE_UPDATE_CHECK: '1' },
         });
         let stdout = '';
         let stderr = '';

--- a/apps/cli/src/__tests__/worktree-e2e.test.ts
+++ b/apps/cli/src/__tests__/worktree-e2e.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+/**
+ * Regression coverage for running the CLI from a linked git worktree.
+ *
+ * Inside a worktree `.git` is a *file* pointing at
+ * `<main>/.git/worktrees/<name>`, so anything that joins `.git/hooks` onto the
+ * worktree root blows up with ENOTDIR. Git itself shares hooks across
+ * worktrees, so the hook must land in the main checkout's hooks directory.
+ */
+
+let tmpDir: string;
+let mainRepo: string;
+let worktree: string;
+let cliEntryPoint: string;
+
+function run(
+    args: string[],
+    cwd: string,
+): Promise<{ code: number; stdout: string; stderr: string }> {
+    return new Promise((resolve, reject) => {
+        const child = spawn(process.execPath, [cliEntryPoint, ...args], {
+            cwd,
+            env: { ...process.env, KODUS_SKIP_UPDATE_CHECK: '1' },
+        });
+        let stdout = '';
+        let stderr = '';
+        child.stdout.on('data', (d) => (stdout += d.toString()));
+        child.stderr.on('data', (d) => (stderr += d.toString()));
+        child.on('error', reject);
+        child.on('close', (code) =>
+            resolve({ code: code ?? 0, stdout, stderr }),
+        );
+    });
+}
+
+function git(args: string[], cwd: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const child = spawn('git', args, {
+            cwd,
+            env: {
+                ...process.env,
+                GIT_AUTHOR_NAME: 'Test',
+                GIT_AUTHOR_EMAIL: 'test@test.com',
+                GIT_COMMITTER_NAME: 'Test',
+                GIT_COMMITTER_EMAIL: 'test@test.com',
+            },
+        });
+        child.on('error', reject);
+        child.on('close', (code) =>
+            code === 0
+                ? resolve()
+                : reject(new Error(`git ${args.join(' ')} failed (${code})`)),
+        );
+    });
+}
+
+describe('Worktree E2E — hook commands', { timeout: 60_000 }, () => {
+    beforeAll(async () => {
+        const cliRoot = path.resolve(
+            import.meta.dirname ??
+                path.dirname(new URL(import.meta.url).pathname),
+            '..',
+            '..',
+        );
+        cliEntryPoint = path.join(cliRoot, 'dist', 'index.js');
+        await fs.access(cliEntryPoint);
+
+        tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'kodus-worktree-'));
+        mainRepo = path.join(tmpDir, 'main');
+        worktree = path.join(tmpDir, 'wt');
+
+        await fs.mkdir(mainRepo, { recursive: true });
+        await git(['init', '--initial-branch=main'], mainRepo);
+        await git(['commit', '--allow-empty', '-m', 'initial'], mainRepo);
+        await git(['worktree', 'add', worktree, '-b', 'feature'], mainRepo);
+    });
+
+    afterAll(async () => {
+        await fs.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    it('installs the pre-push hook into the shared hooks dir', async () => {
+        const result = await run(['hook', 'install', '--force'], worktree);
+
+        expect(result.stderr).not.toContain('ENOTDIR');
+        expect(result.code).toBe(0);
+
+        // Git executes hooks from the main checkout for every linked worktree.
+        const hookPath = path.join(mainRepo, '.git', 'hooks', 'pre-push');
+        const content = await fs.readFile(hookPath, 'utf-8');
+        expect(content).toContain('# kodus-hook');
+
+        // And nothing may have been written under the worktree's `.git` file.
+        const dotGit = await fs.stat(path.join(worktree, '.git'));
+        expect(dotGit.isFile()).toBe(true);
+    });
+
+    it('reports the hook as installed from inside the worktree', async () => {
+        const result = await run(['hook', 'status'], worktree);
+        expect(result.code).toBe(0);
+        expect(result.stdout).toContain('installed');
+        expect(result.stdout).not.toContain('not installed');
+    });
+
+    it('resolves the hooks dir from a nested subdirectory', async () => {
+        // `--git-common-dir` is cwd-relative in an ordinary checkout, so a
+        // fallback that resolved it against the toplevel would climb above the
+        // repo and report the hook as missing.
+        const nested = path.join(worktree, 'deep', 'nested');
+        await fs.mkdir(nested, { recursive: true });
+
+        const result = await run(['hook', 'status'], nested);
+        expect(result.code).toBe(0);
+        expect(result.stdout).toContain('installed');
+        expect(result.stdout).not.toContain('not installed');
+    });
+
+    it('uninstalls the hook from inside the worktree', async () => {
+        const result = await run(['hook', 'uninstall'], worktree);
+        expect(result.code).toBe(0);
+
+        const hookPath = path.join(mainRepo, '.git', 'hooks', 'pre-push');
+        await expect(fs.access(hookPath)).rejects.toThrow();
+    });
+});

--- a/apps/cli/src/commands/__tests__/hook.test.ts
+++ b/apps/cli/src/commands/__tests__/hook.test.ts
@@ -9,6 +9,7 @@ vi.mock('../../services/git.service.js', () => ({
     gitService: {
         isGitRepository: vi.fn().mockResolvedValue(true),
         getGitRoot: vi.fn(),
+        getHooksDir: vi.fn(),
     },
 }));
 
@@ -34,6 +35,7 @@ beforeEach(async () => {
 
     vi.mocked(gitService.isGitRepository).mockResolvedValue(true);
     vi.mocked(gitService.getGitRoot).mockResolvedValue(tmpDir);
+    vi.mocked(gitService.getHooksDir).mockResolvedValue(hooksDir);
 });
 
 afterEach(async () => {

--- a/apps/cli/src/commands/hook/install.ts
+++ b/apps/cli/src/commands/hook/install.ts
@@ -102,8 +102,7 @@ export async function installAction(
             throw new CommandError('NOT_IN_GIT_REPO', 'Not a git repository.');
         }
 
-        const gitRoot = await gitService.getGitRoot();
-        const hooksDir = path.join(gitRoot.trim(), '.git', 'hooks');
+        const hooksDir = await gitService.getHooksDir();
         const hookPath = path.join(hooksDir, 'pre-push');
 
         // Check if hook already exists

--- a/apps/cli/src/commands/hook/status.ts
+++ b/apps/cli/src/commands/hook/status.ts
@@ -13,8 +13,7 @@ export async function statusAction(): Promise<void> {
         exitWithCode(1);
     }
 
-    const gitRoot = await gitService.getGitRoot();
-    const hookPath = path.join(gitRoot.trim(), '.git', 'hooks', 'pre-push');
+    const hookPath = path.join(await gitService.getHooksDir(), 'pre-push');
 
     let content: string;
     try {

--- a/apps/cli/src/commands/hook/uninstall.ts
+++ b/apps/cli/src/commands/hook/uninstall.ts
@@ -35,8 +35,7 @@ export async function uninstallAction(
             throw new CommandError('NOT_IN_GIT_REPO', 'Not a git repository.');
         }
 
-        const gitRoot = await gitService.getGitRoot();
-        const hookPath = path.join(gitRoot.trim(), '.git', 'hooks', 'pre-push');
+        const hookPath = path.join(await gitService.getHooksDir(), 'pre-push');
 
         let content: string;
         try {

--- a/apps/cli/src/commands/status.ts
+++ b/apps/cli/src/commands/status.ts
@@ -51,7 +51,13 @@ async function getPrePushHookStatus(repoRoot: string | null): Promise<string> {
         return 'n/a';
     }
 
-    const hookPath = path.join(repoRoot, '.git', 'hooks', 'pre-push');
+    let hookPath: string;
+    try {
+        hookPath = path.join(await gitService.getHooksDir(), 'pre-push');
+    } catch {
+        return 'n/a';
+    }
+
     try {
         const content = await fs.readFile(hookPath, 'utf-8');
         if (content.includes(KODUS_HOOK_MARKER)) {

--- a/apps/cli/src/commands/status.ts
+++ b/apps/cli/src/commands/status.ts
@@ -7,7 +7,7 @@ import chalk from 'chalk';
 import { gitService } from '../services/git.service.js';
 import { getAuthModeSummary } from '../utils/auth-mode.js';
 import { listBundledSkills } from '../utils/skills.js';
-import { cliInfo } from '../utils/logger.js';
+import { cliDebug, cliInfo } from '../utils/logger.js';
 
 const require = createRequire(import.meta.url);
 const pkg = require('../../package.json') as { version: string };
@@ -54,7 +54,16 @@ async function getPrePushHookStatus(repoRoot: string | null): Promise<string> {
     let hookPath: string;
     try {
         hookPath = path.join(await gitService.getHooksDir(), 'pre-push');
-    } catch {
+    } catch (error) {
+        // `n/a` on its own gives the user nothing to act on, so leave a trail
+        // behind `--verbose` rather than swallowing the cause outright.
+        cliDebug(
+            chalk.dim(
+                `[verbose] status: could not resolve the git hooks dir for ${repoRoot}: ${
+                    error instanceof Error ? error.message : String(error)
+                }`,
+            ),
+        );
         return 'n/a';
     }
 

--- a/apps/cli/src/features/review/__tests__/hunk-context.test.ts
+++ b/apps/cli/src/features/review/__tests__/hunk-context.test.ts
@@ -385,6 +385,39 @@ describe('wrapCodeBlock', () => {
         expect(wrapCodeBlock(code, 80)).toBe(code);
     });
 
+    it('terminates and stays lossless for every indent/width combination', () => {
+        // Regression: the previous implementation re-prepended the full hanging
+        // indent each pass. Once that indent was wide relative to the budget the
+        // remainder grew instead of shrinking, looping forever and eating memory
+        // — reachable from any deeply indented patch in a narrow pane. The old
+        // tests missed it because they only used a 4-space indent.
+        for (let width = 20; width <= 60; width += 4) {
+            for (let indent = 0; indent <= 40; indent += 4) {
+                const line = ' '.repeat(indent) + 'x'.repeat(200);
+                const wrapped = wrapCodeBlock(line, width);
+
+                // Continuation indentation is cosmetic; the payload is not.
+                expect(wrapped.replace(/\s/g, '')).toBe(
+                    line.replace(/\s/g, ''),
+                );
+                for (const emitted of wrapped.split('\n')) {
+                    expect(emitted.length).toBeLessThanOrEqual(width);
+                }
+            }
+        }
+    });
+
+    it('drops the hanging indent when it would leave no room to progress', () => {
+        // Indent (20) + 2 leaves under MIN_CONTINUATION of a 20-column budget,
+        // so prettiness yields to making progress.
+        const line = ' '.repeat(20) + 'x'.repeat(120);
+        const wrapped = wrapCodeBlock(line, 20).split('\n');
+
+        expect(wrapped.length).toBeGreaterThan(1);
+        expect(wrapped.slice(1).every((l) => !l.startsWith(' '))).toBe(true);
+        expect(wrapped.join('').replace(/\s/g, '')).toBe('x'.repeat(120));
+    });
+
     it('indents continuations so a wrap still reads as one line', () => {
         const wrapped = wrapCodeBlock('    ' + 'x'.repeat(60), 20);
         expect(wrapped.split('\n').length).toBeGreaterThan(1);

--- a/apps/cli/src/features/review/__tests__/hunk-context.test.ts
+++ b/apps/cli/src/features/review/__tests__/hunk-context.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest';
 import {
     convertReviewToHunkContext,
+    extractMarkdownLinks,
+    wrapCodeBlock,
     countHunkAnnotations,
 } from '../hunk-context.js';
 import type { ReviewResult } from '../../../types/review.js';
@@ -207,12 +209,79 @@ describe('convertReviewToHunkContext', () => {
             '✖ The selectedResult is computed before the hunk viewer check, resulting in dead computation if applyFieldMask mutates the object.',
         );
 
-        // The rest of the message becomes the lead of the rationale, then a
-        // single trailing attribution tag with metadata.
+        // The body carries the *whole* message, not just the part the summary
+        // left over: the summary is a capped label, so anything it drops has to
+        // survive here.
         expect(annotation.rationale).toBe(
-            'Move the computation below the if (useHunkViewer) block to ensure the hunk viewer receives all required fields. — Kody · severity error · bug',
+            `${longMessage} — Kody · severity error · bug`,
         );
         expect(annotation.rationale).not.toContain('\n');
+    });
+
+    it('never loses message text to the summary cap', () => {
+        // Regression: a first sentence longer than the 140-char cap used to be
+        // truncated into the summary with its tail dropped everywhere else.
+        const tail = 'THE-TAIL-THAT-MUST-SURVIVE';
+        const message = `${'word '.repeat(40)}${tail}. Second sentence.`;
+        const context = convertReviewToHunkContext({
+            ...baseResult,
+            issues: [
+                {
+                    file: 'src/cmd.ts',
+                    line: 10,
+                    severity: 'critical',
+                    message,
+                },
+            ],
+        });
+
+        const annotation = context.files[0]!.annotations[0]!;
+        expect(annotation.summary).toContain('…');
+        expect(annotation.summary).not.toContain(tail);
+        expect(annotation.rationale).toContain(tail);
+        expect(annotation.markup).toContain(tail);
+    });
+
+    it('builds an STML body that separates prose from suggested code', () => {
+        const context = convertReviewToHunkContext({
+            ...baseResult,
+            issues: [
+                {
+                    file: 'src/cmd.ts',
+                    line: 10,
+                    severity: 'high' as never,
+                    category: 'bug',
+                    message: 'Resolve it against the cwd.',
+                    suggestion: 'const dir = resolve(cwd(), common);',
+                },
+            ],
+        });
+
+        const markup = context.files[0]!.annotations[0]!.markup!;
+        // `high` must be normalized before it reaches a severity lookup.
+        expect(markup).toContain('<badge color="danger">error</badge>');
+        expect(markup).toContain('<p>Resolve it against the cwd.</p>');
+        expect(markup).toContain('<h3>Fix</h3>');
+        expect(markup).toContain('<code>');
+        expect(markup).toContain('const dir = resolve(cwd(), common);');
+    });
+
+    it('escapes markup-significant characters in findings', () => {
+        const context = convertReviewToHunkContext({
+            ...baseResult,
+            issues: [
+                {
+                    file: 'src/cmd.ts',
+                    line: 10,
+                    severity: 'error',
+                    message: 'Use <T> & handle A<B> properly.',
+                },
+            ],
+        });
+
+        const markup = context.files[0]!.annotations[0]!.markup!;
+        expect(markup).toContain('&lt;T> &amp; handle A&lt;B>');
+        expect(markup).not.toContain('<T>');
     });
 
     it('does not split on abbreviations like "e.g." or "i.e."', () => {
@@ -289,5 +358,104 @@ describe('convertReviewToHunkContext', () => {
         expect(rationale).toContain('Suggested replace (lines 10-12):');
         expect(rationale).toContain('return [...arr, x];');
         expect(rationale).not.toContain('\n');
+    });
+});
+
+describe('wrapCodeBlock', () => {
+    // STML `code` blocks clip rather than wrap, so an over-long line would be
+    // silently truncated — the exact failure this rework exists to remove.
+    const long =
+        'hunkdiff@0.18.0-beta.0(@opentui/core@0.4.x(...))(@opentui/react@0.4.x(...))(...):';
+
+    it('never drops characters, at any width', () => {
+        for (const width of [20, 40, 52, 92]) {
+            const wrapped = wrapCodeBlock(long, width);
+            expect(wrapped.replace(/\n\s*/g, '')).toBe(long);
+        }
+    });
+
+    it('keeps every emitted line within the budget', () => {
+        for (const line of wrapCodeBlock(long, 40).split('\n')) {
+            expect(line.length).toBeLessThanOrEqual(40);
+        }
+    });
+
+    it('leaves lines that already fit untouched', () => {
+        const code = 'const a = 1;\n  return a;';
+        expect(wrapCodeBlock(code, 80)).toBe(code);
+    });
+
+    it('indents continuations so a wrap still reads as one line', () => {
+        const wrapped = wrapCodeBlock('    ' + 'x'.repeat(60), 20);
+        expect(wrapped.split('\n').length).toBeGreaterThan(1);
+        expect(wrapped.split('\n')[1].startsWith('      ')).toBe(true);
+    });
+});
+
+describe('extractMarkdownLinks', () => {
+    // Kody-rule findings arrive as `... [rule name](https://app.kodus.io/...)`,
+    // which used to wrap a 100-char URL through the middle of a sentence.
+    const message =
+        'Kody rule violation: [Tratamento adequado de exce\u00e7\u00f5es\\.](https://app.kodus.io/settings/code-review/1/kody-rules/abc?teamId=xyz)';
+
+    it('replaces a link with its label and returns the url', () => {
+        const { text, links } = extractMarkdownLinks(message);
+        expect(text).toBe(
+            'Kody rule violation: Tratamento adequado de exce\u00e7\u00f5es.',
+        );
+        expect(links).toEqual([
+            {
+                label: 'Tratamento adequado de exce\u00e7\u00f5es.',
+                url: 'https://app.kodus.io/settings/code-review/1/kody-rules/abc?teamId=xyz',
+            },
+        ]);
+    });
+
+    it('undoes markdown escaping', () => {
+        expect(
+            extractMarkdownLinks('exce\u00e7\u00f5es\\. e \\*isto\\*').text,
+        ).toBe('exce\u00e7\u00f5es. e *isto*');
+    });
+
+    it('leaves text without links untouched', () => {
+        expect(extractMarkdownLinks('plain text').text).toBe('plain text');
+        expect(extractMarkdownLinks('plain text').links).toEqual([]);
+    });
+
+    it('collects every link in the message', () => {
+        const { links } = extractMarkdownLinks(
+            '[a](https://x.test/1) and [b](https://x.test/2)',
+        );
+        expect(links.map((l) => l.url)).toEqual([
+            'https://x.test/1',
+            'https://x.test/2',
+        ]);
+    });
+
+    it('keeps the url in the rendered note rather than dropping it', () => {
+        // STML's `<a>` renders the label and discards the href, so the url has
+        // to survive as text somewhere in the body.
+        const context = convertReviewToHunkContext({
+            ...baseResult,
+            issues: [
+                {
+                    file: 'src/cmd.ts',
+                    line: 10,
+                    severity: 'critical',
+                    ruleId: '43b72fcc-14b5-4917-8b5f-91708a808f88',
+                    message,
+                },
+            ],
+        });
+
+        const annotation = context.files[0]!.annotations[0]!;
+        expect(annotation.markup).toContain(
+            'https://app.kodus.io/settings/code-review/1/kody-rules/abc',
+        );
+        expect(annotation.markup).not.toContain('](');
+        // A raw UUID rule id is noise next to the link, so it is dropped.
+        expect(annotation.markup).not.toContain(
+            '43b72fcc-14b5-4917-8b5f-91708a808f88',
+        );
     });
 });

--- a/apps/cli/src/features/review/__tests__/hunk-extension-findings.test.ts
+++ b/apps/cli/src/features/review/__tests__/hunk-extension-findings.test.ts
@@ -4,6 +4,7 @@ import {
     countBySeverity,
     findFile,
     findHunkIndex,
+    nextCursor,
     orderFindings,
     parseFindings,
     shortenPath,
@@ -236,5 +237,28 @@ describe('countBySeverity', () => {
                 finding({ severity: 'info' }),
             ]),
         ).toEqual({ critical: 1, info: 2 });
+    });
+});
+
+describe('nextCursor', () => {
+    it('starts at the first finding going forward', () => {
+        expect(nextCursor(-1, 1, 3)).toBe(0);
+    });
+
+    it('starts at the last finding going backward', () => {
+        // Regression: the plain modulo gave `length - 2` here, so the first
+        // `p` skipped the last finding and only `n` could ever reach it.
+        expect(nextCursor(-1, -1, 3)).toBe(2);
+        expect(nextCursor(-1, -1, 1)).toBe(0);
+    });
+
+    it('wraps in both directions once started', () => {
+        expect(nextCursor(2, 1, 3)).toBe(0);
+        expect(nextCursor(0, -1, 3)).toBe(2);
+        expect(nextCursor(1, 1, 3)).toBe(2);
+    });
+
+    it('stays out of the way when there is nothing to walk', () => {
+        expect(nextCursor(-1, 1, 0)).toBe(-1);
     });
 });

--- a/apps/cli/src/features/review/__tests__/hunk-extension-findings.test.ts
+++ b/apps/cli/src/features/review/__tests__/hunk-extension-findings.test.ts
@@ -1,0 +1,240 @@
+import { describe, expect, it } from 'vitest';
+import {
+    coerceSeverity,
+    countBySeverity,
+    findFile,
+    findHunkIndex,
+    orderFindings,
+    parseFindings,
+    shortenPath,
+    type KodusFinding,
+} from '../../../../hunk-extension/kodus/findings.js';
+
+function finding(overrides: Partial<KodusFinding> = {}): KodusFinding {
+    return {
+        id: 'kodus-0',
+        file: 'src/a.ts',
+        line: 10,
+        endLine: 10,
+        severity: 'warning',
+        title: 'something',
+        ...overrides,
+    };
+}
+
+describe('orderFindings', () => {
+    it('sorts by severity first, then file, then line', () => {
+        const ordered = orderFindings([
+            finding({
+                id: 'info',
+                severity: 'info',
+                file: 'src/a.ts',
+                line: 1,
+            }),
+            finding({
+                id: 'crit',
+                severity: 'critical',
+                file: 'src/z.ts',
+                line: 99,
+            }),
+            finding({ id: 'warn-b', severity: 'warning', file: 'src/b.ts' }),
+            finding({
+                id: 'warn-a-late',
+                severity: 'warning',
+                file: 'src/a.ts',
+                line: 50,
+            }),
+            finding({
+                id: 'warn-a-early',
+                severity: 'warning',
+                file: 'src/a.ts',
+                line: 5,
+            }),
+        ]);
+
+        expect(ordered.map((f) => f.id)).toEqual([
+            'crit',
+            'warn-a-early',
+            'warn-a-late',
+            'warn-b',
+            'info',
+        ]);
+    });
+
+    it('does not mutate its input', () => {
+        const input = [
+            finding({ id: 'a', severity: 'info' }),
+            finding({ id: 'b', severity: 'critical' }),
+        ];
+        orderFindings(input);
+        expect(input.map((f) => f.id)).toEqual(['a', 'b']);
+    });
+});
+
+describe('findFile', () => {
+    const files = [
+        { id: 'f1', path: 'src/a.ts' },
+        { id: 'f2', path: 'packages/core/src/b.ts' },
+    ];
+
+    it('matches an exact path', () => {
+        expect(findFile(files, 'src/a.ts')?.id).toBe('f1');
+    });
+
+    it('matches when the review path is more qualified than the finding', () => {
+        expect(findFile(files, 'src/b.ts')?.id).toBe('f2');
+    });
+
+    it('matches when the finding is more qualified than the review path', () => {
+        expect(findFile([{ id: 'f3', path: 'a.ts' }], 'src/a.ts')?.id).toBe(
+            'f3',
+        );
+    });
+
+    it('returns undefined when nothing matches', () => {
+        expect(findFile(files, 'src/missing.ts')).toBeUndefined();
+    });
+
+    it('does not match on a partial segment', () => {
+        expect(
+            findFile([{ id: 'f4', path: 'src/ba.ts' }], 'a.ts'),
+        ).toBeUndefined();
+    });
+});
+
+describe('findHunkIndex', () => {
+    const file = {
+        id: 'f1',
+        path: 'src/a.ts',
+        hunks: [
+            { index: 0, newRange: [1, 10] as [number, number] },
+            { index: 1, newRange: [40, 55] as [number, number] },
+        ],
+    };
+
+    it('returns the hunk covering the finding line', () => {
+        expect(findHunkIndex(file, { line: 45 })).toBe(1);
+        expect(findHunkIndex(file, { line: 1 })).toBe(0);
+        expect(findHunkIndex(file, { line: 10 })).toBe(0);
+    });
+
+    it('falls back to the nearest hunk when the line is outside every span', () => {
+        // Kodus reviews whole files; hunk only renders changed spans.
+        expect(findHunkIndex(file, { line: 12 })).toBe(0);
+        expect(findHunkIndex(file, { line: 38 })).toBe(1);
+        expect(findHunkIndex(file, { line: 900 })).toBe(1);
+    });
+
+    it('returns null when the file has no hunks', () => {
+        expect(
+            findHunkIndex({ id: 'f', path: 'p', hunks: [] }, { line: 3 }),
+        ).toBeNull();
+        expect(findHunkIndex({ id: 'f', path: 'p' }, { line: 3 })).toBeNull();
+    });
+
+    it('ignores hunks with no line span', () => {
+        const synthesized = {
+            id: 'f',
+            path: 'p',
+            hunks: [
+                { index: 0 },
+                { index: 1, newRange: [5, 6] as [number, number] },
+            ],
+        };
+        expect(findHunkIndex(synthesized, { line: 5 })).toBe(1);
+    });
+});
+
+describe('parseFindings', () => {
+    it('accepts a well-formed sidecar', () => {
+        const parsed = parseFindings({
+            version: 1,
+            summary: 'two findings',
+            findings: [finding({ id: 'a' }), finding({ id: 'b' })],
+        });
+        expect(parsed.summary).toBe('two findings');
+        expect(parsed.findings).toHaveLength(2);
+    });
+
+    it('drops entries missing a file or line', () => {
+        const parsed = parseFindings({
+            version: 1,
+            findings: [
+                finding({ id: 'ok' }),
+                { id: 'no-file', line: 3 },
+                { id: 'no-line', file: 'src/a.ts' },
+            ],
+        });
+        expect(parsed.findings.map((f) => f.id)).toEqual(['ok']);
+    });
+
+    it('degrades to empty for junk input', () => {
+        expect(parseFindings(null).findings).toEqual([]);
+        expect(parseFindings('nope').findings).toEqual([]);
+        expect(parseFindings({ version: 1 }).findings).toEqual([]);
+        expect(parseFindings({ findings: 'not-an-array' }).findings).toEqual(
+            [],
+        );
+    });
+});
+
+describe('coerceSeverity', () => {
+    it('maps the API vocabulary onto renderable severities', () => {
+        expect(coerceSeverity('high')).toBe('error');
+        expect(coerceSeverity('HIGH')).toBe('error');
+        expect(coerceSeverity('medium')).toBe('warning');
+        expect(coerceSeverity('low')).toBe('info');
+        expect(coerceSeverity('critical')).toBe('critical');
+    });
+
+    it('degrades unknown values to info instead of an undefined glyph', () => {
+        expect(coerceSeverity('blocker')).toBe('info');
+        expect(coerceSeverity(undefined)).toBe('info');
+        expect(coerceSeverity(3)).toBe('info');
+    });
+
+    it('is applied by parseFindings so a stale sidecar still sorts sanely', () => {
+        const parsed = parseFindings({
+            version: 1,
+            findings: [
+                { ...finding({ id: 'high' }), severity: 'high' },
+                { ...finding({ id: 'crit' }), severity: 'critical' },
+            ],
+        });
+        expect(orderFindings(parsed.findings).map((f) => f.id)).toEqual([
+            'crit',
+            'high',
+        ]);
+    });
+});
+
+describe('shortenPath', () => {
+    it('leaves short paths alone', () => {
+        expect(shortenPath('src/a.ts', 30)).toBe('src/a.ts');
+    });
+
+    it('trims leading segments to fit the budget', () => {
+        const short = shortenPath('a/b/c/d/e/file.ts', 14);
+        expect(short.length).toBeLessThanOrEqual(14);
+        expect(short.endsWith('file.ts')).toBe(true);
+        expect(short.startsWith('…/')).toBe(true);
+    });
+
+    it('keeps the basename even when it alone exceeds the budget', () => {
+        expect(shortenPath('a/b/an-extremely-long-file-name.ts', 8)).toContain(
+            'an-extremely-long-file-name.ts',
+        );
+    });
+});
+
+describe('countBySeverity', () => {
+    it('tallies each severity present', () => {
+        expect(
+            countBySeverity([
+                finding({ severity: 'critical' }),
+                finding({ severity: 'info' }),
+                finding({ severity: 'info' }),
+            ]),
+        ).toEqual({ critical: 1, info: 2 });
+    });
+});

--- a/apps/cli/src/features/review/__tests__/hunk-findings.test.ts
+++ b/apps/cli/src/features/review/__tests__/hunk-findings.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest';
+import { convertReviewToHunkFindings } from '../hunk-findings.js';
+import type { ReviewIssue, ReviewResult } from '../../../types/review.js';
+
+function issue(overrides: Partial<ReviewIssue> = {}): ReviewIssue {
+    return {
+        file: 'src/a.ts',
+        line: 12,
+        severity: 'warning',
+        message: 'Something is off here.',
+        ...overrides,
+    } as ReviewIssue;
+}
+
+function review(issues: ReviewIssue[], summary?: string): ReviewResult {
+    return { issues, summary } as ReviewResult;
+}
+
+describe('convertReviewToHunkFindings', () => {
+    it('normalizes the API severity vocabulary the sidebar cannot render', () => {
+        // `/cli/review` skips the suggestions normalizer, so a live review
+        // really does hand us `high` / `medium` / `low`.
+        const { findings } = convertReviewToHunkFindings(
+            review([
+                issue({ severity: 'high' as never }),
+                issue({ severity: 'medium' as never }),
+                issue({ severity: 'low' as never }),
+                issue({ severity: 'critical' }),
+                issue({ severity: undefined as never }),
+            ]),
+        );
+        expect(findings.map((f) => f.severity)).toEqual([
+            'error',
+            'warning',
+            'info',
+            'critical',
+            'info',
+        ]);
+    });
+
+    it('carries severity through as data rather than a glyph', () => {
+        const { findings } = convertReviewToHunkFindings(
+            review([
+                issue({ severity: 'critical' }),
+                issue({ severity: 'info' }),
+            ]),
+        );
+        expect(findings.map((f) => f.severity)).toEqual(['critical', 'info']);
+    });
+
+    it('defaults endLine to line and preserves an explicit range', () => {
+        const { findings } = convertReviewToHunkFindings(
+            review([issue({ line: 12 }), issue({ line: 12, endLine: 20 })]),
+        );
+        expect(findings[0]).toMatchObject({ line: 12, endLine: 12 });
+        expect(findings[1]).toMatchObject({ line: 12, endLine: 20 });
+    });
+
+    it('clamps an endLine that precedes the start line', () => {
+        const { findings } = convertReviewToHunkFindings(
+            review([issue({ line: 30, endLine: 5 })]),
+        );
+        expect(findings[0].endLine).toBe(30);
+    });
+
+    it('drops findings with no file or no usable line', () => {
+        const { findings } = convertReviewToHunkFindings(
+            review([
+                issue({ id: 'keep' } as Partial<ReviewIssue>),
+                issue({ file: undefined }),
+                issue({ line: undefined }),
+                issue({ line: 0 }),
+                issue({ line: -3 }),
+                issue({ line: Number.NaN }),
+            ]),
+        );
+        expect(findings).toHaveLength(1);
+    });
+
+    it('falls back through message → suggestion → recommendation for the title', () => {
+        const { findings } = convertReviewToHunkFindings(
+            review([
+                issue({ message: undefined, suggestion: 'Use const.' }),
+                issue({
+                    message: undefined,
+                    suggestion: undefined,
+                    recommendation: 'Add a test.',
+                }),
+                issue({
+                    message: undefined,
+                    suggestion: undefined,
+                    recommendation: undefined,
+                }),
+            ]),
+        );
+        expect(findings.map((f) => f.title)).toEqual([
+            'Use const.',
+            'Add a test.',
+            'Kodus finding',
+        ]);
+    });
+
+    it('collapses whitespace so a title stays one sidebar row', () => {
+        const { findings } = convertReviewToHunkFindings(
+            review([issue({ message: 'multi\n  line\tmessage' })]),
+        );
+        expect(findings[0].title).toBe('multi line message');
+    });
+
+    it('truncates very long titles', () => {
+        const { findings } = convertReviewToHunkFindings(
+            review([issue({ message: 'x'.repeat(500) })]),
+        );
+        expect(findings[0].title).toHaveLength(200);
+        expect(findings[0].title.endsWith('…')).toBe(true);
+    });
+
+    it('assigns stable ids based on the original issue order', () => {
+        const { findings } = convertReviewToHunkFindings(
+            review([issue({ file: undefined }), issue(), issue()]),
+        );
+        expect(findings.map((f) => f.id)).toEqual(['kodus-1', 'kodus-2']);
+    });
+
+    it('keeps category and ruleId when present, omits them when blank', () => {
+        const { findings } = convertReviewToHunkFindings(
+            review([
+                issue({ category: 'security', ruleId: 'no-eval' }),
+                issue({ category: '', ruleId: '' }),
+            ]),
+        );
+        expect(findings[0]).toMatchObject({
+            category: 'security',
+            ruleId: 'no-eval',
+        });
+        expect(findings[1].category).toBeUndefined();
+        expect(findings[1].ruleId).toBeUndefined();
+    });
+
+    it('handles a review with no issues at all', () => {
+        expect(convertReviewToHunkFindings({} as ReviewResult)).toEqual({
+            version: 1,
+            summary: undefined,
+            findings: [],
+        });
+    });
+});

--- a/apps/cli/src/features/review/__tests__/hunk-viewer.test.ts
+++ b/apps/cli/src/features/review/__tests__/hunk-viewer.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest';
+import {
+    buildHunkArgs,
+    buildHunkViewerScope,
+    canRenderScopeInHunk,
+} from '../hunk-viewer.js';
+
+const CTX = '/tmp/ctx.json';
+
+describe('buildHunkViewerScope', () => {
+    it('maps the default working-tree review', () => {
+        expect(buildHunkViewerScope({})).toEqual({
+            staged: false,
+            paths: undefined,
+        });
+    });
+
+    it('maps --staged', () => {
+        expect(buildHunkViewerScope({ staged: true })).toEqual({
+            staged: true,
+            paths: undefined,
+        });
+    });
+
+    it('maps --branch to a three-dot range against HEAD', () => {
+        expect(buildHunkViewerScope({ branch: 'origin/main' })).toEqual({
+            range: 'origin/main...HEAD',
+            paths: undefined,
+        });
+    });
+
+    it('maps --commit to a single ref', () => {
+        expect(buildHunkViewerScope({ commit: 'abc123' })).toEqual({
+            commit: 'abc123',
+            paths: undefined,
+        });
+    });
+
+    it('carries explicit files through as a pathspec', () => {
+        expect(
+            buildHunkViewerScope({ files: ['src/a.ts', 'src/b.ts'] }),
+        ).toEqual({ staged: false, paths: ['src/a.ts', 'src/b.ts'] });
+    });
+
+    it('rejects --commit combined with --branch', () => {
+        expect(
+            buildHunkViewerScope({ commit: 'abc123', branch: 'main' }),
+        ).toBeNull();
+        expect(canRenderScopeInHunk({ commit: 'abc123', branch: 'main' })).toBe(
+            false,
+        );
+    });
+
+    it('now accepts the scopes that used to fall back to the legacy list', () => {
+        expect(canRenderScopeInHunk({ branch: 'main' })).toBe(true);
+        expect(canRenderScopeInHunk({ commit: 'abc123' })).toBe(true);
+        expect(canRenderScopeInHunk({ files: ['a.ts'] })).toBe(true);
+    });
+});
+
+describe('buildHunkArgs', () => {
+    it('builds a working-tree invocation', () => {
+        expect(buildHunkArgs({ staged: false }, CTX)).toEqual([
+            'diff',
+            '--agent-context',
+            CTX,
+            '--agent-notes',
+            '--experimental',
+        ]);
+    });
+
+    it('builds a staged invocation', () => {
+        expect(buildHunkArgs({ staged: true }, CTX)).toEqual([
+            'diff',
+            '--staged',
+            '--agent-context',
+            CTX,
+            '--agent-notes',
+            '--experimental',
+        ]);
+    });
+
+    it('builds a range invocation', () => {
+        expect(buildHunkArgs({ range: 'main...HEAD' }, CTX)).toEqual([
+            'diff',
+            'main...HEAD',
+            '--agent-context',
+            CTX,
+            '--agent-notes',
+            '--experimental',
+        ]);
+    });
+
+    it('builds a single-commit invocation with `show`', () => {
+        expect(buildHunkArgs({ commit: 'abc123' }, CTX)).toEqual([
+            'show',
+            'abc123',
+            '--agent-context',
+            CTX,
+            '--agent-notes',
+            '--experimental',
+        ]);
+    });
+
+    it('appends pathspecs after a `--` separator', () => {
+        expect(
+            buildHunkArgs({ range: 'main...HEAD', paths: ['src/a.ts'] }, CTX),
+        ).toEqual([
+            'diff',
+            'main...HEAD',
+            '--agent-context',
+            CTX,
+            '--agent-notes',
+            '--experimental',
+            '--',
+            'src/a.ts',
+        ]);
+    });
+
+    it('never emits --staged alongside an explicit range', () => {
+        expect(
+            buildHunkArgs({ range: 'main...HEAD', staged: true }, CTX),
+        ).not.toContain('--staged');
+    });
+
+    it('loads the Kodus sidebar extension when one is available', () => {
+        expect(
+            buildHunkArgs({ staged: false }, CTX, '/pkg/hunk-extension/kodus'),
+        ).toEqual([
+            'diff',
+            '--agent-context',
+            CTX,
+            '--agent-notes',
+            '--experimental',
+            '--extension',
+            '/pkg/hunk-extension/kodus',
+        ]);
+    });
+
+    it('omits --extension when no extension is bundled', () => {
+        expect(buildHunkArgs({ staged: false }, CTX, null)).not.toContain(
+            '--extension',
+        );
+    });
+
+    it('keeps the pathspec last so --extension is never eaten by it', () => {
+        const args = buildHunkArgs(
+            { staged: false, paths: ['src/a.ts'] },
+            CTX,
+            '/pkg/hunk-extension/kodus',
+        );
+        expect(args.indexOf('--extension')).toBeLessThan(args.indexOf('--'));
+        expect(args[args.length - 1]).toBe('src/a.ts');
+    });
+});

--- a/apps/cli/src/features/review/command.ts
+++ b/apps/cli/src/features/review/command.ts
@@ -38,7 +38,7 @@ import {
     shouldUseHunkViewer,
     shouldUseInteractiveReview,
 } from './result.js';
-import { canRenderScopeInHunk, openReviewInHunk } from './hunk-viewer.js';
+import { buildHunkViewerScope, openReviewInHunk } from './hunk-viewer.js';
 import {
     convertReviewToHunkContext,
     countHunkAnnotations,
@@ -235,7 +235,9 @@ async function reviewAction(
                         heavy: options.heavy,
                         quiet: globalOpts.quiet,
                         onProgress: (status) => {
-                            if (globalOpts.quiet || ctx.isAgent) {return;}
+                            if (globalOpts.quiet || ctx.isAgent) {
+                                return;
+                            }
                             if (status === 'PENDING') {
                                 spinner.text = chalk.cyan(
                                     'Queued for review...',
@@ -369,11 +371,13 @@ async function reviewAction(
         const selectedResult = fields ? applyFieldMask(result, fields) : result;
         const ttyOut = Boolean(process.stdout.isTTY);
         const platformSupported = isHunkPlatformSupported();
-        const scopeSupported = canRenderScopeInHunk({
+        const hunkScope = buildHunkViewerScope({
             files,
             commit: options.commit,
             branch: options.branch,
+            staged: options.staged,
         });
+        const scopeSupported = hunkScope !== null;
         // The user is in an "interactive human" context where we'd otherwise
         // route to hunk; we use this to decide whether to surface a one-line
         // hint explaining why hunk was skipped.
@@ -394,7 +398,7 @@ async function reviewAction(
         } else if (interactiveHumanContext && !scopeSupported) {
             cliInfo(
                 chalk.dim(
-                    'ℹ Hunk viewer skipped: --branch / --commit / explicit files have no direct hunk scope yet. Showing the interactive list instead. Pass --no-hunk to silence this hint.',
+                    'ℹ Hunk viewer skipped: this review scope has no direct hunk equivalent. Showing the interactive list instead. Pass --no-hunk to silence this hint.',
                 ),
             );
         }
@@ -459,7 +463,7 @@ async function reviewAction(
             } else {
                 const { exitCode } = await openReviewInHunk({
                     result: reviewResult,
-                    scope: { staged: Boolean(options.staged) },
+                    scope: hunkScope!,
                     keepContextOnExit: Boolean(globalOpts.verbose),
                 });
 

--- a/apps/cli/src/features/review/hunk-context.ts
+++ b/apps/cli/src/features/review/hunk-context.ts
@@ -1,3 +1,4 @@
+import { normalizeSeverity } from '../../services/review-normalizer.js';
 import type {
     ReviewIssue,
     ReviewResult,
@@ -26,6 +27,12 @@ export interface HunkAgentAnnotation {
     newRange: [number, number];
     summary: string;
     rationale?: string;
+    /**
+     * Experimental STML body (hunk >= 0.18, requires `--experimental`).
+     * Ignored by older hunks and by sessions without the flag, which fall back
+     * to `summary` + `rationale`.
+     */
+    markup?: string;
 }
 
 const SEVERITY_LABEL: Record<Severity, string> = {
@@ -107,46 +114,277 @@ function toAnnotation(issue: ReviewIssue): HunkAgentAnnotation | null {
 
     const source =
         firstNonEmpty(message, suggestion, recommendation) ?? 'Kodus finding';
-    const { head, rest } = splitFirstSentence(source);
+    const { head } = splitFirstSentence(source);
+    // `/cli/review` bypasses the suggestions normalizer, so `high` / `medium` /
+    // `low` arrive verbatim and would miss every severity lookup below.
+    const severity = normalizeSeverity(issue.severity);
+    const glyph = SEVERITY_GLYPH[severity] ?? '';
+
+    // The summary is a *label*, not the note's content: hunk renders it as the
+    // note's opening line and STML (when enabled) replaces the body entirely.
+    // Capping it used to be the only place the message appeared, which silently
+    // dropped the tail of any first sentence longer than the cap — the body
+    // below now always carries the full text, so a cut here loses nothing.
     const headline = capHeadline(head, HEADLINE_MAX);
-    const glyph = SEVERITY_GLYPH[issue.severity] ?? '';
     const summary = glyph ? `${glyph} ${headline}` : headline;
 
-    // Hunk's TUI word-wraps the rationale as a single paragraph and ignores
-    // `\n\n` separators, so we keep this as one tight piece of prose: body
-    // text first, then the fix, then a small attribution tail. Reads naturally
-    // even when collapsed onto a single wrapped line.
-    const sentences: string[] = [];
+    const attribution = buildAttribution(issue, severity);
 
-    if (rest) {
-        sentences.push(rest);
-    }
+    // Plain-text fallback, used when `--experimental` (and therefore STML) is
+    // off, or when hunk rejects the markup. Hunk word-wraps this as a single
+    // paragraph and ignores `\n\n`, so it reads as prose rather than sections.
+    const parts: string[] = [withTrailingPeriod(source)];
 
     if (advice && advice !== message && advice !== source) {
-        sentences.push(`Fix: ${withTrailingPeriod(advice)}`);
+        parts.push(`Fix: ${withTrailingPeriod(advice)}`);
     }
 
     if (issue.fix) {
-        const fixLabel = `Suggested ${issue.fix.type} (lines ${issue.fix.startLine}-${issue.fix.endLine}):`;
-        sentences.push(`${fixLabel} ${issue.fix.newCode.trim()}`);
+        parts.push(
+            `Suggested ${issue.fix.type} (lines ${issue.fix.startLine}-${issue.fix.endLine}): ${issue.fix.newCode.trim()}`,
+        );
     }
 
-    const attributionBits: string[] = [
-        `severity ${SEVERITY_LABEL[issue.severity] ?? issue.severity}`,
-    ];
-    if (issue.category) {
-        attributionBits.push(issue.category);
-    }
-    if (issue.ruleId) {
-        attributionBits.push(issue.ruleId);
-    }
-    sentences.push(`— Kody · ${attributionBits.join(' · ')}`);
+    parts.push(`— Kody · ${attribution}`);
 
     return {
         newRange: [start, end],
         summary,
-        rationale: sentences.join(' '),
+        rationale: parts.join(' '),
+        markup: buildMarkup(issue, severity, source, advice, attribution),
     };
+}
+
+const UUID_RE =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+function buildAttribution(issue: ReviewIssue, severity: Severity): string {
+    const bits: string[] = [`severity ${SEVERITY_LABEL[severity]}`];
+    if (issue.category) {
+        bits.push(issue.category);
+    }
+    // Kody-rule findings carry the rule's UUID, which reads as noise and is
+    // already in the rule link the body keeps. Named rule ids still earn a spot.
+    if (issue.ruleId && !UUID_RE.test(issue.ruleId)) {
+        bits.push(issue.ruleId);
+    }
+    return bits.join(' · ');
+}
+
+const SEVERITY_MARKUP_COLOR: Record<Severity, string> = {
+    critical: 'danger',
+    error: 'danger',
+    warning: 'warning',
+    info: 'info',
+};
+
+/**
+ * STML body for the note (`hunk … --experimental`).
+ *
+ * The plain-text rationale has to be one wrapped paragraph, which jams the
+ * explanation, the fix and any suggested code together — the worst case being a
+ * code snippet reflowed as prose. STML lets each of those be its own block, so
+ * the reader can see where the explanation ends and the patch begins.
+ *
+ * Degrades safely: hunk falls back to `summary`/`rationale` when markup is
+ * malformed or `--experimental` is absent.
+ */
+function buildMarkup(
+    issue: ReviewIssue,
+    severity: Severity,
+    body: string,
+    advice: string | undefined,
+    attribution: string,
+): string {
+    const color = SEVERITY_MARKUP_COLOR[severity];
+    const label = SEVERITY_LABEL[severity];
+
+    const { text: prose, links } = extractMarkdownLinks(body);
+
+    const blocks: string[] = [
+        `<text><badge color="${color}">${escapeStml(label)}</badge>${
+            issue.category ? ` <dim>${escapeStml(issue.category)}</dim>` : ''
+        }</text>`,
+        `<p>${escapeStml(prose)}</p>`,
+    ];
+
+    if (advice && advice !== body) {
+        // The API's `suggestion` is often a patch, sometimes a patch behind a
+        // sentence of prose. Reflowing code as a paragraph is what made these
+        // notes unreadable; but `code` clips instead of wrapping, so a prose
+        // lead-in put there loses its tail. Split the two.
+        const { lead, code } = splitAdvice(advice);
+        blocks.push('<h3>Fix</h3>');
+        if (lead) {
+            blocks.push(`<p>${escapeStml(lead)}</p>`);
+        }
+        if (code) {
+            blocks.push(`<code>\n${escapeStml(wrapCodeBlock(code))}\n</code>`);
+        }
+    }
+
+    if (issue.fix) {
+        // `code` is verbatim — it clips instead of wrapping, which is what a
+        // patch needs and exactly what the prose fallback cannot do.
+        blocks.push(
+            `<code title="${escapeStml(
+                `${issue.fix.type} · lines ${issue.fix.startLine}-${issue.fix.endLine}`,
+            )}">\n${escapeStml(wrapCodeBlock(issue.fix.newCode.trim()))}\n</code>`,
+        );
+    }
+
+    // URLs go last, out of the prose flow but never dropped: STML's `<a>`
+    // renders only the label and discards the href entirely (no OSC 8 either),
+    // so a Kody-rule link put there would be unreachable. A dim paragraph keeps
+    // it — and `p` wraps long tokens instead of clipping them.
+    for (const link of links) {
+        // The label already reads inline above, so repeating it only earns its
+        // place when several URLs need telling apart.
+        const caption =
+            links.length > 1
+                ? `${escapeStml(link.label.replace(/[.:\s]+$/, ''))}: `
+                : '';
+        blocks.push(`<p><dim>${caption}${escapeStml(link.url)}</dim></p>`);
+    }
+
+    blocks.push(`<text><dim>— Kody · ${escapeStml(attribution)}</dim></text>`);
+
+    return blocks.join('\n');
+}
+
+export interface ExtractedLink {
+    label: string;
+    url: string;
+}
+
+/**
+ * Pull Markdown links out of a finding and undo Markdown escaping.
+ *
+ * Kody-rule findings arrive with the rule name as `[label](url)` plus
+ * backslash-escaped punctuation, which rendered verbatim in the note: a
+ * hundred-character URL wrapped through the middle of a sentence. The label
+ * stays inline where it reads naturally; the URL is returned for the caller to
+ * place at the end.
+ */
+export function extractMarkdownLinks(text: string): {
+    text: string;
+    links: ExtractedLink[];
+} {
+    const links: ExtractedLink[] = [];
+
+    const withoutLinks = text.replace(
+        /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
+        (_match, label: string, url: string) => {
+            const cleanLabel = unescapeMarkdown(label).trim();
+            links.push({ label: cleanLabel, url });
+            return cleanLabel;
+        },
+    );
+
+    return { text: unescapeMarkdown(withoutLinks), links };
+}
+
+/** `exceções\.` → `exceções` — Markdown escaping has no meaning in a TUI note. */
+function unescapeMarkdown(text: string): string {
+    return text.replace(/\\([\\`*_{}[\]()#+\-.!])/g, '$1');
+}
+
+/**
+ * Split advice into an optional prose lead-in and a verbatim code block.
+ *
+ * Single-line advice is prose. Multi-line advice is code, unless its first line
+ * reads like a sentence introducing the snippet ("…the snippet should read:"),
+ * in which case that line is wrapped as prose and the rest kept verbatim.
+ */
+export function splitAdvice(advice: string): { lead?: string; code?: string } {
+    const lines = advice.split('\n');
+    const first = lines[0];
+    const firstIsCode = /[{}();=]/.test(first) || /^\s/.test(first);
+
+    if (lines.length === 1) {
+        return firstIsCode ? { code: advice } : { lead: advice };
+    }
+
+    if (firstIsCode) {
+        return { code: advice };
+    }
+
+    const rest = lines.slice(1).join('\n').replace(/^\n+/, '');
+    return {
+        lead: first.trim() || undefined,
+        code: rest.trim() ? rest : undefined,
+    };
+}
+
+/**
+ * Width to hard-wrap code blocks at.
+ *
+ * STML `code`/`pre` blocks *clip* long lines instead of wrapping them — text
+ * past the pane edge is silently gone, which is the whole failure this note
+ * rework exists to fix. Hunk sizes the note from the live session and we spawn
+ * it fresh, so there is no width to query; the STML guide's advice is to design
+ * for ~56 columns, and the block's border plus padding costs 4 of those.
+ */
+const CODE_WRAP_FALLBACK = 52;
+
+/**
+ * Width to hard-wrap code blocks at.
+ *
+ * STML `code`/`pre` blocks *clip* long lines instead of wrapping them, so this
+ * has to stay under the note's real interior width — and that width cannot be
+ * derived from the terminal. Measured by rendering a ruler through the live
+ * TUI (terminal columns → usable code columns):
+ *
+ *     80 → 55    100 → 75    120 → 95    140 → 119
+ *    160 → 61    180 → 71    200 → 85    238 → 87    300 → 114
+ *
+ * It drops at 160 because hunk switches to a split diff, and 238 is narrower
+ * than 140 because the sidebar area reappears and takes its share. Layout mode,
+ * sidebar visibility, pane count and the user's own pane resizing all feed in,
+ * so `process.stdout.columns` predicts none of it — an earlier `columns / 2`
+ * estimate clipped at 238. The STML guide's own advice is to design for ~56
+ * columns; the only term that reliably tracks anything is the narrow end, where
+ * the stack layout gives roughly `columns - 25`.
+ *
+ * Wrapping early on a wide terminal is cosmetic. Clipping loses the text.
+ */
+function resolveCodeWrapWidth(): number {
+    const columns = process.stdout.columns;
+    if (!columns || !Number.isFinite(columns)) {
+        return CODE_WRAP_FALLBACK;
+    }
+    return Math.max(20, Math.min(CODE_WRAP_FALLBACK, columns - 25));
+}
+
+export function wrapCodeBlock(
+    code: string,
+    width = resolveCodeWrapWidth(),
+): string {
+    return code
+        .split('\n')
+        .flatMap((line) => {
+            if (line.length <= width) {
+                return [line];
+            }
+            const indent = `${line.match(/^\s*/)?.[0] ?? ''}  `;
+            const chunks: string[] = [];
+            let rest = line;
+            let budget = width;
+            while (rest.length > budget) {
+                chunks.push(rest.slice(0, budget));
+                rest = rest.slice(budget);
+                budget = Math.max(8, width - indent.length);
+                rest = `${indent}${rest}`;
+            }
+            chunks.push(rest);
+            return chunks;
+        })
+        .join('\n');
+}
+
+/** STML is HTML-like, so raw `<`/`&` in a finding would corrupt the body. */
+function escapeStml(text: string): string {
+    return text.replace(/&/g, '&amp;').replace(/</g, '&lt;');
 }
 
 function withTrailingPeriod(text: string): string {

--- a/apps/cli/src/features/review/hunk-context.ts
+++ b/apps/cli/src/features/review/hunk-context.ts
@@ -356,6 +356,9 @@ function resolveCodeWrapWidth(): number {
     return Math.max(20, Math.min(CODE_WRAP_FALLBACK, columns - 25));
 }
 
+/** Columns a continuation must still have left, or the hanging indent is dropped. */
+const MIN_CONTINUATION = 8;
+
 export function wrapCodeBlock(
     code: string,
     width = resolveCodeWrapWidth(),
@@ -366,17 +369,26 @@ export function wrapCodeBlock(
             if (line.length <= width) {
                 return [line];
             }
-            const indent = `${line.match(/^\s*/)?.[0] ?? ''}  `;
-            const chunks: string[] = [];
-            let rest = line;
-            let budget = width;
+            const leading = line.match(/^\s*/)?.[0] ?? '';
+
+            // Continuations carry a hanging indent so a wrap still reads as one
+            // logical line — but only while that leaves room to make real
+            // progress. A deeply indented line in a narrow pane would otherwise
+            // re-add more prefix than the pass consumed, growing the remainder
+            // forever instead of terminating.
+            const indent =
+                leading.length + 2 <= width - MIN_CONTINUATION
+                    ? `${leading}  `
+                    : '';
+            const budget = width - indent.length;
+
+            const chunks: string[] = [line.slice(0, width)];
+            let rest = line.slice(width);
             while (rest.length > budget) {
-                chunks.push(rest.slice(0, budget));
+                chunks.push(`${indent}${rest.slice(0, budget)}`);
                 rest = rest.slice(budget);
-                budget = Math.max(8, width - indent.length);
-                rest = `${indent}${rest}`;
             }
-            chunks.push(rest);
+            chunks.push(`${indent}${rest}`);
             return chunks;
         })
         .join('\n');

--- a/apps/cli/src/features/review/hunk-findings.ts
+++ b/apps/cli/src/features/review/hunk-findings.ts
@@ -1,0 +1,111 @@
+import { normalizeSeverity } from '../../services/review-normalizer.js';
+import type {
+    ReviewIssue,
+    ReviewResult,
+    Severity,
+} from '../../types/review.js';
+
+/**
+ * Structured sidecar consumed by the bundled Kodus hunk extension
+ * (`hunk-extension/kodus`).
+ *
+ * This is deliberately separate from the `--agent-context` payload: that one is
+ * hunk's own inline-note schema and flattens severity down to a glyph inside a
+ * prose string. The sidebar needs the fields back as data so it can group by
+ * severity, count, and jump. Written to a tempfile and handed to the extension
+ * through `KODUS_HUNK_FINDINGS`.
+ */
+export interface KodusHunkFindings {
+    version: 1;
+    summary?: string;
+    findings: KodusHunkFinding[];
+}
+
+export interface KodusHunkFinding {
+    id: string;
+    file: string;
+    /** 1-based start line on the new side of the diff. */
+    line: number;
+    /** Inclusive end line; equal to `line` for single-line findings. */
+    endLine: number;
+    severity: Severity;
+    title: string;
+    category?: string;
+    ruleId?: string;
+}
+
+const TITLE_MAX = 200;
+
+export function convertReviewToHunkFindings(
+    result: ReviewResult,
+): KodusHunkFindings {
+    const findings: KodusHunkFinding[] = [];
+
+    for (const [index, issue] of (result.issues ?? []).entries()) {
+        const finding = toFinding(issue, index);
+        if (finding) {
+            findings.push(finding);
+        }
+    }
+
+    return {
+        version: 1,
+        summary: result.summary?.trim() || undefined,
+        findings,
+    };
+}
+
+function toFinding(issue: ReviewIssue, index: number): KodusHunkFinding | null {
+    if (!issue.file) {
+        return null;
+    }
+
+    const line = normalizeLine(issue.line);
+    if (line === null) {
+        return null;
+    }
+    const endLine = Math.max(line, normalizeLine(issue.endLine) ?? line);
+
+    const title = firstNonEmpty(
+        issue.message,
+        issue.suggestion,
+        issue.recommendation,
+    );
+
+    return {
+        id: `kodus-${index}`,
+        file: issue.file,
+        line,
+        endLine,
+        // `/cli/review` is *not* run through the suggestions normalizer, so the
+        // API's `high` / `medium` / `low` reach us verbatim despite the
+        // `Severity` type. Left unmapped they'd sort ahead of `critical` and
+        // render an undefined glyph in the sidebar.
+        severity: normalizeSeverity(issue.severity),
+        title: truncate(title ?? 'Kodus finding', TITLE_MAX),
+        category: issue.category || undefined,
+        ruleId: issue.ruleId || undefined,
+    };
+}
+
+function normalizeLine(value: number | undefined): number | null {
+    if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+        return null;
+    }
+    return Math.floor(value);
+}
+
+function firstNonEmpty(
+    ...candidates: Array<string | undefined>
+): string | undefined {
+    for (const candidate of candidates) {
+        if (candidate && candidate.trim().length > 0) {
+            return candidate.trim().replace(/\s+/g, ' ');
+        }
+    }
+    return undefined;
+}
+
+function truncate(text: string, max: number): string {
+    return text.length <= max ? text : `${text.slice(0, max - 1)}…`;
+}

--- a/apps/cli/src/features/review/hunk-viewer.ts
+++ b/apps/cli/src/features/review/hunk-viewer.ts
@@ -3,36 +3,110 @@ import os from 'node:os';
 import path from 'node:path';
 import { randomUUID } from 'node:crypto';
 import chalk from 'chalk';
-import { runHunk } from '../../utils/hunk.js';
+import { resolveKodusExtensionDir, runHunk } from '../../utils/hunk.js';
 import { cliDebug, isCliVerboseMode } from '../../utils/logger.js';
 import { convertReviewToHunkContext } from './hunk-context.js';
+import { convertReviewToHunkFindings } from './hunk-findings.js';
 import type { ReviewResult } from '../../types/review.js';
 
 export interface HunkViewerScope {
     /** When true, opens hunk against the staged index instead of the working tree. */
     staged?: boolean;
+    /**
+     * Git range to review (`hunk diff <range>`), used for `--branch`.
+     * Mutually exclusive with `commit`.
+     */
+    range?: string;
+    /** Single commit to review (`hunk show <ref>`), used for `--commit`. */
+    commit?: string;
+    /** Pathspec limiting the review, forwarded after `--`. */
+    paths?: string[];
 }
 
-/**
- * Subset of `kodus review` options the hunk viewer can faithfully render.
- * Anything beyond this (specific files, --commit, --branch) currently has no
- * direct hunk equivalent so the caller should fall back to the terminal output.
- */
-export function canRenderScopeInHunk(opts: {
+export interface ReviewScopeOptions {
     files?: string[];
     commit?: string;
     branch?: string;
-}): boolean {
-    if (opts.files && opts.files.length > 0) {
-        return false;
+    staged?: boolean;
+}
+
+/**
+ * Translate `kodus review` scoping options into the equivalent hunk invocation.
+ *
+ * hunk understands the same shapes git does — `hunk diff <range>`,
+ * `hunk show <ref>`, `--staged`, and a trailing `-- <pathspec...>` — so every
+ * review scope we support maps onto it. Returns `null` only for combinations
+ * hunk genuinely can't express, in which case the caller falls back to the
+ * legacy interactive list.
+ */
+export function buildHunkViewerScope(
+    opts: ReviewScopeOptions,
+): HunkViewerScope | null {
+    const paths = opts.files && opts.files.length > 0 ? opts.files : undefined;
+
+    // `--commit` and `--branch` describe two different anchors; git (and hunk)
+    // have no single invocation that means both.
+    if (opts.commit && opts.branch) {
+        return null;
     }
+
     if (opts.commit) {
-        return false;
+        return { commit: opts.commit, paths };
     }
+
     if (opts.branch) {
-        return false;
+        // Mirrors the diff the API reviewed: `git diff <branch>...HEAD`.
+        return { range: `${opts.branch}...HEAD`, paths };
     }
-    return true;
+
+    return { staged: Boolean(opts.staged), paths };
+}
+
+export function canRenderScopeInHunk(opts: ReviewScopeOptions): boolean {
+    return buildHunkViewerScope(opts) !== null;
+}
+
+/** Build the argv `hunk` should be spawned with for a given scope. */
+export function buildHunkArgs(
+    scope: HunkViewerScope,
+    contextPath: string,
+    extensionDir?: string | null,
+): string[] {
+    const args: string[] = [];
+
+    if (scope.commit) {
+        args.push('show', scope.commit);
+    } else {
+        args.push('diff');
+        if (scope.range) {
+            args.push(scope.range);
+        } else if (scope.staged) {
+            args.push('--staged');
+        }
+    }
+
+    args.push('--agent-context', contextPath, '--agent-notes');
+
+    // Opts into STML note bodies so a finding's explanation, its fix and any
+    // suggested patch render as separate blocks instead of one reflowed
+    // paragraph. Hunk falls back to the plain summary/rationale if the markup
+    // is rejected, so this is safe on its own.
+    args.push('--experimental');
+
+    if (extensionDir) {
+        // `--extension` is explicit user intent as far as hunk is concerned, so
+        // it loads with no trust prompt. Safe here: the path is ours, inside
+        // the installed @kodus/cli package, never anything from the repo under
+        // review.
+        args.push('--extension', extensionDir);
+    }
+
+    // Must stay last: everything after `--` is a pathspec.
+    if (scope.paths && scope.paths.length > 0) {
+        args.push('--', ...scope.paths);
+    }
+
+    return args;
 }
 
 export interface OpenReviewInHunkOptions {
@@ -46,12 +120,23 @@ export async function openReviewInHunk(
     options: OpenReviewInHunkOptions,
 ): Promise<{ exitCode: number }> {
     const context = convertReviewToHunkContext(options.result);
-    const contextPath = path.join(
-        os.tmpdir(),
-        `kodus-review-${randomUUID()}.json`,
-    );
+    const runId = randomUUID();
+    const contextPath = path.join(os.tmpdir(), `kodus-review-${runId}.json`);
+    const findingsPath = path.join(os.tmpdir(), `kodus-findings-${runId}.json`);
 
     await fs.writeFile(contextPath, JSON.stringify(context, null, 2), 'utf-8');
+
+    // Structured sidecar for the bundled sidebar extension. Written even when
+    // the extension is missing — it's cheap, and it keeps the two paths from
+    // drifting apart.
+    const findings = convertReviewToHunkFindings(options.result);
+    await fs.writeFile(
+        findingsPath,
+        JSON.stringify(findings, null, 2),
+        'utf-8',
+    );
+
+    const extensionDir = resolveKodusExtensionDir();
 
     if (isCliVerboseMode()) {
         const totalAnnotations = context.files.reduce(
@@ -80,23 +165,37 @@ export async function openReviewInHunk(
     }
 
     try {
-        const args = ['diff'];
-        if (options.scope.staged) {
-            args.push('--staged');
+        const args = buildHunkArgs(options.scope, contextPath, extensionDir);
+        if (isCliVerboseMode()) {
+            cliDebug(
+                chalk.dim(
+                    `[verbose] hunk: spawning \`hunk ${args.join(' ')}\``,
+                ),
+            );
+            if (!extensionDir) {
+                cliDebug(
+                    chalk.dim(
+                        '[verbose] hunk: Kodus sidebar extension not found on disk; skipping --extension',
+                    ),
+                );
+            }
         }
-        args.push('--agent-context', contextPath, '--agent-notes');
-        return await runHunk(args);
+        return await runHunk(args, {
+            execa: { env: { KODUS_HUNK_FINDINGS: findingsPath } },
+        });
     } finally {
         if (options.keepContextOnExit) {
             cliDebug(
                 chalk.dim(
-                    `[verbose] hunk: agent-context kept at ${contextPath} (inspect with: cat ${contextPath})`,
+                    `[verbose] hunk: agent-context kept at ${contextPath}, findings at ${findingsPath}`,
                 ),
             );
         } else {
-            await fs.unlink(contextPath).catch(() => {
-                // best-effort cleanup; tempdir is reaped by the OS anyway.
-            });
+            // best-effort cleanup; tempdir is reaped by the OS anyway.
+            await Promise.all([
+                fs.unlink(contextPath).catch(() => {}),
+                fs.unlink(findingsPath).catch(() => {}),
+            ]);
         }
     }
 }

--- a/apps/cli/src/services/__tests__/git-hooks.service.test.ts
+++ b/apps/cli/src/services/__tests__/git-hooks.service.test.ts
@@ -5,10 +5,12 @@ import os from 'os';
 import { gitHooksService } from '../git-hooks.service.js';
 
 let tmpDir: string;
+let hooksDir: string;
 
 beforeEach(async () => {
     tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'kodus-git-hooks-'));
-    await fs.mkdir(path.join(tmpDir, '.git', 'hooks'), { recursive: true });
+    hooksDir = path.join(tmpDir, '.git', 'hooks');
+    await fs.mkdir(hooksDir, { recursive: true });
 });
 
 afterEach(async () => {
@@ -16,12 +18,12 @@ afterEach(async () => {
 });
 
 function hookPath(name: string): string {
-    return path.join(tmpDir, '.git', 'hooks', name);
+    return path.join(hooksDir, name);
 }
 
 describe('gitHooksService.install', () => {
     it('installs prepare-commit-msg and post-commit hooks', async () => {
-        const result = await gitHooksService.install(tmpDir);
+        const result = await gitHooksService.install(hooksDir);
 
         expect(result.installed).toContain('prepare-commit-msg');
         expect(result.installed).toContain('post-commit');
@@ -41,7 +43,7 @@ describe('gitHooksService.install', () => {
     });
 
     it('hooks are executable', async () => {
-        await gitHooksService.install(tmpDir);
+        await gitHooksService.install(hooksDir);
 
         const prepareStat = await fs.stat(hookPath('prepare-commit-msg'));
         expect(prepareStat.mode & 0o100).toBeTruthy();
@@ -51,8 +53,8 @@ describe('gitHooksService.install', () => {
     });
 
     it('is idempotent — second install reports alreadyInstalled', async () => {
-        await gitHooksService.install(tmpDir);
-        const result = await gitHooksService.install(tmpDir);
+        await gitHooksService.install(hooksDir);
+        const result = await gitHooksService.install(hooksDir);
 
         expect(result.installed).toHaveLength(0);
         expect(result.alreadyInstalled).toContain('prepare-commit-msg');
@@ -63,7 +65,7 @@ describe('gitHooksService.install', () => {
         const existing = '#!/bin/sh\necho "existing hook"\n';
         await fs.writeFile(hookPath('prepare-commit-msg'), existing);
 
-        await gitHooksService.install(tmpDir);
+        await gitHooksService.install(hooksDir);
 
         const content = await fs.readFile(
             hookPath('prepare-commit-msg'),
@@ -76,8 +78,8 @@ describe('gitHooksService.install', () => {
 
 describe('gitHooksService.uninstall', () => {
     it('removes kodus sections from hooks', async () => {
-        await gitHooksService.install(tmpDir);
-        const result = await gitHooksService.uninstall(tmpDir);
+        await gitHooksService.install(hooksDir);
+        const result = await gitHooksService.uninstall(hooksDir);
 
         expect(result.removed).toContain('prepare-commit-msg');
         expect(result.removed).toContain('post-commit');
@@ -94,10 +96,10 @@ describe('gitHooksService.uninstall', () => {
         await fs.writeFile(hookPath('prepare-commit-msg'), existing);
 
         // Install (appends)
-        await gitHooksService.install(tmpDir);
+        await gitHooksService.install(hooksDir);
 
         // Uninstall (removes only kodus section)
-        await gitHooksService.uninstall(tmpDir);
+        await gitHooksService.uninstall(hooksDir);
 
         const content = await fs.readFile(
             hookPath('prepare-commit-msg'),
@@ -108,7 +110,7 @@ describe('gitHooksService.uninstall', () => {
     });
 
     it('returns empty removed array when hooks do not exist', async () => {
-        const result = await gitHooksService.uninstall(tmpDir);
+        const result = await gitHooksService.uninstall(hooksDir);
         expect(result.removed).toHaveLength(0);
     });
 });

--- a/apps/cli/src/services/git-hooks.service.ts
+++ b/apps/cli/src/services/git-hooks.service.ts
@@ -32,15 +32,20 @@ ${KODY_CHECKPOINT_END_MARKER}
 class GitHooksService {
     /**
      * Install prepare-commit-msg and post-commit hooks for checkpoint tracking.
+     *
+     * `hooksDir` must be the directory git actually executes hooks from —
+     * resolve it with `gitService.getHooksDir()` rather than joining
+     * `.git/hooks` onto the worktree root, which breaks inside linked
+     * worktrees (where `.git` is a file) and ignores `core.hooksPath`.
      */
     async install(
-        gitRoot: string,
+        hooksDir: string,
     ): Promise<{ installed: string[]; alreadyInstalled: string[] }> {
         const installed: string[] = [];
         const alreadyInstalled: string[] = [];
 
         const prepareResult = await this.installHook(
-            gitRoot,
+            hooksDir,
             'prepare-commit-msg',
             PREPARE_COMMIT_MSG_SCRIPT,
         );
@@ -51,7 +56,7 @@ class GitHooksService {
         }
 
         const postResult = await this.installHook(
-            gitRoot,
+            hooksDir,
             'post-commit',
             POST_COMMIT_SCRIPT,
         );
@@ -67,18 +72,18 @@ class GitHooksService {
     /**
      * Remove kodus session hooks from prepare-commit-msg and post-commit.
      */
-    async uninstall(gitRoot: string): Promise<{ removed: string[] }> {
+    async uninstall(hooksDir: string): Promise<{ removed: string[] }> {
         const removed: string[] = [];
 
         const prepareResult = await this.removeHook(
-            gitRoot,
+            hooksDir,
             'prepare-commit-msg',
         );
         if (prepareResult) {
             removed.push('prepare-commit-msg');
         }
 
-        const postResult = await this.removeHook(gitRoot, 'post-commit');
+        const postResult = await this.removeHook(hooksDir, 'post-commit');
         if (postResult) {
             removed.push('post-commit');
         }
@@ -87,11 +92,11 @@ class GitHooksService {
     }
 
     private async installHook(
-        gitRoot: string,
+        hooksDir: string,
         hookName: string,
         script: string,
     ): Promise<{ hookPath: string; alreadyInstalled: boolean }> {
-        const hookPath = path.join(gitRoot, '.git', 'hooks', hookName);
+        const hookPath = path.join(hooksDir, hookName);
 
         let existing = '';
         try {
@@ -120,10 +125,10 @@ class GitHooksService {
     }
 
     private async removeHook(
-        gitRoot: string,
+        hooksDir: string,
         hookName: string,
     ): Promise<boolean> {
-        const hookPath = path.join(gitRoot, '.git', 'hooks', hookName);
+        const hookPath = path.join(hooksDir, hookName);
 
         let content: string;
         try {

--- a/apps/cli/src/services/git.service.ts
+++ b/apps/cli/src/services/git.service.ts
@@ -9,9 +9,7 @@ import {
     extractOrgRepoFromRemote,
     inferPlatformFromRemote,
 } from '../utils/git-remote.js';
-import {
-    parseGitStatus,
-} from '../utils/git-status.js';
+import { parseGitStatus } from '../utils/git-status.js';
 import { countDiffChanges } from '../utils/git-diff.js';
 import {
     buildFileContentReadPlan,
@@ -56,6 +54,44 @@ class GitService {
     async getGitRoot(): Promise<string> {
         await this.ensureRepo();
         return this.git.revparse(['--show-toplevel']);
+    }
+
+    /**
+     * Absolute path to the directory git actually reads hooks from.
+     *
+     * Never assume `<toplevel>/.git/hooks`: inside a linked worktree `.git` is a
+     * *file* pointing at `<main>/.git/worktrees/<name>`, so joining `.git` there
+     * fails with ENOTDIR. `git rev-parse --git-path hooks` resolves the shared
+     * common dir for worktrees and also honours `core.hooksPath`, which is what
+     * git will really execute.
+     */
+    async getHooksDir(): Promise<string> {
+        await this.ensureRepo();
+
+        try {
+            const resolved = (
+                await this.git.revparse([
+                    '--path-format=absolute',
+                    '--git-path',
+                    'hooks',
+                ])
+            ).trim();
+            if (resolved) {
+                return resolved;
+            }
+        } catch {
+            // `--path-format` needs git >= 2.31; fall through to the manual
+            // resolution below for older clients.
+        }
+
+        // `--git-common-dir` prints an absolute path inside a linked worktree
+        // but a *cwd-relative* one in an ordinary checkout (`../../.git` from a
+        // nested directory), so it must be resolved against the cwd — resolving
+        // it against the toplevel would climb above the repo.
+        const commonDir = (
+            await this.git.revparse(['--git-common-dir'])
+        ).trim();
+        return path.resolve(process.cwd(), commonDir, 'hooks');
     }
 
     async getHeadSha(): Promise<string | null> {
@@ -386,7 +422,9 @@ class GitService {
                 const sha = (
                     await this.git.raw(['merge-base', 'HEAD', ref])
                 ).trim();
-                if (sha) {return sha;}
+                if (sha) {
+                    return sha;
+                }
             } catch {
                 // Ref doesn't exist locally / no merge base — try next.
             }

--- a/apps/cli/src/utils/hunk.ts
+++ b/apps/cli/src/utils/hunk.ts
@@ -1,5 +1,7 @@
 import path from 'node:path';
+import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
 import { execa, type ExecaError, type Options as ExecaOptions } from 'execa';
 
 const require = createRequire(import.meta.url);
@@ -33,6 +35,37 @@ export function resolveHunkBin(): string {
 
     cachedHunkBin = path.resolve(path.dirname(pkgPath), binRelative);
     return cachedHunkBin;
+}
+
+let cachedExtensionDir: string | null | undefined;
+
+/**
+ * Absolute path to the Kodus hunk extension bundled with this package, or null
+ * when it isn't on disk.
+ *
+ * It ships as raw `.tsx` outside `src/` (hunk compiles it itself; our `tsc`
+ * must not), so it sits at `<package root>/hunk-extension/kodus` both in the
+ * repo and in the published tarball. This module lands at `dist/utils/hunk.js`
+ * once compiled and `src/utils/hunk.ts` under vitest — same depth either way.
+ */
+export function resolveKodusExtensionDir(): string | null {
+    if (cachedExtensionDir !== undefined) {
+        return cachedExtensionDir;
+    }
+
+    const moduleDir = path.dirname(fileURLToPath(import.meta.url));
+    const candidate = path.resolve(
+        moduleDir,
+        '..',
+        '..',
+        'hunk-extension',
+        'kodus',
+    );
+
+    cachedExtensionDir = existsSync(path.join(candidate, 'index.tsx'))
+        ? candidate
+        : null;
+    return cachedExtensionDir;
 }
 
 export interface RunHunkResult {

--- a/docs-internal/plans/2026-08-04-cli-hunk-upgrade.md
+++ b/docs-internal/plans/2026-08-04-cli-hunk-upgrade.md
@@ -1,0 +1,289 @@
+# CLI × Hunk — upgrade notes and review-UX roadmap
+
+Date: 2026-08-04
+Scope: `apps/cli`
+Baseline: `hunkdiff@0.12.1` (May 2026) → `hunkdiff@0.18.0-beta.0` (Aug 2026)
+
+## What shipped in this change
+
+1. **`hunkdiff` bumped 0.12.1 → 0.18.0-beta.0.** Deliberately the `beta`
+   dist-tag, not `latest` (0.17.7): the extension API we build on below only
+   exists in 0.18. See "Risk of the beta pin" at the bottom.
+2. **Review scopes now route to hunk.** `--branch`, `--commit` and explicit file
+   arguments used to fall back to the legacy inquirer list; hunk understands
+   `hunk diff <range>`, `hunk show <ref>` and `-- <pathspec…>`, so all of them
+   now open the TUI (`features/review/hunk-viewer.ts`).
+3. **A Kodus findings sidebar**, shipped as a bundled hunk extension
+   (`apps/cli/hunk-extension/kodus`) and loaded with `--extension`.
+4. **Rewritten inline notes** using STML (`--experimental`), which also fixed
+   three separate ways the old notes silently dropped text — see below.
+5. **Worktree fix** (unrelated to hunk): hook paths resolve through
+   `git rev-parse --git-path hooks` instead of `<root>/.git/hooks`.
+
+### What the bump buys us for free
+
+| Area | Versions | Impact |
+| --- | --- | --- |
+| Large-review scroll / hunk navigation latency | 0.15.3 | ~100–1000× faster |
+| Retained memory in big reviews | 0.15.1, 0.15.3, 0.17.1, 0.18 | geometry + highlight caches capped |
+| Inline context expansion (`z`, `▾ N unchanged lines`) | 0.14.0 | read around a finding without leaving the review |
+| Open file in `$EDITOR` (`e`), incl. line numbers | 0.13.0, 0.15.1, 0.17.0 | jump from a finding straight to the fix |
+| `,` / `.` file navigation, `g`/`G` | 0.13.0 | faster movement between findings |
+| Moved-line highlighting (`colorMoved`) | 0.15.0 | refactor noise separated from real changes |
+| Themes: default `github-dark-default`, `t` selector, Catppuccin/Zenburn, custom palettes | 0.14.0–0.16.0 | |
+| Mouse-drag selection + OSC 52 copy | 0.14.0 | copy a finding out of the TUI |
+| Configurable `[keybindings]`, Extensions menu | 0.18.0 | every command we register is user-remappable |
+| Windows launches from Cygwin / Git Bash / WSL | 0.15.3 | see "Windows" below |
+| Session daemon hardening (Host/Origin validation, body caps, timeouts) | 0.13.1, 0.15.1 | prerequisite for the live-session work below |
+| CJK / emoji alignment, wrapping, selection | 0.14.0–0.17.6 | |
+
+## The Kodus findings sidebar
+
+`kodus review` now spawns hunk with `--extension <pkg>/hunk-extension/kodus`
+and hands the extension a structured sidecar through `KODUS_HUNK_FINDINGS`.
+
+Why a second sidecar rather than reusing `--agent-context`: that payload is
+hunk's own inline-note schema, and it flattens severity into a glyph inside a
+prose string. The sidebar needs severity back as data, so
+`features/review/hunk-findings.ts` writes `{file, line, endLine, severity,
+title, category, ruleId}` alongside it.
+
+What the pane does that hunk's inline notes don't: inline notes answer "what is
+wrong with this line?" once you are already looking at it. The pane answers
+what a file-ordered diff cannot — "what are the worst things in this changeset,
+and where?" — so it sorts **by severity, not by path**:
+
+```
+ Kodus · 3 findings
+ ‼1  ✖1  ℹ1
+ ‼ src/a.ts:3
+   eval() on a value derived from a hardcoded credential is remote code execution
+ ✖ src/a.ts:2
+   Hardcoded password committed to source
+ ℹ src/b.ts:2
+   Prefer const over let for a value that is never reassigned
+```
+
+Keys (defaults; remappable via hunk's `[keybindings]` as `kodus.*`):
+
+| Command | Key | Does |
+| --- | --- | --- |
+| `kodus.toggle` | `y` | show/hide the pane |
+| `kodus.next` | `n` | jump to the next finding, severity-first |
+| `kodus.previous` | `p` | previous finding |
+
+`n`/`p` are deliberately not hunk's `}` / `{` (next *annotated* hunk, document
+order): a `critical` three files down comes before an `info` in the current
+file.
+
+Implementation notes:
+
+- The pane is `defaultOpen` only when the review has findings — an empty panel
+  stealing width from the diff is worse than no panel. Hunk still owns pane
+  arrangement, so at narrow terminal widths it drops the sidebar area entirely
+  (the built-in file nav included); `y` or `s` brings it back.
+- Kodus reviews whole files while hunk only renders changed spans, so a finding
+  can land outside every hunk. `findHunkIndex` falls back to the nearest hunk
+  rather than refusing to navigate.
+- Path matching is exact-first with a path-segment suffix fallback, so a review
+  scoped to a subdirectory still resolves.
+- The pure logic lives in `hunk-extension/kodus/findings.ts` (no JSX, types
+  only) so it is unit-tested from `src/features/review/__tests__/`. The `.tsx`
+  entry sits outside `src/` so our `tsc` never compiles it — hunk runs it.
+- Verified end-to-end by driving the real TUI in a pty: pane renders, `y`
+  toggles, `n`/`p` walk findings and move the review stream.
+
+## Live validation (2026-08-04)
+
+Ran a real `kodus review` against the production API on this very changeset
+(13 files, ~10 min, `Found 3 issues in 13 files (1 critical)`), then drove the
+real TUI in a pty. It caught three things worth recording.
+
+**1. `getHooksDir()` fallback was wrong — Kody found it.**
+`git rev-parse --git-common-dir` prints an absolute path inside a linked
+worktree but a *cwd-relative* one in an ordinary checkout (`../../.git` from a
+nested directory). Resolving it against `--show-toplevel` climbed above the
+repo. Reproduced, fixed against `process.cwd()`, and covered by a new
+subdirectory case in `worktree-e2e.test.ts`.
+
+**2. `/cli/review` is not run through the severity normalizer.**
+`ReviewIssue.severity` is typed `Severity` (`info|warning|error|critical`) but
+the live endpoint returned `"high"`. `normalizeSeverity` is only wired into the
+*suggestions* path (`review-normalizer.ts`), never into `/cli/review`. Left
+unmapped, `high` sorted ahead of `critical` in the sidebar and rendered an
+undefined glyph. `convertReviewToHunkFindings` now normalizes, and the
+extension coerces defensively on its own side (the sidecar is a file on disk).
+The pre-existing `hunk-context.ts` degrades gracefully here, which is why the
+inline notes never showed the problem — worth normalizing at the API boundary
+instead, as a follow-up.
+
+**3. The `y` toggle did nothing on a narrow terminal.**
+Hunk drops the whole sidebar *area* when the diff is wide relative to the
+terminal, and an extension cannot ask whether the area is visible. With
+`defaultOpen: true` the view was nominally open, so `y` *closed* a pane the
+user had never seen. The first press now always `open()`s (which reveals the
+area); it toggles normally after that. Verified at 140 columns: one `y` reveals
+the pane.
+
+Also verified end-to-end with real API output: `--extension` reaches hunk, the
+`KODUS_HUNK_FINDINGS` sidecar is read, the pane renders `Kodus · 3 findings`
+with `‼1 ✖2`, and `n` walks findings severity-first while moving the review
+stream.
+
+### Open follow-up: `@opentui` peer mismatch
+
+Kody's third finding is real. `hunkdiff@0.18.0-beta.0` declares peers
+`@opentui/core ^0.4.3` / `@opentui/react ^0.4.3`, but pnpm's auto-install-peers
+resolved `0.1.107` — 12 MB in `node_modules` at a version that does not satisfy
+the range. No runtime impact: hunk ships a prebuilt binary (81 MB for
+darwin-arm64) with opentui compiled in, and it serves its own React/OpenTUI to
+extension files at import time, which the pty runs confirm. So this is install
+weight and a wrong type-resolution target for the extension's type-only
+`@opentui/core` import, not a correctness bug. Not touched here to avoid
+another lockfile churn; fix is either pinning `^0.4.x` explicitly or an
+`ignoreMissing` peer rule.
+
+## Inline notes: STML rewrite
+
+`--agent-context` notes were built as one wrapped paragraph, which is all the
+plain-text schema allows. Reviewing real output showed that shape was not just
+ugly — it lost content, in three independent ways, each found only after the
+previous fix. All three are now covered by invariant tests
+(`hunk-context.test.ts`) rather than formatting assertions, because this bug
+kept coming back through a different door.
+
+1. **The summary cap ate the message.** The first sentence became the note's
+   summary, capped at 140 chars with `…`, and the body started from the
+   *second* sentence — so the tail of any long first sentence existed nowhere.
+   The body now always carries the full text; the summary is just a label.
+2. **Code was reflowed as prose.** The API's `suggestion` is usually a patch.
+   `<code>` is verbatim, so the fix now gets its own block — but `code` *clips*
+   rather than wraps, so a prose lead-in placed there lost its tail. `splitAdvice`
+   separates the introducing sentence from the snippet.
+3. **Code blocks clip long lines.** Both `<code>` and `<pre>` truncate at the
+   pane edge with no ellipsis. `wrapCodeBlock` hard-wraps with a hanging indent
+   before emitting.
+
+   Picking that width took two attempts. A `columns / 2 - 8` estimate looked
+   reasonable and still clipped on a 238-column terminal. Measuring the real
+   interior by pushing a ruler through the live TUI explains why:
+
+   | terminal | usable | | terminal | usable |
+   | --- | --- | --- | --- | --- |
+   | 80 | 55 | | 160 | 61 |
+   | 100 | 75 | | 180 | 71 |
+   | 120 | 95 | | 200 | 85 |
+   | 140 | 119 | | 238 | 87 |
+   | | | | 300 | 114 |
+
+   It is not monotonic in terminal width: 238 is narrower than 140. Usable
+   width drops at 160 when hunk switches to a split diff, and drops again once
+   the sidebar area reappears and claims its share — plus the user can resize
+   panes by hand. `process.stdout.columns` predicts none of that, so the width
+   is now the STML guide's own ~56-column recommendation (52 after the frame),
+   relaxed only at the narrow end where the stack layout is predictable.
+   Wrapping early on a wide terminal is cosmetic; clipping loses text.
+
+Also fixed while reading real Kody-rule findings:
+
+- **Markdown leaked verbatim.** `[rule name](https://app.kodus.io/…)` rendered
+  as literal syntax with a 100-char URL wrapped mid-sentence, plus backslash
+  escapes (`exceções\.`). `extractMarkdownLinks` keeps the label inline and
+  moves the URL to a dim trailing paragraph. Note STML's `<a>` is *not* usable
+  here: it renders the label and discards the href entirely — no OSC 8 either —
+  so the URL has to survive as text.
+- **Severity was unnormalized here too**, so `high` produced no glyph and an
+  `info`-coloured badge.
+- **Raw UUID rule ids** were repeated in the attribution line next to the same
+  id inside the rule URL; UUID-shaped ids are now dropped, named ones kept.
+
+The plain-text `rationale` remains a complete fallback for when STML is
+rejected or `--experimental` is absent.
+
+## Recommended next steps
+
+### 1. Live session round-trip
+
+Since 0.13 hunk runs a local session daemon with a full control surface:
+
+```
+hunk session list | get | context | review [--json] [--include-patch]
+hunk session navigate --repo . --file <p> (--hunk n | --new-line n)
+hunk session reload   --repo . -- diff <target> [-- <pathspec>]
+hunk session comment  add | apply --stdin | list [--type user] | rm | clear
+```
+
+Verified working: launched `hunk diff` in a pty, pushed a finding with
+`comment apply --stdin --focus`, read it back with `comment list` and
+`session review --json`.
+
+Two wins:
+
+- **Push findings into an already-open hunk instead of spawning a nested TUI.**
+  Today `kodus review` blocks until the whole review lands, then takes over the
+  terminal. Instead: if `hunk session get --repo <root>` resolves, stream each
+  finding in as it arrives. Also fixes the "I already have hunk open" case.
+- **Read the human's notes back out.** `comment list --type user` returns
+  human-authored inline notes — that closes the loop for `kodus fix`: review in
+  hunk, mark what you actually want fixed, and `kodus fix` acts on exactly
+  those instead of guessing. Today the hand-off is one-way.
+
+### 2. Deepen the sidebar
+
+Now that the extension exists, cheap additions on the same API:
+
+- `ctx.dialogs.confirm` + a `kodus.fix` command to send the selected finding to
+  `kodus fix` without leaving the review.
+- Dismiss/accept state per finding, surfaced back to the API on exit.
+- `transformChangeset` to collapse files with no findings when a review is
+  large.
+
+### 3. Ship hunk's agent skill through `kodus skills`
+
+`hunk skill path` prints a bundled `hunk-review/SKILL.md` teaching an agent to
+drive a live session. We already have a skills sync pipeline
+(`utils/skills-sync*.ts`); re-exporting it lets Claude/Codex narrate a Kodus
+review inside the user's open hunk window.
+
+### 4. Revisit STML when it stabilizes
+
+Shipped now (see "Inline notes" above), but behind hunk's `--experimental`
+flag and an explicitly unstable tag vocabulary. When STML leaves experimental,
+re-check the note layout against whatever the tag set has become, and drop
+`wrapCodeBlock` if `code` gains real wrapping.
+
+### 5. Windows
+
+`isHunkPlatformSupported()` returns `false` for `win32` with a comment claiming
+hunkdiff ships no Windows binary. That is **not accurate** —
+`hunkdiff-windows-x64` has been an optional dependency since at least 0.12.1,
+and 0.15.3 fixed launches from Cygwin / Git Bash / WSL-style paths. Left
+disabled because we have no Windows machine to verify on; flipping it (gated to
+`x64`) should be a small, separately-tested change.
+
+## Risk of the beta pin
+
+`0.18.0-beta.0` is the `beta` dist-tag, not `latest`. The extension API is
+explicitly experimental — "the `hunkdiff/extension` surface may change in
+breaking ways between minor releases while it stabilizes" — and `hunk.apiVersion`
+(currently `2`) identifies the generation an extension was written against.
+
+Containment already in place:
+
+- A broken extension is skipped with a startup notice; a component that throws
+  costs the pane, not the session. Review still works.
+- `resolveKodusExtensionDir()` returns null when the folder is absent, and
+  `buildHunkArgs` simply omits `--extension` — so a build without it degrades
+  to plain hunk.
+
+Still worth doing before a release: pin the exact version (no `^`), and re-run
+the pty smoke test on every hunkdiff bump.
+
+## Unrelated bug found while auditing
+
+`services/git-hooks.service.ts` installs a `prepare-commit-msg` hook that looks
+for sessions in `$(git rev-parse --git-common-dir)/kody-sessions`, but
+`services/session-local.service.ts` writes them to `<repoRoot>/.kody/sessions`.
+Nothing writes `kody-sessions`, so the `Kody-Checkpoint:` trailer never fires.
+The service also has no production caller — only tests reference it. Needs a
+decision: wire it up against the real session dir, or delete it.


### PR DESCRIPTION
## Why

Three things, all found or confirmed by running the CLI for real rather than from tests alone.

**The CLI did not work in a git worktree.** `kodus hook install` crashed with `ENOTDIR` and the other hook commands reported the hook as missing, because they joined `.git/hooks` onto the worktree root — inside a linked worktree `.git` is a *file*.

**Hunk had moved a long way.** We were pinned to `hunkdiff@0.12.1` (May); upstream is at 0.18 with an extension API, a session daemon, and large performance work.

**Inline notes were losing text.** Not just cramped — content was being dropped, in three independent ways.

## What changed

### Worktree fix
Hook paths resolve through `git rev-parse --path-format=absolute --git-path hooks`, which handles the shared common dir *and* `core.hooksPath`. The pre-2.31 fallback resolves `--git-common-dir` against the cwd, not the toplevel — that output is cwd-relative in an ordinary checkout, so the old form climbed above the repo from a subdirectory.

### hunk 0.12.1 → 0.18.0-beta.0
The `beta` dist-tag, not `latest` (0.17.7), because the extension API only exists in 0.18. Free wins: ~100–1000× faster scrolling in large reviews, inline context expansion (`z`), open-in-`$EDITOR` (`e`), moved-line highlighting, theme selector.

`--branch`, `--commit` and explicit file arguments now open the TUI instead of falling back to the legacy list — hunk understands `hunk diff <range>`, `hunk show <ref>` and `-- <pathspec...>`.

### Kodus findings sidebar
A bundled hunk extension (`apps/cli/hunk-extension/kodus`) loaded with `--extension`. Inline notes answer "what is wrong with this line?" once you're already there; the pane answers what a file-ordered diff can't — "what are the worst things in this changeset, and where?" — so it sorts by severity, not path. `y` toggles, `n`/`p` walk findings severity-first while moving the review stream.

```
 Kodus · 3 findings
 ‼1  ✖2
 ‼ …/hunk-viewer.ts:190
   Swallowing the `unlink` failure here hides cleanup problems…
```

### Readable notes (STML)
Bodies are now STML blocks — severity badge, explanation, fix, suggested code — instead of one reflowed paragraph. Markdown links, backslash escapes and duplicated UUID rule ids are cleaned up.

## Bugs this surfaced in our own code

A real `kodus review` against production, on this branch's own diff, reported 3 findings — two of them real bugs in the change under review:

- The `getHooksDir()` fallback resolved `--git-common-dir` against the toplevel instead of the cwd. Reproduced and fixed.
- `/cli/review` never runs the severity normalizer, so the API's `high` reaches the viewer verbatim despite the `Severity` type. It sorted ahead of `critical` and rendered an undefined glyph. Normalized at both surfaces; **normalizing at the API boundary instead is worth a follow-up.**

## Testing

- 808 unit/e2e tests pass; new e2e drives the built CLI inside a real worktree, including from a nested subdirectory.
- The sidebar, key bindings and note rendering were verified by driving the real TUI in a pty at several terminal widths, and against real API output.
- Note tests assert invariants (no width may drop a character; the full message must appear in both `rationale` and `markup`) rather than formatting, because the text-loss bug returned three times through different doors.

## Risk

`0.18.0-beta.0` is a beta tag and the extension API is explicitly experimental. Contained: a missing extension folder just omits `--extension`, a broken extension is skipped by hunk with a startup notice, and rejected markup falls back to plain text. The version is pinned exactly. Re-run the pty smoke test on every hunkdiff bump.

## Known limitations

- Hunk drops the entire sidebar area below ~220 columns and no registered view can reopen it; the extension emits a startup toast naming the key instead.
- Code blocks are wrapped at spawn time against a conservative width, because the note's real interior is not derivable from terminal columns (it depends on layout mode, sidebar visibility and manual pane resizing — 238 columns is narrower than 140). Resizing with hunk already open does not re-wrap.
- `@opentui` peers resolve to 0.1.107 against hunkdiff's declared `^0.4.3`. No runtime impact — hunk's prebuilt binary bundles its own — but it is 12 MB of dead weight. Left for a follow-up to avoid another lockfile churn.

Notes and follow-ups are written up in `docs-internal/plans/2026-08-04-cli-hunk-upgrade.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)