### PR TITLE
fix(e2e): a comment on a context line is not a misplacement

### DIFF
--- a/tests/e2e/lib/__tests__/diff-position.test.ts
+++ b/tests/e2e/lib/__tests__/diff-position.test.ts
@@ -64,15 +64,28 @@ test("a comment on an added line is valid", () => {
     );
 });
 
-// The GitLab bug class: the comment arrives, the old assertions pass, and it
-// is hanging off a line the PR never touched.
-test("a comment on a context line is a violation", () => {
+// A context line INSIDE the hunk is a legitimate anchor: "the line you just
+// added should be guarding this one" belongs exactly there, and GitHub accepts
+// it. Requiring an added line failed a real review on run 31638485154 for a
+// comment one line below the change.
+test("a comment on a context line inside the hunk is valid", () => {
+    assert.deepEqual(
+        findPlacementViolations(FILES, [
+            { path: "src/handler.ts", line: 25, side: "RIGHT" },
+        ]),
+        [],
+    );
+});
+
+// The bug class this check exists for: an anchor with no relationship to the
+// change. GitHub would reject it outright; GitLab has shipped it.
+test("a comment far outside every hunk is a violation", () => {
     const v = findPlacementViolations(FILES, [
-        { path: "src/handler.ts", line: 25, side: "RIGHT" },
+        { path: "src/handler.ts", line: 900, side: "RIGHT" },
     ]);
     assert.equal(v.length, 1);
-    assert.equal(v[0].reason, "line-not-added");
-    assert.match(v[0].detail, /src\/handler\.ts:25/);
+    assert.equal(v[0].reason, "line-not-in-diff");
+    assert.match(v[0].detail, /src\/handler\.ts:900/);
 });
 
 test("a comment on a file the PR does not touch is a violation", () => {
@@ -107,8 +120,9 @@ test("binary files have no patch — never invent a violation", () => {
 
 test("reports every violation, not just the first", () => {
     const v = findPlacementViolations(FILES, [
-        { path: "src/handler.ts", line: 23 }, // ok
-        { path: "src/handler.ts", line: 1 }, // context
+        { path: "src/handler.ts", line: 23 }, // ok: added line
+        { path: "src/handler.ts", line: 25 }, // ok: context inside the hunk
+        { path: "src/handler.ts", line: 900 }, // outside every hunk
         { path: "nope.ts", line: 5 }, // wrong file
     ]);
     assert.equal(v.length, 2);

--- a/tests/e2e/lib/diff-position.ts
+++ b/tests/e2e/lib/diff-position.ts
@@ -37,6 +37,46 @@ export interface InlineCommentRef {
  * the PR, and most providers reject — or silently misplace — a comment
  * anchored to them.
  */
+/**
+ * Lines a comment may legitimately be anchored to: everything the hunk covers
+ * on the new-file side, added AND context.
+ *
+ * Added-only was too strict, and the platform proves it: GitHub REJECTS a
+ * comment anchored outside the diff hunk, so a comment that posted
+ * successfully is by definition inside it. Run 31638485154 failed
+ * code-review-basic on a comment at src/server.ts:31 when the added lines
+ * were 27, 28 and 30 -- a context line immediately below the change, which is
+ * exactly where "this existing line needs guarding by what you just added"
+ * belongs.
+ *
+ * The bug class this check exists for survives the loosening: an anchor in the
+ * wrong FILE, or far from the change, is still caught.
+ */
+export function commentableLinesFromPatch(patch: string): Set<number> {
+    const lines = new Set<number>();
+    let newLine = 0;
+    for (const raw of patch.split("\n")) {
+        const hunk = /^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@/.exec(raw);
+        if (hunk) {
+            newLine = Number(hunk[1]);
+            continue;
+        }
+        if (newLine === 0) continue;
+        if (raw.startsWith("+")) {
+            lines.add(newLine);
+            newLine++;
+        } else if (raw.startsWith("-")) {
+            // removed line: consumes no new-file numbering
+        } else if (raw.startsWith("\\")) {
+            // "\ No newline at end of file"
+        } else {
+            lines.add(newLine); // context line: inside the hunk, commentable
+            newLine++;
+        }
+    }
+    return lines;
+}
+
 export function addedLinesFromPatch(patch: string): Set<number> {
     const added = new Set<number>();
     let newLine = 0;
@@ -65,7 +105,7 @@ export interface PlacementViolation {
     comment: InlineCommentRef;
     reason:
         | "file-not-in-diff"
-        | "line-not-added"
+        | "line-not-in-diff"
         | "missing-anchor"
         | "left-side";
     detail: string;
@@ -84,7 +124,10 @@ export function findPlacementViolations(
 ): PlacementViolation[] {
     const byPath = new Map<string, Set<number> | null>();
     for (const f of files) {
-        byPath.set(f.path, f.patch ? addedLinesFromPatch(f.patch) : null);
+        byPath.set(
+            f.path,
+            f.patch ? commentableLinesFromPatch(f.patch) : null,
+        );
     }
 
     const violations: PlacementViolation[] = [];
@@ -106,17 +149,17 @@ export function findPlacementViolations(
             });
             continue;
         }
-        const added = byPath.get(c.path);
+        const commentable = byPath.get(c.path);
         // Binary file (no patch) — nothing to verify against, don't invent a
         // violation.
-        if (added === null) continue;
+        if (commentable === null) continue;
         // For a multi-line comment, the provider anchors it at `line` and the
         // range starts at `startLine`; the anchor is what has to be valid.
-        if (!added!.has(c.line)) {
+        if (!commentable!.has(c.line)) {
             violations.push({
                 comment: c,
-                reason: "line-not-added",
-                detail: `comment at ${c.path}:${c.line} is not on a line this PR added (added lines: ${[...added!].slice(0, 12).join(", ")}${added!.size > 12 ? "…" : ""})`,
+                reason: "line-not-in-diff",
+                detail: `comment at ${c.path}:${c.line} is outside this PR's diff for that file (hunk lines: ${[...commentable!].slice(0, 12).join(", ")}${commentable!.size > 12 ? "…" : ""})`,
             });
         }
     }


### PR DESCRIPTION
The placement check has been self-skipping all along because no inline comments showed up in the runs. [Run 31638485154](https://github.com/kodustech/kodus-ai/actions/runs/31638485154) was the first time they did, and it failed `code-review-basic`:

```
Review posted 3 inline comment(s), but 1 are anchored outside the PR's added lines:
  - [line-not-added] comment at src/server.ts:31 is not on a line this PR added (added lines: 27, 28, 30)
```

**This is not a product bug.** Line 31 sits immediately below the change, and the platform settles it: GitHub *rejects* a comment anchored outside the diff hunk, so a comment that posted successfully is inside the hunk by definition. The check was stricter than the API it was checking.

It is also often the *right* place for a comment — "the line you just added should be guarding this one" belongs on the line being guarded, not on the addition.

Any line the hunk covers is now a valid anchor, added or context. The bug class the check exists for is untouched, with a test for each: an anchor in the wrong **file**, and an anchor **far outside every hunk**, still fail.

Written as a separate function rather than loosening `addedLinesFromPatch`, which other callers use for exactly what its name says.

**Other results from that run**, for context: bitbucket 6/6 green; gitlab and azure-devops both died on `tunnel URL never appeared`, which is cloudflared provisioning flakiness and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)