### PR TITLE
fix(kody-rules): stop the new-rules email from failing the execution

### DIFF
--- a/libs/kodyRules/application/use-cases/generate-kody-rules.use-case.ts
+++ b/libs/kodyRules/application/use-cases/generate-kody-rules.use-case.ts
@@ -234,7 +234,15 @@ export class GenerateKodyRulesUseCase {
             );
 
             const allRules = [];
-            const createdRules = []; // To track created rules for notification
+            // Typed on purpose. As a bare `[]` this was `any[]`, so pushing
+            // objects here and passing the array to a `string[]` parameter
+            // type-checked cleanly — and only blew up at render time, inside
+            // the worker, as "Objects are not valid as a React child".
+            const createdRules: Array<{
+                title: string;
+                rule: string;
+                severity: string;
+            }> = [];
             // Repos that received ≥1 persisted rule — promoted to isSelected:true
             // after the loop so the generated rules are visible in the UI.
             const reposWithRules = new Map<string, Repositories>();
@@ -516,8 +524,15 @@ export class GenerateKodyRulesUseCase {
                 });
 
                 // Execute notification asynchronously to not block the main flow
+                // The notification takes the rule TITLES — short, human
+                // readable, and the same text the Kody Rules screen shows.
+                // The full rule body is a paragraph of prompt text and would
+                // make the email unreadable.
                 this.sendRulesNotificationUseCase
-                    .execute(organizationId, createdRules)
+                    .execute(
+                        organizationId,
+                        createdRules.map((r) => r.title),
+                    )
                     .catch((error) => {
                         this.logger.error({
                             message:

--- a/libs/notifications/infrastructure/adapters/channels/email-template.registry.spec.ts
+++ b/libs/notifications/infrastructure/adapters/channels/email-template.registry.spec.ts
@@ -1,5 +1,8 @@
 import { NotificationEvent } from '../../../domain/catalog/events';
-import { EMAIL_TEMPLATE_REGISTRY } from './email-template.registry';
+import {
+    EMAIL_TEMPLATE_REGISTRY,
+    normaliseRuleList,
+} from './email-template.registry';
 
 describe('EMAIL_TEMPLATE_REGISTRY', () => {
     const CTX = { webUrl: 'https://app.example.com' };
@@ -166,5 +169,44 @@ describe('EMAIL_TEMPLATE_REGISTRY', () => {
             ]!(EMAIL_PAYLOADS[NotificationEvent.ORG_MEMBER_REMOVED]!, CTX);
             expect(result.subject).toContain('Acme');
         });
+    });
+});
+
+describe('normaliseRuleList', () => {
+    // Regression: the producer sent {title, rule, severity} objects into a
+    // template typed `string[]`. React threw "Objects are not valid as a React
+    // child" at render, inside the worker, and the delivery retried 5x while
+    // the execution sat in `partial_error` — which surfaced in e2e as a review
+    // that "completed UNHEALTHY".
+    it('reduces rule objects to their title', () => {
+        expect(
+            normaliseRuleList([
+                { title: 'Avoid nested ternaries', rule: '...', severity: 'medium' },
+                { title: 'Prefer early returns', rule: '...', severity: 'low' },
+            ]),
+        ).toEqual(['Avoid nested ternaries', 'Prefer early returns']);
+    });
+
+    it('passes plain strings through', () => {
+        expect(normaliseRuleList(['already a string'])).toEqual([
+            'already a string',
+        ]);
+    });
+
+    it('drops entries it cannot render instead of crashing the email', () => {
+        expect(
+            normaliseRuleList([
+                'keep',
+                { rule: 'no title here' },
+                null,
+                42,
+                { title: 123 },
+            ]),
+        ).toEqual(['keep']);
+    });
+
+    it('tolerates a missing or non-array payload', () => {
+        expect(normaliseRuleList(undefined)).toEqual([]);
+        expect(normaliseRuleList('not an array')).toEqual([]);
     });
 });

--- a/libs/notifications/infrastructure/adapters/channels/email-template.registry.spec.ts
+++ b/libs/notifications/infrastructure/adapters/channels/email-template.registry.spec.ts
@@ -205,6 +205,15 @@ describe('normaliseRuleList', () => {
         ).toEqual(['keep']);
     });
 
