### PR TITLE
fix(kody-rules): discover .agents/rules/** rule files

### DIFF
--- a/apps/web/src/core/utils/kody-rules/infer-origin.spec.ts
+++ b/apps/web/src/core/utils/kody-rules/infer-origin.spec.ts
@@ -1,0 +1,31 @@
+import { inferRuleOrigin, isIdeRuleSource } from "./infer-origin";
+
+describe("inferRuleOrigin — .agents/rules discovery", () => {
+    it("ships the .agents/rules/** pattern in the web mirror list", () => {
+        expect(isIdeRuleSource(".agents/rules/architecture.md")).toBe(true);
+    });
+
+    it("recognises nested .agents/rules files (monorepo subdir)", () => {
+        expect(
+            isIdeRuleSource("applications/sales/.agents/rules/style.md"),
+        ).toBe(true);
+    });
+
+    it("classifies a repo-root .agents/rules file as Auto-sync", () => {
+        expect(
+            inferRuleOrigin({
+                origin: null,
+                sourcePath: ".agents/rules/architecture.md",
+            }),
+        ).toBe("Auto-sync");
+    });
+
+    it("classifies a nested .agents/rules file as Auto-sync", () => {
+        expect(
+            inferRuleOrigin({
+                origin: null,
+                sourcePath: "applications/sales/.agents/rules/style.md",
+            }),
+        ).toBe("Auto-sync");
+    });
+});

--- a/apps/web/src/core/utils/kody-rules/infer-origin.ts
+++ b/apps/web/src/core/utils/kody-rules/infer-origin.ts
@@ -25,6 +25,7 @@ const IDE_RULE_SOURCE_PATTERNS: RegExp[] = [
     /(?:^|\/)\.github\/instructions\//i,
     /(?:^|\/)AGENTS\.md$/i,
     /(?:^|\/)\.agents?\.md$/i,
+    /(?:^|\/)\.agents\/rules\//i,
     /(?:^|\/)CLAUDE\.md$/i,
     /(?:^|\/)\.claude\//i,
     /(?:^|\/)\.windsurfrules$/i,

--- a/libs/common/utils/kody-rules/file-patterns.spec.ts
+++ b/libs/common/utils/kody-rules/file-patterns.spec.ts
@@ -1,0 +1,35 @@
+import {
+    isIdeRuleSource,
+    RULE_FILE_PATTERNS,
+    extractRepoSubdirFromIdeSource,
+} from './file-patterns';
+
+describe('file-patterns — .agents/rules discovery', () => {
+    it('ships the .agents/rules/** pattern in RULE_FILE_PATTERNS', () => {
+        expect(RULE_FILE_PATTERNS).toContain('.agents/rules/**');
+    });
+
+    it('recognises repo-root .agents/rules files as IDE rule sources', () => {
+        expect(isIdeRuleSource('.agents/rules/architecture.md')).toBe(true);
+    });
+
+    it('recognises nested .agents/rules files (monorepo subdir)', () => {
+        expect(
+            isIdeRuleSource('applications/sales/.agents/rules/style.md'),
+        ).toBe(true);
+    });
+
+    it('scopes a nested .agents/rules source to its repo subdir', () => {
+        expect(
+            extractRepoSubdirFromIdeSource(
+                'applications/sales/.agents/rules/style.md',
+            ),
+        ).toBe('applications/sales');
+    });
+
+    it('treats a repo-root .agents/rules file as repo-wide', () => {
+        expect(extractRepoSubdirFromIdeSource('.agents/rules/style.md')).toBe(
+            null,
+        );
+    });
+});

--- a/libs/common/utils/kody-rules/file-patterns.ts
+++ b/libs/common/utils/kody-rules/file-patterns.ts
@@ -18,6 +18,7 @@ export const RULE_FILE_PATTERNS = [
     'AGENTS.md',
     '.agents.md',
     '.agent.md',
+    '.agents/rules/**',
 
     // Claude
     'CLAUDE.md',

--- a/libs/core/infrastructure/database/mongo/kody-rules/migrate-origin-request-type.spec.ts
+++ b/libs/core/infrastructure/database/mongo/kody-rules/migrate-origin-request-type.spec.ts
@@ -1,0 +1,24 @@
+import { migrateRule } from './migrate-origin-request-type';
+
+describe('migrateRule — .agents/rules origin mapping', () => {
+    it('maps a legacy rule with a .agents/rules sourcePath to repo_file_sync', () => {
+        const rule = { origin: 'user', sourcePath: '.agents/rules/architecture.md' };
+        expect(migrateRule(rule)?.origin).toBe('repo_file_sync');
+    });
+
+    it('maps a nested .agents/rules sourcePath to repo_file_sync', () => {
+        const rule = {
+            origin: 'user',
+            sourcePath: 'applications/sales/.agents/rules/style.md',
+        };
+        expect(migrateRule(rule)?.origin).toBe('repo_file_sync');
+    });
+
+    it('leaves an already-migrated .agents/rules rule untouched', () => {
+        const rule = {
+            origin: 'repo_file_sync',
+            sourcePath: '.agents/rules/architecture.md',
+        };
+        expect(migrateRule(rule)).toBeNull();
+    });
+});

--- a/libs/core/infrastructure/database/mongo/kody-rules/migrate-origin-request-type.spec.ts
+++ b/libs/core/infrastructure/database/mongo/kody-rules/migrate-origin-request-type.spec.ts
@@ -14,6 +14,14 @@ describe('migrateRule — .agents/rules origin mapping', () => {
         expect(migrateRule(rule)?.origin).toBe('repo_file_sync');
     });
 
+    it('maps a case-variant .agents/rules sourcePath to repo_file_sync', () => {
+        const rule = {
+            origin: 'user',
+            sourcePath: '.AGENTS/RULES/architecture.md',
+        };
+        expect(migrateRule(rule)?.origin).toBe('repo_file_sync');
+    });
+
     it('leaves an already-migrated .agents/rules rule untouched', () => {
         const rule = {
             origin: 'repo_file_sync',

--- a/libs/core/infrastructure/database/mongo/kody-rules/migrate-origin-request-type.ts
+++ b/libs/core/infrastructure/database/mongo/kody-rules/migrate-origin-request-type.ts
@@ -42,6 +42,7 @@ const IDE_RULE_SOURCE_PATTERNS: RegExp[] = [
     /(?:^|\/)\.github\/copilot-instructions\.md$/,
     /(?:^|\/)\.github\/instructions\//,
     /(?:^|\/)\.agents?\.md$/,
+    /(?:^|\/)\.agents\/rules\//,
     /(?:^|\/)CLAUDE\.md$/,
     /(?:^|\/)\.claude\//,
     /(?:^|\/)\.windsurfrules$/,

--- a/libs/core/infrastructure/database/mongo/kody-rules/migrate-origin-request-type.ts
+++ b/libs/core/infrastructure/database/mongo/kody-rules/migrate-origin-request-type.ts
@@ -42,7 +42,7 @@ const IDE_RULE_SOURCE_PATTERNS: RegExp[] = [
     /(?:^|\/)\.github\/copilot-instructions\.md$/,
     /(?:^|\/)\.github\/instructions\//,
     /(?:^|\/)\.agents?\.md$/,
-    /(?:^|\/)\.agents\/rules\//,
+    /(?:^|\/)\.agents\/rules\//i,
     /(?:^|\/)CLAUDE\.md$/,
     /(?:^|\/)\.claude\//,
     /(?:^|\/)\.windsurfrules$/,


### PR DESCRIPTION
Fixes #1539

## Problem

The IDE rules auto-sync never discovers rule files under `.agents/rules/**`. `RULE_FILE_PATTERNS` in `libs/common/utils/kody-rules/file-patterns.ts` covers `AGENTS.md`, `.agents.md`, `.agent.md`, `.cursor/rules/**/*.mdc`, `.rules/**/*`, `.kody/rules/**`, etc., but has no pattern for the `.agents/rules/` directory convention — files there are silently skipped by the sync.

## Change

Add `.agents/rules/**` to `RULE_FILE_PATTERNS`. Everything else derives automatically from the list at module load, so no other code changes are needed:

- `RULE_FILE_DISCOVERY_PATTERNS` gets the `**/`-prefixed variant for monorepo subdirectories
- `IDE_RULE_DIR_MARKERS` picks up `.agents/rules` for subdir scoping in `extractRepoSubdirFromIdeSource`
- `pathMatchesIdeRuleDir` / `validateAndScopeIdeRulePath` reject IDE-path hallucinations against the new marker

## Testing

Added `libs/common/utils/kody-rules/file-patterns.spec.ts` (5 tests):

- pattern is present in `RULE_FILE_PATTERNS`
- repo-root `.agents/rules/*.md` recognized as an IDE rule source
- nested `applications/sales/.agents/rules/*.md` recognized (monorepo subdir)
- nested source scopes to its repo subdir
- repo-root source stays repo-wide

TDD: the three discovery tests failed before the fix (`isIdeRuleSource` returned false for `.agents/rules` paths) and pass after. `jest libs/common/utils/kody-rules/` — 5 passed.
