### PR TITLE
fix(e2e): a severity badge means finding, not license notice

### DIFF
--- a/tests/e2e/lib/__tests__/kody-comment-classify.test.ts
+++ b/tests/e2e/lib/__tests__/kody-comment-classify.test.ts
@@ -1,0 +1,64 @@
+import { strict as assert } from "node:assert";
+import { test } from "node:test";
+import { classifyKodyComment } from "../../providers/github.js";
+
+const MARKER = "<!-- kody-codereview -->";
+const badge = (sev: string) =>
+    `![kody code-review](https://img.shields.io/badge/kody-code--review-312B4B) ![Security](https://img.shields.io/badge/Security-D50000) ![${sev}](https://img.shields.io/badge/severity_level-${sev}-FF3D3D)`;
+
+test("a comment without the marker is somebody else's", () => {
+    assert.equal(classifyKodyComment("just a human comment"), "review");
+});
+
+test("the completion notice is not a license block", () => {
+    assert.equal(
+        classifyKodyComment(`${MARKER} kody-codereview-completed 🔥`),
+        "review",
+    );
+});
+
+test("a real license notice is recognised", () => {
+    assert.equal(
+        classifyKodyComment(`${MARKER}\nYour trial has ended — activate your plan`),
+        "license-block",
+    );
+    assert.equal(
+        classifyKodyComment(`${MARKER}\nConfigure BYOK to keep reviewing`),
+        "license-block",
+    );
+});
+
+// The bug: on THIS codebase a security finding routinely says "BYOK" or "API
+// key", because that is what the product's features are called. Cloud run
+// 31616209955 failed license-attribution × community-byok on a genuine
+// Security/critical finding about /stats exposing an API key.
+test("a finding that mentions BYOK is a finding, not a license notice", () => {
+    const finding = `${badge("critical")}\n\n${MARKER}\n\nThe /stats endpoint exposes the BYOK api key in its response.`;
+
+    assert.equal(classifyKodyComment(finding), "review");
+});
+
+test("severity decides regardless of the wording", () => {
+    for (const sev of ["critical", "high", "medium", "low"]) {
+        const body = `${badge(sev)}\n${MARKER}\nTrial has ended handling is wrong here`;
+        assert.equal(classifyKodyComment(body), "review");
+    }
+});
+
+// A license notice carries no severity badge, so the keyword path must still
+// be reachable — otherwise the guard would swallow the case it protects.
+test("the guard does not swallow genuine notices", () => {
+    assert.equal(
+        classifyKodyComment(
+            `${MARKER}\nYour trial has expired. Talk to our founders.`,
+        ),
+        "license-block",
+    );
+});
+
+test("anything else from Kody is the start placeholder", () => {
+    assert.equal(
+        classifyKodyComment(`${MARKER}\nCode Review Started! 🚀`),
+        "started",
+    );
+});

--- a/tests/e2e/providers/github.ts
+++ b/tests/e2e/providers/github.ts
@@ -38,6 +38,44 @@ function classifyLicenseNotice(
     return 'other';
 }
 
+/**
+ * Classify a Kody comment on a PR. Hoisted and exported because it has
+ * misread comments twice: once ranking an incidental status above a real
+ * one, and once reading a security finding that mentions BYOK as a BYOK
+ * license notice (cloud run 31616209955).
+ */
+export function classifyKodyComment(
+    body: string,
+): 'started' | 'license-block' | 'review' {
+    if (!body.includes('<!-- kody-codereview')) return 'review';
+    if (body.includes('kody-codereview-completed'))
+        return 'review';
+    // A severity badge means this is a FINDING, whatever words
+    // it happens to contain. License notices never carry one.
+    //
+    // Without this, a review finding that mentions BYOK is read
+    // as a BYOK license notice -- and on THIS codebase that is
+    // routine: cloud run 31616209955 failed
+    // license-attribution x community-byok on a genuine
+    // Security/critical finding about /stats exposing an API
+    // key. The keyword match below cannot tell "Kody is telling
+    // you to configure a key" from "Kody found a key problem in
+    // your code", so the badge has to decide first.
+    if (/severity_level-/.test(body)) return 'review';
+    // Trial / BYOK / plan-activation prompts. Stable
+    // markers: the "Your trial has ended" and "activate
+    // your plan" / "BYOK" wording. Loose match so minor
+    // copy edits don't silently flip the classification.
+    if (
+        /trial.*ended|trial.*expired|byok|activate.*plan|talk.*to.*our.*founders/i.test(
+            body,
+        )
+    ) {
+        return 'license-block';
+    }
+    return 'started';
+}
+
 export class GitHubProvider extends BaseProvider {
     readonly name: ProviderName = 'github';
     readonly integrationType = 'GITHUB';
@@ -542,25 +580,7 @@ export class GitHubProvider extends BaseProvider {
                 //      summary with "Kody Review Complete" / "Kody
                 //      Guide") or individual finding comments with the
                 //      docs.kodus.io footer. Keep as a review signal.
-                const classify = (
-                    body: string,
-                ): 'started' | 'license-block' | 'review' => {
-                    if (!body.includes('<!-- kody-codereview')) return 'review';
-                    if (body.includes('kody-codereview-completed'))
-                        return 'review';
-                    // Trial / BYOK / plan-activation prompts. Stable
-                    // markers: the "Your trial has ended" and "activate
-                    // your plan" / "BYOK" wording. Loose match so minor
-                    // copy edits don't silently flip the classification.
-                    if (
-                        /trial.*ended|trial.*expired|byok|activate.*plan|talk.*to.*our.*founders/i.test(
-                            body,
-                        )
-                    ) {
-                        return 'license-block';
-                    }
-                    return 'started';
-                };
+                const classify = classifyKodyComment;
                 const filterNonTrigger = <
                     T extends { id: number; body: string },
                 >(


### PR DESCRIPTION
Cloud run [31616209955](https://github.com/kodustech/kodus-ai/actions/runs/31616209955) — the run confirming #1706 — cleared the free tenant correctly and then failed a *different* cell:

```
FAIL license-attribution × cloud × github × community-byok:
  License=community-byok should NOT trigger a trial/BYOK notice, but Kody posted one
  {"message":"![kody code-review] ![Security] ![critical] ... The /stats and","kind":"byok-required"}
```

Kody posted no notice. It posted a **Security/critical finding about `/stats` exposing an API key**.

The classifier decided by keyword: a comment carrying the code-review marker and matching `/byok|own api key|api[ -]?key/` was taken for a license notice. On this codebase that is routine rather than rare — the product's own features are *called* BYOK and API keys, so any finding about them trips it. No keyword can separate "Kody is telling you to configure a key" from "Kody found a key problem in your code".

The severity badge can, and now decides first: a body carrying one is a finding, whatever words follow. Genuine notices carry no badge, so the keyword path stays reachable — there is a test for exactly that, because a guard that swallowed the case it was protecting would be worse than the bug.

Hoisted to module scope and exported so it can be tested at all. This classifier has now misread comments twice in one day, in opposite directions, and each time it cost a 45-minute matrix run.

Note this is content-dependent, so it was always latent: it surfaced now because the matrix moved to DeepSeek today and the findings changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)