### PR TITLE
ci: validate the api DI graph on every PR

### DIFF
--- a/.github/workflows/di-graph-gate.yml
+++ b/.github/workflows/di-graph-gate.yml
@@ -1,0 +1,86 @@
+name: DI Graph Gate (api)
+
+# Builds the real ApiModule dependency graph and fails the PR if Nest cannot
+# resolve it. This is the class of bug nothing else in CI can see:
+#
+#   - `nest build` and `tsc --noEmit` only compile. A constructor parameter
+#     whose provider is not registered in that module is valid TypeScript.
+#   - The unit suites instantiate classes directly or build purpose-made
+#     testing modules; none of them assemble the real ApiModule graph.
+#
+# The miss that motivated this gate: a class registered by TWO modules gains a
+# constructor dependency, and only one of the two modules gets the matching
+# `imports:` entry. Build green, tests green, container dead on boot.
+#
+# Nest's `preview: true` walks the graph and resolves every constructor's
+# dependencies without instantiating a single provider, so this opens no
+# database, Redis, RabbitMQ or HTTP connection and needs no real credentials.
+# See scripts/ci/validate-di-graph.ts.
+
+on:
+    pull_request:
+        paths:
+            - "apps/api/**"
+            - "libs/**"
+            - "packages/**"
+            - "scripts/ci/validate-di-graph.ts"
+            - ".github/workflows/di-graph-gate.yml"
+            - "tsconfig*.json"
+            - "package.json"
+            - "pnpm-lock.yaml"
+
+permissions:
+    contents: read
+
+jobs:
+    api-di-graph:
+        name: ApiModule DI graph resolves
+        runs-on: ubuntu-latest
+        # The graph build itself takes ~150ms; the rest is install + transpile.
+        # If this ever approaches the limit, something started doing real I/O.
+        timeout-minutes: 10
+
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v6.0.2
+
+            - uses: pnpm/action-setup@v4
+
+            - name: Set up Node
+              uses: actions/setup-node@v4
+              with:
+                  node-version: "22"
+                  cache: "pnpm"
+
+            - name: Install dependencies
+              run: pnpm install --frozen-lockfile
+
+            - name: Create environment.ts
+              # libs/ee/configs/environment/environment.ts is gitignored and
+              # generated per-target (Dockerfile does it with sed). The dev
+              # values are fine here: nothing is instantiated, so nothing reads
+              # them for real.
+              run: |
+                  cat <<'EOF' > libs/ee/configs/environment/environment.ts
+                  import { environment as devEnvironment } from './environment.dev';
+
+                  export const environment = devEnvironment;
+                  EOF
+
+            - name: Validate ApiModule dependency graph
+              # Every value below is a throwaway placeholder, NOT a secret. They
+              # exist only to satisfy import-time guards and the Joi env schema
+              # that run before the graph is built:
+              #   - API_CRYPTO_KEY / CODE_MANAGEMENT_SECRET are parsed as 32-byte
+              #     hex at module scope (libs/common/utils/crypto.ts and
+              #     webhooks/webhookTokenCrypto.ts).
+              #   - CODE_MANAGEMENT_WEBHOOK_TOKEN is asserted non-empty there too.
+              #   - API_PORT is the only Joi-required key (config.schema.ts).
+              # No DB/broker host is set: providers are never instantiated, so
+              # nothing connects. Do not add real credentials here.
+              env:
+                  API_CRYPTO_KEY: "0000000000000000000000000000000000000000000000000000000000000000"
+                  CODE_MANAGEMENT_SECRET: "0000000000000000000000000000000000000000000000000000000000000000"
+                  CODE_MANAGEMENT_WEBHOOK_TOKEN: "ci-placeholder"
+                  API_PORT: "3001"
+              run: pnpm run ci:validate-di-graph

--- a/package.json
+++ b/package.json
@@ -220,6 +220,7 @@
         "sentry:sourcemaps": "sentry-cli sourcemaps inject --org kodus --project kodus-orchestrator ./dist && sentry-cli sourcemaps upload --org kodus --project kodus-orchestrator ./dist",
         "typecheck": "node --max-old-space-size=8192 ./node_modules/.bin/tsc --noEmit --skipLibCheck",
         "typecheck:libs-gate": "bash scripts/typecheck-libs-gate.sh",
