### PR TITLE
fix(ci): unbreak the QA deploy pipeline

### DIFF
--- a/.github/workflows/e2e-cloud.yml
+++ b/.github/workflows/e2e-cloud.yml
@@ -64,6 +64,14 @@ jobs:
     cloud-matrix:
         name: cloud matrix (${{ inputs.matrix_file || 'matrix/fast.yml' }})
         runs-on: ubuntu-latest
+        # Stated at the `history` job below: this matrix runs third-party
+        # provider code with long-lived tokens and must never carry write
+        # scope. The workflow-level default already says `contents: read`,
+        # but a caller now has to grant `contents: write` as a ceiling so
+        # `history` can push — so pin the boundary on the job itself rather
+        # than leave it resting on precedence rules.
+        permissions:
+            contents: read
         # QA environment: where the QA-scoped secrets live (GH_REPO_ADMIN_TOKEN
         # for trial-managed-review's throwaway repos). Branch policy allows
         # `main` only — fine, every real trigger (qa-build workflow_call,

--- a/.github/workflows/qa-build-push-and-pr-green.yml
+++ b/.github/workflows/qa-build-push-and-pr-green.yml
@@ -315,6 +315,11 @@ jobs:
         needs: build_push_and_open_pr
         if: needs.build_push_and_open_pr.result == 'success'
         runs-on: ubuntu-latest
+        # Same environment as the build job. Without it the qa-scoped secrets
+        # and vars resolve to empty strings, so configure-aws-credentials gets
+        # no role to assume and every run dies with "Credentials could not be
+        # loaded" — which then skips the e2e matrix and the tier-0 benchmark.
+        environment: qa
         permissions:
             contents: read
             id-token: write # OIDC for configure-aws-credentials
@@ -381,8 +386,14 @@ jobs:
         if: >-
             needs.build_push_and_open_pr.result == 'success' &&
             needs.wait_for_qa_rollout.result == 'success'
+        # The called workflow's `history` job appends the run to the e2e
+        # history and needs `contents: write`. A caller cannot grant a nested
+        # job less than it asks for — GitHub rejects the whole file at parse
+        # time, so the entire deploy never starts. This ceiling was written
+        # before that job existed; the nested jobs still declare their own
+        # narrower permissions.
         permissions:
-            contents: read
+            contents: write
         uses: ./.github/workflows/e2e-cloud.yml
         with:
             image_tag: ${{ github.event.inputs.image_tag || github.sha }}


### PR DESCRIPTION
## Summary

The QA deploy pipeline is broken in two independent ways. One started today and stops the pipeline from running at all; the other has been silently in place since 2026-07-15.

## 1. The workflow file no longer parses

#1664 added a `history` job to the reusable `e2e-cloud.yml` — it appends the run to the e2e history and so declares `contents: write`. This call site pins `contents: read`, written in July when that job did not exist. A caller cannot grant a nested job less than it asks for, so GitHub rejects the whole file at parse time:

```
Invalid workflow file: qa-build-push-and-pr-green.yml#L373
The nested job 'history' is requesting 'contents: write',
but is only allowed 'contents: read'.
```

The result is `startup_failure` with zero jobs: no image is built and no deploy PR is opened. The first run to hit it was the merge of #1705; every push to `main` since behaves the same.

Raising the ceiling to `contents: write` is exactly what the nested job asks for. Nested jobs still declare their own narrower permissions.

**Correction after review:** an earlier version of this description claimed the nested jobs all declare their own narrower permissions. That was wrong — `cloud-matrix` had no `permissions` block and rested on the workflow-level default. Since raising the caller's ceiling makes that boundary depend on precedence rules, `cloud-matrix` is now pinned to `contents: read` on the job itself, which is what the comment above `history` says the boundary should be: that job runs third-party provider code with long-lived tokens and must never carry write scope.

**Reviewer note:** this does mean the `history` job will commit the e2e history file on QA deploys, which is what it was built to do. If that is unwanted, the alternative is to stop calling that job from this workflow rather than to grant the permission — say the word and I will switch it.

## 2. `wait_for_qa_rollout` has never worked

The job was born without an `environment`, so qa-scoped secrets resolve to empty strings. `AWS_ROLE_TO_ASSUME` is blank and the run dies at:

```
##[error]Credentials could not be loaded, please check your action inputs
ECR_REPOSITORY_API:
INFRA_REPO:
INFRA_BASE_BRANCH:
```

Checked every commit that has touched this file: the job block has never carried an `environment`. It was not removed — it was never added. The intent was clearly there, since the job already declares `id-token: write` for OIDC; only the environment holding the secrets was missing. The build job above it has always had `environment: qa`, which is why images were still built and the deploy PR still opened while verification failed.

The e2e matrix and the tier-0 benchmark both gate on this job succeeding, so **both have been skipped for a month** while QA deploys went out unverified.

## Test plan

- [x] Workflow parses and the job graph resolves (`js-yaml`; `needs` all exist)
- [x] `wait_for_qa_rollout.environment == "qa"`, matching `build_push_and_open_pr`
- [x] `e2e-cloud.permissions == { contents: write }`, matching what the nested `history` job declares
- [ ] Merge and confirm on the next push to `main`: the run starts, a `QA: deploy (<sha>)` PR appears in `kodus-infra`, and the e2e matrix stops reporting `skipped`
