### PR TITLE
fix(cli): surface contextual message for non-JSON 403 responses

### DIFF
--- a/apps/cli/src/services/api/__tests__/api.real.test.ts
+++ b/apps/cli/src/services/api/__tests__/api.real.test.ts
@@ -611,6 +611,31 @@ describe('RealApi config repository methods', () => {
         );
     });
 
+    it('surfaces the contextual endpoint message when a 403 has no JSON body', async () => {
+        // Non-JSON error bodies (gateway/CDN pages, empty bodies) used to
+        // surface the raw "Request failed with status 403" — a synthesized
+        // placeholder that masked the actionable per-endpoint message.
+        fetchMock.mockResolvedValue(
+            new Response('Forbidden', {
+                status: 403,
+                headers: { 'Content-Type': 'text/plain' },
+            }),
+        );
+
+        const api = new RealApi();
+
+        await expect(
+            api.config.getAvailableRepositories('kodus_team_key'),
+        ).rejects.toEqual(
+            expect.objectContaining({
+                name: 'ApiError',
+                statusCode: 403,
+                message:
+                    'Access denied for Kodus API endpoint (/cli/config/repositories/available).',
+            } satisfies Partial<ApiError>),
+        );
+    });
+
     it('sends X-Team-Key when getting repository settings', async () => {
         fetchMock.mockResolvedValue(
             new Response(

--- a/apps/cli/src/services/api/api-core.ts
+++ b/apps/cli/src/services/api/api-core.ts
@@ -351,7 +351,7 @@ export async function request<T>(
     if (!response.ok) {
         const rawError = isJson
             ? await response.json().catch(() => ({ message: 'Request failed' }))
-            : { message: `Request failed with status ${response.status}` };
+            : {};
         const errorData: ApiErrorPayload =
             rawError &&
             typeof rawError === 'object' &&
@@ -495,7 +495,7 @@ export async function requestBinary(
         const isJson = contentType.includes('application/json');
         const rawError = isJson
             ? await response.json().catch(() => ({ message: 'Request failed' }))
-            : { message: `Request failed with status ${response.status}` };
+            : {};
         const errorData: ApiErrorPayload =
             rawError &&
             typeof rawError === 'object' &&


### PR DESCRIPTION
Fixes #1503

## Problem

`kodus review` fails with a bare `Request failed with status 403` on larger runs — no mention of quota, rate limit, payload size, or which endpoint failed. The user cannot tell a transient limit from a real failure.

**Root cause:** when the API returns a 403 with a non-JSON body (gateway/CDN page, empty body), the CLI synthesized its own `{ message: 'Request failed with status 403' }` payload. Because that string is ASCII, `normalizeApiErrorMessage` returned it verbatim (the 403 branch prefers a clean server message over the fallback), masking the actionable per-endpoint message that already exists: `Access denied for Kodus API endpoint (<path>).`

## Change

`apps/cli/src/services/api/api-core.ts` (both request paths):
- Only build the error payload from the JSON body.
- For non-JSON error responses, pass an empty payload so `normalizeApiErrorMessage` falls back to the contextual per-status message (`Access denied for Kodus API endpoint (<path>).` for 403, plus the existing rate-limit / unavailable / not-found messages for other statuses).

## Validation

- Added regression test: a 403 with `Content-Type: text/plain` now surfaces `Access denied for Kodus API endpoint (/cli/config/repositories/available).` instead of the raw placeholder.
- `api.real.test.ts`: 27/27 pass (26 existing + 1 new); `imports.test.ts`: 6/6.