+        "ci:validate-di-graph": "TS_NODE_PROJECT=tsconfig.json node -r ts-node/register/transpile-only -r tsconfig-paths/register scripts/ci/validate-di-graph.ts",
         "prepare": "husky || true",
         "dev:yalc": "pnpm run dev:yalc:init && pnpm run dev:yalc:up && pnpm run dev:yalc:watch",
         "dev:yalc:tunel": "pnpm run tunnel & pnpm run dev:yalc:up && pnpm run dev:yalc:init && pnpm run dev:yalc:watch && pnpm run docker:logs",

--- a/scripts/ci/validate-di-graph.ts
+++ b/scripts/ci/validate-di-graph.ts
@@ -1,0 +1,120 @@
+/**
+ * Validates that the Nest dependency-injection graph actually resolves.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * A missing provider is a *runtime* failure raised while Nest builds the
+ * container, so nothing else in CI can see it:
+ *   - `nest build` / `tsc --noEmit` only compile. A constructor parameter
+ *     whose provider is not registered in that module is perfectly valid
+ *     TypeScript.
+ *   - The unit suites instantiate classes directly (or through a
+ *     purpose-built `Test.createTestingModule`), never the real ApiModule
+ *     graph.
+ *
+ * The concrete miss this guards against: a class is registered by *two*
+ * modules, a PR adds a constructor dependency, and only one of the two
+ * modules gets the corresponding `imports:` entry. The app then dies on
+ * boot. `grep -rn "<StageName>" libs --include="*.module.ts"` shows the
+ * asymmetry, but only if somebody remembers to run it.
+ *
+ * HOW IT WORKS
+ * ------------
+ * `preview: true` walks the whole module graph and resolves every
+ * constructor's dependencies, but never instantiates a provider — the
+ * guard lives inside Nest's `instantiateClass`, while
+ * `resolveConstructorParams` runs unguarded. So we get full DI validation
+ * with no constructor bodies, meaning no database, Redis, RabbitMQ or
+ * HTTP connections are opened.
+ *
+ * `abortOnError: false` makes Nest throw the resolution error instead of
+ * logging a partial message and killing the process itself, which lets us
+ * print the full "Nest can't resolve dependencies of X ... available in
+ * the Y module" text — the part that names the module you forgot.
+ */
+import { NestFactory } from '@nestjs/core';
+
+import { ApiModule } from '../../apps/api/src/api.module';
+
+/**
+ * Belt-and-braces: the whole point of this job is to be fast and
+ * deterministic. If some module-level import ever starts waiting on a
+ * socket, fail loudly instead of burning the CI job's wall clock.
+ */
+const TIMEOUT_MS = 60_000;
+
+async function main(): Promise<void> {
+    const startedAt = process.hrtime.bigint();
+
+    const timeout = setTimeout(() => {
+        console.error(
+            `\n[di-graph] TIMED OUT after ${TIMEOUT_MS}ms building the module graph.\n` +
+                `[di-graph] Building the graph should never block — something is ` +
+                `opening a connection at import time.`,
+        );
+        process.exit(1);
+    }, TIMEOUT_MS);
+    // Do not hold the event loop open just for the watchdog.
+    timeout.unref();
+
+    console.log('[di-graph] building ApiModule graph (preview mode)...');
+
+    const context = await NestFactory.createApplicationContext(ApiModule, {
+        // Resolve every dependency, instantiate nothing.
+        preview: true,
+        // Throw on failure instead of process.exit()-ing with a truncated log.
+        abortOnError: false,
+        // Drop the per-module "dependencies initialized" chatter; keep anything
+        // that signals a real problem.
+        logger: ['error', 'warn'],
+    });
+
+    await context.close();
+    clearTimeout(timeout);
+
+    const elapsedMs = Number(process.hrtime.bigint() - startedAt) / 1e6;
+    console.log(
+        `[di-graph] OK — ApiModule resolves (${elapsedMs.toFixed(0)}ms).`,
+    );
+}
+
+main()
+    .then(() => {
+        // Module-level imports can leave timers/handles open even though we
+        // never instantiated a provider. Exit explicitly so the job ends.
+        process.exit(0);
+    })
+    .catch((error: unknown) => {
+        console.error('\n[di-graph] FAILED — the module graph does not resolve.\n');
+        console.error(error instanceof Error ? error.message : error);
+
+        if (error instanceof Error && error.stack) {
+            console.error('\n--- stack ---');
+            console.error(error.stack);
+        }
+
+        const message = error instanceof Error ? error.message : String(error);
+
+        if (message.includes('cannot export a provider/module')) {
+            // UnknownExportException: a module lists a token in `exports:` that
+            // it does not own. Nest only lets you export a token from your own
+            // `providers:`, or re-export a whole imported module class.
+            console.error(
+                '\n[di-graph] Fix: a module can only export a token it declares in its own\n' +
+                    '[di-graph] `providers:`. To pass along a token owned by a module you import,\n' +
+                    '[di-graph] re-export that module instead:\n' +
+                    '[di-graph]   exports: [ /* the Module */ ]   // not the token\n',
+            );
+        } else {
+            // Missing provider: the class is registered in a module whose
+            // imports do not reach the provider it needs.
+            console.error(
+                '\n[di-graph] Fix: every module that registers the class above needs the\n' +
+                    '[di-graph] module exporting the missing provider in its `imports:`.\n' +
+                    '[di-graph] A class registered by more than one module needs the import in\n' +
+                    '[di-graph] EACH of them. Find all registration sites with:\n' +
+                    '[di-graph]   grep -rn "<ClassName>" libs apps --include="*.module.ts"\n',
+            );
+        }
+        process.exit(1);
+    });


