### PR TITLE
feat(subscription): add self-hosted trial request CTA

### DIFF
--- a/.kodus/workspace.yaml
+++ b/.kodus/workspace.yaml
@@ -1,0 +1,28 @@
+version: 1
+setup:
+  - docker network create kodus-backend-services 2>/dev/null || true
+  - docker network create shared-network 2>/dev/null || true
+  # build sequencial da imagem compartilhada (api/worker/webhooks usam a MESMA
+  # tag; build paralelo do compose up tem race de export — igual aos scripts do repo)
+  - docker compose -f docker-compose.dev.yml build kodus-api
+  - pnpm install
+files:
+  copy: [.env]
+services:
+  compose:
+    file: docker-compose.dev.yml
+    public: kodus-api
+    health: /health/simple
+    health_timeout: 1200
+data:
+  migrate: pnpm run migration:run
+  seed: pnpm run seed
+validate:
+  - name: lint
+    run: pnpm run lint
+  - name: test-rbac
+    run: pnpm run test:rbac
+limits:
+  instance: m7i-flex.xlarge  # nao-burstavel: build sem throttling de creditos
+  disk: 100gb
+  idle_suspend: 10m

--- a/apps/web/src/features/ee/subscription/_components/license-key-settings.tsx
+++ b/apps/web/src/features/ee/subscription/_components/license-key-settings.tsx
@@ -19,10 +19,11 @@ import {
     ShieldCheckIcon,
     XCircleIcon,
 } from "lucide-react";
-import { cn } from "src/core/utils/components";
 import { apiProxyPath } from "src/core/utils/api-proxy";
+import { cn } from "src/core/utils/components";
 
 import { useSubscriptionStatus } from "../_hooks/use-subscription-status";
+import { RequestTrialCta } from "./request-trial-cta";
 
 type LicenseActivationResult = {
     valid: boolean;
@@ -180,9 +181,14 @@ function CommunityCard() {
                 </div>
                 <CardDescription className="text-pretty">
                     You&apos;re running Kodus in self-hosted mode without a
-                    license. Activate a key below to unlock enterprise features.
+                    license. Don&apos;t have a key yet? Request a trial and
+                    we&apos;ll send you one to activate below.
                 </CardDescription>
             </CardHeader>
+
+            <CardContent>
+                <RequestTrialCta />
+            </CardContent>
         </Card>
     );
 }

--- a/apps/web/src/features/ee/subscription/_components/request-trial-cta.spec.tsx
+++ b/apps/web/src/features/ee/subscription/_components/request-trial-cta.spec.tsx
@@ -1,0 +1,70 @@
+/** @jest-environment jsdom */
+import "@testing-library/jest-dom";
+
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { RequestTrialCta } from "./request-trial-cta";
+
+jest.mock("src/core/providers/auth.provider", () => ({
+    useAuth: () => ({
+        email: "dev@acme.com",
+        organizationId: "org-123",
+    }),
+}));
+
+const mockVersion = (body: unknown, ok = true) => {
+    global.fetch = jest.fn().mockResolvedValue({
+        ok,
+        json: async () => body,
+    }) as unknown as typeof fetch;
+};
+
+describe("RequestTrialCta", () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+        mockVersion({ current: "1.4.2" });
+    });
+
+    it("links to the trial form with the instance context prefilled", async () => {
+        render(<RequestTrialCta />);
+
+        const link = screen.getByRole("link", { name: /request a trial/i });
+
+        await waitFor(() => {
+            const url = new URL(link.getAttribute("href")!);
+            expect(url.searchParams.get("version")).toBe("1.4.2");
+        });
+
+        const url = new URL(link.getAttribute("href")!);
+        expect(url.origin + url.pathname).toBe(
+            "https://kodus.io/self-hosted-trial",
+        );
+        expect(url.searchParams.get("org_id")).toBe("org-123");
+        expect(url.searchParams.get("email")).toBe("dev@acme.com");
+    });
+
+    it("still links out when the version lookup fails", async () => {
+        // /api/version reaches out to GitHub — an instance with no egress
+        // gets nothing back, and the CTA must survive that.
+        global.fetch = jest
+            .fn()
+            .mockRejectedValue(
+                new Error("no egress"),
+            ) as unknown as typeof fetch;
+
+        render(<RequestTrialCta />);
+
+        const link = screen.getByRole("link", { name: /request a trial/i });
+        expect(link).toHaveAttribute(
+            "href",
+            "https://kodus.io/self-hosted-trial?org_id=org-123&email=dev%40acme.com",
+        );
+    });
+
+    it("renders the link as the only action", () => {
+        render(<RequestTrialCta />);
+
+        expect(screen.getAllByRole("link")).toHaveLength(1);
+        expect(screen.queryByText(/copy/i)).not.toBeInTheDocument();
+    });
+});

