### PR TITLE
fix(e2e): say why the tunnel failed before destroying the evidence

### DIFF
--- a/tests/e2e/provisioning/self-hosted/vm.sh
+++ b/tests/e2e/provisioning/self-hosted/vm.sh
@@ -478,7 +478,23 @@ for i in $(seq 1 30); do
     if [ -n "$URL" ]; then SERVER_TUNNEL_URL="$URL"; break; fi
     sleep 3
 done
-[ -n "$SERVER_TUNNEL_URL" ] || { err "tunnel URL never appeared"; exit 1; }
+if [ -z "$SERVER_TUNNEL_URL" ]; then
+    # Say WHY before the instance dies. This path used to fail and terminate
+    # the VM one second later, destroying the only record of what cloudflared
+    # was doing -- so "the tunnel did not come up" was all anyone ever learned,
+    # run after run (gitlab and azure-devops, run 31638485154).
+    err "tunnel URL never appeared after 90s — dumping tunnel state before teardown"
+    echo "----- systemctl status kodus-tunnel -----"
+    ssh_vm "systemctl status kodus-tunnel --no-pager 2>&1 | tail -n 20" || true
+    echo "----- journalctl -u kodus-tunnel -----"
+    ssh_vm "journalctl -u kodus-tunnel --no-pager -n 30 2>&1" || true
+    echo "----- /var/log/cloudflared.log (tail) -----"
+    ssh_vm "tail -n 40 /var/log/cloudflared.log 2>&1" || true
+    echo "----- cloudflared binary -----"
+    ssh_vm "ls -l /usr/local/bin/cloudflared 2>&1; /usr/local/bin/cloudflared --version 2>&1" || true
+    echo "---------------------------------------"
+    exit 1
+fi
 ok "Tunnel: $SERVER_TUNNEL_URL"
 
 # ---------- write .env on VM ----------


### PR DESCRIPTION
`gitlab` and `azure-devops` both died on `tunnel URL never appeared` in [run 31638485154](https://github.com/kodustech/kodus-ai/actions/runs/31638485154):

```
20:39:57  Installer transferred
20:42:06  [err] tunnel URL never appeared
20:42:07  [ok]  Terminated EC2 instance i-0d6b2f3…
```

One second between the failure and the teardown. cloudflared writes to `/var/log/cloudflared.log` **on the VM**, and nothing reads it — droplet log collection only runs once the stack is up, which is after this point. So every occurrence of this failure teaches exactly one thing: that it occurred.

The failure path now dumps, before teardown: `systemctl status kodus-tunnel` and its journal, the tail of `/var/log/cloudflared.log`, and whether the binary is on disk at all.

**Deliberately no retry and no longer timeout yet.** Both would paper over a cause nobody has seen. The candidates behave differently and this dump tells them apart:

- binary missing → the cloud-init download failed (it fetches `releases/latest` from GitHub, unpinned)
- unit never started → something else entirely
- unit running with no URL in its log → Cloudflare throttling the free quick tunnels, which four droplets request simultaneously

Once the next occurrence says which, the fix can be the right one rather than a longer wait.

**A bug in the fix itself, caught before shipping:** the status command named the wrong unit. The service is `kodus-tunnel`, not `cloudflared`, so the first draft would have printed `Unit cloudflared.service could not be found` — the exact failure mode this exists to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)