### PR TITLE
fix(github): fail fast + requeue on rate limit instead of sleeping silently (+ split e2e account by license)

### DIFF
--- a/.github/workflows/e2e-cloud.yml
+++ b/.github/workflows/e2e-cloud.yml
@@ -238,13 +238,6 @@ jobs:
                   echo "::error::QA backend never settled (app-ready + expected build, $NEED_OK consecutive) in ~15min — aborting before the matrix to avoid deploy-race false failures."
                   exit 1
 
-            # Stamp the run deadline (now + the runner STEP's 135-min timeout,
-            # the bound the matrix actually runs under) as an epoch the runner
-            # reads for its retry budget gate (shouldRetryFailure). Set right
-            # before the step so "now" ≈ the step start.
-            - name: Record run deadline for the retry budget gate
-              run: echo "E2E_DEADLINE_EPOCH_MS=$(( ($(date +%s) + 8100) * 1000 ))" >> "$GITHUB_ENV"
-
             - name: Run cloud matrix
               id: matrix
               # Deliberately BELOW the job's timeout-minutes. When the JOB

--- a/.github/workflows/e2e-self-hosted-matrix.yml
+++ b/.github/workflows/e2e-self-hosted-matrix.yml
@@ -112,14 +112,6 @@ jobs:
             matrix:
                 cell: ${{ fromJson(needs.plan.outputs.cells) }}
         steps:
-            # Stamp the run deadline (job start + the 60-min job timeout) as an
-            # epoch the matrix runner reads for its retry budget gate
-            # (shouldRetryFailure). MUST be the first step: ~7min provisioning +
-            # checkout/install run before the runner but still burn the 60-min
-            # job budget, so measuring from runMatrix entry would undercount.
-            - name: Record run deadline for the retry budget gate
-              run: echo "E2E_DEADLINE_EPOCH_MS=$(( ($(date +%s) + 3600) * 1000 ))" >> "$GITHUB_ENV"
-
             - name: Checkout monorepo
               uses: actions/checkout@v6.0.2
 

--- a/.github/workflows/e2e-self-hosted-matrix.yml
+++ b/.github/workflows/e2e-self-hosted-matrix.yml
@@ -171,9 +171,16 @@ jobs:
                   # pool above. The self-hosted product uses this for all its
                   # own GitHub calls (read diff/files, post comments) — pinning
                   # it to GH_TEST_TOKEN meant product + harness drained one
-                  # account and tripped the rate limit mid-cell. Falls back to
-                  # GH_TEST_TOKEN when unset (see github.ts authToken()).
-                  GH_INTEGRATION_TOKEN: ${{ secrets.GH_INTEGRATION_TOKEN }}
+                  # account and tripped the rate limit mid-cell.
+                  #
+                  # Split by license so the two github cells don't share ONE
+                  # product account: the license-paid cell (heavy — ~13 review
+                  # scenarios, several multi-PR) gets its own bot, license-free
+                  # keeps GH_INTEGRATION_TOKEN. Falls back to GH_INTEGRATION_TOKEN
+                  # when GH_INTEGRATION_TOKEN_PAID is unset (graceful until the
+                  # secret is added), and to GH_TEST_TOKEN when both are unset
+                  # (see github.ts authToken()).
+                  GH_INTEGRATION_TOKEN: ${{ (matrix.cell.license == 'license-paid' && secrets.GH_INTEGRATION_TOKEN_PAID) || secrets.GH_INTEGRATION_TOKEN }}
                   GH_TEST_REPO: ${{ secrets.GH_TEST_REPO }}
                   GH_TEST_PR_NUMBER: ${{ secrets.GH_TEST_PR_NUMBER }}
 

--- a/libs/automation/webhook-processing/webhook-processing-job.processor.ts
+++ b/libs/automation/webhook-processing/webhook-processing-job.processor.ts
@@ -17,6 +17,8 @@ import {
     WORKFLOW_JOB_REPOSITORY_TOKEN,
 } from '@libs/core/workflow/domain/contracts/workflow-job.repository.contract';
 import { raceWithAbortSignal } from '@libs/core/workflow/infrastructure/abort-signal-race';