--- a/apps/web/src/features/ee/subscription/_components/request-trial-cta.tsx
+++ b/apps/web/src/features/ee/subscription/_components/request-trial-cta.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Button } from "@components/ui/button";
+import { Link } from "@components/ui/link";
+import { ArrowUpRightIcon } from "lucide-react";
+import { useAuth } from "src/core/providers/auth.provider";
+
+import {
+    buildTrialRequestUrl,
+    type TrialRequestContext,
+} from "../_utils/trial-request";
+
+/**
+ * Way out of the dead end an unlicensed self-hosted instance lands in:
+ * the license card asks for a key without saying how to get one.
+ *
+ * The form itself lives outside the product (see
+ * SELF_HOSTED_TRIAL_REQUEST_URL) — a self-hosted instance stays on a
+ * pinned version for months, so an in-app form would freeze with it. Only
+ * the button ships here, carrying the context we already know so nobody
+ * retypes their org id.
+ *
+ * Note the network shape: the browser opens the link, the instance never
+ * calls out. An instance with no egress of its own still works, as long as
+ * the operator's machine has internet — the common "airgapped" case.
+ */
+export const RequestTrialCta = () => {
+    const { email, organizationId } = useAuth();
+    const [version, setVersion] = useState<string>();
+
+    useEffect(() => {
+        const ac = new AbortController();
+
+        fetch("/api/version", { signal: ac.signal })
+            .then((res) => (res.ok ? (res.json() as Promise<unknown>) : null))
+            .then((json) => {
+                const current = (json as { current?: string } | null)?.current;
+                if (current && current !== "unknown") setVersion(current);
+            })
+            .catch(() => {
+                // Best-effort: the version only enriches the request, and
+                // this endpoint reaches out to GitHub. Never block the CTA.
+            });
+
+        return () => ac.abort();
+    }, []);
+
+    const context: TrialRequestContext = { organizationId, email, version };
+    const requestUrl = buildTrialRequestUrl(context);
+
+    return (
+        <Link href={requestUrl} target="_blank" noHoverUnderline>
+            {/* `decorative` renders a span: the Link already provides the
+                anchor, and <a><button> is invalid nesting. */}
+            <Button
+                decorative
+                size="md"
+                variant="primary"
+                rightIcon={<ArrowUpRightIcon />}>
+                Request a trial
+            </Button>
+        </Link>
+    );
+};

--- a/apps/web/src/features/ee/subscription/_constants/trial.ts
+++ b/apps/web/src/features/ee/subscription/_constants/trial.ts
@@ -4,3 +4,15 @@ export const TRIAL_UNLOCK_COMPANY_EMAIL_REWARD = 5;
 export const TRIAL_UNLOCK_TEAM_REWARD = 5;
 export const TRIAL_UNLOCK_CODE_ORG_REWARD = 20;
 export const TRIAL_UNLOCK_BYOK_REWARD_LABEL = "Unlimited with your key";
+
+/**
+ * Where the self-hosted "Request a trial" CTA points.
+ *
+ * Deliberately a URL on our own domain that redirects to the form, rather
+ * than the form provider's URL: a self-hosted instance runs a pinned
+ * version for months, so whatever we ship here is frozen in that build.
+ * Redirecting lets us change the form's questions — or replace the
+ * provider entirely — without stranding instances deployed before then.
+ */
+export const SELF_HOSTED_TRIAL_REQUEST_URL =
+    "https://kodus.io/self-hosted-trial";

