### PR TITLE
fix(e2e): stop reporting a failed BYOK clear as CLEARED

### DIFF
--- a/tests/e2e/lib/runner.ts
+++ b/tests/e2e/lib/runner.ts
@@ -311,9 +311,24 @@ async function refreshCloudTenantByok(log: {
                         timeoutMs: 30_000,
                     },
                 );
-                log.info(
-                    `[byok-refresh] ${entry.provider}/free: byok_config CLEARED (HTTP ${resp.status}) — a free tenant is defined by having no key of its own`,
-                );
+                // 2xx cleared something; 400/404 means there was nothing to
+                // clear, which is the state we want and not a failure. Saying
+                // "CLEARED" on a 400 was a line that lied about its own
+                // result -- the exact habit this matrix spent the day
+                // removing from everywhere else.
+                if (resp.status >= 200 && resp.status < 300) {
+                    log.info(
+                        `[byok-refresh] ${entry.provider}/free: byok_config CLEARED — a free tenant is defined by having no key of its own`,
+                    );
+                } else if (resp.status === 400 || resp.status === 404) {
+                    log.info(
+                        `[byok-refresh] ${entry.provider}/free: no byok_config to clear (HTTP ${resp.status}) — already in the state a free tenant should be in`,
+                    );
+                } else {
+                    log.warn(
+                        `[byok-refresh] ${entry.provider}/free: clearing byok_config returned HTTP ${resp.status} — license-attribution will fail if a key is still stored`,
+                    );
+                }
             } catch (err) {
                 log.warn(
                     `[byok-refresh] ${entry.provider}/free: could not clear byok_config (${(err as Error).message.slice(0, 120)}) — license-attribution will fail if a key is still stored`,


### PR DESCRIPTION
Spotted in cloud run [31622858837](https://github.com/kodustech/kodus-ai/actions/runs/31622858837):

```
[byok-refresh] github/free: byok_config CLEARED (HTTP 400)
```

A 400 cleared nothing. The line asserted success from a status that denied it.

Here it is benign — the delete 400s because the free tenant has no key left to remove after #1706, which is exactly the state the clear exists to guarantee. But a real failure would have printed the same word, and the whole point of this matrix work is that a message must not claim more than its evidence.

Now 2xx says cleared, 400/404 says there was nothing to clear and why that is fine, and anything else warns and names what will break.

Unrelated to the run's outcome: that run was **cancelled**, not failed — the QA GitOps deploy restored by #1708 started at 17:23 and took the concurrency group. The cloud cell result is still unconfirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)