+import { classifyGitHubError } from '@libs/core/workflow/domain/errors/classify-github-error';
+import { isRateLimitError } from '@libs/core/workflow/domain/errors/rate-limit.error';
 
 /**
  * Processor for WEBHOOK_PROCESSING jobs
@@ -172,12 +174,21 @@ export class WebhookProcessingJobProcessorService implements IJobProcessorServic
                         result: 'Processed',
                     },
                 });
-            } catch (error) {
+            } catch (rawError) {
+                // Wrap octokit 403/429 in RateLimitError (else pass through) so
+                // the consumer error handler re-queues with a delay aligned to
+                // the bucket reset instead of DLQ'ing it as PERMANENT. Before
+                // this, a rate-limited webhook (the product's GitHub account out
+                // of quota) was marked PERMANENT and the review was silently
+                // LOST — matching the octokit throttle that used to sleep the
+                // whole reset window inside the call. Both are fixed together.
+                const error = classifyGitHubError(rawError) as Error;
+                const rateLimited = isRateLimitError(error);
                 const errorMessage =
                     error instanceof Error ? error.message : String(error);
 
                 this.logger.error({
-                    message: `WEBHOOK_PROCESSING job ${jobId} failed`,
+                    message: `WEBHOOK_PROCESSING job ${jobId} failed${rateLimited ? ' (GitHub rate limit — will retry after reset)' : ''}`,
                     context: WebhookProcessingJobProcessorService.name,
                     error: error instanceof Error ? error : undefined,
                     metadata: {
@@ -185,15 +196,21 @@ export class WebhookProcessingJobProcessorService implements IJobProcessorServic
                         correlationId: job.correlationId,
                         platformType: job.metadata?.platformType,
                         event: job.metadata?.event,
+                        rateLimited,
                     },
                 });
 
                 await this.jobRepository.update(jobId, {
                     status: JobStatus.FAILED,
-                    errorClassification: ErrorClassification.PERMANENT,
+                    errorClassification: rateLimited
+                        ? ErrorClassification.RATE_LIMITED
+                        : ErrorClassification.PERMANENT,
                     lastError: errorMessage,
                 });
 
+                // Throw the CLASSIFIED error so RabbitMQErrorHandler sees the
+                // typed RateLimitError and applies the smart (reset-aligned)
+                // re-queue delay — not the raw octokit shape.
                 throw error;
             }
         };

--- a/libs/code-review/infrastructure/agents/collaborators/context-fit-planner.ts
+++ b/libs/code-review/infrastructure/agents/collaborators/context-fit-planner.ts
@@ -64,7 +64,7 @@ export const LARGE_PR_AGGRESSIVE_FILTER_PATTERNS = [
  * tool schemas + coverage list + PR context) already exceeds the
  * model's context window, no PR can ever fit and the LLM call would
  * fail immediately with a 4xx. Without this check the agent silently
- * hangs until AGENT_TIMEOUT_MS (20 min) — see runAgentLoop's setTimeout
+ * hangs until AGENT_TIMEOUT_MS (30 min) — see runAgentLoop's setTimeout
  * — burning a queue slot and producing zero output.
  *
  * Exported so it can be unit-tested in isolation. Called from

--- a/libs/code-review/infrastructure/agents/providers/base-code-review-agent.provider.ts
+++ b/libs/code-review/infrastructure/agents/providers/base-code-review-agent.provider.ts
@@ -253,7 +253,7 @@ export abstract class BaseCodeReviewAgentProvider {
         };
         // Fail fast when the configured model's context window cannot
         // even hold the agent's static overhead. Without this, the loop
-        // would run to AGENT_TIMEOUT_MS (20 min) while the LLM 400s on
+        // would run to AGENT_TIMEOUT_MS (30 min) while the LLM 400s on
         // every retry — see runAgentLoop. Surfaces as CONTEXT_OVERFLOW
         // via classifyLLMError → friendlyMessage on lastReviewError.
         assertContextWindowFitsOverhead({

--- a/libs/llm/agent-run-context.ts
+++ b/libs/llm/agent-run-context.ts
@@ -25,7 +25,7 @@ export function createAgentRunContext(params: {
     runId: string;
     /** Caller signal (workflow/router timeout) — cancellation propagates in. */
     parentSignal?: AbortSignal;