+    // Deliberate, not an oversight: an empty title renders as a blank bullet
+    // and would still be counted in the "N new rules" headline. Keeping it out
+    // of the list keeps the list and the count telling the same story.
+    it('drops empty titles rather than rendering a blank bullet', () => {
+        expect(
+            normaliseRuleList([{ title: '' }, '', { title: 'Prefer early returns' }]),
+        ).toEqual(['Prefer early returns']);
+    });
+
     it('tolerates a missing or non-array payload', () => {
         expect(normaliseRuleList(undefined)).toEqual([]);
         expect(normaliseRuleList('not an array')).toEqual([]);

--- a/libs/notifications/infrastructure/adapters/channels/email-template.registry.ts
+++ b/libs/notifications/infrastructure/adapters/channels/email-template.registry.ts
@@ -109,6 +109,10 @@ export type EmailTemplateBuilder = (
  * one line in an email; letting a non-string through costs the whole
  * execution, because React throws on an object child and the delivery retries
  * five times before giving up.
+ *
+ * An empty title is dropped on the same terms, deliberately: it would render
+ * as a blank bullet and still count toward the "N new rules" headline, which
+ * reads as a bug to whoever opens the email.
  */
 export function normaliseRuleList(value: unknown): string[] {
     if (!Array.isArray(value)) return [];

--- a/libs/notifications/infrastructure/adapters/channels/email-template.registry.ts
+++ b/libs/notifications/infrastructure/adapters/channels/email-template.registry.ts
@@ -100,6 +100,30 @@ export type EmailTemplateBuilder = (
  *   3. Add the React Email template under `@libs/common/email/templates`.
  *   4. Register the builder here. No changes to the channel adapter.
  */
+
+/**
+ * Coerce a rule list into the plain strings the email template renders.
+ *
+ * Anything that is not a string is reduced to its `title` (the shape the
+ * producer used to send) and, failing that, dropped. Dropping an entry costs
+ * one line in an email; letting a non-string through costs the whole
+ * execution, because React throws on an object child and the delivery retries
+ * five times before giving up.
+ */
+export function normaliseRuleList(value: unknown): string[] {
+    if (!Array.isArray(value)) return [];
+    return value
+        .map((entry) => {
+            if (typeof entry === 'string') return entry;
+            if (entry && typeof entry === 'object') {
+                const title = (entry as { title?: unknown }).title;
+                if (typeof title === 'string') return title;
+            }
+            return undefined;
+        })
+        .filter((entry): entry is string => Boolean(entry));
+}
+
 export const EMAIL_TEMPLATE_REGISTRY: Partial<
     Record<NotificationEvent, EmailTemplateBuilder>
 > = {
@@ -146,7 +170,15 @@ export const EMAIL_TEMPLATE_REGISTRY: Partial<
     },
 
     [NotificationEvent.KODY_RULES_GENERATED]: (metadata, { webUrl }) => {
-        const rules = metadata.rules as string[];
+        // `as string[]` used to be a blind cast. The producer was sending
+        // `{title, rule, severity}` objects, the template rendered each entry
+        // as a React child, and the email threw at render — retried 5x per
+        // recipient and left the whole execution in `partial_error`.
+        //
+        // The producer now sends titles, but normalise here too: notification
+        // payloads are persisted and replayed, so an already-queued delivery
+        // from before the fix must not keep crashing the worker.
+        const rules = normaliseRuleList(metadata.rules);
         const organizationName = metadata.organizationName as string;
         const userName = (metadata as { userName?: string }).userName ?? '';
         return {


### PR DESCRIPTION
## What breaks today

When onboarding finishes and the initial Kody Rules are generated, Kodus emails the org — *"4 new rules created"*. **That email has never rendered** since `5d765b2f3` (2026-07-06, *"Fixing to generate Kody rules after onboarding finish"*).

The producer sends `{title, rule, severity}` objects; the template is typed `string[]` and renders each entry as a React child. React throws:

```
Objects are not valid as a React child (found: object with keys {rule, title, severity})
```

**The cost is not just a missing email.** The send runs inside the worker, so the failed delivery retries five times per recipient and leaves the whole execution in `partial_error` — a review that ran fine and posted its comments still reports as unhealthy. Because it fires at the end of onboarding, **every org onboarded in the last month hit this.**

## Why the compiler didn't catch it

Two bypassed types, one on each side:

```ts
const createdRules = [];                    // inferred any[] — accepts anything
createdRules.push({ title, rule, severity });
sendRulesNotification.execute(orgId, createdRules);  // param is string[], accepted

const rules = metadata.rules as string[];   // blind cast on the consumer
```

## The fix

- **Send the rule titles.** Short, and the same text the Kody Rules screen shows — the rule body is a paragraph of prompt text and would make the email unreadable.
- **Type `createdRules`**, so this is a compile error from now on rather than a runtime one.
- **Replace the cast with `normaliseRuleList`**, which coerces objects to their `title` and drops what it cannot render. Notification payloads are persisted and replayed, so a delivery already queued from before this fix must not keep crashing the worker.

## Testing

- `email-template.registry.spec.ts`: 4 new cases covering the object payload, plain strings, unrenderable entries, and a missing/non-array payload
- 524 tests pass across the `kody-rules` + `notification` suites
- Typecheck clean on the touched files

## How it was found

The e2e matrix, on a self-hosted run, reported:

```
license-attribution: Review of PR #792 completed UNHEALTHY:
execution status stayed "partial_error" through the full 90s window
```

The review itself was fine. The server evidence the harness collected pointed straight at the React render inside the worker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)