--- a/apps/web/src/features/ee/subscription/_utils/trial-request.spec.ts
+++ b/apps/web/src/features/ee/subscription/_utils/trial-request.spec.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { SELF_HOSTED_TRIAL_REQUEST_URL } from "../_constants/trial";
+import { buildTrialRequestUrl } from "./trial-request";
+
+describe("buildTrialRequestUrl", () => {
+    it("prefills the context we already know", () => {
+        const url = new URL(
+            buildTrialRequestUrl({
+                organizationId: "org-123",
+                email: "dev@acme.com",
+                version: "1.4.2",
+            }),
+        );
+
+        expect(url.searchParams.get("org_id")).toBe("org-123");
+        expect(url.searchParams.get("email")).toBe("dev@acme.com");
+        expect(url.searchParams.get("version")).toBe("1.4.2");
+    });
+
+    it("points at our own domain, not the form provider", () => {
+        expect(buildTrialRequestUrl()).toMatch(/^https:\/\/kodus\.io\//);
+    });
+
+    it("omits missing values instead of sending them empty", () => {
+        // The version fetch is best-effort and the session may still be
+        // loading — a partial context must still produce a usable link.
+        const url = buildTrialRequestUrl({ organizationId: "org-123" });
+
+        expect(url).toBe(`${SELF_HOSTED_TRIAL_REQUEST_URL}?org_id=org-123`);
+        expect(url).not.toContain("email");
+        expect(url).not.toContain("undefined");
+    });
+
+    it("drops whitespace-only values", () => {
+        expect(
+            buildTrialRequestUrl({ organizationId: "   ", email: "  " }),
+        ).toBe(SELF_HOSTED_TRIAL_REQUEST_URL);
+    });
+
+    it("returns a bare url when nothing is known", () => {
+        expect(buildTrialRequestUrl()).toBe(SELF_HOSTED_TRIAL_REQUEST_URL);
+        expect(buildTrialRequestUrl({})).toBe(SELF_HOSTED_TRIAL_REQUEST_URL);
+    });
+
+    it("encodes values that are unsafe in a query string", () => {
+        const url = new URL(
+            buildTrialRequestUrl({ email: "dev+kodus@acme.com" }),
+        );
+
+        // `+` must survive the round trip rather than decoding to a space.
+        expect(url.searchParams.get("email")).toBe("dev+kodus@acme.com");
+    });
+});

--- a/apps/web/src/features/ee/subscription/_utils/trial-request.ts
+++ b/apps/web/src/features/ee/subscription/_utils/trial-request.ts
@@ -1,0 +1,45 @@
+import { SELF_HOSTED_TRIAL_REQUEST_URL } from "../_constants/trial";
+
+/**
+ * Instance context we can attach to a trial request without asking the
+ * user to retype what we already know. It rides along as query params so
+ * the form arrives tied to the instance that opened it.
+ *
+ * Every field is optional on purpose: `/api/version` is best-effort and
+ * the session may still be loading when the card renders. A missing value
+ * is dropped from the URL rather than sent as an empty or "undefined"
+ * param.
+ *
+ * These values are prefill, not proof — the user can edit them in the
+ * URL. That's fine: this is a lead form, not authentication.
+ */
+export type TrialRequestContext = {
+    organizationId?: string;
+    email?: string;
+    /** Running self-hosted release, from `/api/version` (`current`). */
+    version?: string;
+};
+
+const toParams = (context: TrialRequestContext): Array<[string, string]> => {
+    const entries: Array<[string, string | undefined]> = [
+        ["org_id", context.organizationId],
+        ["email", context.email],
+        ["version", context.version],
+    ];
+
+    return entries.flatMap(([key, value]) => {
+        const trimmed = value?.trim();
+        return trimmed ? [[key, trimmed] as [string, string]] : [];
+    });
+};
+
+export const buildTrialRequestUrl = (
+    context: TrialRequestContext = {},
+): string => {
+    const params = new URLSearchParams(toParams(context));
+    const query = params.toString();
+
+    return query
+        ? `${SELF_HOSTED_TRIAL_REQUEST_URL}?${query}`
+        : SELF_HOSTED_TRIAL_REQUEST_URL;
+};


### PR DESCRIPTION
## Summary

Unlicensed self-hosted instances currently hit a dead end: the license card asks for a key without saying how to get one. This PR adds a **Request a trial** CTA to the community card that links out to the trial form, prefilled with the context we already know.

- New `RequestTrialCta` component on the community (no-license) card, linking to `https://kodus.io/self-hosted-trial` with `org_id`, `email`, and `version` as query params.
- The URL points at our own domain (redirecting to the form) so the form provider/questions can change without stranding instances pinned to old builds.
- `buildTrialRequestUrl` drops missing/blank values instead of sending empty or `undefined` params.
- Version comes from `/api/version` and is best-effort — the CTA still works on instances with no egress (the browser opens the link, the instance never calls out).
- Adds `.kodus/workspace.yaml` preview-environment config.

## Test plan

- `pnpm run test --testPathPatterns="ee/subscription"` — 26 tests, 5 suites, all passing (URL building edge cases + component rendering/fallback).
- ESLint clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)