### PR TITLE
docs(env): register KODUS_REGISTRY in the schema

### DIFF
--- a/.env.schema
+++ b/.env.schema
@@ -136,6 +136,15 @@ USE_LOCAL_DB=true
 # kodus: audience=self-hosted
 USE_LOCAL_RABBITMQ=true
 
+# Registry the installer's docker-compose pulls the Kodus images from.
+# Leave unset to use the public images; set it to mirror them into an
+# internal registry (restricted networks) or to run throwaway e2e builds
+# without publishing next to the production images. Read by
+# kodus-installer/docker-compose.yml; not consumed by kodus-ai itself.
+# @type=string
+# kodus: audience=self-hosted
+KODUS_REGISTRY=
+
 # ============================================================
 # Server
 # kodus: category=server

--- a/docs/_snippets/env-vars-generated.mdx
+++ b/docs/_snippets/env-vars-generated.mdx
@@ -19,6 +19,7 @@
 | `RUN_SEEDS` | – | boolean | ⚙️ Both | Run database seeds on container boot. Required for first-time setup (creates default org, admin role, etc). Idempotent — safe to leave on. |
 | `USE_LOCAL_DB` | – | boolean | 🏠 Self-hosted | When true, the installer's docker-compose spins up a local Postgres container. Set to false to point at an externally-managed Postgres (managed RDS/Supabase/Neon/Railway). Read by kodus-installer/scripts/ install.sh + doctor.sh; not consumed by kodus-ai itself. |
 | `USE_LOCAL_RABBITMQ` | – | boolean | 🏠 Self-hosted | Same logic as USE_LOCAL_DB but for RabbitMQ. False if you bring your own broker (CloudAMQP, AWS MQ, etc). |
+| `KODUS_REGISTRY` | – | string | 🏠 Self-hosted | Registry the installer's docker-compose pulls the Kodus images from. Leave unset to use the public images; set it to mirror them into an internal registry (restricted networks) or to run throwaway e2e builds without publishing next to the production images. Read by kodus-installer/docker-compose.yml; not consumed by kodus-ai itself. |
 
 ## Server
 


### PR DESCRIPTION
Companion to **kodustech/kodus-installer#48**, which makes the image registry overridable:

```diff
-image: ghcr.io/kodustech/kodus-ai-api:${IMAGE_TAG:-latest}
+image: ${KODUS_REGISTRY:-ghcr.io/kodustech}/kodus-ai-api:${IMAGE_TAG:-latest}
```

Installer-only variables are documented here, not in the installer repo — `USE_LOCAL_DB` and `USE_LOCAL_RABBITMQ` both live in `.env.schema` with a note that kodus-ai does not consume them. That is what puts them in the generated `.env.example` and the docs table, so adding the lever without registering it would have shipped an undocumented one.

`audience=self-hosted`, empty default, so nothing changes for anyone who does not set it.

Generated outputs regenerated; `check-drift` reports all targets in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)