### PR TITLE
fix(reaper): retire DigitalOcean and unblock the EC2 sweep

### DIFF
--- a/.github/workflows/reap-droplets.yml
+++ b/.github/workflows/reap-droplets.yml
@@ -51,9 +51,11 @@ jobs:
                   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_E2E_SECRET_ACCESS_KEY }}
                   AWS_DEFAULT_REGION: us-east-2
               run: |
+                  # No longer fatal: DigitalOcean is retired and the EC2 sweep
+                  # is the one that matters. reap.sh skips DO cleanly when the
+                  # token is absent.
                   if [ -z "$DIGITALOCEAN_TOKEN" ]; then
-                      echo "::error::DIGITALOCEAN_TOKEN secret is not set"
-                      exit 1
+                      echo "::warning::DIGITALOCEAN_TOKEN not set — sweeping EC2 only"
                   fi
                   TTL="${{ github.event.inputs.ttl_hours || '6' }}"
                   ARGS=(--ttl "$TTL" -y)

--- a/scripts/selfhosted/reap.sh
+++ b/scripts/selfhosted/reap.sh
@@ -86,7 +86,10 @@ done
 
 require_cmd jq
 require_cmd curl
-require_env DIGITALOCEAN_TOKEN
+# DigitalOcean is retired -- the matrix provisions on AWS. The token is no
+# longer required: without one we skip DO entirely and still sweep EC2, which
+# is the sweep that matters. Kept (rather than deleted) so leftover droplets
+# can still be reaped by anyone who supplies a working token.
 
 TTL_SECS=$(( TTL_HOURS * 3600 ))
 NOW=$(date -u +%s)
@@ -130,64 +133,6 @@ else
 fi
 [ "$DRY_RUN" = "1" ] && warn "DRY RUN — nothing will be deleted"
 [ "${#KEEP[@]}" -gt 0 ] && log "Exempt (--keep): ${KEEP[*]}"
-
-# ---------- pull live droplets (source of truth) ----------
-DROPLETS_JSON=$(curl -fsS \
-    -H "Authorization: Bearer ${DIGITALOCEAN_TOKEN}" \
-    "https://api.digitalocean.com/v2/droplets?per_page=200") \
-    || { err "Failed to list droplets from DigitalOcean"; exit 1; }
-
-# name<TAB>id<TAB>created_at, filtered to our prefix.
-PREFIX_JSON=$(printf '%s\n' "${PREFIXES[@]}" | jq -R . | jq -sc .)
-MATCHES=$(echo "$DROPLETS_JSON" | jq -r \
-    --argjson ps "$PREFIX_JSON" \
-    '.droplets[] | select([.name | startswith($ps[])] | any) | "\(.name)\t\(.id)\t\(.created_at)"')
-
-LIVE_NAMES=$(echo "$DROPLETS_JSON" | jq -r '.droplets[].name')
-
-# ---------- decide what to reap ----------
-TO_REAP=()        # instance short-names (suffix after prefix)
-TO_REAP_IDS=()    # parallel array of droplet ids
-TO_REAP_NAMES=()  # parallel array of FULL droplet names (namespace intact)
-SKIPPED_YOUNG=0
-
-if [ -n "$MATCHES" ]; then
-    while IFS=$'\t' read -r name id created; do
-        [ -n "$name" ] || continue
-        short="$(strip_prefix "$name")"
-        if is_kept "$short"; then
-            dim "  keep   $name (exempt)"
-            continue
-        fi
-        created_epoch=$(iso_to_epoch "$created")
-        if [ -z "$created_epoch" ]; then
-            warn "  skip   $name — could not parse created_at '$created'; refusing to guess its age"
-            continue
-        fi
-        age=$(( NOW - created_epoch ))
-        age_h=$(( age / 3600 ))
-        if [ "$REAP_ALL" != "1" ] && [ "$age" -lt "$TTL_SECS" ]; then
-            dim "  young  $name (${age_h}h < ${TTL_HOURS}h) — keeping"
-            SKIPPED_YOUNG=$(( SKIPPED_YOUNG + 1 ))
-            continue
-        fi
-        warn "  REAP   $name (${age_h}h old, id=$id)"
-        TO_REAP+=("$short")
-        TO_REAP_IDS+=("$id")
-        TO_REAP_NAMES+=("$name")
-    done <<< "$MATCHES"
-fi
-
-# ---------- find orphaned state files (droplet already gone) ----------
-ORPHAN_STATES=()
-while IFS= read -r inst; do
-    [ -n "$inst" ] || continue
-    full="${PREFIX}${inst}"
-    if ! echo "$LIVE_NAMES" | grep -qx "$full"; then
-        ORPHAN_STATES+=("$inst")
-        dim "  stale  state file for '$inst' (no live droplet) — will clean"
-    fi
-done < <(list_instances)
 
 # ---------- AWS EC2 sweep ----------
 # Additive and independent of the DigitalOcean flow above, so it cannot break