### PR DESCRIPTION
## Problem

A missing provider is a **runtime** failure raised while Nest builds the container, so nothing in CI can currently see it:

- `nest build` and `tsc --noEmit` only compile. A constructor parameter whose provider is not registered in that module is perfectly valid TypeScript.
- The unit suites instantiate classes directly or build purpose-made testing modules. None of them assemble the real `ApiModule` graph.

The miss that motivated this: a class is registered by **two** modules, a PR adds a constructor dependency, and only one of the two modules gets the matching `imports:` entry. Build green, tests green, container dead on boot. The grep that exposes the asymmetry only runs if somebody remembers to run it — DI resolution shouldn't depend on that.

## How it works

`scripts/ci/validate-di-graph.ts` builds the real graph:

```ts
await NestFactory.createApplicationContext(ApiModule, {
    preview: true,
    abortOnError: false,
});
```

`preview: true` walks the graph and resolves every constructor's dependencies **without instantiating a single provider** — the guard sits inside Nest's `instantiateClass`, while `resolveConstructorParams` runs unguarded. `abortOnError: false` surfaces the full `available in the Y module` text instead of a truncated log, which is the part that names what you forgot.

The script distinguishes the two failure shapes and prints the right remediation, since they are opposites: a missing provider needs an added `imports:` entry, while an `UnknownExportException` needs the module re-exported rather than the token.

## Verification

Both failure shapes and the green path were exercised end-to-end through the real CI entrypoint (`pnpm run ci:validate-di-graph`):

| Check | Result |
| --- | --- |
| Green on `main` | exit 0, graph resolves in ~115ms |
| Missing provider | exit 1, names the class, the argument and the owning module |
| `UnknownExportException` | exit 1, names the token and the module |
| Opens no DB/Redis/RabbitMQ/HTTP | 0 real network handles after the build; only stdio fds 0/1/2 remain |
| Runtime | ~10s total, install-bound; graph build itself ~150ms |

The no-I/O claim was checked two ways: by inspecting `process._getActiveHandles()` after the build, and by a run with every DB/broker host pointed at the black-hole address `192.0.2.1`, which still passes in the same time — a real connection attempt would block.

## Cost

Needs no secrets and no populated `.env`. Four throwaway placeholders satisfy the import-time guards and the Joi schema that run before the graph is built: `API_CRYPTO_KEY` and `CODE_MANAGEMENT_SECRET` (parsed as 32-byte hex at module scope), `CODE_MANAGEMENT_WEBHOOK_TOKEN` (asserted non-empty), and `API_PORT` (the only Joi-required key). No DB or broker host is set at all.

Scoped to `ApiModule` deliberately. `ReportCliModule`, `BackfillModule` and `mcp-manager` are follow-ups once this is proven.

## Note for reviewers

Test-drive against `feat/kodus-trace` (#1667) surfaced two **real** boot-breaking DI bugs on that branch's HEAD, both of which this gate catches and neither of which is fixed here:

1. `libs/code-review/pipeline/code-review-pipeline.module.ts:216` exports `LOAD_EXTERNAL_CONTEXT_STAGE_TOKEN`, a token `PromptsModule` owns. Nest only permits exporting a token from your own `providers:`, or re-exporting the whole module class.
2. `libs/code-review/pipeline/stages/finish-comments.stage.ts:42` — `UpdateCommentsAndGenerateSummaryStage` injects `PostTracePrCommentUseCase`, but `CodeReviewPipelineModule` never imports `TraceContextModule`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)