### PR TITLE
fix(centralized-config): plain-ify rule payloads before yaml.dump

### DIFF
--- a/libs/centralized-config/utils/kody-rules-centralized-pr.builder.ts
+++ b/libs/centralized-config/utils/kody-rules-centralized-pr.builder.ts
@@ -130,5 +130,8 @@ export function formatRuleToYaml(rule: Partial<IKodyRule>): string {
         ...(rule.status === KodyRulesStatus.PAUSED ? { enabled: false } : {}),
     };
 
-    return yaml.dump(ruleForYaml);
+    // js-yaml 5 only dumps plain Objects. Nest ValidationPipe + @Type()
+    // turns examples/inheritance into DTO class instances, which throw
+    // "unacceptable kind of an object to dump".
+    return yaml.dump(JSON.parse(JSON.stringify(ruleForYaml)));
 }

--- a/test/unit/centralized-config/kody-rules-centralized-pr.builder.spec.ts
+++ b/test/unit/centralized-config/kody-rules-centralized-pr.builder.spec.ts
@@ -1,6 +1,10 @@
 import * as yaml from 'js-yaml';
 
 import { formatRuleToYaml } from '@libs/centralized-config/utils/kody-rules-centralized-pr.builder';
+import {
+    KodyRulesExampleDto,
+    KodyRulesInheritanceDto,
+} from '@libs/ee/kodyRules/dtos/create-kody-rule.dto';
 import { KodyRulesStatus } from '@libs/kodyRules/domain/interfaces/kodyRules.interface';
 
 describe('formatRuleToYaml — enabled field', () => {
@@ -26,5 +30,48 @@ describe('formatRuleToYaml — enabled field', () => {
             formatRuleToYaml({ ...base, status: KodyRulesStatus.PAUSED }),
         ) as Record<string, unknown>;
         expect(parsed.enabled).toBe(false);
+    });
+});
+
+describe('formatRuleToYaml — Nest class instances', () => {
+    const base = { title: 'No console.log', rule: 'Do not commit console.log' };
+
+    it('dumps examples that are KodyRulesExampleDto class instances', () => {
+        const example = new KodyRulesExampleDto();
+        example.snippet = 'if (value == null) return;';
+        example.isCorrect = false;
+
+        const parsed = yaml.load(
+            formatRuleToYaml({ ...base, examples: [example] }),
+        ) as {
+            examples: Array<{ snippet: string; isCorrect: boolean }>;
+        };
+
+        expect(parsed.examples).toEqual([
+            { snippet: 'if (value == null) return;', isCorrect: false },
+        ]);
+    });
+
+    it('dumps inheritance that is a KodyRulesInheritanceDto class instance', () => {
+        const inheritance = new KodyRulesInheritanceDto();
+        inheritance.inheritable = true;
+        inheritance.include = ['src/**'];
+        inheritance.exclude = ['src/legacy/**'];
+
+        const parsed = yaml.load(
+            formatRuleToYaml({ ...base, inheritance }),
+        ) as {
+            inheritance: {
+                inheritable: boolean;
+                include: string[];
+                exclude: string[];
+            };
+        };
+
+        expect(parsed.inheritance).toEqual({
+            inheritable: true,
+            include: ['src/**'],
+            exclude: ['src/legacy/**'],
+        });
     });
 });


### PR DESCRIPTION
## Summary

Fixes #1688. `formatRuleToYaml` now strips Nest DTO class prototypes (via `JSON.parse(JSON.stringify(...))`) before `yaml.dump`, so adding library Kody Rules with `examples`/`inheritance` no longer 500s under centralized config PRs when js-yaml 5 rejects non-plain objects.

## Test plan

- [x] Unit: `formatRuleToYaml` dumps `KodyRulesExampleDto` and `KodyRulesInheritanceDto` instances without throwing
- [x] Existing `formatRuleToYaml` enabled-field tests still pass
- [ ] Manually add a library Kody Rule that includes examples with centralized config enabled; confirm no 500 and mutation PR YAML is written

## Notes for the reviewer

Root cause: Nest `ValidationPipe` + `@Type(() => KodyRulesExampleDto)` produces class instances; js-yaml 5 only accepts plain Objects. Same risk applied to `KodyRulesInheritanceDto`.