@@ -266,6 +211,86 @@ reap_aws_ec2() {
         esac
     done < <(aws ec2 describe-key-pairs --region "$region" --query 'KeyPairs[].KeyName' --output text 2>/dev/null | tr '\t' '\n')
 }
+
+# ---------- pull live droplets (source of truth) ----------
+# A dead DigitalOcean token must not take the EC2 sweep down with it. The two
+# clouds are independent, the matrix provisions on AWS now, and `exit 1` here
+# meant an expired DO credential silently stopped the only cleanup that still
+# matters -- leaked instances billing while the job merely reported failure
+# (observed: run 31629073157, DO returning 401).
+if [ -z "${DIGITALOCEAN_TOKEN:-}" ]; then
+    log "No DIGITALOCEAN_TOKEN - DigitalOcean is retired; sweeping EC2 only."
+    rc=0
+    reap_aws_ec2 || rc=1
+    [ "$rc" -eq 0 ] && ok "Reap complete (EC2 only)." || warn "Reap completed with failures (rc=$rc)."
+    exit "$rc"
+fi
+
+if ! DROPLETS_JSON=$(curl -fsS \
+    -H "Authorization: Bearer ${DIGITALOCEAN_TOKEN}" \
+    "https://api.digitalocean.com/v2/droplets?per_page=200"); then
+    # A token that is SET but rejected is different from no token: someone
+    # meant DigitalOcean to be reaped and it was not. Sweep EC2 anyway, then
+    # fail so the dead credential stays visible.
+    err "DigitalOcean returned an error (token expired or revoked?) - skipping DO, still sweeping EC2"
+    rc=0
+    reap_aws_ec2 || rc=1
+    err "DigitalOcean reap did NOT run. Rotate DIGITALOCEAN_TOKEN, or unset it if DO is gone for good."
+    exit 1
+fi
+
+# name<TAB>id<TAB>created_at, filtered to our prefix.
+PREFIX_JSON=$(printf '%s\n' "${PREFIXES[@]}" | jq -R . | jq -sc .)
+MATCHES=$(echo "$DROPLETS_JSON" | jq -r \
+    --argjson ps "$PREFIX_JSON" \
+    '.droplets[] | select([.name | startswith($ps[])] | any) | "\(.name)\t\(.id)\t\(.created_at)"')
+
+LIVE_NAMES=$(echo "$DROPLETS_JSON" | jq -r '.droplets[].name')
+
+# ---------- decide what to reap ----------
+TO_REAP=()        # instance short-names (suffix after prefix)
+TO_REAP_IDS=()    # parallel array of droplet ids
+TO_REAP_NAMES=()  # parallel array of FULL droplet names (namespace intact)
+SKIPPED_YOUNG=0
+
+if [ -n "$MATCHES" ]; then
+    while IFS=$'\t' read -r name id created; do
+        [ -n "$name" ] || continue
+        short="$(strip_prefix "$name")"
+        if is_kept "$short"; then
+            dim "  keep   $name (exempt)"
+            continue
+        fi
+        created_epoch=$(iso_to_epoch "$created")
+        if [ -z "$created_epoch" ]; then
+            warn "  skip   $name — could not parse created_at '$created'; refusing to guess its age"
+            continue
+        fi
+        age=$(( NOW - created_epoch ))
+        age_h=$(( age / 3600 ))
+        if [ "$REAP_ALL" != "1" ] && [ "$age" -lt "$TTL_SECS" ]; then
+            dim "  young  $name (${age_h}h < ${TTL_HOURS}h) — keeping"
+            SKIPPED_YOUNG=$(( SKIPPED_YOUNG + 1 ))
+            continue
+        fi
+        warn "  REAP   $name (${age_h}h old, id=$id)"
+        TO_REAP+=("$short")
+        TO_REAP_IDS+=("$id")
+        TO_REAP_NAMES+=("$name")
+    done <<< "$MATCHES"
+fi
+
+# ---------- find orphaned state files (droplet already gone) ----------
+ORPHAN_STATES=()
+while IFS= read -r inst; do
+    [ -n "$inst" ] || continue
+    full="${PREFIX}${inst}"
+    if ! echo "$LIVE_NAMES" | grep -qx "$full"; then
+        ORPHAN_STATES+=("$inst")
+        dim "  stale  state file for '$inst' (no live droplet) — will clean"
+    fi
+done < <(list_instances)
+
 
 rc=0
 