-    /** Hard ceiling per agent. Defaults to AGENT_TIMEOUT_MS (20 min). */
+    /** Hard ceiling per agent. Defaults to AGENT_TIMEOUT_MS (30 min). */
     timeoutMs?: number;
 }): AgentRunContext {
     const controller = new AbortController();

--- a/libs/llm/byok-to-vercel.ts
+++ b/libs/llm/byok-to-vercel.ts
@@ -18,50 +18,6 @@ import {
     BYOKProvider,
 } from '@kodus/kodus-common/llm';
 import { decrypt } from '@libs/common/utils/crypto';
-import { createLogger } from '@libs/core/log/logger';
-
-const rateLimitLogger = createLogger('LlmRateLimit');
-// Process-wide counters so a run can see the aggregate at a glance.
-let rateLimitHits = 0;
-let overloadHits = 0;
-
-/**
- * Pass-through fetch that surfaces provider back-pressure (HTTP 429 rate
- * limits, 503 overloads) as structured WARN logs. The Vercel AI SDK retries
- * these internally (maxRetries: 3, exponential backoff), so they NEVER reach
- * the caller as errors — they show up only as extra wall-clock. Under a
- * parallel workload hammering one account (e.g. the E2E matrix on a shared
- * OpenAI key) that backoff can stretch a single model call past the agent
- * budget; this is how we tell "the review is slow because it's being
- * throttled" apart from "the model is just slow". Behaviour-neutral: reads
- * only status + headers and returns the response untouched (never the body).
- */
-export const instrumentedFetch: typeof globalThis.fetch = async (
-    input,
-    init,
-) => {
-    const res = await globalThis.fetch(input as any, init as any);
-    if (res.status === 429 || res.status === 503) {
-        const kind = res.status === 429 ? 'rate_limit' : 'overloaded';
-        const n =
-            res.status === 429 ? (rateLimitHits += 1) : (overloadHits += 1);
-        rateLimitLogger.warn({
-            message: `[llm-backpressure] HTTP ${res.status} (${kind}) from model provider — SDK will back off + retry`,
-            context: 'LlmRateLimit',
-            metadata: {
-                status: res.status,
-                kind,
-                retryAfter: res.headers.get('retry-after') ?? undefined,
-                url:
-                    typeof input === 'string'
-                        ? input
-                        : (input as any)?.url,
-                processHitsForKind: n,
-            },
-        });
-    }
-    return res;
-};
 
 /**
  * Build a Vercel AI SDK model from a base64-encoded Google Service Account
@@ -400,7 +356,6 @@ export function byokToVercelModel(
                     baseURL: openaiBaseURL || 'https://api.openai.com/v1',
                     supportsStructuredOutputs:
                         options.structuredOutputs === true,
-                    fetch: instrumentedFetch,
                 })(envMode);
             }
             // self-hosted mode declared but no usable env key — fall through
@@ -441,7 +396,6 @@ export function byokToVercelModel(
             return createOpenAI({
                 apiKey,
                 ...(baseURL ? { baseURL } : {}),
-                fetch: instrumentedFetch,
             })(model);
 
         case BYOKProvider.ANTHROPIC:

--- a/libs/llm/llm-call.timeout.spec.ts
+++ b/libs/llm/llm-call.timeout.spec.ts
@@ -7,11 +7,8 @@ import {
 
 describe('llm-call timeout primitives', () => {
     describe('AGENT_TIMEOUT_MS contract', () => {
-        it('caps a single agent at exactly 20 minutes', () => {
-            // Lowered from 30 min so a slow review aborts + posts before the
-            // E2E command-review poll window (25 min) gives up. See
-            // fix/review-timeout-robustness and the invariant on the constant.
-            expect(AGENT_TIMEOUT_MS).toBe(20 * 60 * 1000);
+        it('caps a single agent at exactly 30 minutes', () => {
+            expect(AGENT_TIMEOUT_MS).toBe(30 * 60 * 1000);
         });
 
         it('caps a single LLM call at exactly 10 minutes', () => {
@@ -39,7 +36,7 @@ describe('llm-call timeout primitives', () => {
             expect(signal.aborted).toBe(true);
         });
 
-        it('produces an aborted signal after AGENT_TIMEOUT_MS (20min)', () => {
+        it('produces an aborted signal after AGENT_TIMEOUT_MS (30min)', () => {
             const signal = timeoutSignal(AGENT_TIMEOUT_MS);
             jest.advanceTimersByTime(AGENT_TIMEOUT_MS);
             expect(signal.aborted).toBe(true);
@@ -116,8 +113,8 @@ describe('llm-call timeout primitives', () => {
             await expect(wrapped).rejects.toThrow('inner-fail');
         });
 
-        it('uses AGENT_TIMEOUT_MS as the contract for a 20-minute agent run', async () => {
-            // End-to-end: a 20-min budget + 5s grace ⇒ rejects at 20:05.
+        it('uses AGENT_TIMEOUT_MS as the contract for a 30-minute agent run', async () => {
+            // End-to-end: a 30-min budget + 5s grace ⇒ rejects at 30:05.
             const inner = new Promise<never>(() => {});
             const wrapped = hardTimeout(
                 inner,
@@ -131,8 +128,8 @@ describe('llm-call timeout primitives', () => {
             const err = await result;
             expect((err as Error).message).toContain('[HARD-TIMEOUT]');
             expect((err as Error).message).toContain('agent-loop');
-            // 20 minutes = 1200 seconds
-            expect((err as Error).message).toContain('1200s');
+            // 30 minutes = 1800 seconds
+            expect((err as Error).message).toContain('1800s');
         });
     });
 });

--- a/libs/llm/llm-call.ts
+++ b/libs/llm/llm-call.ts
@@ -9,16 +9,7 @@
  */
 import { generateText as _aiSdkGenerateText } from 'ai';
 
-// 20 minutes max per agent. This is the wall-clock ceiling for a whole
-// agent run (the sum of its sequential model calls), NOT a single call —
-// that's LLM_CALL_TIMEOUT_MS below. It MUST stay below the slowest
-// consumer's patience so a long review aborts and still reaches the
-// posting stages (finish-comments) instead of being cut off mid-run with
-// nothing posted. Concretely it must be < the E2E command-review poll
-// window (1500s / 25 min in command-review-focus.ts) — otherwise a slow
-// review reads as "no review posted" and the whole matrix job times out.
-// Lowered from 30 min for exactly that reason (fix/review-timeout-robustness).
-export const AGENT_TIMEOUT_MS = 20 * 60 * 1000;
+export const AGENT_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes max per agent
 // 10 minutes per individual LLM call — matches the undici headersTimeout
 // set in the worker bootstrap so neither layer aborts the other. Large
 // Gemini calls (>500K prompt + high reasoning) can legitimately take

--- a/libs/platform/infrastructure/adapters/services/github/github.service.ts
+++ b/libs/platform/infrastructure/adapters/services/github/github.service.ts
@@ -2947,27 +2947,63 @@ export class GithubService
                         doNotRetry: [400, 401, 403, 404, 422, 451],
                     },
                     throttle: {
+                        // NEVER sleep inside the octokit call (mirrors the App
+                        // path above). A primary-rate-limit retryAfter is the
+                        // time until the hourly bucket resets — up to ~59 min.
+                        // Returning `true` made octokit sleep that whole window
+                        // holding the worker slot; the webhook job's own 9-min
+                        // watchdog then killed it with ZERO user-facing signal,
+                        // so the review just vanished. Return false → the 403
+                        // throws immediately → the processor converts it to
+                        // RateLimitError(resetAt) and the RabbitMQ error handler
+                        // republishes the job aligned to the reset. A review
+                        // that can't reach GitHub must surface a clear error,
+                        // not hang silently.
                         onRateLimit: (
-                            _retryAfter,
+                            retryAfter,
                             options: { method: string; url: string },
                             octokit,
                         ) => {
                             octokit.log.warn(
-                                `Request quota exhausted for request ${options.method} ${options.url}`,
+                                `RATE-LIMIT: ${options.method} ${options.url} — retryAfter=${retryAfter}s (failing fast, not sleeping)`,
                             );
-
-                            return true;
+                            this.logger.warn({
+                                message: `GitHub primary rate limit — failing fast (retryAfter=${retryAfter}s) so the review surfaces a clear error instead of hanging silently`,
+                                context: GithubService.name,
+                                serviceName: 'GithubService',
+                                metadata: {
+                                    method: options.method,
+                                    url: options.url,
+                                    retryAfter,
+                                    organizationId:
+                                        organizationAndTeamData?.organizationId,
+                                    teamId: organizationAndTeamData?.teamId,
+                                },
+                            });
+                            return false;
                         },
                         onSecondaryRateLimit: (
-                            _retryAfter,
+                            retryAfter,
                             options: { method: string; url: string },
                             octokit,
                         ) => {
                             octokit.log.warn(
-                                `Secondary rate limit hit for request ${options.method} ${options.url}`,
+                                `SECONDARY-RATE-LIMIT: ${options.method} ${options.url} — wait=${retryAfter}s (failing fast)`,
                             );
-
-                            return true;
+                            this.logger.warn({
+                                message: `GitHub secondary rate limit — failing fast (wait=${retryAfter}s)`,
+                                context: GithubService.name,
+                                serviceName: 'GithubService',
+                                metadata: {
+                                    method: options.method,
+                                    url: options.url,
+                                    retryAfter,
+                                    organizationId:
+                                        organizationAndTeamData?.organizationId,
+                                    teamId: organizationAndTeamData?.teamId,
+                                },
+                            });
+                            return false;
                         },
                     },
                 });

