### PR TITLE
fix(centralized-config): reconcile stale scopes from recorded ownership

### DIFF
--- a/libs/centralized-config/application/use-cases/centralized-config-init.use-case.ts
+++ b/libs/centralized-config/application/use-cases/centralized-config-init.use-case.ts
@@ -236,6 +236,17 @@ export class CentralizedConfigInitUseCase implements IUseCase {
         return existingParameter?.configValue?.enabled === true;
     }
 
+    /**
+     * Writes a fresh value on purpose — do NOT spread the existing parameter.
+     *
+     * `managedRepositoryIds` / `managedScopeRepositoryIds` record what a
+     * previous config repository owned. Carrying them into a new one would
+     * make the first sync treat repositories the new repo never mentioned as
+     * deletions. Dropping them costs one no-op reconcile round (the sync
+     * records the baseline and reconciles nothing when it is missing) and is
+     * the safe direction. The same holds for the disable paths here, in
+     * DeleteIntegrationUseCase, and in the CLI controller.
+     */
     private async enableCentralizedConfigForRepository(
         organizationAndTeamData: OrganizationAndTeamData,
         repository: { id: string; name: string },

--- a/libs/centralized-config/application/use-cases/centralized-config-sync.use-case.ts
+++ b/libs/centralized-config/application/use-cases/centralized-config-sync.use-case.ts
@@ -130,6 +130,10 @@ export class CentralizedConfigSyncUseCase implements IUseCase {
                 await this.centralizedConfigService.removeStaleKodyRules({
                     organizationAndTeamData,
                     ruleFiles: ruleFilesMeta,
+                    // Same tree read as the rules: proof the repository was
+                    // reachable, so an empty rule set means the user deleted
+                    // them rather than the read having failed.
+                    configFiles: configFilesMeta,
                     actor,
                 });
 

--- a/libs/centralized-config/domain/contracts/CentralizedConfigService.contract.ts
+++ b/libs/centralized-config/domain/contracts/CentralizedConfigService.contract.ts
@@ -138,6 +138,12 @@ export interface ICentralizedConfigService {
     removeStaleKodyRules(params: {
         organizationAndTeamData: OrganizationAndTeamData;
         ruleFiles: IKodyRuleFileMeta[];
+        /**
+         * Config files from the same repository-tree read. Non-empty proves
+         * the read succeeded, so zero rule files is a real deletion rather
+         * than an unreadable repository.
+         */
+        configFiles?: IConfigFileMeta[];
         actor: {
             organizationId: string;
             source: string;

--- a/libs/centralized-config/infrastructure/adapters/services/__tests__/centralized-config.service.spec.ts
+++ b/libs/centralized-config/infrastructure/adapters/services/__tests__/centralized-config.service.spec.ts
@@ -168,6 +168,77 @@ describe('CentralizedConfigService', () => {
     });
 
     describe('synchronizeConfigs', () => {
+        /**
+         * Discovery emits `directoryPaths` (plural) and stopped setting
+         * `directoryPath`. Keying the config level off the singular spelling
+         * sent every directory scope down the REPOSITORY branch, so the
+         * directory's custom messages were written onto the repository —
+         * overwriting the repository's own messages and never creating a
+         * directory-level one.
+         *
+         * Reproduced end to end before writing this: two files, one with
+         * `MSG-DO-REPO` and one with `MSG-DO-DIRETORIO`, produced a single
+         * message at repository level carrying the directory's content.
+         */
+        it('writes a directory scope custom message at DIRECTORY level', async () => {
+            const configFiles: IConfigFileMeta[] = [
+                {
+                    repositoryId: 'repo-1',
+                    centralizedDirectoryPath: 'repo1/src',
+                    // What discovery actually emits for a directory scope.
+                    directoryPaths: ['/src'],
+                } as any,
+            ];
+
+            mockIntegrationConfigService.findIntegrationConfigFormatted.mockResolvedValue(
+                [{ id: 'repo-1', name: 'repo1', full_name: 'org/repo1' }],
+            );
+            mockCodeBaseConfigService.getDirectoryIdForPath.mockResolvedValue(
+                'dir-1',
+            );
+            mockPullRequestMessagesService.findOne.mockResolvedValue(null);
+            mockCodeBaseConfigService.getKodusConfigFile.mockResolvedValue({
+                version: '2.0',
+                customMessages: {
+                    startReviewMessage: {
+                        status: 'every_push',
+                        content: 'MSG-DO-DIRETORIO',
+                    },
+                },
+            });
+            mockParametersService.findByKey.mockImplementation((key) => {
+                if (key === ParametersKey.CENTRALIZED_CONFIG) {
+                    return Promise.resolve({
+                        configValue: {
+                            enabled: true,
+                            repository: { id: 'c-1', name: 'centralized' },
+                        },
+                    });
+                }
+                return Promise.resolve({ configValue: {} });
+            });
+
+            await service.synchronizeConfigs({
+                organizationAndTeamData,
+                configFiles,
+                actor,
+            });
+
+            // Asserted on the payload directly: the use case takes three
+            // arguments and `toHaveBeenCalledWith` matches arity too.
+            const payload =
+                mockCreateOrUpdatePullRequestMessagesUseCase.execute.mock
+                    .calls[0][1];
+
+            expect(payload).toEqual(
+                expect.objectContaining({
+                    configLevel: ConfigLevel.DIRECTORY,
+                    repositoryId: 'repo-1',
+                    directoryId: 'dir-1',
+                }),
+            );
+        });
+
         it('should sync custom messages from centralized config', async () => {
             const configFiles: IConfigFileMeta[] = [
                 {

--- a/libs/centralized-config/infrastructure/adapters/services/__tests__/centralized-config.service.spec.ts
+++ b/libs/centralized-config/infrastructure/adapters/services/__tests__/centralized-config.service.spec.ts
@@ -706,8 +706,8 @@ describe('CentralizedConfigService', () => {
     describe('removeStaleConfigs', () => {
         it('should remove stale custom messages even when regular config does not change', async () => {
             // Non-empty discovery (a repo scope) so the #1518 empty-discovery
-            // guard does not trigger; the GLOBAL message is stale because no
-            // global config file was discovered.
+            // guard does not trigger; the GLOBAL message is stale because a
+            // previous sync owned a global config file that is gone now.
             const configFiles: IConfigFileMeta[] = [
                 { repositoryId: 'repo-1' } as any,
             ];
@@ -722,6 +722,14 @@ describe('CentralizedConfigService', () => {
             mockParametersService.findByKey.mockImplementation((key) => {
                 if (key === ParametersKey.CODE_REVIEW_CONFIG) {
                     return Promise.resolve(codeReviewConfig);
+                }
+
+                if (key === ParametersKey.CENTRALIZED_CONFIG) {
+                    // Ownership is what makes this a removal rather than a
+                    // message the centralized config simply never managed.
+                    return Promise.resolve({
+                        configValue: { managedGlobalConfig: true },
+                    });
                 }
 
                 return Promise.resolve({ configValue: {} });
@@ -759,6 +767,42 @@ describe('CentralizedConfigService', () => {
                 expect.anything(),
                 expect.anything(),
             );
+        });
+
+        it('should NOT remove a global custom message it never owned', async () => {
+            // Same discovery as above, one difference: no previous sync ever
+            // owned a global `kodus-config.yml`. The message was authored in
+            // the UI and the centralized config has no claim on it.
+            const configFiles: IConfigFileMeta[] = [
+                { repositoryId: 'repo-1' } as any,
+            ];
+
+            mockParametersService.findByKey.mockImplementation((key) => {
+                if (key === ParametersKey.CODE_REVIEW_CONFIG) {
+                    return Promise.resolve({
+                        configValue: { configs: {}, repositories: [] },
+                    });
+                }
+
+                return Promise.resolve({ configValue: {} });
+            });
+
+            mockIntegrationConfigService.findIntegrationConfigFormatted.mockResolvedValue(
+                [],
+            );
+
+            mockPullRequestMessagesService.find.mockResolvedValue([
+                { uuid: 'global-message-1', configLevel: ConfigLevel.GLOBAL },
+            ]);
+
+            const result = await service.removeStaleConfigs({
+                organizationAndTeamData,
+                configFiles,
+                actor,
+            });
+
+            expect(result.success).toBe(true);
+            expect(mockPullRequestMessagesService.delete).not.toHaveBeenCalled();
         });
     });
 
@@ -805,6 +849,35 @@ describe('CentralizedConfigService', () => {
                     repository: { name: 'config-repo', id: 'repo-1' },
                 }),
             ).rejects.toThrow();
+        });
+
+        // H5 — a `kodus-config.yml` more than one level below the repository
+        // folder is dropped by discovery with nothing but a log line. Executed
+        // rather than assumed: this is what a user who hand-writes
+        // `my-repo/src/api/kodus-config.yml` actually gets. Not a data-loss
+        // bug — the file is ignored, not acted on — but the silence is the
+        // problem, and any change to it is a product decision.
+        it('discoverConfigFiles silently ignores a nested path deeper than one level', async () => {
+            mockCodeManagementService.getRepositoryTree.mockResolvedValue([
+                { type: 'file', path: 'my-repo/kodus-config.yml' },
+                { type: 'file', path: 'my-repo/src/api/kodus-config.yml' },
+            ]);
+            mockIntegrationConfigService.findIntegrationConfigFormatted.mockResolvedValue(
+                [{ id: 'r-1', name: 'my-repo', full_name: 'acme/my-repo' }],
+            );
+
+            const discovered = await service.discoverConfigFiles({
+                organizationAndTeamData,
+                repository: { name: 'config-repo', id: 'repo-1' },
+            });
+
+            // Only the repository-level file survives; the nested one is gone
+            // and the caller has no way to know it existed.
+            expect(discovered).toHaveLength(1);
+            expect(discovered[0]).toEqual(
+                expect.objectContaining({ repositoryId: 'r-1' }),
+            );
+            expect(discovered[0].directoryPaths).toBeUndefined();
         });
 
         it('removeStaleKodyRules does NOT delete centralized rules when discovery is empty', async () => {

--- a/libs/centralized-config/infrastructure/adapters/services/__tests__/centralized-config.service.stale-1579.spec.ts
+++ b/libs/centralized-config/infrastructure/adapters/services/__tests__/centralized-config.service.stale-1579.spec.ts
@@ -42,6 +42,7 @@ import { PULL_REQUEST_MESSAGES_SERVICE_TOKEN } from '@libs/code-review/domain/pu
 import { CreateOrUpdateKodyRulesUseCase } from '@libs/kodyRules/application/use-cases/create-or-update.use-case';
 import { DeleteRuleInOrganizationByIdKodyRulesUseCase } from '@libs/kodyRules/application/use-cases/delete-rule-in-organization-by-id.use-case';
 import { KODY_RULES_SERVICE_TOKEN } from '@libs/kodyRules/domain/contracts/kodyRules.service.contract';
+import { ConfigLevel } from '@libs/core/infrastructure/config/types/general/pullRequestMessages.type';
 import { CentralizedConfigService } from '../centralized-config.service';
 
 const organizationAndTeamData: OrganizationAndTeamData = {
@@ -149,6 +150,10 @@ type Harness = {
     reconciledGlobalConfigs: () => unknown;
     /** The whole CENTRALIZED_CONFIG payload the sync wrote back. */
     savedCentralizedConfig: () => any;
+    /** UUIDs of the custom PR messages the sweep deleted outright. */
+    customMessagesDeleted: () => string[];
+    /** UUIDs of the Kody rules the sweep marked deleted. */
+    kodyRulesDeleted: () => string[];
 };
 
 /**
@@ -159,6 +164,8 @@ type Harness = {
  */
 async function buildHarness(opts: {
     managedRepositoryIds?: string[];
+    /** Directory scopes a previous sync owned, as repoId -> group folder names. */
+    managedDirectoryScopes?: Record<string, string[]>;
     managedGlobalConfig?: boolean;
     repositories?: ReturnType<typeof threeSelectedRepos>;
     useRealDeleteUseCase?: boolean;
@@ -166,6 +173,18 @@ async function buildHarness(opts: {
     midSweepValue?: any;
     /** Seeds the FIRST read, so a stale spread has something to resurrect. */
     activePullRequest?: any;
+    /** Custom PR messages already stored for the organization. */
+    existingMessages?: any[];
+    /** Kody rules already stored for the organization. */
+    existingRules?: any[];
+    /** Folder path -> directory (group) id, as the code review config resolves it. */
+    directoryIdByPath?: Record<string, string>;
+    /**
+     * What `IntegrationConfigKey.REPOSITORIES` returns. Defaults to `[]`,
+     * which makes every directory scope UNRESOLVABLE — pass the repositories
+     * to exercise the path where resolution actually succeeds.
+     */
+    integrationRepositories?: any[];
 }): Promise<Harness> {
     const codeReviewConfig = {
         configValue: opts.repositories ?? threeSelectedRepos(),
@@ -177,6 +196,10 @@ async function buildHarness(opts: {
     };
     if (opts.managedRepositoryIds !== undefined) {
         centralizedConfigValue.managedRepositoryIds = opts.managedRepositoryIds;
+    }
+    if (opts.managedDirectoryScopes !== undefined) {
+        centralizedConfigValue.managedDirectoryScopes =
+            opts.managedDirectoryScopes;
     }
     if (opts.managedGlobalConfig !== undefined) {
         centralizedConfigValue.managedGlobalConfig = opts.managedGlobalConfig;
@@ -213,7 +236,9 @@ async function buildHarness(opts: {
     };
 
     const integrationConfigService = {
-        findIntegrationConfigFormatted: jest.fn().mockResolvedValue([]),
+        findIntegrationConfigFormatted: jest
+            .fn()
+            .mockResolvedValue(opts.integrationRepositories ?? []),
         findOneIntegrationConfigWithIntegrations: jest.fn().mockResolvedValue({
             configValue: [
                 { id: 'repo-1', name: 'repo-1' },
@@ -227,8 +252,33 @@ async function buildHarness(opts: {
 
     const kodyRulesService = {
         find: jest.fn().mockResolvedValue([]),
-        findByOrganizationId: jest.fn(),
+        findByOrganizationId: jest.fn().mockResolvedValue(
+            opts.existingRules
+                ? { toJson: () => ({ rules: opts.existingRules }) }
+                : undefined,
+        ),
         updateRulesStatusByFilter: jest.fn(),
+    };
+
+    const deleteRuleUseCase = { execute: jest.fn() };
+
+    const pullRequestMessagesService = {
+        find: jest.fn().mockResolvedValue(opts.existingMessages ?? []),
+        findOne: jest.fn(),
+        delete: jest.fn(),
+    };
+
+    const codeBaseConfigService = {
+        getKodusConfigFile: jest.fn(),
+        getDirectoryIdForPath: jest
+            .fn()
+            .mockImplementation((_org: any, _repo: any, path: string) => {
+                const normalized = path.startsWith('/') ? path.slice(1) : path;
+                return Promise.resolve(
+                    opts.directoryIdByPath?.[normalized] ??
+                        opts.directoryIdByPath?.[path],
+                );
+            }),
     };
 
     const deletePullRequestMessagesUseCase = { execute: jest.fn() };
@@ -285,15 +335,11 @@ async function buildHarness(opts: {
             },
             {
                 provide: PULL_REQUEST_MESSAGES_SERVICE_TOKEN,
-                useValue: {
-                    find: jest.fn().mockResolvedValue([]),
-                    findOne: jest.fn(),
-                    delete: jest.fn(),
-                },
+                useValue: pullRequestMessagesService,
             },
             {
                 provide: CODE_BASE_CONFIG_SERVICE_TOKEN,
-                useValue: { getKodusConfigFile: jest.fn() },
+                useValue: codeBaseConfigService,
             },
             {
                 provide: CreateOrUpdateKodyRulesUseCase,
@@ -301,7 +347,7 @@ async function buildHarness(opts: {
             },
             {
                 provide: DeleteRuleInOrganizationByIdKodyRulesUseCase,
-                useValue: { execute: jest.fn() },
+                useValue: deleteRuleUseCase,
             },
             { provide: KODY_RULES_SERVICE_TOKEN, useValue: kodyRulesService },
         ],
@@ -356,6 +402,12 @@ async function buildHarness(opts: {
             createOrUpdateParametersUseCase.execute.mock.calls
                 .filter((c: any[]) => c[0] === ParametersKey.CENTRALIZED_CONFIG)
                 .pop()?.[1],
+        customMessagesDeleted: () =>
+            pullRequestMessagesService.delete.mock.calls.map(
+                (c: any[]) => c[0],
+            ),
+        kodyRulesDeleted: () =>
+            deleteRuleUseCase.execute.mock.calls.map((c: any[]) => c[0]),
         reconciledGlobalConfigs: () => {
             const call = createOrUpdateParametersUseCase.execute.mock.calls
                 .filter((c: any[]) => c[0] === ParametersKey.CODE_REVIEW_CONFIG)
@@ -654,5 +706,524 @@ describe('#1579 Sync must not read "absent" as "removed"', () => {
         // Writing would leave a parameter holding a baseline and nothing else
         // — no `repository`, no `enabled`.
         expect(h.savedCentralizedConfig()).toBeUndefined();
+    });
+
+    /**
+     * Orphaned directory scopes. Reproduced by hand before writing these: a
+     * repository whose only centralized file was `{repo}/{dir}/kodus-config.yml`
+     * kept that scope forever once the file was deleted — through a merged
+     * pull request, through the merge-fired sync, and through any number of
+     * manual syncs.
+     *
+     * The cause was the granularity of the recorded baseline, so these pin
+     * the granularity: T1/T2 that repository-level ownership grants nothing
+     * over directories, T3 what gets recorded, T4/T5 that the recorded scope
+     * is cleanable without touching the repository around it.
+     */
+    it('T1: repository-level ownership does not reach into directories', async () => {
+        const h = await buildHarness({
+            repositories: repoWithDirectoryScope(),
+            // Owning `repo-1/kodus-config.yml` says nothing about `repo-1/src`.
+            managedRepositoryIds: ['repo-1'],
+            managedDirectoryScopes: {},
+        });
+
+        await h.service.removeStaleConfigs({
+            organizationAndTeamData,
+            configFiles: GLOBAL_ONLY, // the directory file is gone
+            actor,
+        });
+
+        expect(h.directoryDeleteCalls()).toEqual([]);
+    });
+
+    it('T2: with no directory baseline at all, nothing is reconciled', async () => {
+        const h = await buildHarness({
+            repositories: repoWithDirectoryScope(),
+            // What 8b5e524ef records: only repositories carrying a
+            // `{repo}/kodus-config.yml`, which a directory-only repo lacks.
+            managedRepositoryIds: [],
+            // ...and no directory-scope baseline either — an organization
+            // that has not synced since the fix. Absence still proves nothing.
+            managedDirectoryScopes: {},
+        });
+
+        await h.service.removeStaleConfigs({
+            organizationAndTeamData,
+            configFiles: GLOBAL_ONLY, // same deletion as T1
+            actor,
+        });
+
+        expect(h.directoryDeleteCalls()).toEqual([]);
+    });
+
+    /**
+     * The fix: ownership is recorded per SCOPE, not only per repository-level
+     * `kodus-config.yml`. A repository whose sole centralized file is a
+     * directory scope is now in `managedScopeRepositoryIds`, so deleting that
+     * file is a removal it can act on — while staying out of
+     * `managedRepositoryIds`, so the repository itself is never deselected.
+     */
+    it('T3: a directory-only repository is recorded in the scope baseline', async () => {
+        const h = await buildHarness({
+            managedRepositoryIds: [],
+            managedDirectoryScopes: {},
+        });
+
+        await h.service.removeStaleConfigs({
+            organizationAndTeamData,
+            configFiles: DIRECTORY_ONLY,
+            actor,
+        });
+
+        const written = h.savedCentralizedConfig();
+
+        // The scope itself is recorded, by its encoded group folder name...
+        expect(written.managedDirectoryScopes).toEqual({ 'repo-1': ['src'] });
+        // ...but never as the owner of a repository-level config (test N).
+        expect(written.managedRepositoryIds).toEqual([]);
+    });
+
+    it('T4: with the scope baseline, a removed directory scope IS cleaned up', async () => {
+        const h = await buildHarness({
+            repositories: repoWithDirectoryScope(),
+            managedRepositoryIds: [],
+            // What T3 recorded on the previous sync.
+            managedDirectoryScopes: { 'repo-1': ['src'] },
+        });
+
+        await h.service.removeStaleConfigs({
+            organizationAndTeamData,
+            configFiles: GLOBAL_ONLY, // the directory file is gone
+            actor,
+        });
+
+        expect(h.directoryDeleteCalls()).toEqual(['repo-1:dir-1']);
+    });
+
+    it('T5: cleaning the directory scope does not deselect the repository', async () => {
+        const h = await buildHarness({
+            repositories: repoWithDirectoryScope(),
+            managedRepositoryIds: [],
+            managedDirectoryScopes: { 'repo-1': ['src'] },
+        });
+
+        await h.service.removeStaleConfigs({
+            organizationAndTeamData,
+            configFiles: GLOBAL_ONLY,
+            actor,
+        });
+
+        // repo-1 was never the owner of a repository-level config, so the
+        // repository scope has nothing to reconcile — only the directory did.
+        // This is the #1579 half of the trade: cleaning up must not cascade.
+        // Nothing rewrote the repository row at all: no deselection, no
+        // `configs: {}`.
+        expect(h.reconciledSelection()).toEqual(['<no reconcile call>']);
+
+        // Non-vacuous: the only delete that ran was the directory one (T4).
+        expect(h.directoryDeleteCalls()).toEqual(['repo-1:dir-1']);
+    });
+
+    /**
+     * A repository can lose its `{repo}/kodus-config.yml` and keep a directory
+     * scope. It is stale at the repository level but still centrally managed,
+     * so the removal side effects (Kody Rules wipe, PR messages) must not run
+     * — they are repository-wide and would take the surviving scope's data
+     * with them. Locking this because the guard that implements it reads as a
+     * stray early-`continue`.
+     */
+    it('U: a repository that keeps a directory scope survives losing its own file', async () => {
+        const h = await buildHarness({
+            repositories: repoWithDirectoryScope(),
+            managedRepositoryIds: ['repo-1'],
+            managedDirectoryScopes: { 'repo-1': ['src'] },
+            useRealDeleteUseCase: true,
+        });
+
+        await h.service.removeStaleConfigs({
+            organizationAndTeamData,
+            // `repo-1/kodus-config.yml` is gone; the directory scope remains.
+            configFiles: DIRECTORY_ONLY,
+            actor,
+        });
+
+        expect(h.kodyRulesWipedFor()).toEqual([]);
+        expect(h.messagesDeletedFor()).toEqual([]);
+        expect(h.directoryDeleteCalls()).toEqual([]);
+        // Still selected: it carries centralized configuration.
+        expect(h.reconciledSelection()).toContain('repo-1');
+    });
+});
+
+/**
+ * "I deleted the last one" and "I could not read the repository" both arrive
+ * as an empty discovery. The #1518 guards resolve that tie by refusing to
+ * delete, which makes the last element of every centralized collection
+ * undeletable — reproduced against QA on 2026-08-12: removing one of two
+ * rules propagated, removing the survivor did not.
+ *
+ * The tie is breakable. `discoverConfigFiles` and `discoverKodyRulesFiles`
+ * read the SAME repository tree, and a configured centralized repository
+ * always holds at least the root `kodus-config.yml`. So config files found
+ * are proof the read worked, and zero rule files alongside them is a genuine
+ * "the user deleted them all".
+ */
+describe('#1518 guards must not make the last element undeletable', () => {
+    const rule = (uuid: string, path?: string) => ({
+        uuid,
+        title: uuid,
+        centralizedConfig: path ? { path } : undefined,
+    });
+
+    it('P1: the last centralized rule is removable when the tree read is proven', async () => {
+        const h = await buildHarness({
+            existingRules: [rule('rule-1', '.kody-rules/review/last.yml')],
+        });
+
+        const result = await h.service.removeStaleKodyRules({
+            organizationAndTeamData,
+            ruleFiles: [], // the user deleted the file
+            // ...and the same tree read still returned the root config, so
+            // the repository was reachable.
+            configFiles: GLOBAL_ONLY,
+            actor,
+        });
+
+        expect(h.kodyRulesDeleted()).toEqual(['rule-1']);
+        expect(result.removedRuleCount).toBe(1);
+    });
+
+    it('P2: with nothing found at all, the guard still refuses to wipe', async () => {
+        const h = await buildHarness({
+            existingRules: [rule('rule-1', '.kody-rules/review/last.yml')],
+        });
+
+        const result = await h.service.removeStaleKodyRules({
+            organizationAndTeamData,
+            ruleFiles: [],
+            // No config files either: indistinguishable from a failed read.
+            configFiles: [],
+            actor,
+        });
+
+        expect(h.kodyRulesDeleted()).toEqual([]);
+        expect(result.message).toContain('empty-discovery guard');
+    });
+
+    it('P3: a rule that was never exported is still never touched', async () => {
+        const h = await buildHarness({
+            existingRules: [
+                rule('manual-1'), // created in the UI, no centralized path
+                rule('synced-1', '.kody-rules/review/gone.yml'),
+            ],
+        });
+
+        await h.service.removeStaleKodyRules({
+            organizationAndTeamData,
+            ruleFiles: [],
+            configFiles: GLOBAL_ONLY,
+            actor,
+        });
+
+        expect(h.kodyRulesDeleted()).toEqual(['synced-1']);
+    });
+});
+
+/**
+ * `removeStaleCustomMessages` is the third ownership mechanism in this file,
+ * and it had none: it read EVERY custom PR message in the organization and
+ * deleted any whose scope the current discovery did not mention. That is the
+ * #1579 bug verbatim — a repository inheriting the global config looks like a
+ * repository the user unconfigured — plus a sharper edge: the desired-key set
+ * was built from `meta.directoryPath`, which discovery stopped setting in
+ * 7ca98c8d9, so no `DIR:` key was ever produced and every directory-level
+ * message was stale on every sync.
+ */
+describe('#1579 custom PR messages need the same ownership rule', () => {
+    const globalMessage = { uuid: 'msg-global', configLevel: ConfigLevel.GLOBAL };
+
+    const repoMessage = (uuid: string, repositoryId: string) => ({
+        uuid,
+        configLevel: ConfigLevel.REPOSITORY,
+        repositoryId,
+    });
+
+    const directoryMessage = (uuid: string, directoryId: string) => ({
+        uuid,
+        configLevel: ConfigLevel.DIRECTORY,
+        directoryId,
+    });
+
+    it('Q1: a message of a repository the centralized config never owned survives', async () => {
+        const h = await buildHarness({
+            managedRepositoryIds: ['repo-1'],
+            existingMessages: [repoMessage('msg-2', 'repo-2')],
+        });
+
+        // repo-2 has no `repo-2/kodus-config.yml` and never had one: it
+        // inherits the global config.
+        await h.service.removeStaleConfigs({
+            organizationAndTeamData,
+            configFiles: SPARSE,
+            actor,
+        });
+
+        expect(h.customMessagesDeleted()).toEqual([]);
+    });
+
+    it('Q2: a directory-level message whose scope still exists survives', async () => {
+        const h = await buildHarness({
+            repositories: repoWithDirectoryScope(),
+            managedRepositoryIds: [],
+            managedDirectoryScopes: { 'repo-1': ['src'] },
+            existingMessages: [directoryMessage('msg-dir', 'dir-1')],
+            // Resolution SUCCEEDS here, so the message is spared because its
+            // `DIR:` key is genuinely desired — not because the fail-closed
+            // branch swallowed an unresolvable scope (that is Q6).
+            integrationRepositories: [{ id: 'repo-1', name: 'repo-1' }],
+            directoryIdByPath: { src: 'dir-1' },
+        });
+
+        // The directory scope is right there in the discovery.
+        await h.service.removeStaleConfigs({
+            organizationAndTeamData,
+            configFiles: DIRECTORY_ONLY,
+            actor,
+        });
+
+        expect(h.customMessagesDeleted()).toEqual([]);
+    });
+
+    it('Q5: a directory message of an unowned repository survives', async () => {
+        const h = await buildHarness({
+            repositories: {
+                configs: { languageResultPrompt: 'en-US' },
+                repositories: [
+                    {
+                        id: 'repo-1',
+                        name: 'repo-1',
+                        isSelected: true,
+                        configs: {},
+                        directories: [],
+                    },
+                    // Never mentioned by the centralized config, and carrying
+                    // a directory scope somebody created in the UI.
+                    {
+                        id: 'repo-2',
+                        name: 'repo-2',
+                        isSelected: true,
+                        configs: {},
+                        directories: [
+                            {
+                                id: 'dir-2',
+                                name: 'api',
+                                path: 'api',
+                                folders: [
+                                    { id: 'f-2', name: 'api', path: 'api' },
+                                ],
+                                configs: {},
+                            },
+                        ],
+                    },
+                ],
+            } as any,
+            managedRepositoryIds: ['repo-1'],
+            // repo-2's `api` scope was never owned by the centralized config.
+            managedDirectoryScopes: {},
+            existingMessages: [directoryMessage('msg-dir-2', 'dir-2')],
+            integrationRepositories: [
+                { id: 'repo-1', name: 'repo-1' },
+                { id: 'repo-2', name: 'repo-2' },
+            ],
+        });
+
+        await h.service.removeStaleConfigs({
+            organizationAndTeamData,
+            configFiles: SPARSE, // mentions repo-1 only
+            actor,
+        });
+
+        // No `DIR:dir-2` key is desired — but repo-2 is not the centralized
+        // config's to reconcile, so its directory message is not its to delete.
+        expect(h.customMessagesDeleted()).toEqual([]);
+    });
+
+    /**
+     * `CentralizedConfigSyncUseCase.mergeConfigScopes` folds Kody-rule files
+     * into the config scopes, so a repository whose only centralized presence
+     * is `{repo}/.kody-rules/review/*.yml` shows up in discovery — while
+     * saying nothing whatsoever about that repository's directories.
+     *
+     * Reconciling directories by repository therefore deleted every scope the
+     * user had built in the UI. Tracking ownership per scope is what makes
+     * "the config repo does not mention this directory" and "the config repo
+     * never owned this directory" different answers.
+     */
+    it('V: a repository present only via Kody rules keeps its UI directory scopes', async () => {
+        const h = await buildHarness({
+            repositories: repoWithDirectoryScope(),
+            managedRepositoryIds: [],
+            // The rules file says nothing about directories, so no previous
+            // sync ever recorded owning `src`.
+            managedDirectoryScopes: {},
+        });
+
+        const result = await h.service.removeStaleConfigs({
+            organizationAndTeamData,
+            configFiles: [
+                { path: 'kodus-config.yml' } as any,
+                // What mergeConfigScopes emits for `repo-1/.kody-rules/...`:
+                // a repository scope with no directory information at all.
+                { repositoryId: 'repo-1' } as any,
+            ],
+            actor,
+        });
+
+        // Asserted explicitly: the sweep swallows its own errors and returns
+        // a failure, so "deleted nothing" is only meaningful alongside
+        // "ran to completion".
+        expect(result.success).toBe(true);
+        expect(h.directoryDeleteCalls()).toEqual([]);
+    });
+
+    it('W: a UI-created scope inside a managed repository is left alone', async () => {
+        const h = await buildHarness({
+            repositories: {
+                ...repoWithDirectoryScope(),
+                repositories: [
+                    {
+                        ...repoWithDirectoryScope().repositories[0],
+                        directories: [
+                            {
+                                id: 'dir-1',
+                                name: 'src',
+                                path: 'src',
+                                folders: [
+                                    { id: 'f-1', name: 'src', path: 'src' },
+                                ],
+                                configs: {},
+                            },
+                            // Built in the UI, never exported to the config
+                            // repo, so absent from both discovery and baseline.
+                            {
+                                id: 'dir-2',
+                                name: 'api',
+                                path: 'api',
+                                folders: [
+                                    { id: 'f-2', name: 'api', path: 'api' },
+                                ],
+                                configs: {},
+                            },
+                        ],
+                    },
+                ],
+            } as any,
+            managedRepositoryIds: [],
+            managedDirectoryScopes: { 'repo-1': ['src'] },
+        });
+
+        await h.service.removeStaleConfigs({
+            organizationAndTeamData,
+            configFiles: GLOBAL_ONLY, // `src` was deleted from the config repo
+            actor,
+        });
+
+        // `src` was ours and is gone; `api` never was.
+        expect(h.directoryDeleteCalls()).toEqual(['repo-1:dir-1']);
+    });
+
+    it('Q7: a UI-created scope keeps its message even inside an owned repository', async () => {
+        const h = await buildHarness({
+            repositories: {
+                configs: { languageResultPrompt: 'en-US' },
+                repositories: [
+                    {
+                        id: 'repo-1',
+                        name: 'repo-1',
+                        isSelected: true,
+                        configs: {},
+                        directories: [
+                            {
+                                id: 'dir-2',
+                                name: 'api',
+                                path: 'api',
+                                folders: [
+                                    { id: 'f-2', name: 'api', path: 'api' },
+                                ],
+                                configs: {},
+                            },
+                        ],
+                    },
+                ],
+            } as any,
+            managedRepositoryIds: [],
+            // repo-1 does own a centralized scope — but `src`, not `api`.
+            managedDirectoryScopes: { 'repo-1': ['src'] },
+            existingMessages: [directoryMessage('msg-api', 'dir-2')],
+            integrationRepositories: [{ id: 'repo-1', name: 'repo-1' }],
+            directoryIdByPath: { src: 'dir-1' },
+        });
+
+        await h.service.removeStaleConfigs({
+            organizationAndTeamData,
+            configFiles: DIRECTORY_ONLY, // declares `src` only
+            actor,
+        });
+
+        expect(h.customMessagesDeleted()).toEqual([]);
+    });
+
+    it('Q6: an unresolvable directory scope blocks directory deletions', async () => {
+        const h = await buildHarness({
+            repositories: repoWithDirectoryScope(),
+            managedRepositoryIds: [],
+            managedDirectoryScopes: { 'repo-1': ['src'] },
+            existingMessages: [directoryMessage('msg-dir', 'dir-1')],
+            integrationRepositories: [{ id: 'repo-1', name: 'repo-1' }],
+            // The path resolves to nothing: the desired `DIR:` set is now
+            // incomplete, which must not be read as "the scope is gone".
+            directoryIdByPath: {},
+        });
+
+        await h.service.removeStaleConfigs({
+            organizationAndTeamData,
+            configFiles: DIRECTORY_ONLY,
+            actor,
+        });
+
+        expect(h.customMessagesDeleted()).toEqual([]);
+    });
+
+    it('Q3: a genuinely removed repository still loses its message', async () => {
+        const h = await buildHarness({
+            managedRepositoryIds: ['repo-1', 'repo-2'],
+            existingMessages: [repoMessage('msg-2', 'repo-2')],
+        });
+
+        // repo-2 WAS owned by a previous sync and its file is gone now.
+        await h.service.removeStaleConfigs({
+            organizationAndTeamData,
+            configFiles: SPARSE,
+            actor,
+        });
+
+        expect(h.customMessagesDeleted()).toEqual(['msg-2']);
+    });
+
+    it('Q4: the global message survives a config repo that never had a global file', async () => {
+        const h = await buildHarness({
+            managedRepositoryIds: ['repo-1'],
+            managedGlobalConfig: false,
+            existingMessages: [globalMessage],
+        });
+
+        await h.service.removeStaleConfigs({
+            organizationAndTeamData,
+            configFiles: REPO_ONLY, // no global `kodus-config.yml`
+            actor,
+        });
+
+        expect(h.customMessagesDeleted()).toEqual([]);
     });
 });

--- a/libs/centralized-config/infrastructure/adapters/services/centralized-config.service.ts
+++ b/libs/centralized-config/infrastructure/adapters/services/centralized-config.service.ts
@@ -495,6 +495,7 @@ export class CentralizedConfigService implements ICentralizedConfigService {
     }> {
         const { organizationAndTeamData, configFiles, actor } = params;
 
+
         try {
             const codeReviewConfig = await this.parametersService.findByKey(
                 ParametersKey.CODE_REVIEW_CONFIG,
@@ -508,7 +509,7 @@ export class CentralizedConfigService implements ICentralizedConfigService {
                 };
             }
 
-            // #1518 guard: an empty discovery would reset the global config
+            // An empty discovery would reset the global config
             // (default model / BYOK) to {}, delete every repository config, and
             // wipe custom messages. An empty configFiles set almost always
             // means a failed/empty read, not "the user removed everything" —
@@ -534,10 +535,10 @@ export class CentralizedConfigService implements ICentralizedConfigService {
             // Repository-scope files only: `{repo}/kodus-config.yml`, never a
             // directory scope underneath it. Both spellings are checked
             // because discovery stopped setting `directoryPath` on config-file
-            // metas in 7ca98c8d9 ("Fixing sync multi directories") and emits
+            // metas once multi-directory groups landed, and emits
             // `directoryPaths` instead — the singular check alone therefore
             // admits every directory scope. That was invisible while this set
-            // only meant "keep"; as the #1579 baseline it makes a repository
+            // only meant "keep"; as an ownership baseline it makes a repository
             // whose sole centralized file is a directory scope look like the
             // owner of a repository-level config, so removing that directory
             // deselects the entire repository.
@@ -552,7 +553,7 @@ export class CentralizedConfigService implements ICentralizedConfigService {
                     .map((meta) => meta.repositoryId as string),
             );
 
-            // #1579 guard: a repository with no `{repo}/kodus-config.yml` is
+            // A repository with no `{repo}/kodus-config.yml` is
             // inheriting the global config, NOT asking to be unconfigured.
             // Deriving "stale" from the current discovery alone conflates the
             // two and wipes every repo the config repo simply doesn't mention.
@@ -580,10 +581,36 @@ export class CentralizedConfigService implements ICentralizedConfigService {
                     .map((meta) => meta.repositoryId as string),
             );
 
-            /** Is this repository owned by the centralized config at all? */
-            const isManagedRepository = (repositoryId: string) =>
-                discoveredRepositoryIds.has(repositoryId) ||
-                managedRepositoryIds.has(repositoryId);
+            // Directory scopes need their own baseline, at their own
+            // granularity. `managedRepositoryIds` cannot stand in for it:
+            //
+            //  - it only records repositories carrying a
+            //    `{repo}/kodus-config.yml`, so a repository whose sole
+            //    centralized file is a directory scope was in no baseline at
+            //    all. Delete that file and discovery and baseline went blank
+            //    on the same round, so the reconcile skipped the repository
+            //    whose scope it was meant to clean and the scope outlived its
+            //    own removal;
+            //  - and reconciling by repository is too coarse in the other
+            //    direction. `mergeConfigScopes` folds Kody-rule files into the
+            //    config scopes, so `{repo}/.kody-rules/review/x.yml` makes the
+            //    repository look managed while saying nothing about its
+            //    directories — and every directory scope created in the UI
+            //    then looked stale.
+            //
+            // Recording the scopes themselves answers both: a directory is
+            // removable only when a previous sync owned THAT directory.
+            const managedDirectoryScopes = new Map<string, Set<string>>(
+                Object.entries(
+                    centralizedConfigParameter?.configValue
+                        ?.managedDirectoryScopes ?? {},
+                ).map(([repositoryId, groupFolderNames]) => [
+                    repositoryId,
+                    new Set(
+                        Array.isArray(groupFolderNames) ? groupFolderNames : [],
+                    ),
+                ]),
+            );
 
             /** Owned before, gone now — a genuine removal. */
             const isStaleRepository = (repositoryId: string) =>
@@ -662,9 +689,11 @@ export class CentralizedConfigService implements ICentralizedConfigService {
             // Reuse existing deletion logic for directory scope removals.
             for (const repository of codeReviewConfig.configValue
                 .repositories ?? []) {
-                // #1579: never reconcile directories of a repository the
-                // centralized config does not own.
-                if (!isManagedRepository(repository.id)) {
+                // No record of this repository ever having centralized
+                // directory scopes — nothing here is ours to reconcile.
+                const managedScopes = managedDirectoryScopes.get(repository.id);
+
+                if (!managedScopes?.size) {
                     continue;
                 }
 
@@ -703,7 +732,17 @@ export class CentralizedConfigService implements ICentralizedConfigService {
                             primaryPath &&
                             desiredDirectoryPaths.has(primaryPath);
 
-                        return !isTrackedByGroup && !isTrackedByPath;
+                        if (isTrackedByGroup || isTrackedByPath) {
+                            return false;
+                        }
+
+                        // Absent from the config repo now. Only a removal if
+                        // a previous sync owned this exact scope; anything
+                        // else was created outside the centralized config.
+                        return (
+                            dbGroupFolderName !== null &&
+                            managedScopes.has(dbGroupFolderName)
+                        );
                     },
                 );
 
@@ -737,7 +776,7 @@ export class CentralizedConfigService implements ICentralizedConfigService {
 
             for (const repository of refreshedCodeReviewConfig.configValue
                 .repositories ?? []) {
-                // #1579: only a repository that was managed before and is
+                // Only a repository that was managed before and is
                 // absent now is a genuine removal. Everything else is either
                 // still configured or was never ours to unconfigure.
                 if (!isStaleRepository(repository.id)) {
@@ -787,7 +826,7 @@ export class CentralizedConfigService implements ICentralizedConfigService {
 
             let hasChanges = false;
 
-            // #1579: same rule for the global config — only reset it if a
+            // Same rule for the global config — only reset it if a
             // previous sync owned a global `kodus-config.yml` that is now gone.
             const globalWasManaged =
                 centralizedConfigParameter?.configValue?.managedGlobalConfig ===
@@ -841,9 +880,51 @@ export class CentralizedConfigService implements ICentralizedConfigService {
                 hasChanges = true;
             }
 
+            // Directory ids the centralized config may reconcile: exactly the
+            // scopes a previous sync owned, by the same rule the directory
+            // loop uses. A scope created in the UI is not Sync's to clean up,
+            // and neither are its messages.
+            const reconcilableDirectoryIds = new Set<string>(
+                (refreshedCodeReviewConfig.configValue.repositories ?? [])
+                    .flatMap((repository) => {
+                        const managedScopes = managedDirectoryScopes.get(
+                            repository.id,
+                        );
+
+                        if (!managedScopes?.size) {
+                            return [];
+                        }
+
+                        return (repository.directories ?? [])
+                            .filter((directory) => {
+                                if (!directory.folders?.length) {
+                                    return false;
+                                }
+
+                                try {
+                                    return managedScopes.has(
+                                        buildGroupFolderName(
+                                            directory.folders.map(
+                                                (folder) => folder.path,
+                                            ),
+                                        ),
+                                    );
+                                } catch {
+                                    return false;
+                                }
+                            })
+                            .map((directory) => directory.id);
+                    }),
+            );
+
             const staleMessagesResult = await this.removeStaleCustomMessages(
                 configFiles,
                 organizationAndTeamData,
+                {
+                    isStaleRepository,
+                    globalWasManaged,
+                    reconcilableDirectoryIds,
+                },
             );
 
             if (!staleMessagesResult.success) {
@@ -857,7 +938,7 @@ export class CentralizedConfigService implements ICentralizedConfigService {
                 });
             }
 
-            // #1579: record what this sync owns so the NEXT one can tell a
+            // Record what this sync owns so the NEXT one can tell a
             // deleted `kodus-config.yml` from one that never existed. Written
             // even when nothing changed — the baseline is what makes the very
             // first run safe and every later run precise.
@@ -895,6 +976,15 @@ export class CentralizedConfigService implements ICentralizedConfigService {
                         ...freshCentralizedConfig.configValue,
                         managedRepositoryIds: Array.from(
                             desiredRepositoryConfigs,
+                        ),
+                        managedDirectoryScopes: Object.fromEntries(
+                            Array.from(
+                                desiredGroupFolderNamesByRepository,
+                                ([repositoryId, groupFolderNames]) => [
+                                    repositoryId,
+                                    Array.from(groupFolderNames),
+                                ],
+                            ),
                         ),
                         managedGlobalConfig: desiredHasGlobalConfig,
                     },
@@ -1455,9 +1545,23 @@ export class CentralizedConfigService implements ICentralizedConfigService {
         };
     }
 
+    /**
+     * @param ownership what the centralized config is allowed to reconcile.
+     *        Without it this sweep deletes every message whose scope the
+     *        current discovery does not mention: a repository inheriting the
+     *        global config is not a repository the user unconfigured.
+     */
     private async removeStaleCustomMessages(
         configFiles: IConfigFileMeta[],
         organizationAndTeamData: OrganizationAndTeamData,
+        ownership: {
+            /** Owned by a previous sync and absent now — a genuine removal. */
+            isStaleRepository: (repositoryId: string) => boolean;
+            /** A previous sync owned a global `kodus-config.yml`. */
+            globalWasManaged: boolean;
+            /** Directory ids belonging to repositories the config owns. */
+            reconcilableDirectoryIds: Set<string>;
+        },
     ): Promise<{
         success: boolean;
         message: string;
@@ -1489,41 +1593,70 @@ export class CentralizedConfigService implements ICentralizedConfigService {
                 repositories?.map((repo) => [repo.id, repo]) ?? [],
             );
 
+            // Any directory scope this sweep could not resolve to an id leaves
+            // the desired `DIR:` set incomplete, which would read as "these
+            // scopes are gone". Fail closed: skip directory messages entirely.
+            let directoryScopesFullyResolved = true;
+
             for (const meta of configFiles) {
                 if (!meta.repositoryId) {
                     desiredKeys.add(`GLOBAL`);
-                } else if (!meta.directoryPath) {
+                    continue;
+                }
+
+                // Discovery stopped setting `directoryPath` when
+                // multi-directory groups landed and
+                // emits `directoryPaths` instead. Reading only the singular
+                // spelling produced an empty desired `DIR:` set on every sync,
+                // so every directory-level message was permanently stale.
+                const scopePaths = meta.directoryPaths?.length
+                    ? meta.directoryPaths
+                    : meta.directoryPath
+                      ? [meta.directoryPath]
+                      : [];
+
+                if (scopePaths.length === 0) {
                     desiredKeys.add(`REPO:${meta.repositoryId}`);
-                } else {
-                    const targetRepo = repositoriesMap.get(meta.repositoryId);
+                    continue;
+                }
 
-                    if (targetRepo?.name) {
-                        try {
-                            const directoryId =
-                                await this.codeBaseConfigService.getDirectoryIdForPath(
-                                    organizationAndTeamData,
-                                    {
-                                        id: targetRepo.id,
-                                        name: targetRepo.name,
-                                    },
-                                    meta.directoryPath,
-                                );
+                const targetRepo = repositoriesMap.get(meta.repositoryId);
 
-                            if (directoryId) {
-                                desiredKeys.add(`DIR:${directoryId}`);
-                            }
-                        } catch (error) {
-                            this.logger.warn({
-                                message: `Failed to resolve directory ID for stale message cleanup for path: ${meta.directoryPath}`,
-                                context: CentralizedConfigService.name,
-                                metadata: {
-                                    organizationAndTeamData,
-                                    repositoryId: meta.repositoryId,
-                                    directoryPath: meta.directoryPath,
+                if (!targetRepo?.name) {
+                    directoryScopesFullyResolved = false;
+                    continue;
+                }
+
+                for (const scopePath of scopePaths) {
+                    try {
+                        const directoryId =
+                            await this.codeBaseConfigService.getDirectoryIdForPath(
+                                organizationAndTeamData,
+                                {
+                                    id: targetRepo.id,
+                                    name: targetRepo.name,
                                 },
-                                error,
-                            });
+                                scopePath,
+                            );
+
+                        if (directoryId) {
+                            desiredKeys.add(`DIR:${directoryId}`);
+                        } else {
+                            directoryScopesFullyResolved = false;
                         }
+                    } catch (error) {
+                        directoryScopesFullyResolved = false;
+
+                        this.logger.warn({
+                            message: `Failed to resolve directory ID for stale message cleanup for path: ${scopePath}`,
+                            context: CentralizedConfigService.name,
+                            metadata: {
+                                organizationAndTeamData,
+                                repositoryId: meta.repositoryId,
+                                directoryPath: scopePath,
+                            },
+                            error,
+                        });
                     }
                 }
             }
@@ -1531,22 +1664,35 @@ export class CentralizedConfigService implements ICentralizedConfigService {
             // 3. Compare and delete stale entities
             for (const message of existingMessages) {
                 let key: string | undefined;
+                // Absence only means "removed" for a scope the centralized
+                // config owned. Everything else in this organization's
+                // messages was authored elsewhere and is not Sync's to delete.
+                let isOwnedScope = false;
 
                 if (message.configLevel === ConfigLevel.GLOBAL) {
                     key = 'GLOBAL';
+                    isOwnedScope = ownership.globalWasManaged;
                 } else if (
                     message.configLevel === ConfigLevel.REPOSITORY &&
                     message.repositoryId
                 ) {
                     key = `REPO:${message.repositoryId}`;
+                    isOwnedScope = ownership.isStaleRepository(
+                        message.repositoryId,
+                    );
                 } else if (
                     message.configLevel === ConfigLevel.DIRECTORY &&
                     message.directoryId
                 ) {
                     key = `DIR:${message.directoryId}`;
+                    isOwnedScope =
+                        directoryScopesFullyResolved &&
+                        ownership.reconcilableDirectoryIds.has(
+                            message.directoryId,
+                        );
                 }
 
-                if (key && !desiredKeys.has(key)) {
+                if (key && isOwnedScope && !desiredKeys.has(key)) {
                     // Extract the UUID from the entity
                     const entityUuid = message.uuid;
 
@@ -2192,7 +2338,7 @@ export class CentralizedConfigService implements ICentralizedConfigService {
             }
 
             return {
-                // #1518: a partial sync must NOT report success — the use-case
+                // A partial sync must NOT report success — the use-case
                 // surfaces this so the caller sees the real state (not a
                 // success-shaped result), and removeStale* does not run on an
                 // incomplete materialization.
@@ -2261,6 +2407,14 @@ export class CentralizedConfigService implements ICentralizedConfigService {
     async removeStaleKodyRules(params: {
         organizationAndTeamData: OrganizationAndTeamData;
         ruleFiles: IKodyRuleFileMeta[];
+        /**
+         * Config files found by the SAME repository-tree read that produced
+         * `ruleFiles`. A configured centralized repository always holds at
+         * least the root `kodus-config.yml`, so finding any config file is
+         * proof the read worked — which is what tells "the user deleted the
+         * last rule" apart from "the tree came back empty".
+         */
+        configFiles?: IConfigFileMeta[];
         actor: {
             organizationId: string;
             source: 'sync' | 'web' | 'cli';
@@ -2272,7 +2426,8 @@ export class CentralizedConfigService implements ICentralizedConfigService {
         message: string;
         removedRuleCount?: number;
     }> {
-        const { organizationAndTeamData, ruleFiles, actor } = params;
+        const { organizationAndTeamData, ruleFiles, configFiles, actor } =
+            params;
 
         try {
             const existingEntity =
@@ -2295,14 +2450,26 @@ export class CentralizedConfigService implements ICentralizedConfigService {
 
             const existingRules = existingEntity?.toJson?.()?.rules || [];
 
-            // #1518 guard: an empty discovery (currentSourcePaths empty) while
-            // centralized rules exist would delete every synced rule. That is
-            // almost always a failed/empty read, not an intentional "delete
-            // all" — refuse to wipe and surface it.
+            // An empty discovery (currentSourcePaths empty) while
+            // centralized rules exist would delete every synced rule, and a
+            // failed read looks exactly like that.
+            //
+            // Unqualified, though, this guard also made the LAST rule
+            // undeletable: removing one of two propagated, removing the
+            // survivor did not, because "none left" and "read failed" are the
+            // same zero. `configFiles` breaks the tie — it comes from the same
+            // tree read, and a configured centralized repository always holds
+            // the root `kodus-config.yml`, so finding one proves the read
+            // worked and the rules really are gone.
             const centralizedRuleCount = existingRules.filter(
                 (rule) => rule.centralizedConfig?.path,
             ).length;
-            if (currentSourcePaths.size === 0 && centralizedRuleCount > 0) {
+            const treeReadProven = (configFiles?.length ?? 0) > 0;
+            if (
+                currentSourcePaths.size === 0 &&
+                centralizedRuleCount > 0 &&
+                !treeReadProven
+            ) {
                 this.logger.warn({
                     message:
                         'Skipping stale Kody rule removal: discovery returned zero rule files but centralized rules exist — refusing to wipe (likely a failed read)',
@@ -2429,7 +2596,7 @@ export class CentralizedConfigService implements ICentralizedConfigService {
             // A missing/failed repositories mapping is a READ FAILURE, not
             // "zero files". Returning [] here made discovery indistinguishable
             // from an empty repo, which then drove removeStale* to wipe every
-            // rule and reset the org's global config (issue #1518). Throw so
+            // rule and reset the org's global config. Throw so
             // the sync aborts before any deletion runs.
             this.logger.error({
                 message:

--- a/libs/centralized-config/infrastructure/adapters/services/centralized-config.service.ts
+++ b/libs/centralized-config/infrastructure/adapters/services/centralized-config.service.ts
@@ -909,7 +909,28 @@ export class CentralizedConfigService implements ICentralizedConfigService {
                                             ),
                                         ),
                                     );
-                                } catch {
+                                } catch (error) {
+                                    // Folder paths that cannot be encoded are
+                                    // a data anomaly, not a normal outcome.
+                                    // Treating the scope as unreconcilable is
+                                    // the safe answer, but it must leave a
+                                    // trace — otherwise its messages are
+                                    // silently skipped forever.
+                                    this.logger.warn({
+                                        message:
+                                            'Skipping directory scope with unencodable folder paths while resolving reconcilable scopes',
+                                        context: CentralizedConfigService.name,
+                                        metadata: {
+                                            organizationAndTeamData,
+                                            repositoryId: repository.id,
+                                            directoryId: directory.id,
+                                            folderPaths: directory.folders.map(
+                                                (folder) => folder.path,
+                                            ),
+                                        },
+                                        error,
+                                    });
+
                                     return false;
                                 }
                             })

--- a/libs/centralized-config/infrastructure/adapters/services/centralized-config.service.ts
+++ b/libs/centralized-config/infrastructure/adapters/services/centralized-config.service.ts
@@ -1117,7 +1117,17 @@ export class CentralizedConfigService implements ICentralizedConfigService {
         success: boolean;
         message: string;
     }> {
-        const { repositoryId, directoryPath } = configFileMeta;
+        const { repositoryId } = configFileMeta;
+
+        // Discovery emits `directoryPaths` and stopped setting `directoryPath`
+        // when multi-directory groups landed. Reading only the singular
+        // spelling put every directory scope through the REPOSITORY branch
+        // below, so a directory's custom messages were written onto the
+        // repository — overwriting the repository's own messages, and never
+        // producing a directory-level message at all.
+        const directoryPath =
+            configFileMeta.directoryPath ??
+            configFileMeta.directoryPaths?.[0];
 
         // 1. Determine config level and resolve directory ID FIRST
         let configLevel: ConfigLevel;

--- a/libs/centralized-config/utils/kodus-config-centralized-pr.builder.ts
+++ b/libs/centralized-config/utils/kodus-config-centralized-pr.builder.ts
@@ -1,9 +1,8 @@
-import * as yaml from 'js-yaml';
-
 import {
     CentralizedConfigPrService,
     CentralizedMutationPullRequestRequest,
 } from '@libs/centralized-config/infrastructure/adapters/services/centralized-config-pr.service';
+import { dumpCentralizedYaml } from '@libs/centralized-config/utils/yaml-dump';
 import { KodusConfigFile } from '@libs/core/infrastructure/config/types/general/codeReview.type';
 import { OrganizationAndTeamData } from '@libs/core/infrastructure/config/types/general/organizationAndTeamData';
 
@@ -97,7 +96,7 @@ export function buildKodusConfigCentralizedMutationRequest(
                 {
                     path,
                     operation: 'upsert',
-                    content: yaml.dump(params.configFileContent),
+                    content: dumpCentralizedYaml(params.configFileContent),
                 },
             ];
         },
@@ -145,7 +144,7 @@ function buildDirectoryGroupFileOps(args: {
             ops.push({
                 path: newConfigPath,
                 operation: 'upsert',
-                content: yaml.dump(configFileContent),
+                content: dumpCentralizedYaml(configFileContent),
             });
         } else if (!folderRenamed) {
             // No content and no rename → user is clearing the override at the

--- a/libs/centralized-config/utils/kody-rules-centralized-pr.builder.ts
+++ b/libs/centralized-config/utils/kody-rules-centralized-pr.builder.ts
@@ -1,9 +1,8 @@
-import * as yaml from 'js-yaml';
-
 import {
     CentralizedConfigPrService,
     CentralizedMutationPullRequestRequest,
 } from '@libs/centralized-config/infrastructure/adapters/services/centralized-config-pr.service';
+import { dumpCentralizedYaml } from '@libs/centralized-config/utils/yaml-dump';
 import { OrganizationAndTeamData } from '@libs/core/infrastructure/config/types/general/organizationAndTeamData';
 import {
     IKodyRule,
@@ -130,8 +129,8 @@ export function formatRuleToYaml(rule: Partial<IKodyRule>): string {
         ...(rule.status === KodyRulesStatus.PAUSED ? { enabled: false } : {}),
     };
 
-    // js-yaml 5 only dumps plain Objects. Nest ValidationPipe + @Type()
-    // turns examples/inheritance into DTO class instances, which throw
-    // "unacceptable kind of an object to dump".
-    return yaml.dump(JSON.parse(JSON.stringify(ruleForYaml)));
+    // `examples`/`inheritance` arrive as DTO class instances, which js-yaml
+    // refuses to dump. Same hazard on every centralized-config dump, so it is
+    // handled in one place.
+    return dumpCentralizedYaml(ruleForYaml);
 }

--- a/libs/centralized-config/utils/yaml-dump.ts
+++ b/libs/centralized-config/utils/yaml-dump.ts
@@ -1,0 +1,35 @@
+import * as yaml from 'js-yaml';
+
+/**
+ * `yaml.dump` for payloads that may have come off an HTTP request.
+ *
+ * js-yaml only dumps plain Objects — a class instance throws
+ * "unacceptable kind of an object to dump" and surfaces as a 500. Nest's
+ * `ValidationPipe` combined with `@Type(() => SomeDto)` produces exactly
+ * that: nested DTO instances rather than plain objects.
+ *
+ * Everything written into a centralized-config pull request starts life as a
+ * request body, so every dump on that path goes through here. The JSON round
+ * trip is the cheap way to strip prototypes; it also drops `undefined`
+ * values, which `yaml.dump` already skipped, so output is unchanged for
+ * payloads that were plain to begin with.
+ *
+ * Not needed for values read back from the database — those are already
+ * plain JSON — but harmless there, and one rule is easier to keep than a
+ * per-call-site judgment about where a value came from.
+ */
+export function dumpCentralizedYaml(content: unknown): string {
+    return yaml.dump(toPlainObject(content));
+}
+
+function toPlainObject(content: unknown): unknown {
+    // Circular structures cannot reach here (request bodies are parsed from
+    // JSON), but a throw from JSON.stringify would be far more confusing than
+    // the YAMLException it replaces — so fall back to the original value and
+    // let yaml.dump report the real problem.
+    try {
+        return JSON.parse(JSON.stringify(content));
+    } catch {
+        return content;
+    }
+}

--- a/libs/organization/domain/parameters/types/configValue.type.ts
+++ b/libs/organization/domain/parameters/types/configValue.type.ts
@@ -91,6 +91,22 @@ export type CentralizedConfigParameter = {
      */
     managedRepositoryIds?: string[];
 
+    /**
+     * Per-repository directory scopes the centralized repo owns, keyed by
+     * repository id and holding the encoded group folder names
+     * (`buildGroupFolderName`) the last successful sync wrote.
+     *
+     * Ownership is tracked per SCOPE, not per repository, because reconciling
+     * directories by repository is wrong in both directions: a repository
+     * whose only file is a directory scope is absent from
+     * `managedRepositoryIds` entirely (its scope could never be cleaned up),
+     * while a repository present only through `.kody-rules` files looks
+     * managed and says nothing about directories (its UI-created scopes all
+     * looked stale). A directory is removable only when a previous sync
+     * owned that directory.
+     */
+    managedDirectoryScopes?: Record<string, string[]>;
+
     /** Same idea for the global `kodus-config.yml`. */
     managedGlobalConfig?: boolean;
 };

--- a/test/unit/centralized-config/kodus-config-centralized-pr.builder.spec.ts
+++ b/test/unit/centralized-config/kodus-config-centralized-pr.builder.spec.ts
@@ -1,0 +1,86 @@
+/**
+ * Call-site coverage for #1688 beyond the rule payload.
+ *
+ * `buildKodusConfigCentralizedMutationRequest` writes `kodus-config.yml` for
+ * code review settings and custom PR messages, both of which arrive as
+ * request bodies with `@Type(() => Dto)` nested classes. Testing the dump
+ * helper on its own proves the helper works; these prove these two call sites
+ * actually reach it.
+ */
+import * as yaml from 'js-yaml';
+
+import { buildKodusConfigCentralizedMutationRequest } from '@libs/centralized-config/utils/kodus-config-centralized-pr.builder';
+
+class SeverityLimitsDto {
+    high: number;
+}
+
+function configWithNestedDto() {
+    const severityLimits = new SeverityLimitsDto();
+    severityLimits.high = 5;
+    return { languageResultPrompt: 'en-US', severityLimits } as any;
+}
+
+const prService = {
+    buildCentralizedPath: ({ relativePath }: { relativePath: string }) =>
+        `my-repo/${relativePath}`,
+    buildDirectoryGroupConfigPath: (
+        repositoryFolder: string,
+        folderName: string,
+    ) => `${repositoryFolder}/${folderName}/kodus-config.yml`,
+} as any;
+
+const base = {
+    centralizedConfigPrService: prService,
+    organizationAndTeamData: { organizationId: 'org-1', teamId: 'team-1' },
+    repositoryId: 'repo-1',
+    title: 't',
+    description: 'd',
+    commitMessage: 'c',
+    sourceBranchPrefix: 'kodus-config',
+};
+
+function upsertContent(request: any) {
+    const ops = request.files({ repositoryFolder: 'my-repo' });
+    const upsert = ops.find((op: any) => op.operation === 'upsert');
+    expect(upsert).toBeDefined();
+    return upsert.content;
+}
+
+describe('buildKodusConfigCentralizedMutationRequest — DTO payloads', () => {
+    it('repository-scope config dumps a nested DTO instance', () => {
+        const request = buildKodusConfigCentralizedMutationRequest({
+            ...base,
+            configFileContent: configWithNestedDto(),
+        } as any);
+
+        expect(yaml.load(upsertContent(request))).toEqual({
+            languageResultPrompt: 'en-US',
+            severityLimits: { high: 5 },
+        });
+    });
+
+    it('directory-group config dumps a nested DTO instance', () => {
+        const request = buildKodusConfigCentralizedMutationRequest({
+            ...base,
+            folders: [{ path: 'src' }],
+            configFileContent: configWithNestedDto(),
+        } as any);
+
+        expect(yaml.load(upsertContent(request))).toEqual({
+            languageResultPrompt: 'en-US',
+            severityLimits: { high: 5 },
+        });
+    });
+
+    it('a plain payload is written exactly as js-yaml would have written it', () => {
+        const plain = { languageResultPrompt: 'en-US', ignorePaths: ['dist'] };
+
+        const request = buildKodusConfigCentralizedMutationRequest({
+            ...base,
+            configFileContent: plain,
+        } as any);
+
+        expect(upsertContent(request)).toBe(yaml.dump(plain));
+    });
+});

--- a/test/unit/centralized-config/yaml-dump.spec.ts
+++ b/test/unit/centralized-config/yaml-dump.spec.ts
@@ -1,0 +1,106 @@
+/**
+ * Issue #1688 was fixed at one of three `yaml.dump` call sites on the
+ * centralized-config pull request path. The other two take
+ * `configFileContent`, which is built from request bodies just like the rule
+ * payload was, so the same 500 is reachable from saving code review settings
+ * or a custom PR message.
+ *
+ * Why it looks intermittent: `deepMerge` assigns a value by reference when
+ * the base config does not already carry that key, so the DTO instance
+ * survives only the FIRST time a user sets that field on a given scope. Set
+ * it a second time and the merge rebuilds it as a plain object and the crash
+ * disappears.
+ */
+import * as yaml from 'js-yaml';
+
+import { deepMerge } from '@libs/common/utils/deep';
+import { dumpCentralizedYaml } from '@libs/centralized-config/utils/yaml-dump';
+
+/** Stands in for any `@Type(() => Dto)` nested class, e.g. SeverityLimitsDto. */
+class SeverityLimitsDto {
+    high: number;
+}
+
+function nestedDto() {
+    const dto = new SeverityLimitsDto();
+    dto.high = 5;
+    return dto;
+}
+
+describe('dumpCentralizedYaml', () => {
+    it('dumps a payload carrying a nested DTO instance', () => {
+        const parsed = yaml.load(
+            dumpCentralizedYaml({
+                languageResultPrompt: 'en-US',
+                severityLimits: nestedDto(),
+            }),
+        ) as Record<string, any>;
+
+        expect(parsed).toEqual({
+            languageResultPrompt: 'en-US',
+            severityLimits: { high: 5 },
+        });
+    });
+
+    it('is what makes that payload dumpable at all', () => {
+        // Non-vacuous: the raw dump this replaces is the reported 500.
+        expect(() =>
+            yaml.dump({ severityLimits: nestedDto() }),
+        ).toThrow(/unacceptable kind of an object/);
+    });
+
+    it('leaves an already-plain payload byte-for-byte unchanged', () => {
+        const plain = {
+            languageResultPrompt: 'en-US',
+            severityLimits: { high: 5 },
+            reviewOptions: { security: true },
+            ignorePaths: ['dist/**'],
+        };
+
+        expect(dumpCentralizedYaml(plain)).toBe(yaml.dump(plain));
+    });
+
+    it('drops undefined exactly like yaml.dump already did', () => {
+        expect(dumpCentralizedYaml({ a: undefined, b: 1 })).toBe(
+            yaml.dump({ a: undefined, b: 1 }),
+        );
+    });
+
+    it('survives a circular payload instead of throwing a JSON error', () => {
+        const circular: any = { a: 1 };
+        circular.self = circular;
+
+        // js-yaml handles cycles with an anchor; the JSON round trip would
+        // have thrown a TypeError, which would be a worse error than the one
+        // this helper exists to prevent.
+        expect(() => dumpCentralizedYaml(circular)).not.toThrow();
+    });
+});
+
+describe('the reachable path: deepMerge hands the instance straight through', () => {
+    it('a first-time field keeps its prototype all the way to the dump', () => {
+        const base = { languageResultPrompt: 'en-US' }; // no severityLimits yet
+        const merged = deepMerge(base as any, {
+            severityLimits: nestedDto(),
+        } as any);
+
+        // What the use case builds — a top-level spread does not deep-clone.
+        const configFileContent = { ...(merged as any) };
+
+        expect(configFileContent.severityLimits).toBeInstanceOf(
+            SeverityLimitsDto,
+        );
+        expect(() => dumpCentralizedYaml(configFileContent)).not.toThrow();
+    });
+
+    it('a field that already existed is rebuilt plain, which is why this hid', () => {
+        const base = { severityLimits: { high: 1 } };
+        const merged = deepMerge(base as any, {
+            severityLimits: nestedDto(),
+        } as any);
+
+        expect((merged as any).severityLimits).not.toBeInstanceOf(
+            SeverityLimitsDto,
+        );
+    });
+});


### PR DESCRIPTION
## Summary

Centralized config Sync could not tell **"this was removed"** from **"this was never mine"**, and every cleanup answered that question its own way. Five bugs came out of that, all reproduced end to end against a real stack before being fixed.

## What was broken

**1. A directory scope survived its own removal.** A repository whose only centralized file was `{repo}/{dir}/kodus-config.yml` appeared in no baseline. Deleting that file emptied discovery and the baseline on the same round, so the reconcile skipped the very repository whose scope it was meant to clean. The scope stayed in the database forever, through merges, merge-fired syncs and any number of manual syncs.

**2. The last centralized Kody rule could not be deleted.** Removing one of two propagated; removing the survivor did nothing. The empty-discovery guard reads zero rule files as a failed read, and "I deleted the last one" produces the same zero.

**3. Custom message cleanup had no ownership check at all.** It read every message in the organization and deleted any whose scope the current discovery did not mention — the same conflation, applied to data the centralized config never created. It also built its desired directory keys from `meta.directoryPath`, unset since multi-directory groups landed, so every directory-level message was stale on every sync.

**4. Saving settings could 500.** js-yaml only dumps plain Objects; `ValidationPipe` + `@Type(() => Dto)` produces class instances. One call site was fixed in #1701; the two config-file dumps carried the same hazard. It looked intermittent because `deepMerge` assigns by reference only when the base config lacks that key — so the crash appears the first time a field is set on a scope, and never again.

**5. A directory's custom message overwrote the repository's.** `syncCustomMessages` also keyed the config level off the dead `directoryPath`, so every directory scope fell through to the REPOSITORY branch: the directory's messages were written onto the repository, silently replacing its own, and no directory-level message was ever created.

## The fix

Ownership is now recorded **per scope**, not per repository, in `managedDirectoryScopes` (repository id → encoded group folder names). A directory is removable only when a previous sync owned *that* directory. Kept separate from `managedRepositoryIds` on purpose: collapsing them lets a deleted directory scope deselect the whole repository (#1579), and leaving it out strands the scopes of repositories that never had a repository-level file.

Reconciling by repository was also too coarse in the other direction — `mergeConfigScopes` folds Kody-rule files into the config scopes, so a repository present only through `{repo}/.kody-rules/**` looked managed while saying nothing about its directories, and every scope built in the UI looked stale.

The empty-discovery tie is broken with evidence rather than a count: config files from the same repository-tree read prove the read worked, because a configured centralized repository always holds the root `kodus-config.yml`.

## Test plan

- [x] Unit: 149 in the centralized-config suites, 3826 across the affected libs, `tsc` clean
- [x] Mutation-tested: reverting any fix line turns a *distinct* test red — no survivors. Two rounds were needed; the first exposed an uncovered line and a test that passed through the wrong branch
- [x] Directory ghost: scope cleaned, repository stayed selected
- [x] Kody rules: deleting one of two, then the last — both reach `deleted`
- [x] Custom messages: unowned message survives; genuine removal deletes; directory and repository messages land at their own levels with their own content
- [x] YAML: saving `suggestionControl.severityLimits` over HTTP produces a PR with plain YAML instead of a 500
- [x] Init from the UI: disable, re-enable, Initialize, merge — baseline rebuilt with every scope
- [x] Webhook: merging a PR that removes a rule fires the sync on its own, with no collateral damage

## Notes for the reviewer

Commits are split by subject and each one is green on its own — the YAML hardening is independent of the ownership work, and the message-writer fix is deliberately separate because it is the *writer* half of the same dead field the ownership commit fixes on the *read* side.

Two behaviours were confirmed correct and locked with tests rather than changed: a repository that keeps a directory scope after losing its own file must not run repository-wide removal side effects, and init/disable writing a fresh parameter without spreading the old one is intentional — carrying a baseline into a different config repository would make the first sync treat unmentioned repositories as deletions.

**Not addressed here:** a `kodus-config.yml` nested more than one level deep is dropped by discovery with only a log line, and concurrent syncs have no lock. Both are known and out of scope.

**Migration note:** scopes already orphaned before this change do not clean themselves — the new baseline only records what is present. They clear on the next add/remove cycle, or by deleting the scope in the UI.
