### PR TITLE
fix(e2e): clear the free tenant's stored BYOK key instead of just skipping it

### DIFF
--- a/tests/e2e/lib/runner.ts
+++ b/tests/e2e/lib/runner.ts
@@ -290,9 +290,35 @@ async function refreshCloudTenantByok(log: {
     const seen = new Set<string>();
     for (const entry of entries) {
         if (entry.license === 'free') {
-            log.info(
-                `[byok-refresh] ${entry.provider}/free: SKIPPED — a free tenant with a BYOK key is a community tenant, and reviews for it are expected`,
-            );
+            // Skipping the write is not enough: the key persists on the tenant
+            // from every run before this one, so the free tenant stays a
+            // community tenant forever and license-attribution keeps failing
+            // (observed on cloud runs 31601925282 and 31608293474 -- the second
+            // one WITH the skip in place). Its identity has to be ENFORCED each
+            // run, not assumed.
+            try {
+                const session = await login(target, {
+                    email: entry.email,
+                    password: entry.password,
+                });
+                const resp = await http(
+                    `${target.apiBaseUrl}/organization-parameters/delete-byok-config?configType=main`,
+                    {
+                        method: 'DELETE',
+                        headers: {
+                            Authorization: `Bearer ${session.accessToken}`,
+                        },
+                        timeoutMs: 30_000,
+                    },
+                );
+                log.info(
+                    `[byok-refresh] ${entry.provider}/free: byok_config CLEARED (HTTP ${resp.status}) — a free tenant is defined by having no key of its own`,
+                );
+            } catch (err) {
+                log.warn(
+                    `[byok-refresh] ${entry.provider}/free: could not clear byok_config (${(err as Error).message.slice(0, 120)}) — license-attribution will fail if a key is still stored`,
+                );
+            }
             continue;
         }
         if (seen.has(entry.email)) continue;


### PR DESCRIPTION
Follow-up to #1704, which was necessary but not sufficient.

#1704 stopped **writing** a BYOK key to the free cloud tenant. The next cloud run from main ([31608293474](https://github.com/kodustech/kodus-ai/actions/runs/31608293474)) failed identically, with the skip visibly working:

```
[byok-refresh] github/free: SKIPPED — a free tenant with a BYOK key is a community tenant...
...
FAIL license-attribution × cloud × github × free: Expected NO real review for license=free but Kody posted one
```

Not writing does not unwrite. The key had been persisted on that tenant by every run since 2026-07-28, so it remained a community tenant regardless of what this run did.

The free tenant is defined by having no key of its own, so the run now **enforces** that with `DELETE /organization-parameters/delete-byok-config?configType=main` rather than assuming it.

The general lesson is worth more than the fix: cloud tenants are seeded once and persist across runs, so any state the matrix depends on has to be asserted at run start or it drifts silently. This one drifted for two weeks, and only surfaced when the cloud matrix finally ran with a harness that reports what it verified.

A failed clear warns and names what will break, rather than leaving the next reader to connect a BYOK refresh to a licensing assertion three scenarios later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)