### PR TITLE
fix(kody-rules): bound the onboarding backfill instead of walking every PR

### DIFF
--- a/libs/kodyRules/application/use-cases/generate-kody-rules.use-case.ts
+++ b/libs/kodyRules/application/use-cases/generate-kody-rules.use-case.ts
@@ -80,6 +80,70 @@ import { RepositoryCodeReviewConfig } from '@libs/core/infrastructure/config/typ
 // is already detached via setImmediate for the background path.
 export const PR_FETCH_CONCURRENCY = 2;
 
+// Ceiling on the per-PR walk, which is the fallback for providers with no
+// repository-level comment listing (GitLab, Bitbucket, Azure DevOps, Forgejo).
+//
+// Without it the walk costs 3 API calls per pull request in the window, with
+// nothing bounding the window's size but the customer's own activity. On a
+// repo with 816 PRs that is ~2450 requests -- most of an hourly GitHub budget,
+// spent to build a list this use case then truncates to 100 comments. See
+// issue #1686.
+//
+// Two limits, because either one alone leaves a hole: TARGET stops early on a
+// repo where a few PRs carry long review threads, and MAX_SCANNED stops a repo
+// whose PRs are mostly empty from walking forever looking for a target it will
+// never reach.
+export const MAX_PULL_REQUESTS_SCANNED = 100;
+
+// Oversampled against the ~100 comments the pipeline keeps: bot authors,
+// Kody's own past comments and denylisted reviewers are dropped downstream.
+export const TARGET_SAMPLED_COMMENTS = 300;
+
+// Mirrors the filter in commentAnalysis.service (`body.length > 100`), so the
+// budget counts comments that can actually become a rule rather than "LGTM".
+const SUBSTANTIVE_COMMENT_LENGTH = 100;
+
+/**
+ * Newest pull requests first, tolerating providers that do not return a
+ * creation date (bitbucket and forgejo do not populate `created_at` on this
+ * shape). Undated entries keep their original relative order, which is
+ * already newest-first for every provider we call -- sorting them to the back
+ * would be worse than leaving them where the API put them.
+ */
+export function orderPullRequestsNewestFirst<
+    T extends { created_at?: string; createdAt?: string },
+>(pullRequests: T[]): T[] {
+    const time = (pr: T): number | undefined => {
+        const raw = pr?.created_at ?? pr?.createdAt;
+        if (!raw) return undefined;
+        const t = new Date(raw).getTime();
+        return Number.isNaN(t) ? undefined : t;
+    };
+    return [...(pullRequests ?? [])]
+        .map((pr, index) => ({ pr, index, t: time(pr) }))
+        .sort((a, b) => {
+            if (a.t === undefined || b.t === undefined) {
+                return a.index - b.index;
+            }
+            return b.t - a.t;
+        })
+        .map((entry) => entry.pr);
+}
+
+/** Comments long enough to carry a convention worth learning. */
+export function countSubstantiveComments(entry: {
+    generalComments?: any[];
+    reviewComments?: any[];
+}): number {
+    return [
+        ...(entry?.generalComments ?? []),
+        ...(entry?.reviewComments ?? []),
+    ].filter(
+        (comment) =>
+            (comment?.body ?? '').length > SUBSTANTIVE_COMMENT_LENGTH,
+    ).length;
+}
+
 @Injectable()
 export class GenerateKodyRulesUseCase {
     private readonly logger = createLogger(GenerateKodyRulesUseCase.name);
@@ -622,19 +686,64 @@ export class GenerateKodyRulesUseCase {
     ): Promise<any[]> {
         const limit = pLimit(PR_FETCH_CONCURRENCY);
 
-        const settled = await Promise.allSettled(
-            pullRequests.map((pr) =>
-                limit(() =>
-                    this.fetchSinglePullRequestComments(
-                        repository,
-                        pr,
-                        organizationAndTeamData,
-                    ),
-                ),
-            ),
-        );
+        // Newest first, then walk in chunks and stop as soon as we have
+        // enough. Fetching everything and truncating later is what made this
+        // cost an hour of the customer's GitHub budget (issue #1686); the
+        // chunking is what lets us stop, since the previous single
+        // Promise.allSettled committed to every PR before seeing any result.
+        const ordered = orderPullRequestsNewestFirst(pullRequests ?? []);
+        const scannable = ordered.slice(0, MAX_PULL_REQUESTS_SCANNED);
 
         const collected: any[] = [];
+        const settled: PromiseSettledResult<any>[] = [];
+        let sampled = 0;
+        let scanned = 0;
+
+        for (let i = 0; i < scannable.length; i += PR_FETCH_CONCURRENCY) {
+            const chunk = scannable.slice(i, i + PR_FETCH_CONCURRENCY);
+            const chunkSettled = await Promise.allSettled(
+                chunk.map((pr) =>
+                    limit(() =>
+                        this.fetchSinglePullRequestComments(
+                            repository,
+                            pr,
+                            organizationAndTeamData,
+                        ),
+                    ),
+                ),
+            );
+            settled.push(...chunkSettled);
+            scanned += chunk.length;
+
+            for (const result of chunkSettled) {
+                if (result.status === 'fulfilled') {
+                    sampled += countSubstantiveComments(result.value);
+                }
+            }
+
+            if (sampled >= TARGET_SAMPLED_COMMENTS) {
+                break;
+            }
+        }
+
+        // Never silent: a cap that trims coverage has to say what it left on
+        // the floor, or a thin rule set reads as "this repo has no
+        // conventions" instead of "we stopped early".
+        if (scanned < ordered.length) {
+            this.logger.log({
+                message:
+                    'Stopped sampling pull requests early (comment budget reached or scan ceiling hit)',
+                context: GenerateKodyRulesUseCase.name,
+                metadata: {
+                    pullRequestsInWindow: ordered.length,
+                    pullRequestsScanned: scanned,
+                    substantiveCommentsSampled: sampled,
+                    targetComments: TARGET_SAMPLED_COMMENTS,
+                    maxScanned: MAX_PULL_REQUESTS_SCANNED,
+                },
+            });
+        }
+
         for (const result of settled) {
             if (result.status === 'fulfilled') {
                 collected.push(result.value);

--- a/libs/kodyRules/application/use-cases/generate-kody-rules.use-case.ts
+++ b/libs/kodyRules/application/use-cases/generate-kody-rules.use-case.ts
@@ -376,6 +376,8 @@ export class GenerateKodyRulesUseCase {
                                 'Failed to fetch pull requests (code management integration/auth error)',
                             context: GenerateKodyRulesUseCase.name,
                             metadata: {
+                                organizationId:
+                                    organizationAndTeamData?.organizationId,
                                 dateFilter,
                                 repositoryId:
                                     repository?.id ?? 'repository not found',
@@ -735,6 +737,7 @@ export class GenerateKodyRulesUseCase {
                     'Stopped sampling pull requests early (comment budget reached or scan ceiling hit)',
                 context: GenerateKodyRulesUseCase.name,
                 metadata: {
+                    organizationId: organizationAndTeamData?.organizationId,
                     pullRequestsInWindow: ordered.length,
                     pullRequestsScanned: scanned,
                     substantiveCommentsSampled: sampled,

--- a/libs/kodyRules/application/use-cases/generate-kody-rules.use-case.ts
+++ b/libs/kodyRules/application/use-cases/generate-kody-rules.use-case.ts
@@ -261,8 +261,22 @@ export class GenerateKodyRulesUseCase {
                 );
 
             for (const repository of filteredRepositories) {
-                const pullRequests =
-                    await this.codeManagementService.getPullRequestsByRepository(
+                // Preferred path: ask the provider for the repo's recent
+                // comments directly, newest first, and stop once we have
+                // enough. Bounded by the sample we want rather than by how
+                // many PRs the repo happens to have.
+                //
+                // The fallback below walks every PR in the window and spends
+                // 3 calls on each, which on an active repo can exceed the
+                // account's entire hourly GitHub budget before it finishes
+                // (issue #1686). It stays only for providers with no
+                // repository-level comment listing.
+                // Optional call: the capability is declared optional on the
+                // contract, so a platform (or a partially-wired facade) that
+                // lacks it degrades to the walk below instead of failing rule
+                // generation outright.
+                const sampled =
+                    await this.codeManagementService.getRecentRepositoryComments?.(
                         {
                             organizationAndTeamData,
                             repository,
@@ -272,42 +286,61 @@ export class GenerateKodyRulesUseCase {
                         },
                     );
 
-                // null/undefined = fetch failed (e.g. GitHub App install
-                // returning 404 on the access token); an empty array is a
-                // legitimate "no PRs in this window".
-                if (pullRequests == null) {
-                    this.logger.error({
-                        message:
-                            'Failed to fetch pull requests (code management integration/auth error)',
-                        context: GenerateKodyRulesUseCase.name,
-                        metadata: {
-                            dateFilter,
-                            repositoryId: repository?.id ?? 'repository not found',
-                        },
-                    });
-                    failedRepositories.push(repository?.id ?? 'unknown');
-                    continue;
-                }
+                let comments = sampled;
 
-                if (pullRequests.length === 0) {
-                    this.logger.log({
-                        message: 'No pull requests found',
-                        context: GenerateKodyRulesUseCase.name,
-                        metadata: {
-                            dateFilter,
-                            repositoryId: repository
-                                ? repository.id
-                                : 'repository not found',
-                        },
-                    });
-                    continue;
-                }
+                // null means the provider has no repository-level listing (or
+                // the call failed) -- NOT "no comments". Only then do we pay
+                // for the per-PR walk.
+                if (comments == null) {
+                    const pullRequests =
+                        await this.codeManagementService.getPullRequestsByRepository(
+                            {
+                                organizationAndTeamData,
+                                repository,
+                                filters: {
+                                    ...dateFilter,
+                                },
+                            },
+                        );
 
-                const comments = await this.fetchPullRequestComments(
-                    repository,
-                    pullRequests,
-                    organizationAndTeamData,
-                );
+                    // null/undefined = fetch failed (e.g. GitHub App install
+                    // returning 404 on the access token); an empty array is a
+                    // legitimate "no PRs in this window".
+                    if (pullRequests == null) {
+                        this.logger.error({
+                            message:
+                                'Failed to fetch pull requests (code management integration/auth error)',
+                            context: GenerateKodyRulesUseCase.name,
+                            metadata: {
+                                dateFilter,
+                                repositoryId:
+                                    repository?.id ?? 'repository not found',
+                            },
+                        });
+                        failedRepositories.push(repository?.id ?? 'unknown');
+                        continue;
+                    }
+
+                    if (pullRequests.length === 0) {
+                        this.logger.log({
+                            message: 'No pull requests found',
+                            context: GenerateKodyRulesUseCase.name,
+                            metadata: {
+                                dateFilter,
+                                repositoryId: repository
+                                    ? repository.id
+                                    : 'repository not found',
+                            },
+                        });
+                        continue;
+                    }
+
+                    comments = await this.fetchPullRequestComments(
+                        repository,
+                        pullRequests,
+                        organizationAndTeamData,
+                    );
+                }
 
                 if (!comments || comments.length === 0) {
                     this.logger.log({

--- a/libs/platform/domain/platformIntegrations/interfaces/code-management.interface.ts
+++ b/libs/platform/domain/platformIntegrations/interfaces/code-management.interface.ts
@@ -183,6 +183,26 @@ export interface ICodeManagementService extends ICommonPlatformIntegrationServic
     ): Promise<IntegrationConfigEntity | null>;
     getDefaultBranch(params: any): Promise<string>;
     getPullRequestReviewComment(params: any): Promise<any | null>;
+    /**
+     * Recent review + conversation comments for a whole repository, newest
+     * first, grouped by pull request.
+     *
+     * OPTIONAL: only providers with a repository-level comment listing can
+     * answer this in a bounded number of calls (GitHub can; GitLab, Bitbucket
+     * and Azure DevOps expose comments per merge/pull request only). Callers
+     * must fall back to the per-PR walk when it is absent -- see issue #1686.
+     */
+    getRecentRepositoryComments?(params: {
+        organizationAndTeamData: OrganizationAndTeamData;
+        repository: { id: string; name: string };
+        filters?: { startDate?: string; endDate?: string };
+        limit?: number;
+    }): Promise<Array<{
+        pr: { pull_number: number };
+        generalComments: any[];
+        reviewComments: any[];
+        files: { filename: string }[];
+    }> | null>;
     createResponseToComment(params: any): Promise<any | null>;
     updateDescriptionInPullRequest(params: any): Promise<any | null>;
     getAuthenticationOAuthToken(params: any): Promise<string>;

--- a/libs/platform/infrastructure/adapters/services/codeManagement.service.ts
+++ b/libs/platform/infrastructure/adapters/services/codeManagement.service.ts
@@ -806,6 +806,32 @@ export class CodeManagementService implements ICodeManagementService {
         return codeManagementService.getPullRequestReviewComment(params);
     }
 
+    /**
+     * Repository-level comment sample. Returns null when the active platform
+     * has no such endpoint, which is the caller's signal to fall back to the
+     * per-PR walk rather than treat it as "no comments".
+     */
+    async getRecentRepositoryComments(params: any, type?: PlatformType) {
+        if (!type) {
+            type = await this.getTypeIntegration(
+                extractOrganizationAndTeamData(params),
+            );
+        }
+
+        if (!type) {
+            return null;
+        }
+
+        const codeManagementService =
+            this.platformIntegrationFactory.getCodeManagementService(type);
+
+        if (!codeManagementService.getRecentRepositoryComments) {
+            return null;
+        }
+
+        return codeManagementService.getRecentRepositoryComments(params);
+    }
+
     async createResponseToComment(params: any, type?: PlatformType) {
         if (!type) {
             type = await this.getTypeIntegration(

--- a/libs/platform/infrastructure/adapters/services/github/github-comment-sample.ts
+++ b/libs/platform/infrastructure/adapters/services/github/github-comment-sample.ts
@@ -1,0 +1,100 @@
+/**
+ * Shaping helpers for the repository-level comment sample used by Kody-rules
+ * generation (see `GithubService.getRecentRepositoryComments`).
+ *
+ * Kept out of the service so the part with actual decisions in it — which
+ * comments belong to a pull request, which PR each one belongs to, and where
+ * the file paths come from — is testable without an Octokit or a network.
+ */
+
+export interface SampledPullRequestComments {
+    pr: { pull_number: number };
+    generalComments: any[];
+    reviewComments: any[];
+    files: { filename: string }[];
+}
+
+/**
+ * Pull the PR/issue number out of an API url.
+ *
+ * Anchored on the trailing segment so a repository whose OWNER or NAME
+ * contains "pulls" or "issues" cannot shift the match onto the wrong number.
+ */
+export function pullRequestNumberFromUrl(url?: string): number | undefined {
+    const match = /\/(?:pulls|issues)\/(\d+)(?:$|[/?#])/.exec(url ?? '');
+    return match ? Number(match[1]) : undefined;
+}
+
+/**
+ * On GitHub every pull request is also an issue, so
+ * `GET /repos/{owner}/{repo}/issues/comments` returns comments from both.
+ * Only the html_url distinguishes them: PR conversation comments live under
+ * `/pull/<n>`, plain issue comments under `/issues/<n>`.
+ *
+ * Getting this wrong feeds issue chatter into rule generation, which is how a
+ * bug report's discussion turns into a coding convention.
+ */
+export function isPullRequestIssueComment(comment: {
+    html_url?: string;
+}): boolean {
+    return /\/pull\/\d+/.test(comment?.html_url ?? '');
+}
+
+/**
+ * Group a flat comment sample by pull request.
+ *
+ * `files` is derived from the `path` each review comment was left on, not
+ * fetched. The only consumer of that field counts extensions to tag comments
+ * with a language (`commentAnalysis.service.fileExtensionFrequencyAnalysis`
+ * reads nothing but `filename`), so the per-PR files request it used to cost —
+ * one third of all requests in the old shape — bought data we already had.
+ *
+ * A PR contributes an entry as soon as it has any comment; a PR whose only
+ * comments are conversation comments simply gets an empty `files`, which
+ * downstream reads as "no language tag", exactly as a failed files fetch did.
+ */
+export function groupCommentsByPullRequest(
+    reviewComments: Array<{ pull_request_url?: string; path?: string }>,
+    issueComments: Array<{ issue_url?: string; html_url?: string }>,
+): SampledPullRequestComments[] {
+    const byPr = new Map<number, SampledPullRequestComments>();
+
+    const bucket = (prNumber: number): SampledPullRequestComments => {
+        let entry = byPr.get(prNumber);
+        if (!entry) {
+            entry = {
+                pr: { pull_number: prNumber },
+                generalComments: [],
+                reviewComments: [],
+                files: [],
+            };
+            byPr.set(prNumber, entry);
+        }
+        return entry;
+    };
+
+    for (const comment of reviewComments ?? []) {
+        const prNumber = pullRequestNumberFromUrl(comment?.pull_request_url);
+        if (prNumber === undefined) {
+            continue;
+        }
+        const entry = bucket(prNumber);
+        entry.reviewComments.push(comment);
+        if (comment?.path) {
+            entry.files.push({ filename: comment.path });
+        }
+    }
+
+    for (const comment of issueComments ?? []) {
+        if (!isPullRequestIssueComment(comment)) {
+            continue;
+        }
+        const prNumber = pullRequestNumberFromUrl(comment?.issue_url);
+        if (prNumber === undefined) {
+            continue;
+        }
+        bucket(prNumber).generalComments.push(comment);
+    }
+
+    return [...byPr.values()];
+}

--- a/libs/platform/infrastructure/adapters/services/github/github.service.ts
+++ b/libs/platform/infrastructure/adapters/services/github/github.service.ts
@@ -6729,6 +6729,14 @@ This is an experimental feature that generates committable changes. Review the d
                 ...(filters?.startDate && { since: filters.startDate }),
             };
 
+            // Sequential on purpose, NOT a missed Promise.all. Both listings
+            // draw from one budget, and running them in order gives review
+            // comments first claim on it -- they carry the `path` they were
+            // left on, which is what replaces the per-PR files call. In
+            // parallel the split between the two sources would depend on
+            // which pages return first, making the sample that feeds rule
+            // generation nondeterministic. The cost is one extra round trip
+            // on a background job nobody is waiting for.
             const reviewComments = await octokit.paginate(
                 octokit.pulls.listReviewCommentsForRepo,
                 listParams,

--- a/libs/platform/infrastructure/adapters/services/github/github.service.ts
+++ b/libs/platform/infrastructure/adapters/services/github/github.service.ts
@@ -5,6 +5,7 @@ import { INTEGRATION_REQUEST_TIMEOUT_MS } from '@libs/core/infrastructure/http/i
 import { graphql } from '@octokit/graphql';
 import { enterpriseServer313 } from '@octokit/plugin-enterprise-server';
 import { retry } from '@octokit/plugin-retry';
+import { groupCommentsByPullRequest } from './github-comment-sample';
 import { throttling } from '@octokit/plugin-throttling';
 import { Octokit, RestEndpointMethodTypes } from '@octokit/rest';
 
@@ -6617,6 +6618,147 @@ This is an experimental feature that generates committable changes. Review the d
                 error: error.message,
                 metadata: params,
             });
+            return null;
+        }
+    }
+
+    /**
+     * Recent review + conversation comments for a whole repository, newest
+     * first, grouped by pull request.
+     *
+     * Answers the question rule generation actually asks -- "what have
+     * reviewers been saying in this repo lately" -- with two paginated
+     * listings, instead of walking every PR in the window and issuing three
+     * calls each.
+     *
+     * The old shape cost 3 requests per PR, uncapped, to produce a list the
+     * consumer then truncated to 100 comments. On a repo with 816 PRs in the
+     * window that was ~2450 requests out of GitHub's 5000/hour, spent to
+     * throw almost all of it away -- see issue #1686. Here the cap lives at
+     * the source: we stop paginating once enough substantive comments are in
+     * hand.
+     *
+     * It also fixes what those 100 comments WERE. The per-PR loop filled the
+     * quota in PR order, so the surviving comments came from the OLDEST pull
+     * requests in the window -- rules were being learned from the least
+     * current conventions in the repo. Sorting by recency is the point, not a
+     * side effect.
+     */
+    async getRecentRepositoryComments(params: {
+        organizationAndTeamData: OrganizationAndTeamData;
+        repository: {
+            id: string;
+            name: string;
+        };
+        filters?: {
+            startDate?: string;
+            endDate?: string;
+        };
+        limit?: number;
+    }): Promise<Array<{
+        pr: { pull_number: number };
+        generalComments: any[];
+        reviewComments: any[];
+        files: { filename: string }[];
+    }> | null> {
+        try {
+            const { organizationAndTeamData, repository, filters } = params;
+            // Oversampled against the ~100 the consumer keeps: bot authors,
+            // Kody's own past comments and denylisted reviewers are all
+            // dropped downstream, so collecting exactly 100 here would leave
+            // fewer than that after filtering.
+            const limit = params.limit ?? 300;
+
+            const githubAuthDetail = await this.getGithubAuthDetails(
+                organizationAndTeamData,
+            );
+            const octokit = await this.instanceOctokit(organizationAndTeamData);
+
+            const startTime = filters?.startDate
+                ? new Date(filters.startDate).getTime()
+                : null;
+            const endTime = filters?.endDate
+                ? new Date(filters.endDate).getTime()
+                : null;
+
+            // Mirrors the consumer's own filter (commentAnalysis.service:
+            // `body.length > 100`). Applying it while paginating means the
+            // budget counts comments that can actually become a rule, not
+            // "LGTM" and ":+1:".
+            const substantive = (body?: string): boolean =>
+                (body ?? '').length > 100;
+
+            const budget = { kept: 0 };
+
+            // Shared across both listings: the two endpoints feed one sample,
+            // so they must not each spend the full budget.
+            const collectPage = <T extends { created_at: string; body?: string }>(
+                page: T[],
+                done: () => void,
+            ): T[] => {
+                const inWindow: T[] = [];
+                for (const comment of page) {
+                    const t = new Date(comment.created_at).getTime();
+                    // Sorted newest first, so the first one older than the
+                    // window means every remaining page is older too.
+                    if (startTime !== null && t < startTime) {
+                        done();
+                        break;
+                    }
+                    if (endTime !== null && t > endTime) {
+                        continue;
+                    }
+                    inWindow.push(comment);
+                    if (substantive(comment.body)) {
+                        budget.kept++;
+                        if (budget.kept >= limit) {
+                            done();
+                            break;
+                        }
+                    }
+                }
+                return inWindow;
+            };
+
+            const listParams = {
+                owner: githubAuthDetail.org,
+                repo: repository.name,
+                sort: 'created' as const,
+                direction: 'desc' as const,
+                per_page: 100,
+                ...(filters?.startDate && { since: filters.startDate }),
+            };
+
+            const reviewComments = await octokit.paginate(
+                octokit.pulls.listReviewCommentsForRepo,
+                listParams,
+                (response, done) => collectPage(response.data, done),
+            );
+
+            const issueComments = await octokit.paginate(
+                octokit.issues.listCommentsForRepo,
+                listParams,
+                (response, done) => collectPage(response.data, done),
+            );
+
+            // /issues/comments covers issues AND pull requests -- on GitHub a
+            // PR is an issue -- so the sample is filtered and grouped by
+            // github-comment-sample.ts, where that logic is unit-tested.
+            return groupCommentsByPullRequest(
+                reviewComments as any[],
+                issueComments as any[],
+            );
+        } catch (error) {
+            this.logger.error({
+                message: 'Error to get recent repository comments',
+                context: GithubService.name,
+                serviceName: 'GithubService getRecentRepositoryComments',
+                error: error.message,
+                metadata: params,
+            });
+            // null (not []) so the caller can tell "this provider path
+            // failed, fall back to the per-PR walk" from "this repo genuinely
+            // has no recent comments".
             return null;
         }
     }

--- a/test/unit/kodyRules/use-cases/generate-kody-rules.sampling.spec.ts
+++ b/test/unit/kodyRules/use-cases/generate-kody-rules.sampling.spec.ts
@@ -198,6 +198,23 @@ describe('fetchPullRequestComments (the walk itself)', () => {
     // The quality half of the bug: the old walk filled its quota in the order
     // the provider returned, so rules were learned from the OLDEST reviews in
     // the window -- the least current conventions in the repo.
+    // Multi-tenant: "we stopped early on repo X" is unusable without knowing
+    // whose repo X is, and this log is the only trace that coverage was
+    // trimmed at all.
+    it('names the organization when it reports an early stop', async () => {
+        const useCase = makeUseCase(0);
+
+        await useCase.fetchPullRequestComments({}, prs(816), {
+            organizationId: 'org-1',
+        });
+
+        expect(useCase.logger.log).toHaveBeenCalledWith(
+            expect.objectContaining({
+                metadata: expect.objectContaining({ organizationId: 'org-1' }),
+            }),
+        );
+    });
+
     it('takes the NEWEST pull requests, not the first ones the API returned', async () => {
         const useCase = makeUseCase(0);
 

--- a/test/unit/kodyRules/use-cases/generate-kody-rules.sampling.spec.ts
+++ b/test/unit/kodyRules/use-cases/generate-kody-rules.sampling.spec.ts
@@ -1,0 +1,213 @@
+import {
+    GenerateKodyRulesUseCase,
+    MAX_PULL_REQUESTS_SCANNED,
+    PR_FETCH_CONCURRENCY,
+    TARGET_SAMPLED_COMMENTS,
+    countSubstantiveComments,
+    orderPullRequestsNewestFirst,
+} from '@libs/kodyRules/application/use-cases/generate-kody-rules.use-case';
+
+const longBody = 'x'.repeat(150);
+const shortBody = 'LGTM';
+
+describe('orderPullRequestsNewestFirst', () => {
+    it('puts the most recent pull requests first', () => {
+        const ordered = orderPullRequestsNewestFirst([
+            { pull_number: 1, created_at: '2026-01-01T00:00:00Z' },
+            { pull_number: 3, created_at: '2026-03-01T00:00:00Z' },
+            { pull_number: 2, created_at: '2026-02-01T00:00:00Z' },
+        ]);
+
+        expect(ordered.map((pr: any) => pr.pull_number)).toEqual([3, 2, 1]);
+    });
+
+    it('accepts either date field name', () => {
+        const ordered = orderPullRequestsNewestFirst([
+            { pull_number: 1, createdAt: '2026-01-01T00:00:00Z' },
+            { pull_number: 2, createdAt: '2026-05-01T00:00:00Z' },
+        ]);
+
+        expect(ordered.map((pr: any) => pr.pull_number)).toEqual([2, 1]);
+    });
+
+    // Bitbucket and Forgejo do not populate a creation date on this shape.
+    // Their APIs already return newest-first, so the original order is better
+    // information than anything we could invent — sorting undated entries to
+    // the back would actively make the sample worse.
+    it('preserves provider order when no date is available', () => {
+        const ordered = orderPullRequestsNewestFirst<{
+            pull_number: number;
+            created_at?: string;
+        }>([{ pull_number: 9 }, { pull_number: 8 }, { pull_number: 7 }]);
+
+        expect(ordered.map((pr: any) => pr.pull_number)).toEqual([9, 8, 7]);
+    });
+
+    it('does not reorder around an unparseable date', () => {
+        const ordered = orderPullRequestsNewestFirst([
+            { pull_number: 1, created_at: 'not a date' },
+            { pull_number: 2, created_at: '2026-05-01T00:00:00Z' },
+        ]);
+
+        expect(ordered.map((pr: any) => pr.pull_number)).toEqual([1, 2]);
+    });
+
+    it('leaves the caller\'s array alone', () => {
+        const input = [
+            { pull_number: 1, created_at: '2026-01-01T00:00:00Z' },
+            { pull_number: 2, created_at: '2026-02-01T00:00:00Z' },
+        ];
+        orderPullRequestsNewestFirst(input);
+
+        expect(input.map((pr) => pr.pull_number)).toEqual([1, 2]);
+    });
+
+    it('tolerates empty and missing input', () => {
+        expect(orderPullRequestsNewestFirst([])).toEqual([]);
+        expect(orderPullRequestsNewestFirst(undefined as any)).toEqual([]);
+    });
+});
+
+describe('countSubstantiveComments', () => {
+    // Mirrors commentAnalysis.service's own `body.length > 100`. Counting
+    // "LGTM" toward the budget would stop the walk before it collected
+    // anything a rule could be written from.
+    it('counts only comments long enough to carry a convention', () => {
+        expect(
+            countSubstantiveComments({
+                generalComments: [{ body: longBody }, { body: shortBody }],
+                reviewComments: [{ body: longBody }],
+            }),
+        ).toBe(2);
+    });
+
+    it('treats missing sides and bodies as zero', () => {
+        expect(countSubstantiveComments({})).toBe(0);
+        expect(
+            countSubstantiveComments({ reviewComments: [{}, { body: null }] }),
+        ).toBe(0);
+    });
+});
+
+describe('sampling budget', () => {
+    // The two limits cover different repos: TARGET stops a repo whose PRs
+    // carry long review threads, MAX_SCANNED stops one whose PRs are empty
+    // and would otherwise be walked forever chasing a target it never hits.
+    it('bounds the walk by both a comment target and a scan ceiling', () => {
+        expect(TARGET_SAMPLED_COMMENTS).toBeGreaterThan(100);
+        expect(MAX_PULL_REQUESTS_SCANNED).toBeGreaterThan(0);
+    });
+
+    // The whole point is a bounded worst case. 3 provider calls per PR times
+    // the ceiling has to stay well inside GitHub's 5000/hour, or a customer
+    // still loses their budget to onboarding.
+    it('keeps the worst case far below an hourly GitHub budget', () => {
+        const worstCaseRequests = MAX_PULL_REQUESTS_SCANNED * 3;
+
+        expect(worstCaseRequests).toBeLessThanOrEqual(500);
+    });
+
+    it('walks in chunks so it can stop before committing to every PR', () => {
+        expect(PR_FETCH_CONCURRENCY).toBeLessThan(MAX_PULL_REQUESTS_SCANNED);
+    });
+});
+
+describe('fetchPullRequestComments (the walk itself)', () => {
+    const makeUseCase = (perPrComments: number) => {
+        const useCase: any = Object.create(GenerateKodyRulesUseCase.prototype);
+        useCase.logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+        useCase.fetchSinglePullRequestComments = jest.fn(
+            async (_repo: any, pr: any) => ({
+                pr,
+                generalComments: Array.from({ length: perPrComments }, () => ({
+                    body: longBody,
+                })),
+                reviewComments: [],
+                files: [],
+            }),
+        );
+        return useCase;
+    };
+
+    // Oldest first, the way an API that ignores our sort would hand them over:
+    // PR 1 is the oldest, PR n the newest.
+    const prs = (n: number) =>
+        Array.from({ length: n }, (_, i) => ({
+            pull_number: i + 1,
+            created_at: new Date(
+                Date.UTC(2026, 0, 1) + i * 60_000,
+            ).toISOString(),
+        }));
+
+    // The bug: 816 PRs in the window meant 816 fetches (2448 API calls) to
+    // build a list truncated to 100 comments.
+    it('stops once the comment target is met instead of walking every PR', async () => {
+        const useCase = makeUseCase(10);
+
+        await useCase.fetchPullRequestComments({}, prs(816), {});
+
+        const fetched = useCase.fetchSinglePullRequestComments.mock.calls
+            .length;
+        expect(fetched).toBeLessThanOrEqual(
+            TARGET_SAMPLED_COMMENTS / 10 + PR_FETCH_CONCURRENCY,
+        );
+        expect(fetched).toBeLessThan(816);
+    });
+
+    // A repo full of "LGTM" never reaches the target, so the ceiling is the
+    // only thing standing between it and the whole window.
+    it('stops at the scan ceiling when the target is never reached', async () => {
+        const useCase = makeUseCase(0);
+
+        await useCase.fetchPullRequestComments({}, prs(816), {});
+
+        expect(
+            useCase.fetchSinglePullRequestComments.mock.calls.length,
+        ).toBe(MAX_PULL_REQUESTS_SCANNED);
+    });
+
+    it('walks a small repo completely and says nothing about stopping', async () => {
+        const useCase = makeUseCase(1);
+
+        const out = await useCase.fetchPullRequestComments({}, prs(12), {});
+
+        expect(useCase.fetchSinglePullRequestComments.mock.calls.length).toBe(
+            12,
+        );
+        expect(out).toHaveLength(12);
+        expect(useCase.logger.log).not.toHaveBeenCalled();
+    });
+
+    // A cap that trims coverage silently reads as "this repo has no
+    // conventions" when someone later wonders why the rule set is thin.
+    it('reports what it left unscanned', async () => {
+        const useCase = makeUseCase(0);
+
+        await useCase.fetchPullRequestComments({}, prs(816), {});
+
+        expect(useCase.logger.log).toHaveBeenCalledWith(
+            expect.objectContaining({
+                metadata: expect.objectContaining({
+                    pullRequestsInWindow: 816,
+                    pullRequestsScanned: MAX_PULL_REQUESTS_SCANNED,
+                }),
+            }),
+        );
+    });
+
+    // The quality half of the bug: the old walk filled its quota in the order
+    // the provider returned, so rules were learned from the OLDEST reviews in
+    // the window -- the least current conventions in the repo.
+    it('takes the NEWEST pull requests, not the first ones the API returned', async () => {
+        const useCase = makeUseCase(0);
+
+        await useCase.fetchPullRequestComments({}, prs(300), {});
+
+        const scanned = useCase.fetchSinglePullRequestComments.mock.calls.map(
+            (call: any[]) => call[1].pull_number,
+        );
+        expect(scanned).toHaveLength(MAX_PULL_REQUESTS_SCANNED);
+        expect(Math.max(...scanned)).toBe(300);
+        expect(Math.min(...scanned)).toBe(300 - MAX_PULL_REQUESTS_SCANNED + 1);
+    });
+});

--- a/test/unit/platform/services/github-comment-sample.spec.ts
+++ b/test/unit/platform/services/github-comment-sample.spec.ts
@@ -1,0 +1,138 @@
+import {
+    groupCommentsByPullRequest,
+    isPullRequestIssueComment,
+    pullRequestNumberFromUrl,
+} from '@libs/platform/infrastructure/adapters/services/github/github-comment-sample';
+
+const reviewComment = (prNumber: number, path?: string) => ({
+    id: `${prNumber}-${path ?? 'nopath'}`,
+    body: 'x'.repeat(120),
+    pull_request_url: `https://api.github.com/repos/acme/web/pulls/${prNumber}`,
+    ...(path ? { path } : {}),
+});
+
+const issueComment = (number: number, kind: 'pull' | 'issues') => ({
+    id: `${kind}-${number}`,
+    body: 'x'.repeat(120),
+    issue_url: `https://api.github.com/repos/acme/web/issues/${number}`,
+    html_url: `https://github.com/acme/web/${kind}/${number}#issuecomment-1`,
+});
+
+describe('pullRequestNumberFromUrl', () => {
+    it('reads the number from pull and issue urls alike', () => {
+        expect(
+            pullRequestNumberFromUrl(
+                'https://api.github.com/repos/acme/web/pulls/839',
+            ),
+        ).toBe(839);
+        expect(
+            pullRequestNumberFromUrl(
+                'https://api.github.com/repos/acme/web/issues/12',
+            ),
+        ).toBe(12);
+    });
+
+    // A repo literally named "pulls" (or an org named "issues") is legal on
+    // GitHub. An unanchored match would take the first segment it saw and
+    // attribute every comment to whatever number followed it.
+    it('is not fooled by a repo or owner named after the path segment', () => {
+        expect(
+            pullRequestNumberFromUrl(
+                'https://api.github.com/repos/pulls/issues/pulls/77',
+            ),
+        ).toBe(77);
+    });
+
+    it('returns undefined rather than guessing', () => {
+        expect(pullRequestNumberFromUrl(undefined)).toBeUndefined();
+        expect(pullRequestNumberFromUrl('')).toBeUndefined();
+        expect(
+            pullRequestNumberFromUrl('https://api.github.com/repos/acme/web'),
+        ).toBeUndefined();
+    });
+});
+
+describe('isPullRequestIssueComment', () => {
+    // The endpoint returns both kinds. Letting issue chatter through turns a
+    // bug report's discussion into a coding convention.
+    it('keeps PR conversation comments and drops issue comments', () => {
+        expect(isPullRequestIssueComment(issueComment(4, 'pull'))).toBe(true);
+        expect(isPullRequestIssueComment(issueComment(4, 'issues'))).toBe(
+            false,
+        );
+    });
+
+    it('drops a comment with no html_url instead of assuming', () => {
+        expect(isPullRequestIssueComment({})).toBe(false);
+    });
+});
+
+describe('groupCommentsByPullRequest', () => {
+    it('groups both comment kinds under their pull request', () => {
+        const grouped = groupCommentsByPullRequest(
+            [reviewComment(10, 'src/a.ts'), reviewComment(11, 'src/b.ts')],
+            [issueComment(10, 'pull')],
+        );
+
+        expect(grouped).toHaveLength(2);
+        const ten = grouped.find((g) => g.pr.pull_number === 10);
+        expect(ten.reviewComments).toHaveLength(1);
+        expect(ten.generalComments).toHaveLength(1);
+    });
+
+    // The per-PR files request existed only to count extensions. Review
+    // comments already carry the path, so the same data comes out at no extra
+    // request -- that is one third of the old call volume removed.
+    it('derives files from the paths review comments were left on', () => {
+        const [entry] = groupCommentsByPullRequest(
+            [
+                reviewComment(7, 'src/app.ts'),
+                reviewComment(7, 'src/util.ts'),
+                reviewComment(7),
+            ],
+            [],
+        );
+
+        expect(entry.files).toEqual([
+            { filename: 'src/app.ts' },
+            { filename: 'src/util.ts' },
+        ]);
+    });
+
+    it('leaves files empty when a PR has only conversation comments', () => {
+        const [entry] = groupCommentsByPullRequest(
+            [],
+            [issueComment(3, 'pull')],
+        );
+
+        // Downstream reads this as "no language tag", the same as a files
+        // fetch that failed -- not as an error.
+        expect(entry.files).toEqual([]);
+        expect(entry.generalComments).toHaveLength(1);
+    });
+
+    it('excludes issue comments from the grouping entirely', () => {
+        const grouped = groupCommentsByPullRequest(
+            [],
+            [issueComment(3, 'pull'), issueComment(99, 'issues')],
+        );
+
+        expect(grouped.map((g) => g.pr.pull_number)).toEqual([3]);
+    });
+
+    it('skips comments whose url cannot be parsed', () => {
+        const grouped = groupCommentsByPullRequest(
+            [{ pull_request_url: undefined, path: 'src/a.ts' } as any],
+            [],
+        );
+
+        expect(grouped).toEqual([]);
+    });
+
+    it('tolerates empty and missing inputs', () => {
+        expect(groupCommentsByPullRequest([], [])).toEqual([]);
+        expect(
+            groupCommentsByPullRequest(undefined as any, undefined as any),
+        ).toEqual([]);
+    });
+});


### PR DESCRIPTION
Fixes the root cause behind #1686.

## The problem

Rule generation asked the wrong question. `finishOnboarding` triggers `generateKodyRules({ months: 3 })`, which walked **every** pull request in that window and spent **3 API calls on each** — comments, review comments, files — to build a list the consumer then truncated to 100 comments:

```js
.flatMap((pr) => pr.comments)
.slice(0, 100);
```

Cost scaled with the customer's repo activity; output was a fixed 100 either way. On a repo with 816 PRs in the window that is ~2450 requests against GitHub's 5000/hour, spent to throw nearly all of it away. A customer selecting a handful of active repos exhausts the credential they just connected, during onboarding — and once the budget is gone, code review stops too, surfacing as `partial_error` and "no review activity" with nothing pointing at rate limiting.

This is not new, it just grew. The code already carried a note about a May 2026 incident with the identical shape at a twentieth of the volume (a Bitbucket 429 at "38+ historical PRs").

## The fix

**GitHub** now asks the repository directly — `/repos/{o}/{r}/pulls/comments` and `/issues/comments`, paginated, newest first — and stops once enough substantive comments are in hand. The cap moves to the source instead of sitting at the end of the pipe. Same output, a handful of requests instead of thousands.

**Every other provider** (GitLab, Bitbucket, Azure DevOps, Forgejo) has no repository-level comment listing, so the per-PR walk stays as the fallback — now bounded by two limits, because either alone leaves a hole: a comment target ends it early on a repo whose PRs carry long review threads, and a scan ceiling ends it on a repo full of `LGTM` that would otherwise be walked to the end chasing a target it never reaches. Worst case: 100 PRs, 300 calls.

Stopping required chunking the fan-out. The previous single `Promise.allSettled` committed to every pull request before any result returned, so there was no point at which it could decide it had enough.

## Two things that fall out

- **The per-PR files call is gone.** Its only consumer counted file extensions to tag comments with a language, and review comments already carry the `path` they were left on. A third of the old call volume was buying data we already had.

- **The comments kept are now the most recent ones.** The old loop filled its 100-comment quota in provider order, so rules were learned from the *oldest* reviews in the window — the least current conventions in the repo. A quality bug that was hiding inside a cost bug, and it affected every provider.

## Evidence

Self-hosted E2E matrix, [run 31504796937](https://github.com/kodustech/kodus-ai/actions/runs/31504796937), all four providers green — github 8/8, gitlab 6/6, bitbucket 6/6, azure-devops 6/6.

GitHub per-scenario cost, on the same 816-PR fixture that exhausted the account five minutes into the previous run:

| scenario | GitHub requests |
|---|---|
| onboarding-webhook-registration | 12 |
| code-review-basic | 22 |
| command-review | 18 |
| kody-rules-create-and-apply | 12 |
| license-attribution | 27 |
| per-seat-license-toggle | 31 |
| **run total** | **122 / 5000** |

The onboarding scenario went from ~2450 requests to 12.

**What that run does NOT prove:** the GitLab, Bitbucket and Azure fixture repos have far fewer than 100 PRs, so the cap never fired there — the run shows the fallback path still works, not that its limits engage. Those are covered by unit tests that assert on how many times the fetch is called: stops at the comment target, stops at the scan ceiling when the target is unreachable, walks a small repo completely, reports what it left unscanned, and takes the newest PRs even when the API returns oldest-first.

One flake on bitbucket (`command-review` found no findings, passed on retry) — a known absence-shaped flake, unrelated to this change.

## Still open in #1686

The rate-limit gate does not cover this path. The backfill is bounded now because its shape is bounded, not because anything stops it, and a future change could reintroduce an unbounded fan-out with nothing to catch it. The gate as written also passes through for non-GitHub platforms (`if (platformType !== PlatformType.GITHUB) return`), so covering the fallback would need it widened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