--- a/tests/e2e/provisioning/self-hosted/vm.sh
+++ b/tests/e2e/provisioning/self-hosted/vm.sh
@@ -37,7 +37,10 @@ if [ -f "$E2E_ROOT/.env" ]; then
     set -a; . "$E2E_ROOT/.env"; set +a
 fi
 
-TEST_VM_PROVIDER="${TEST_VM_PROVIDER:-digitalocean}"
+# AWS is the default: DigitalOcean is retired, and defaulting to a provider
+# whose credentials no longer exist turns an unset variable into a confusing
+# 401 instead of a working provision.
+TEST_VM_PROVIDER="${TEST_VM_PROVIDER:-aws}"
 MATRIX_FILE="${MATRIX_FILE:-matrix/fast.yml}"
 LICENSE_MODE="${LICENSE_MODE:-license-paid}"
 # Which product topology this stack runs.


### PR DESCRIPTION
The scheduled reaper is failing ([run 31629073157](https://github.com/kodustech/kodus-ai/actions/runs/31629073157)):

```
curl: (22) The requested URL returned error: 401
[err] Failed to list droplets from DigitalOcean
```

DigitalOcean returns 401, the script exits at the droplet listing, and **the EC2 sweep below it never runs**. Since the matrix moved to AWS this week that is the only sweep that still matters, so the practical effect is leaked instances billing while the job reports a generic `failure`.

**Confirmed, not theorised.** A dry run with the DO step out of the way found a live instance:

```
[warn] REAP i-0030979ea41b1d229 kodus-e2e-20260811-191014-674 (24h old) [dry-run]
```

24 hours against a 6h TTL — from yesterday, when the matrix first ran on AWS.

## DigitalOcean stops being a hard dependency

It is retired, so:

- **no token** → skip DO, sweep EC2, exit clean
- **bad token** → sweep EC2, then exit 1, so a dead credential someone still intends to use stays visible rather than being absorbed into a green run
- the workflow no longer aborts when the secret is absent
- `vm.sh` now defaults to `aws`. It defaulted to `digitalocean`, which turned an unset variable into a 401 against an account that no longer exists

The DO code paths are **kept, not deleted**: leftover droplets can only be reaped with a working token, and removing the path would take that option away along with the dependency. Deleting it is a follow-up for whenever the DO account is confirmed empty.

## Note

`reap_aws_ec2` moved above its first use. Bash resolves functions at call time, so the first version of this fix called it 70 lines before it was defined and died with `command not found` — caught by running the failure path rather than reading it.
