### PR TITLE
feat(llm): add OrcaRouter as a named BYOK provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -361,6 +361,11 @@ API_CEREBRAS_API_KEY=
 # (secret)
 API_OPEN_ROUTER_API_KEY=
 
+# OrcaRouter API key (keys start with sk-orca-). Used by the BYOK provider in
+# libs/organization/.../get-models-by-provider.use-case.ts.
+# (secret)
+API_ORCA_ROUTER_API_KEY=
+
 # MorphLLM (fast-apply model). When set, the review pipeline uses MorphLLM
 # to apply LLM-suggested code edits automatically and reliably (better than
 # letting the main LLM rewrite files). Used in

--- a/.env.schema
+++ b/.env.schema
@@ -512,6 +512,12 @@ API_CEREBRAS_API_KEY=
 # kodus: audience=cloud
 API_OPEN_ROUTER_API_KEY=
 
+# OrcaRouter API key (keys start with sk-orca-). Used by the BYOK provider in
+# libs/organization/.../get-models-by-provider.use-case.ts.
+# @optional @sensitive
+# kodus: audience=cloud
+API_ORCA_ROUTER_API_KEY=
+
 # MorphLLM (fast-apply model). When set, the review pipeline uses MorphLLM
 # to apply LLM-suggested code edits automatically and reliably (better than
 # letting the main LLM rewrite files). Used in

--- a/.env.template
+++ b/.env.template
@@ -371,6 +371,11 @@ API_CEREBRAS_API_KEY=op://Kodus-Dev/API_CEREBRAS_API_KEY/password
 # (secret)
 API_OPEN_ROUTER_API_KEY=op://Kodus-Dev/API_OPEN_ROUTER_API_KEY/password
 
+# OrcaRouter API key (keys start with sk-orca-). Used by the BYOK provider in
+# libs/organization/.../get-models-by-provider.use-case.ts.
+# (secret)
+API_ORCA_ROUTER_API_KEY=op://Kodus-Dev/API_ORCA_ROUTER_API_KEY/password
+
 # MorphLLM (fast-apply model). When set, the review pipeline uses MorphLLM
 # to apply LLM-suggested code edits automatically and reliably (better than
 # letting the main LLM rewrite files). Used in

--- a/apps/web/src/features/ee/byok/_components/catalog/model-card.tsx
+++ b/apps/web/src/features/ee/byok/_components/catalog/model-card.tsx
@@ -33,6 +33,7 @@ const PROVIDER_LABELS: Record<string, string> = {
     openai: "OpenAI",
     google_gemini: "Google",
     openrouter: "OpenRouter",
+    orcarouter: "OrcaRouter",
     novita: "Novita",
     openai_compatible: "OpenAI-compatible",
 };

--- a/apps/web/src/features/ee/byok/_components/page.client.tsx
+++ b/apps/web/src/features/ee/byok/_components/page.client.tsx
@@ -47,6 +47,7 @@ const CURATED_PROVIDERS = new Set([
     "anthropic_compatible",
     "google_gemini",
     "openrouter",
+    "orcarouter",
 ]);
 
 const isEditableInCatalog = (config: BYOKConfig | undefined): boolean =>

--- a/docs/_snippets/env-vars-generated.mdx
+++ b/docs/_snippets/env-vars-generated.mdx
@@ -128,6 +128,7 @@
 | `API_CEREBRAS_BASE_URL` | – | url | ☁️ Cloud |  |
 | `API_CEREBRAS_API_KEY` | – | secret | ☁️ Cloud |  |
 | `API_OPEN_ROUTER_API_KEY` | – | secret | ☁️ Cloud | OpenRouter API key. Used by BYOK provider in libs/organization/.../get-models-by-provider.use-case.ts. |
+| `API_ORCA_ROUTER_API_KEY` | – | secret | ☁️ Cloud | OrcaRouter API key (keys start with sk-orca-). Used by BYOK provider in libs/organization/.../get-models-by-provider.use-case.ts. |
 | `API_MORPHLLM_API_KEY` | – | secret | ⚙️ Both (opt-in) | MorphLLM (fast-apply model). When set, the review pipeline uses MorphLLM to apply LLM-suggested code edits automatically and reliably (better than letting the main LLM rewrite files). Used in libs/code-review/pipeline/stages/validate-suggestions.stage.ts. Without it, the "apply suggested fix" feature falls back to the main LLM with lower accuracy. |
 | `API_EXA_KEY` | – | secret | ⚙️ Both (opt-in) | Exa (semantic web search). When set, code-review agents can search external documentation during review (e.g. fetch docs about a library API the PR uses). Used in libs/code-review/infrastructure/adapters/services/documentation- search-exa.service.ts and the agent providers. Without it, agents skip the documentation-fetching loop and review using only repo context. |
 

--- a/docs/how_to_use/en/byok.mdx
+++ b/docs/how_to_use/en/byok.mdx
@@ -147,7 +147,7 @@ When the model you want isn't in the curated list (custom endpoint, self-hosted 
 
 <Steps>
   <Step title="Pick a provider">