--- a/tests/e2e/lib/__tests__/transient-failure.test.ts
+++ b/tests/e2e/lib/__tests__/transient-failure.test.ts
@@ -1,10 +1,6 @@
 import { strict as assert } from "node:assert";
 import { test } from "node:test";
-import {
-    absenceRetryDelayMs,
-    isTransientFailure,
-    shouldRetryFailure,
-} from "../runner.js";
+import { absenceRetryDelayMs, isTransientFailure } from "../runner.js";
 
 // The retry classifier decides which cell failures get ONE automatic
 // re-run. The split is ABSENCE/NETWORK (retry — a lost webhook or provider
@@ -67,60 +63,6 @@ test("absenceRetryDelayMs: review-never-started shapes get the 120s settle", () 
     for (const msg of absent) {
         assert.equal(absenceRetryDelayMs(msg), 120_000, msg.slice(0, 60));
     }
-});
-
-// shouldRetryFailure gates a transient-shaped failure on whether a WORST-CASE
-// second attempt (unconditional settle + a full scenario-timeout poll) still
-// finishes before the run deadline — not on a fraction of the scenario budget.
-// Absence failures surface at the poll ceiling, so a lost-webhook flake and a
-// slow review are indistinguishable by duration; the deciding factor is the
-// wall-clock left before the job/step deadline. Signature is
-// (message, scenarioTimeoutMs, nowMs, deadlineMs) — we pin now + deadline so the
-// tests are deterministic. See fix/review-timeout-robustness.
-const T = 1_000_000_000_000; // fixed "now" epoch
-const MIN = 60_000;
-const deadline60 = T + 60 * MIN; // a 60-min run window starting at T
-
-test("shouldRetryFailure: absence retries when a worst-case retry fits before the deadline", () => {
-    // kody-rules regression guard: 1200s scenario whose 720s poll is > 50% of
-    // its budget. Worst case = 120s settle + 1200s = 22min; early in a 60-min
-    // window it fits, so it MUST retry — the old fraction gate wrongly killed it.
-    const msg =
-        "Assertion failed: No review activity on PR https://x/-/merge_requests/74 within timeout";
-    assert.ok(shouldRetryFailure(msg, 1200 * 1000, T, deadline60));
-});
-
-test("shouldRetryFailure: absence does NOT retry when a worst-case retry would overrun the deadline", () => {
-    // The original command-review-focus failure: a 1800s scenario 36min into a
-    // 60-min window — a worst-case ~32min second attempt lands past the deadline.
-    const msg =
-        'Assertion failed: No review on PR/MR #8 within 1502s after posting "@kody review".';
-    assert.ok(isTransientFailure(msg), "shape is still transient");
-    assert.ok(!shouldRetryFailure(msg, 1800 * 1000, T + 36 * MIN, deadline60));
-});
-
-test("shouldRetryFailure: same slow scenario DOES retry early with the whole window ahead", () => {
-    const msg =
-        'Assertion failed: No review on PR/MR #8 within 1502s after posting "@kody review".';
-    assert.ok(shouldRetryFailure(msg, 1800 * 1000, T, deadline60));
-});
-
-test("shouldRetryFailure: a FAST-failing absence is still charged a full second attempt", () => {
-    // "within 60s" fails fast, but attempt-2 can run the full poll window, so the
-    // gate charges the scenario timeout — not the (tiny) first-attempt duration.
-    const msg =
-        "[provider:github] No kody-codereview status comment on PR #23 within 60s — review pipeline likely never started.";
-    assert.ok(isTransientFailure(msg), "fast absence is still a transient shape");
-    // Late in the job the worst-case retry overruns → no retry...
-    assert.ok(!shouldRetryFailure(msg, 1800 * 1000, T + 40 * MIN, deadline60));
-    // ...but early, the same fast failure retries.
-    assert.ok(shouldRetryFailure(msg, 1800 * 1000, T, deadline60));
-});
-
-test("shouldRetryFailure: deterministic mismatch never retries, even with the whole window ahead", () => {
-    const msg =
-        "Assertion failed: Expected NO real review for license=free but Kody posted one.";
-    assert.ok(!shouldRetryFailure(msg, 1800 * 1000, T, deadline60));
 });
 
 test("absenceRetryDelayMs: transport noise retries immediately (0ms)", () => {

--- a/tests/e2e/lib/runner.ts
+++ b/tests/e2e/lib/runner.ts
@@ -389,45 +389,6 @@ export function isTransientFailure(message: string): boolean {
     return TRANSIENT_FAILURE_PATTERNS.some((re) => re.test(message ?? ''));
 }
 
-// Absolute wall-clock deadline (epoch ms) by which THIS runner invocation must
-// finish. Set by the workflow as (deadline-clock start + the bounding timeout),
-// so the retry gate knows the REAL time left — INCLUDING the provisioning +
-// checkout + npm-install that run before runMatrix but still count against the
-// job timeout (measuring from runMatrix entry would undercount that setup). Each
-// workflow sets its own: the self-hosted matrix JOB is 60min, the cloud runner
-// STEP is 135min. Local/dev fallback: a fresh 60min from process start.
-export const RUN_DEADLINE_EPOCH_MS =
-    Number(process.env.E2E_DEADLINE_EPOCH_MS) || Date.now() + 60 * 60 * 1000;
-// Headroom left after the last permitted work for evidence upload + teardown
-// before the runner hits the hard timeout.
-export const RUN_DEADLINE_SAFETY_MS = 5 * 60 * 1000;
-
-// A poll-based absence ("No review … within timeout") surfaces at the POLL
-// CEILING, not "in seconds": a genuinely lost webhook AND a too-slow review both
-// fail only after the full poll window elapses, so attempt duration can't tell a
-// retryable flake from a deterministic slow review. What decides safety is
-// whether a second attempt still fits before the deadline — re-running is
-// harmful only when its wall-clock would overrun the job/step timeout (grey
-// "cancelled", no evidence). Gating on the real deadline (not a fraction of the
-// scenario budget) also keeps retries for scenarios whose poll window exceeds
-// half their budget (kody-rules: a 720s poll in a 1200s budget), i.e. exactly
-// the lost-webhook flake the retry exists for. See fix/review-timeout-robustness.
-export function shouldRetryFailure(
-    message: string,
-    scenarioTimeoutMs: number,
-    nowMs: number = Date.now(),
-    deadlineMs: number = RUN_DEADLINE_EPOCH_MS,
-): boolean {
-    if (!isTransientFailure(message)) return false;
-    // Charge the retry's WORST-CASE wall-clock: the unconditional absence settle
-    // (absenceRetryDelayMs) + a full second attempt (the runner caps each attempt
-    // at the scenario's timeoutSec). Charging the upper bound means a permitted
-    // retry can never overrun the deadline, even when attempt-1 failed fast but
-    // attempt-2 runs to the poll ceiling.
-    const worstCaseRetryMs = absenceRetryDelayMs(message) + scenarioTimeoutMs;
-    return nowMs + worstCaseRetryMs < deadlineMs - RUN_DEADLINE_SAFETY_MS;
-}
-
 // GitHub's primary rate limit is per ACCOUNT and resets hourly, so an
 // in-run retry can't clear it — re-running just burns more of the same
 // quota. When a cell fails purely because GitHub said "rate limit
@@ -806,38 +767,20 @@ export async function runMatrix(opts: RunOptions): Promise<RunOutcome> {
                         );
                         break;
                     }
-                    const scenarioTimeoutMs = (scenario.timeoutSec ?? 1800) * 1000;
-                    if (attempt === 1 && !opts.failFast) {
-                        if (shouldRetryFailure(e.message, scenarioTimeoutMs)) {
-                            retriedAfter = e.message;
-                            const settleMs = absenceRetryDelayMs(e.message);
-                            log.info(
-                                `RETRY ${cellLabel}: transient failure shape, re-running once${settleMs ? ` after a ${settleMs / 1000}s settle (absence shape — likely a deploy/worker rollout window)` : ''} (${e.message.slice(0, 160)})`,
-                            );
-                            if (settleMs) {
-                                await settle(settleMs);
-                            }
-                            continue;
+                    if (
+                        attempt === 1 &&
+                        !opts.failFast &&
+                        isTransientFailure(e.message)
+                    ) {
+                        retriedAfter = e.message;
+                        const settleMs = absenceRetryDelayMs(e.message);
+                        log.info(
+                            `RETRY ${cellLabel}: transient failure shape, re-running once${settleMs ? ` after a ${settleMs / 1000}s settle (absence shape — likely a deploy/worker rollout window)` : ''} (${e.message.slice(0, 160)})`,
+                        );
+                        if (settleMs) {
+                            await settle(settleMs);
                         }
-                        // Transient SHAPE, but a worst-case retry (settle + a full
-                        // second attempt) wouldn't finish before the job/step
-                        // deadline — stacking it risks a grey cancel with no
-                        // evidence. Say so (so it doesn't read as a missed retry)
-                        // and fail fast with evidence instead.
-                        if (isTransientFailure(e.message)) {
-                            const worstCaseMin = (
-                                (absenceRetryDelayMs(e.message) +
-                                    scenarioTimeoutMs) /
-                                60_000
-                            ).toFixed(0);
-                            const leftMin = (
-                                (RUN_DEADLINE_EPOCH_MS - Date.now()) /
-                                60_000
-                            ).toFixed(0);
-                            log.info(
-                                `NO-RETRY ${cellLabel}: transient shape but a worst-case retry (~${worstCaseMin}min) wouldn't fit the ~${leftMin}min left before the deadline — failing fast with evidence`,
-                            );
-                        }
+                        continue;
                     }
                     // Infra vs product: if the target itself is down, the
                     // result is INCONCLUSIVE (skipped), not a red product


### PR DESCRIPTION
## What this replaces

Reverts #1657 (first commit) and ships the **correct** fix. #1657 chased a wrong "review is LLM-slow" hypothesis (lowered the agent timeout, reworked the e2e retry gate). The real trigger, confirmed from matrix run 31040432619 worker evidence, was **GitHub API quota exhaustion** on the product's integration account — and the product reacting by **sleeping silently**.

## Root cause

When the product's GitHub PAT account runs out of API quota, the octokit throttling plugin was set to **sleep until the hourly bucket reset (up to ~59 min) inside the call**. The webhook-processing job then sat mute until its own 9-min watchdog killed it (`Job aborted by parent signal`) — so the review was silently **lost**, and every following scenario in the cell burned its full poll window → the 60-min matrix job went **grey with no signal**. This bites real customers too, not just CI.

## Fix

**Product — stop sleeping silently, and recover** (mirrors the already-correct GitHub App path):
- `github.service.ts` PAT throttle: `onRateLimit` / `onSecondaryRateLimit` return `false` (never sleep) + structured logging → the 403 throws immediately.
- `webhook-processing-job.processor.ts`: classify the caught error; when it's a rate limit, mark the job `RATE_LIMITED` and re-throw the typed `RateLimitError` so `RabbitMQErrorHandler` requeues with a reset-aligned delay — instead of DLQ'ing it as `PERMANENT`. The review recovers after the bucket resets.

**Infra — e2e green:** the `license-paid` and `license-free` github cells shared ONE product account (`GH_INTEGRATION_TOKEN`) and drained it concurrently. Split by license: `license-paid` → `GH_INTEGRATION_TOKEN_PAID` (dedicated bot), `license-free` keeps `GH_INTEGRATION_TOKEN`. Graceful fallback until the secret is wired (now wired).

## Verification
- Aggregate typecheck: zero new errors (baseline unchanged).
- Pre-push suite: green.
- Next matrix run validates green end-to-end.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
