### PR TITLE
fix(e2e): stop handing the free cloud tenant a BYOK key

### DIFF
--- a/tests/e2e/lib/runner.ts
+++ b/tests/e2e/lib/runner.ts
@@ -280,8 +280,21 @@ async function refreshCloudTenantByok(log: {
         process.env.API_OPENAI_FORCE_BASE_URL ?? 'https://api.openai.com/v1';
     const model = process.env.API_LLM_PROVIDER_MODEL ?? 'gpt-5.4-mini';
 
+    // The `free` tenant is DEFINED by not having a key of its own: that is what
+    // makes it a free tenant rather than a community-plan one, and
+    // license-attribution asserts it receives no review. Writing byok_config
+    // onto it turns it into exactly the tenant the registry already keeps
+    // separately as `community-byok`, and the product then reviews its PRs --
+    // correctly. The test was refuting an entitlement rule it had just spent
+    // the run start dismantling (observed live, cloud run 31601925282).
     const seen = new Set<string>();
     for (const entry of entries) {
+        if (entry.license === 'free') {
+            log.info(
+                `[byok-refresh] ${entry.provider}/free: SKIPPED — a free tenant with a BYOK key is a community tenant, and reviews for it are expected`,
+            );
+            continue;
+        }
         if (seen.has(entry.email)) continue;
         seen.add(entry.email);
         try {


### PR DESCRIPTION
First cloud matrix run from `main` after #1664 ([run 31601925282](https://github.com/kodustech/kodus-ai/actions/runs/31601925282)) came back **22/23 passed, 23/23 applicable executed**. The single failure was `license-attribution × cloud × github × free`:

```
Expected NO real review for license=free but Kody posted one
```

The product was right. The test was wrong, and it was wrong at its own hand.

`refreshCloudTenantByok` writes `byok_config` onto **every** tenant in the registry at run start, with no license filter. A free tenant holding its own LLM key is precisely the community plan — the registry already keeps that separately as `community-byok` — and reviews for it work by design. So the run started by converting the free tenant into a community tenant, and then asserted that the free tenant receives no review.

The free tenant is defined by not having a key. It is now skipped, and skipped **loudly**: a silent skip inside a BYOK refresh is how a tenant ends up stranded on a revoked key, which is the exact problem that refresh was added to solve.

Trial and paid keep being refreshed. Only the tenant whose entire identity is the absence of a key is excluded.

**Note on the pre-existing state:** this is not a regression from #1664 — `refreshCloudTenantByok` landed 2026-07-28. The cell simply had never run with this harness before, because the QA environment only accepts `main` and the harness lived on a branch until today. The durable history has exactly one row for this cell, from this run, for the same reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)