-    Choose from OpenAI, Anthropic, Google Gemini, Google Vertex AI, Amazon Bedrock, OpenRouter, Novita, **OpenAI-compatible** (for any OpenAI-format endpoint), or **Anthropic-compatible** (for any Anthropic Messages-format endpoint).
+    Choose from OpenAI, Anthropic, Google Gemini, Google Vertex AI, Amazon Bedrock, OpenRouter, OrcaRouter, Novita, **OpenAI-compatible** (for any OpenAI-format endpoint), or **Anthropic-compatible** (for any Anthropic Messages-format endpoint).
 
     Vertex and Bedrock are marked **Beta** and ask for provider-specific credentials instead of a single key — see [Supported Providers](#supported-providers) below.
   </Step>
@@ -231,6 +231,19 @@ When the model you want isn't in the curated list (custom endpoint, self-hosted 
     <Warning>
       OpenRouter routes each request to a different upstream provider by default, which can cause quality and latency drift between calls. **Pin specific upstreams** under Advanced settings → OpenRouter routing to keep behavior stable. See [Pinning OpenRouter providers](#pinning-openrouter-providers).
     </Warning>
+  </Tab>
+
+  <Tab title="OrcaRouter">
+    **Best for:** One billing relationship across many models through a single OpenAI-compatible endpoint.
+
+    **Get an API key:**
+    1. Create an account at [OrcaRouter](https://www.orcarouter.ai)
+    2. Add credits
+    3. Generate a key in settings (keys start with `sk-orca-`)
+
+    <Info>
+      OrcaRouter is an OpenAI-compatible gateway: one key unlocks 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single `https://api.orcarouter.ai/v1` endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+    </Info>
   </Tab>
 
   <Tab title="Google Vertex AI">
@@ -325,6 +338,7 @@ When you pick Low / Medium / High, Kodus translates the level to each provider's
 | **Google** (Gemini 3.1 Pro) | `thinkingConfig: { thinkingLevel: "medium" }` |
 | **OpenAI** (GPT-5.4) | `reasoningEffort: "medium"` |
 | **OpenRouter** | `reasoning: { effort: "medium" }` |
+| **OrcaRouter** | `thinking: { type: "enabled" }` — binary on/off, level ignored |
 | **OpenAI-compatible** (Kimi K2.6 / GLM 5.1) | `thinking: { type: "enabled" }` — binary on/off, level ignored |
 
 <Note>
@@ -407,6 +421,16 @@ Use this when:
     ```
   </Tab>
 
+  <Tab title="OrcaRouter">
+    OrcaRouter is OpenAI-compatible, so the OpenAI-compatible shape applies:
+
+    ```json
+    {
+      "thinking": { "type": "enabled", "budget_tokens": 25000 }
+    }
+    ```
+  </Tab>
+
   <Tab title="OpenAI-compatible (Kimi, GLM, etc.)">
     Enable thinking with a budget hint:
 
@@ -451,6 +475,7 @@ Under the hood, these are the namespace mappings Kodus uses:
 | `google_gemini` / `google_vertex` | `google` |
 | `openai` | `openai` |
 | `open_router` | `openrouter` |
+| `orcarouter` | `openaiCompatible` |
 | `openai_compatible` / `novita` | `openaiCompatible` |
 
 #### Gotchas

--- a/docs/how_to_use/es/byok.mdx
+++ b/docs/how_to_use/es/byok.mdx
@@ -147,7 +147,7 @@ Cuando el modelo que quieres no está en la lista curada (endpoint personalizado
 
 <Steps>
   <Step title="Elegir un proveedor">
-    Elige entre OpenAI, Anthropic, Google Gemini, Google Vertex AI, Amazon Bedrock, OpenRouter, Novita, **OpenAI Compatible** (para cualquier endpoint con formato OpenAI) o **Anthropic-compatible** (para cualquier endpoint con formato Messages de Anthropic).
+    Elige entre OpenAI, Anthropic, Google Gemini, Google Vertex AI, Amazon Bedrock, OpenRouter, OrcaRouter, Novita, **OpenAI Compatible** (para cualquier endpoint con formato OpenAI) o **Anthropic-compatible** (para cualquier endpoint con formato Messages de Anthropic).
 
     Vertex y Bedrock aparecen como **Beta** y piden credenciales específicas en lugar de una sola clave — consulta [Proveedores compatibles](#proveedores-compatibles) más abajo.
   </Step>
@@ -233,6 +233,19 @@ Cuando el modelo que quieres no está en la lista curada (endpoint personalizado
     </Warning>
   </Tab>
 
+  <Tab title="OrcaRouter">
+    **Ideal para:** Una sola relación de facturación para muchos modelos a través de un único endpoint compatible con OpenAI.
+
+    **Obtener una clave de API:**
+    1. Crea una cuenta en [OrcaRouter](https://www.orcarouter.ai)
+    2. Agrega créditos
+    3. Genera una clave en la configuración (las claves empiezan con `sk-orca-`)
+
+    <Info>
+      OrcaRouter es una puerta de enlace compatible con OpenAI: una sola clave desbloquea más de 150 modelos de OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax y xAI detrás de un único endpoint `https://api.orcarouter.ai/v1`. También ofrece seguridad de confianza cero a nivel de puerta de enlace para agentes de IA en el mismo endpoint: examina cada prompt/respuesta y gobierna cada llamada de herramienta con una base de denegación predeterminada, sin cambios en el código de la aplicación.
+    </Info>
+  </Tab>
+
   <Tab title="Google Vertex AI">
     <Info>**Beta.** Integración más reciente, con una vía de autenticación más compleja que la norma de clave única.</Info>
 
@@ -313,6 +326,7 @@ Cuando eliges Low / Medium / High, Kodus traduce el nivel al formato nativo de c
 | **Google** (Gemini 3.1 Pro) | `thinkingConfig: { thinkingLevel: "medium" }` |
 | **OpenAI** (GPT-5.4) | `reasoningEffort: "medium"` |
 | **OpenRouter** | `reasoning: { effort: "medium" }` |
+| **OrcaRouter** | `thinking: { type: "enabled" }` — binario on/off, el nivel se ignora |
 | **Compatible con OpenAI** (Kimi K2.6 / GLM 5.1) | `thinking: { type: "enabled" }` — binario on/off, el nivel se ignora |
 
 <Note>
@@ -395,6 +409,16 @@ Elegir **Custom** en el interruptor de Thinking revela un área de texto JSON. P
     ```
   </Tab>
 
+  <Tab title="OrcaRouter">
+    OrcaRouter es compatible con OpenAI, por lo que aplica la forma de OpenAI-compatible:
+
+    ```json
+    {
+      "thinking": { "type": "enabled", "budget_tokens": 25000 }
+    }
+    ```
+  </Tab>
+
   <Tab title="Compatible con OpenAI (Kimi, GLM, etc.)">
     Habilitar pensamiento con una sugerencia de presupuesto:
 
@@ -439,6 +463,7 @@ Internamente, estos son los mapeos de namespace que Kodus usa:
 | `google_gemini` / `google_vertex` | `google` |
 | `openai` | `openai` |
 | `open_router` | `openrouter` |
+| `orcarouter` | `openaiCompatible` |
 | `openai_compatible` / `novita` | `openaiCompatible` |
 
 #### Detalles a tener en cuenta

--- a/docs/how_to_use/ja/byok.mdx
+++ b/docs/how_to_use/ja/byok.mdx
@@ -147,7 +147,7 @@ Z.ai と Moonshot はどちらも、ペイパートークンの Developer API �
 
 <Steps>
   <Step title="プロバイダーを選択">
-    OpenAI、Anthropic、Google Gemini、Google Vertex AI、Amazon Bedrock、OpenRouter、Novita、**OpenAI Compatible**（任意の OpenAI フォーマットのエンドポイント向け）、**Anthropic-compatible**（任意の Anthropic Messages フォーマットのエンドポイント向け）から選択します。
+    OpenAI、Anthropic、Google Gemini、Google Vertex AI、Amazon Bedrock、OpenRouter、OrcaRouter、Novita、**OpenAI Compatible**（任意の OpenAI フォーマットのエンドポイント向け）、**Anthropic-compatible**（任意の Anthropic Messages フォーマットのエンドポイント向け）から選択します。
 
     Vertex と Bedrock は **Beta** と表示され、単一キーではなくプロバイダー固有の認証情報を求められます — 下記の[対応プロバイダー](#対応プロバイダー)を参照してください。
   </Step>
@@ -233,6 +233,19 @@ Z.ai と Moonshot はどちらも、ペイパートークンの Developer API �
     </Warning>
   </Tab>
 
+  <Tab title="OrcaRouter">
+    **おすすめの用途:** 単一の OpenAI 互換エンドポイントで多くのモデルにアクセスできる、1つの請求関係。
+
+    **APIキーの取得方法:**
+    1. [OrcaRouter](https://www.orcarouter.ai) でアカウントを作成
+    2. クレジットを追加
+    3. 設定でキーを生成（キーは `sk-orca-` で始まります）
+
+    <Info>
+      OrcaRouter は OpenAI 互換のゲートウェイです。1つのキーで OpenAI、Anthropic、Google、DeepSeek、Qwen、MiniMax、xAI の150以上のモデルを単一の `https://api.orcarouter.ai/v1` エンドポイントで利用できます。また、同じエンドポイント上で AI エージェント向けのゲートウェイレベルのゼロトラストセキュリティを実行し、すべてのプロンプト/レスポンスをスクリーニングし、すべてのツール呼び出しをデフォルト拒否で制御します。アプリケーションコードの変更は不要です。
+    </Info>
+  </Tab>
+
   <Tab title="Google Vertex AI">
     <Info>**ベータ。** 新しめの統合で、単一キーが基本の他プロバイダーより認証の手順が複雑です。</Info>
 
@@ -313,6 +326,7 @@ Low / Medium / High を選択すると、Kodus はそのレベルを各プロバ
 | **Google** (Gemini 3.1 Pro) | `thinkingConfig: { thinkingLevel: "medium" }` |
 | **OpenAI** (GPT-5.4) | `reasoningEffort: "medium"` |
 | **OpenRouter** | `reasoning: { effort: "medium" }` |
+| **OrcaRouter** | `thinking: { type: "enabled" }` — バイナリの on/off、レベルは無視 |
 | **OpenAI-compatible** (Kimi K2.6 / GLM 5.1) | `thinking: { type: "enabled" }` — バイナリの on/off、レベルは無視 |
 
 <Note>
@@ -395,6 +409,16 @@ Thinking トグルで **Custom** を選択すると JSON テキストエリア�
     ```
   </Tab>
 
+  <Tab title="OrcaRouter">
+    OrcaRouter は OpenAI 互換のため、OpenAI-compatible と同じ形式が適用されます:
+
+    ```json
+    {
+      "thinking": { "type": "enabled", "budget_tokens": 25000 }
+    }
+    ```
+  </Tab>
+
   <Tab title="OpenAI-compatible (Kimi、GLM など)">
     予算ヒント付きで thinking を有効化：
 
@@ -439,6 +463,7 @@ JSON にすでに既知の名前空間キー（`anthropic`、`google`、`openai`
 | `google_gemini` / `google_vertex` | `google` |
 | `openai` | `openai` |
 | `open_router` | `openrouter` |
+| `orcarouter` | `openaiCompatible` |
 | `openai_compatible` / `novita` | `openaiCompatible` |
 
 #### 注意点

--- a/docs/how_to_use/pt-br/byok.mdx
+++ b/docs/how_to_use/pt-br/byok.mdx
@@ -147,7 +147,7 @@ Quando o modelo que você quer não está na lista curada (endpoint personalizad
 
 <Steps>
   <Step title="Escolha um provedor">
-    Escolha entre OpenAI, Anthropic, Google Gemini, Google Vertex AI, Amazon Bedrock, OpenRouter, Novita, **OpenAI Compatible** (para qualquer endpoint no formato OpenAI) ou **Anthropic-compatible** (para qualquer endpoint no formato Messages da Anthropic).
+    Escolha entre OpenAI, Anthropic, Google Gemini, Google Vertex AI, Amazon Bedrock, OpenRouter, OrcaRouter, Novita, **OpenAI Compatible** (para qualquer endpoint no formato OpenAI) ou **Anthropic-compatible** (para qualquer endpoint no formato Messages da Anthropic).
 
     Vertex e Bedrock aparecem como **Beta** e pedem credenciais específicas em vez de uma chave única — veja [Provedores Suportados](#provedores-suportados) abaixo.
   </Step>
@@ -233,6 +233,19 @@ Quando o modelo que você quer não está na lista curada (endpoint personalizad
     </Warning>
   </Tab>
 
+  <Tab title="OrcaRouter">
+    **Melhor para:** uma única relação de cobrança para muitos modelos por meio de um único endpoint compatível com OpenAI.
+
+    **Obter uma chave de API:**
+    1. Crie uma conta em [OrcaRouter](https://www.orcarouter.ai)
+    2. Adicione créditos
+    3. Gere uma chave nas configurações (chaves começam com `sk-orca-`)
+
+    <Info>
+      OrcaRouter é um gateway compatível com OpenAI: uma única chave desbloqueia mais de 150 modelos da OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax e xAI por trás de um único endpoint `https://api.orcarouter.ai/v1`. Ele também executa segurança de confiança zero no nível do gateway para agentes de IA no mesmo endpoint — examinando cada prompt/resposta e governando cada chamada de ferramenta em uma base de negação por padrão, sem alterações no código da aplicação.
+    </Info>
+  </Tab>
+
   <Tab title="Google Vertex AI">
     <Info>**Beta.** Integração mais nova, com caminho de autenticação mais complexo que o padrão de chave única.</Info>
 
@@ -313,6 +326,7 @@ Quando você escolhe Low / Medium / High, o Kodus traduz o nível para o formato
 | **Google** (Gemini 3.1 Pro) | `thinkingConfig: { thinkingLevel: "medium" }` |
 | **OpenAI** (GPT-5.4) | `reasoningEffort: "medium"` |
 | **OpenRouter** | `reasoning: { effort: "medium" }` |
+| **OrcaRouter** | `thinking: { type: "enabled" }` — on/off binário, nível ignorado |
 | **OpenAI-compatible** (Kimi K2.6 / GLM 5.1) | `thinking: { type: "enabled" }` — on/off binário, nível ignorado |
 
 <Note>
@@ -395,6 +409,16 @@ Use isso quando:
     ```
   </Tab>
 
+  <Tab title="OrcaRouter">
+    O OrcaRouter é compatível com OpenAI, então a forma OpenAI-compatible se aplica:
+
+    ```json
+    {
+      "thinking": { "type": "enabled", "budget_tokens": 25000 }
+    }
+    ```
+  </Tab>
+
   <Tab title="OpenAI-compatible (Kimi, GLM, etc.)">
     Habilitar thinking com uma dica de budget:
 
@@ -439,6 +463,7 @@ Nos bastidores, estes são os mapeamentos de namespace que o Kodus usa:
 | `google_gemini` / `google_vertex` | `google` |
 | `openai` | `openai` |
 | `open_router` | `openrouter` |
+| `orcarouter` | `openaiCompatible` |
 | `openai_compatible` / `novita` | `openaiCompatible` |
 
 #### Pegadinhas

--- a/docs/how_to_use/zh/byok.mdx
+++ b/docs/how_to_use/zh/byok.mdx
@@ -147,7 +147,7 @@ Z.ai 和 Moonshot 都在按 token 付费的开发者 API 之外提供一个订�
 
 <Steps>
   <Step title="选择提供商">
-    从 OpenAI、Anthropic、Google Gemini、Google Vertex AI、Amazon Bedrock、OpenRouter、Novita、**OpenAI Compatible**(用于任意 OpenAI 格式的端点)或 **Anthropic-compatible**(用于任意 Anthropic Messages 格式的端点)中选择。
+    从 OpenAI、Anthropic、Google Gemini、Google Vertex AI、Amazon Bedrock、OpenRouter、OrcaRouter、Novita、**OpenAI Compatible**(用于任意 OpenAI 格式的端点)或 **Anthropic-compatible**(用于任意 Anthropic Messages 格式的端点)中选择。
 
     Vertex 和 Bedrock 标记为 **Beta**,需要提供商特定的凭证而非单一密钥 —— 参见下方的[支持的提供商](#支持的提供商)。
   </Step>
@@ -233,6 +233,19 @@ Z.ai 和 Moonshot 都在按 token 付费的开发者 API 之外提供一个订�
     </Warning>
   </Tab>
 
+  <Tab title="OrcaRouter">
+    **最适合:**通过一个计费关系、经由单一 OpenAI 兼容端点访问多个模型。
+
+    **获取 API 密钥:**
+    1. 在 [OrcaRouter](https://www.orcarouter.ai) 创建账号
+    2. 添加积分
+    3. 在设置中生成密钥(密钥以 `sk-orca-` 开头)
+
+    <Info>
+      OrcaRouter 是一个 OpenAI 兼容的网关:一个密钥即可在单个 `https://api.orcarouter.ai/v1` 端点背后解锁 OpenAI、Anthropic、Google、DeepSeek、Qwen、MiniMax 和 xAI 的 150+ 模型。它还在同一端点上为 AI 智能体提供网关级零信任安全——以默认拒绝为基础审查每个提示/响应并管控每个工具调用,无需任何应用代码改动。
+    </Info>
+  </Tab>
+
   <Tab title="Google Vertex AI">
     <Info>**Beta。** 较新的集成,认证路径比"单一密钥"的常规方式更复杂。</Info>
 
@@ -313,6 +326,7 @@ Z.ai 和 Moonshot 都在按 token 付费的开发者 API 之外提供一个订�
 | **Google**(Gemini 3.1 Pro) | `thinkingConfig: { thinkingLevel: "medium" }` |
 | **OpenAI**(GPT-5.4) | `reasoningEffort: "medium"` |
 | **OpenRouter** | `reasoning: { effort: "medium" }` |
+| **OrcaRouter** | `thinking: { type: "enabled" }` — 二元开关,级别被忽略 |
 | **OpenAI 兼容**(Kimi K2.6 / GLM 5.1) | `thinking: { type: "enabled" }` — 二元开关,级别被忽略 |
 
 <Note>
@@ -395,6 +409,16 @@ Z.ai 和 Moonshot 都在按 token 付费的开发者 API 之外提供一个订�
     ```
   </Tab>
 
+  <Tab title="OrcaRouter">
+    OrcaRouter 兼容 OpenAI,因此适用 OpenAI 兼容的写法:
+
+    ```json
+    {
+      "thinking": { "type": "enabled", "budget_tokens": 25000 }
+    }
+    ```
+  </Tab>
+
   <Tab title="OpenAI 兼容(Kimi、GLM 等)">
     启用 thinking 并带上预算提示:
 
@@ -439,6 +463,7 @@ Z.ai 和 Moonshot 都在按 token 付费的开发者 API 之外提供一个订�
 | `google_gemini` / `google_vertex` | `google` |
 | `openai` | `openai` |
 | `open_router` | `openrouter` |
+| `orcarouter` | `openaiCompatible` |
 | `openai_compatible` / `novita` | `openaiCompatible` |
 
 #### 注意事项

--- a/evals/structured-outputs/README.md
+++ b/evals/structured-outputs/README.md
@@ -72,7 +72,7 @@ probe asserts that two outbound requests were captured, first with
 
 The gate is in `shouldEnableJsonSchema(provider, model, baseURL)`:
 
-- **OPEN_ROUTER**: model prefix in `OPENROUTER_JSON_SCHEMA_PREFIXES`
+- **OPEN_ROUTER / ORCAROUTER**: model prefix in `GATEWAY_JSON_SCHEMA_PREFIXES`
   (`openai/`, `anthropic/`, `google/`, `moonshotai/`)
 - **OPENAI_COMPATIBLE**: `baseURL` contains `:8000/` (vLLM heuristic),
   or matches any substring listed in
@@ -82,7 +82,7 @@ The gate is in `shouldEnableJsonSchema(provider, model, baseURL)`:
 To add a model:
 1. Add a scenario to `SCENARIOS` in `repro.ts` with the expected outcome.
 2. If the model legitimately supports `json_schema`, add its prefix to
-   `OPENROUTER_JSON_SCHEMA_PREFIXES`.
+   `GATEWAY_JSON_SCHEMA_PREFIXES`.
 3. Re-run the matrix.
 
 If you're not sure — leave the prefix out. The retry-on-error wrapper

--- a/libs/core/infrastructure/services/providers/provider.service.ts
+++ b/libs/core/infrastructure/services/providers/provider.service.ts
@@ -63,6 +63,14 @@ export class ProviderService {
             requiresApiKey: true,
             requiresBaseUrl: false,
         },
+        [BYOKProvider.ORCAROUTER]: {
+            id: BYOKProvider.ORCAROUTER,
+            name: 'OrcaRouter',
+            description: 'Multiple models through OrcaRouter',
+            supported: true,
+            requiresApiKey: true,
+            requiresBaseUrl: false,
+        },
         [BYOKProvider.NOVITA]: {
             id: BYOKProvider.NOVITA,
             name: 'Novita',

--- a/libs/llm/README.md
+++ b/libs/llm/README.md
@@ -18,7 +18,7 @@ lives here (NOT review/agent logic).
   through the process-wide BYOK concurrency limiter and reports BYOK failures
   (model-level, via AI SDK `wrapLanguageModel`; the failure reporter is injected).
 - **`reasoning-options.ts`** — builds provider-specific reasoning/thinking
-  `providerOptions` (Anthropic / Gemini / OpenAI / OpenRouter / compatible) from a
+  `providerOptions` (Anthropic / Gemini / OpenAI / OpenRouter / OrcaRouter / compatible) from a
   normalized `ReasoningEffort`, plus OpenRouter provider-pinning.
 - **`llm-call.ts`** — call timeouts (`AGENT_TIMEOUT_MS`, `LLM_CALL_TIMEOUT_MS`,
   `timeoutSignal`, `hardTimeout`) and `tracedGenerateText` (generateText + hard

--- a/libs/llm/byok-to-vercel.ts
+++ b/libs/llm/byok-to-vercel.ts
@@ -171,6 +171,7 @@ const DEFAULT_MODEL = {
  * - GOOGLE_GEMINI → @ai-sdk/google
  * - GOOGLE_VERTEX → @ai-sdk/google-vertex
  * - OPEN_ROUTER → @ai-sdk/openai-compatible (OpenRouter is OpenAI-compatible)
+ * - ORCAROUTER → @ai-sdk/openai-compatible (OrcaRouter is OpenAI-compatible)
  * - OPENAI_COMPATIBLE → @ai-sdk/openai-compatible
  * - NOVITA → @ai-sdk/openai-compatible
  *
@@ -196,7 +197,11 @@ export type ByokModelOptions = {
     structuredOutputs?: boolean;
 };
 
-const OPENROUTER_JSON_SCHEMA_PREFIXES = [
+// Shared upstream-prefix allowlist for routers that translate
+// `response_format: json_schema` into each upstream's native format
+// (OpenRouter, OrcaRouter). Models outside these prefixes keep the
+// conservative `json_object` path.
+const GATEWAY_JSON_SCHEMA_PREFIXES = [
     'openai/',
     'anthropic/',
     'google/',
@@ -219,8 +224,11 @@ function shouldEnableJsonSchema(
     model: string,
     baseURL?: string,
 ): boolean {
-    if (provider === BYOKProvider.OPEN_ROUTER) {
-        return OPENROUTER_JSON_SCHEMA_PREFIXES.some((p) =>
+    if (
+        provider === BYOKProvider.OPEN_ROUTER ||
+        provider === BYOKProvider.ORCAROUTER
+    ) {
+        return GATEWAY_JSON_SCHEMA_PREFIXES.some((p) =>
             model.toLowerCase().startsWith(p),
         );
     }
@@ -440,6 +448,16 @@ export function byokToVercelModel(
                 name: 'open-router',
                 apiKey,
                 baseURL: baseURL || 'https://openrouter.ai/api/v1',
+                supportsStructuredOutputs:
+                    options.structuredOutputs === true &&
+                    shouldEnableJsonSchema(provider, model, baseURL),
+            })(model);
+
+        case BYOKProvider.ORCAROUTER:
+            return createOpenAICompatible({
+                name: 'orcarouter',
+                apiKey,
+                baseURL: baseURL || 'https://api.orcarouter.ai/v1',
                 supportsStructuredOutputs:
                     options.structuredOutputs === true &&
                     shouldEnableJsonSchema(provider, model, baseURL),

--- a/libs/llm/model-context-window.ts
+++ b/libs/llm/model-context-window.ts
@@ -57,7 +57,7 @@ const MANUAL_OVERRIDES: Record<string, number> = {
 function normalize(name: string): string {
     return name
         .toLowerCase()
-        .replace(/^(openai|anthropic|google|gemini|vertex_ai|bedrock|azure|together_ai|openrouter|novita|fireworks_ai|deepseek|mistral|moonshot|hf|huggingface)\//, '')
+        .replace(/^(openai|anthropic|google|gemini|vertex_ai|bedrock|azure|together_ai|openrouter|orcarouter|novita|fireworks_ai|deepseek|mistral|moonshot|hf|huggingface)\//, '')
         .replace(/[-_.\s/:]/g, '');
 }
 

--- a/libs/llm/reasoning-options.spec.ts
+++ b/libs/llm/reasoning-options.spec.ts
@@ -240,6 +240,16 @@ describe('buildReasoningProviderOptions', () => {
         });
     });
 
+    describe('OrcaRouter', () => {
+        it('emits thinking.type=enabled under openaiCompatible key (effort ignored)', () => {
+            expect(
+                buildReasoningProviderOptions(BYOKProvider.ORCAROUTER, 'high'),
+            ).toEqual({
+                openaiCompatible: { thinking: { type: 'enabled' } },
+            });
+        });
+    });
+
     describe('OpenAI-Compatible', () => {
         it('emits thinking.type=enabled (effort ignored)', () => {
             expect(

--- a/libs/llm/reasoning-options.ts
+++ b/libs/llm/reasoning-options.ts
@@ -119,6 +119,7 @@ const PROVIDER_OPTIONS_NAMESPACE: Partial<Record<string, string>> = {
     [BYOKProvider.GOOGLE_VERTEX]: 'google',
     [BYOKProvider.OPENAI]: 'openai',
     [BYOKProvider.OPEN_ROUTER]: 'openrouter',
+    [BYOKProvider.ORCAROUTER]: 'openaiCompatible',
     [BYOKProvider.OPENAI_COMPATIBLE]: 'openaiCompatible',
     [BYOKProvider.NOVITA]: 'openaiCompatible',
 };
@@ -187,6 +188,7 @@ function mergeOpenRouterOptions(
  *   - Google Gemini 2.5: thinkingConfig.thinkingBudget
  *   - OpenAI o-series: reasoningEffort (low/medium/high)
  *   - OpenRouter: reasoning.effort (normalized across providers)
+ *   - OrcaRouter: thinking.type enabled/disabled (OpenAI-compatible gateway)
  *   - Kimi/GLM/others via OPENAI_COMPATIBLE: thinking.type enabled/disabled
  *
  * Defaults when nothing configured: thinking stays OFF for all providers.
@@ -273,7 +275,10 @@ export function buildReasoningProviderOptions(
                 openrouter: { reasoning: { effort } },
             };
 
+        case BYOKProvider.ORCAROUTER:
         case BYOKProvider.OPENAI_COMPATIBLE: {
+            // OrcaRouter is an OpenAI-compatible gateway — send the standard
+            // OpenAI-compatible thinking param and let it forward upstream.
             // Kimi K2.5: thinking ON by default, only need to send disable
             // GLM-5/5.1: thinking.type = enabled/disabled
             // For compatible providers that support thinking, send the

--- a/libs/organization/application/use-cases/organizationParameters/get-models-by-provider.use-case.ts
+++ b/libs/organization/application/use-cases/organizationParameters/get-models-by-provider.use-case.ts
@@ -130,6 +130,11 @@ export class GetModelsByProviderUseCase {
                     creds?.apiKey ?? process.env.API_OPEN_ROUTER_API_KEY,
                 );
 
+            case BYOKProvider.ORCAROUTER:
+                return this.getOrcaRouterModels(
+                    creds?.apiKey ?? process.env.API_ORCA_ROUTER_API_KEY,
+                );
+
             case BYOKProvider.NOVITA:
                 return this.getNovitaModels(
                     creds?.apiKey ?? process.env.API_NOVITA_AI_API_KEY,
@@ -379,6 +384,32 @@ export class GetModelsByProviderUseCase {
         } catch (error) {
             throw new BadRequestException(
                 `Error fetching OpenRouter models: ${(error as Error).message}`,
+            );
+        }
+    }
+
+    private async getOrcaRouterModels(apiKey?: string): Promise<ModelResponse> {
+        try {
+            const response = await axios.get<OpenAIResponse>(
+                'https://api.orcarouter.ai/v1/models',
+                {
+                    headers: {
+                        'Authorization': `Bearer ${apiKey}`,
+                        'Content-Type': 'application/json',
+                    },
+                },
+            );
+
+            return {
+                provider: BYOKProvider.ORCAROUTER,
+                models: response.data.data.map((model: OpenAIModel) => ({
+                    id: model.id,
+                    name: model.id,
+                })),
+            };
+        } catch (error) {
+            throw new BadRequestException(
+                `Error fetching OrcaRouter models: ${(error as Error).message}`,
             );
         }
     }

--- a/libs/organization/application/use-cases/organizationParameters/test-byok-connection.use-case.ts
+++ b/libs/organization/application/use-cases/organizationParameters/test-byok-connection.use-case.ts
@@ -673,6 +673,15 @@ export class TestByokConnectionUseCase {
                     },
                 };
 
+            case BYOKProvider.ORCAROUTER:
+                return {
+                    url: 'https://api.orcarouter.ai/v1/models',
+                    headers: {
+                        Authorization: `Bearer ${apiKey}`,
+                        'Content-Type': 'application/json',
+                    },
+                };
+
             case BYOKProvider.NOVITA:
                 return {
                     url: 'https://api.novita.ai/v3/openai/models',

--- a/packages/kodus-common/src/llm/byokProvider.service.ts
+++ b/packages/kodus-common/src/llm/byokProvider.service.ts
@@ -16,6 +16,7 @@ export enum BYOKProvider {
     OPENAI_COMPATIBLE = 'openai_compatible',
     ANTHROPIC_COMPATIBLE = 'anthropic_compatible',
     OPEN_ROUTER = 'open_router',
+    ORCAROUTER = 'orcarouter',
     NOVITA = 'novita',
 }
 
@@ -150,7 +151,9 @@ export class BYOKProviderService {
                     ? baseURL
                     : provider === BYOKProvider.OPEN_ROUTER
                       ? 'https://openrouter.ai/api/v1'
-                      : undefined,
+                      : provider === BYOKProvider.ORCAROUTER
+                        ? 'https://api.orcarouter.ai/v1'
+                        : undefined,
             options: {
                 temperature: options?.temperature,
                 maxTokens: options?.maxTokens,
@@ -272,6 +275,7 @@ export class BYOKProviderService {
             [BYOKProvider.OPENAI_COMPATIBLE]: 'OpenAI Compatible',
             [BYOKProvider.ANTHROPIC_COMPATIBLE]: 'Anthropic Compatible',
             [BYOKProvider.OPEN_ROUTER]: 'OpenRouter',
+            [BYOKProvider.ORCAROUTER]: 'OrcaRouter',
             [BYOKProvider.NOVITA]: 'Novita',
         };
 

--- a/packages/kodus-common/src/llm/providerAdapters/index.ts
+++ b/packages/kodus-common/src/llm/providerAdapters/index.ts
@@ -20,6 +20,7 @@ export function getAdapter(providerId: string): ProviderAdapter {
             return new OpenAIAdapter();
         case 'openai_compatible':
         case 'open_router':
+        case 'orcarouter':
             return new OpenAIAdapter();
         case 'anthropic':
         case 'anthropic_compatible':


### PR DESCRIPTION
## Summary

Adds OrcaRouter as a named BYOK provider, wired the same way the existing OpenRouter provider is — so the manual provider picker, model listing, connection probe, reasoning/thinking mapping and docs all treat it as a first-class gateway rather than a generic OpenAI-compatible endpoint.

This adds a dedicated [OrcaRouter](https://www.orcarouter.ai) provider rather than relying on the generic OpenAI-compatible endpoint, mirroring how this repo already treats OpenRouter-style aggregators. Named routers such as `orcarouter/auto` pick an upstream per request. OrcaRouter is an OpenAI-compatible gateway that exposes 150+ models behind one API key, and it also provides gateway-level security controls for AI agents.

## What's in the change

- `BYOKProvider.ORCAROUTER = 'orcarouter'` in `@kodus/kodus-common` — enum member, display name, default base URL `https://api.orcarouter.ai/v1`, and adapter mapping (OpenAI-compatible).
- `libs/llm/byok-to-vercel.ts` — routes OrcaRouter through `@ai-sdk/openai-compatible`, with the same json-schema prefix gate as OpenRouter. The shared prefix list is renamed `OPENROUTER_JSON_SCHEMA_PREFIXES` → `GATEWAY_JSON_SCHEMA_PREFIXES`.
- `libs/llm/reasoning-options.ts` — OrcaRouter maps to the `openaiCompatible` reasoning namespace (binary thinking on/off), since it forwards OpenAI-compatible thinking params upstream.
- `libs/core/.../provider.service.ts` — registers OrcaRouter so it appears in the manual wizard provider dropdown.
- Model listing + connection probe (`get-models-by-provider.use-case.ts`, `test-byok-connection.use-case.ts`) — `GET https://api.orcarouter.ai/v1/models` with `Bearer` auth.
- Web BYOK UI — provider label in the catalog and catalog-edit eligibility.
- Env var `API_ORCA_ROUTER_API_KEY` in `.env.example` / `.env.schema` / `.env.template` and the generated docs snippet.
- Docs — OrcaRouter tab, reasoning table row, and namespace table row in all five `byok.mdx` languages (en/es/ja/pt-br/zh), plus `libs/llm/README.md`.

## Test plan

- `libs/llm/reasoning-options.spec.ts` + `libs/llm/byok-to-vercel.spec.ts`: 34/34 pass (includes a new OrcaRouter reasoning test).
- `@kodus/kodus-common` test suite: 30/30 pass; package `tsc` clean.
- Scoped `tsc` over the changed libs (llm/core/organization): 0 errors.
- ESLint on all changed TS files: clean.
- Live against `https://api.orcarouter.ai/v1` with a real key: `GET /models` → 200 (192 models); chat completion on `anthropic/claude-sonnet-4.6` → 200; `response_format: json_schema` → 200 for `openai/` and `google/` models and routed (converted to Anthropic `output_config`) for `anthropic/`; `response_format: json_object` on `deepseek/deepseek-chat` → 200; a `thinking` param is forwarded to a Claude model → 200; invalid key → 401.

## Notes for the reviewer

OpenRouter's provider-pinning advanced settings (`openrouterProviderOrder` / `openrouterAllowFallbacks`) are intentionally not mirrored — OrcaRouter doesn't expose an equivalent pinning mechanism, so those fields stay OpenRouter-only.

I'm an engineer on the OrcaRouter team.
