### PR TITLE
fix(bitbucket): read Data Center webhook payload from pullRequest key

### DIFF
--- a/apps/webhooks/src/controllers/bitbucket.controller.ts
+++ b/apps/webhooks/src/controllers/bitbucket.controller.ts
@@ -54,6 +54,14 @@ export class BitbucketController {
                     event,
                     payload: {
                         ...payload,
+                        // Bitbucket Data Center sends the pull request under
+                        // `pullRequest` (capital R), while Cloud sends `pullrequest`.
+                        // Normalize once here so the mappers and the handler can rely
+                        // on a single key.
+                        // https://confluence.atlassian.com/bitbucketserver/event-payload-938025882.html
+                        ...(isDataCenterEvent && payload?.pullRequest
+                            ? { pullrequest: payload.pullRequest }
+                            : {}),
                         isDataCenterEvent,
                     },
                 })

--- a/libs/platform/domain/platformIntegrations/types/webhooks/webhooks-bitbucket.type.ts
+++ b/libs/platform/domain/platformIntegrations/types/webhooks/webhooks-bitbucket.type.ts
@@ -204,6 +204,12 @@ export interface IWebhookBitbucketDataCenterPullRequestEvent {
     eventKey: string;
     date: string;
     actor: IWebhookBitbucketDataCenterActor;
+    /**
+     * Bitbucket Data Center sends this as `pullRequest` (capital R).
+     * `BitbucketController` normalizes it to `pullrequest` before enqueueing,
+     * so every consumer downstream sees the lowercase key.
+     * @see https://confluence.atlassian.com/bitbucketserver/event-payload-938025882.html
+     */
     pullrequest: IWebhookBitbucketDataCenterPullRequest;
     comment?: IWebhookBitbucketDataCenterComment;
     commentParentId?: number;

--- a/test/unit/webhooks/controllers/bitbucket.controller.spec.ts
+++ b/test/unit/webhooks/controllers/bitbucket.controller.spec.ts
@@ -126,6 +126,122 @@ describe('BitbucketController', () => {
         });
     });
 
+    describe('Data Center events', () => {
+        /**
+         * Bitbucket Data Center sends the pull request under `pullRequest`
+         * (capital R), while Cloud sends `pullrequest`.
+         * @see https://confluence.atlassian.com/bitbucketserver/event-payload-938025882.html
+         */
+        const dataCenterBody = {
+            eventKey: 'pr:opened',
+            pullRequest: {
+                id: 1,
+                title: 'a new file added',
+                toRef: {
+                    displayId: 'master',
+                    repository: { id: 84, name: 'repo-1' },
+                },
+            },
+        };
+
+        it('should normalize the Data Center "pullRequest" key to "pullrequest"', async () => {
+            mockRequest = {
+                headers: { 'x-event-key': 'pr:opened' },
+                body: dataCenterBody,
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            expect(mockResponse.status).toHaveBeenCalledWith(HttpStatus.OK);
+            expect(mockResponse.send).toHaveBeenCalledWith('Webhook received');
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            const enqueued = enqueueWebhookUseCase.execute.mock.calls[0][0];
+
+            expect(enqueued.payload.pullrequest).toEqual(
+                dataCenterBody.pullRequest,
+            );
+            expect(enqueued.payload.isDataCenterEvent).toBe(true);
+        });
+
+        it.each([
+            'pr:opened',
+            'pr:modified',
+            'pr:reviewer:updated',
+            'pr:comment:added',
+            'pr:merged',
+            'pr:declined',
+        ])('should enqueue "%s" with the normalized key', async (event) => {
+            mockRequest = {
+                headers: { 'x-event-key': event },
+                body: { ...dataCenterBody, eventKey: event },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            expect(enqueueWebhookUseCase.execute).toHaveBeenCalledTimes(1);
+
+            const enqueued = enqueueWebhookUseCase.execute.mock.calls[0][0];
+
+            expect(enqueued.event).toBe(event);
+            expect(enqueued.payload.isDataCenterEvent).toBe(true);
+            expect(enqueued.payload.pullrequest).toBeDefined();
+        });
+
+        it('should not invent a "pullrequest" key when Data Center sends none', async () => {
+            mockRequest = {
+                headers: { 'x-event-key': 'pr:opened' },
+                body: { eventKey: 'pr:opened' },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            const enqueued = enqueueWebhookUseCase.execute.mock.calls[0][0];
+
+            expect(enqueued.payload.pullrequest).toBeUndefined();
+            expect(enqueued.payload.isDataCenterEvent).toBe(true);
+        });
+
+        it('should not normalize "pullRequest" on a Cloud event', async () => {
+            // A Cloud event whose body happens to carry a capital-R
+            // `pullRequest` key must pass through untouched — normalization
+            // is gated on the event being a Data Center one.
+            mockRequest = {
+                headers: { 'x-event-key': 'pullrequest:created' },
+                body: {
+                    pullrequest: { id: 1 },
+                    pullRequest: { id: 999 },
+                },
+            };
+
+            controller.handleWebhook(
+                mockRequest as Request,
+                mockResponse as Response,
+            );
+
+            await new Promise((resolve) => setImmediate(resolve));
+
+            const enqueued = enqueueWebhookUseCase.execute.mock.calls[0][0];
+
+            expect(enqueued.payload.pullrequest).toEqual({ id: 1 });
+            expect(enqueued.payload.isDataCenterEvent).toBe(false);
+        });
+    });
+
     describe('unsupported events - should NOT enqueue', () => {
         it('should ignore "repo:push" event', async () => {
             mockRequest = {

--- a/test/unit/webhooks/mappers/bitbucket-mapped-platform.spec.ts
+++ b/test/unit/webhooks/mappers/bitbucket-mapped-platform.spec.ts
@@ -1,0 +1,165 @@
+import { BitbucketMappedPlatform } from '../../../../libs/common/utils/webhooks/bitbucket';
+import { IMappedPlatform } from '../../../../libs/platform/domain/platformIntegrations/types/webhooks/webhooks-common.type';
+
+describe('BitbucketMappedPlatform', () => {
+    const platform: IMappedPlatform = new BitbucketMappedPlatform();
+
+    /**
+     * Bitbucket Data Center sends the pull request under `pullRequest`
+     * (capital R), while Bitbucket Cloud sends `pullrequest` (lowercase).
+     * See https://confluence.atlassian.com/bitbucketserver/event-payload-938025882.html
+     *
+     * `BitbucketController` normalizes the Data Center key before enqueueing,
+     * so by the time the mapper runs the payload always carries `pullrequest`.
+     */
+    const buildDataCenterPayload = (overrides: object = {}) => ({
+        eventKey: 'pr:opened',
+        date: '2017-09-19T09:58:11+1000',
+        actor: { name: 'admin', displayName: 'Administrator' },
+        pullrequest: {
+            id: 1,
+            title: 'a new file added',
+            description: 'description',
+            state: 'OPEN',
+            author: { user: { name: 'admin' } },
+            reviewers: [],
+            participants: [],
+            fromRef: {
+                id: 'refs/heads/a-branch',
+                displayId: 'a-branch',
+                repository: { id: 84, name: 'repo-1', slug: 'repo-1' },
+            },
+            toRef: {
+                id: 'refs/heads/master',
+                displayId: 'master',
+                repository: { id: 84, name: 'repo-1', slug: 'repo-1' },
+            },
+            ...overrides,
+        },
+        isDataCenterEvent: true,
+    });
+
+    const buildCloudPayload = (overrides: object = {}) => ({
+        pullrequest: {
+            id: 7,
+            title: 'cloud pr',
+            description: 'description',
+            author: { nickname: 'joe' },
+            reviewers: [],
+            participants: [],
+            links: {
+                html: { href: 'https://bitbucket.org/org/repo/pull-requests/7' },
+            },
+            source: {
+                branch: { name: 'feature' },
+                repository: { full_name: 'org/repo' },
+            },
+            destination: {
+                branch: { name: 'main' },
+                repository: { full_name: 'org/repo' },
+            },
+            ...overrides,
+        },
+        repository: {
+            uuid: '{a1b2c3}',
+            name: 'repo',
+            full_name: 'org/repo',
+            links: { html: { href: 'https://bitbucket.org/org/repo' } },
+        },
+        isDataCenterEvent: false,
+    });
+
+    describe('mapPullRequest', () => {
+        it('maps a Data Center pull request using fromRef and toRef', () => {
+            const result = platform.mapPullRequest({
+                payload: buildDataCenterPayload(),
+            });
+
+            expect(result?.number).toBe(1);
+            expect(result?.title).toBe('a new file added');
+            expect(result?.head?.ref).toBe('a-branch');
+            expect(result?.base?.ref).toBe('master');
+            expect(result?.base?.repo?.fullName).toBe('repo-1');
+        });
+
+        it('maps a Cloud pull request using source and destination', () => {
+            const result = platform.mapPullRequest({
+                payload: buildCloudPayload(),
+            });
+
+            expect(result?.number).toBe(7);
+            expect(result?.head?.ref).toBe('feature');
+            expect(result?.base?.ref).toBe('main');
+            expect(result?.url).toBe(
+                'https://bitbucket.org/org/repo/pull-requests/7',
+            );
+        });
+
+        it('maps missing draft to false', () => {
+            const result = platform.mapPullRequest({
+                payload: buildDataCenterPayload(),
+            });
+
+            expect(result?.isDraft).toBe(false);
+        });
+
+        it('returns null when the pull request is absent', () => {
+            const payload = buildDataCenterPayload();
+            delete (payload as any).pullrequest;
+
+            expect(platform.mapPullRequest({ payload })).toBeNull();
+        });
+
+        it('returns null when isDataCenterEvent was not set by the controller', () => {
+            const payload = buildDataCenterPayload();
+            delete (payload as any).isDataCenterEvent;
+
+            expect(platform.mapPullRequest({ payload })).toBeNull();
+        });
+    });
+
+    describe('mapRepository', () => {
+        it('maps a Data Center repository from toRef', () => {
+            const result = platform.mapRepository({
+                payload: buildDataCenterPayload(),
+            });
+
+            expect(result?.id).toBe('84');
+            expect(result?.name).toBe('repo-1');
+            expect(result?.fullName).toBe('repo-1');
+        });
+
+        it('maps a Cloud repository and strips curly braces from the uuid', () => {
+            const result = platform.mapRepository({
+                payload: buildCloudPayload(),
+            });
+
+            expect(result?.name).toBe('repo');
+            expect(result?.fullName).toBe('org/repo');
+        });
+
+        it('returns null when the Data Center payload has no toRef repository', () => {
+            const payload = buildDataCenterPayload();
+            delete (payload as any).pullrequest.toRef;
+
+            expect(platform.mapRepository({ payload })).toBeNull();
+        });
+    });
+
+    describe('mapUsers', () => {
+        it('maps the author of a Data Center pull request', () => {
+            const result = platform.mapUsers({
+                payload: buildDataCenterPayload(),
+            });
+
+            expect(result?.user).toEqual({ user: { name: 'admin' } });
+        });
+
+        it('returns null when the pull request is absent', () => {
+            const payload = buildDataCenterPayload();
+            delete (payload as any).pullrequest;
+
+            expect(platform.mapUsers({ payload })).toBeNull();
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Pull request webhooks from Bitbucket Data Center / Server were silently dropped and never produced a code review. Data Center sends the pull request under `pullRequest` (capital R), while the code reads `pullrequest` (lowercase), so every mapper returned `null` and the handler returned early without logging an error.

This normalizes the key once in `BitbucketController`, before the payload is enqueued, and adds the test coverage that was missing for Data Center events.

Closes #1713

## Test plan

- [x] `pnpm run test -- "test/unit/webhooks/(controllers|mappers)/bitbucket"` → 2 suites, 30 tests passing
- [x] New `bitbucket-mapped-platform.spec.ts` covers Cloud and Data Center side by side, plus the guards that return `null` (10 tests)
- [x] New `Data Center events` block in the existing controller spec covers the normalization, all 6 `pr:*` events, the case where Data Center sends no pull request at all, and a Cloud payload carrying a stray `pullRequest` key
- [x] The 11 pre-existing Cloud tests in `bitbucket.controller.spec.ts` still pass unchanged, so the Cloud path is untouched
- [x] **Mutation check**: reverted only the controller change and re-ran. 7 tests failed (the normalization test and all 6 cases of the `it.each`). Restored the fix and all 30 passed again, confirming the new tests actually lock the behaviour rather than passing regardless.

## Notes for the reviewer

**Why the controller and not the mapper.** `libs/common/utils/webhooks/bitbucket.ts` reads `payload.pullrequest` in 26 places and `chatWithKodyFromGit.use-case.ts` in 8 more. Normalizing once at the entry point fixes all of them without touching any of them. Fixing it inside the mapper alone would have left `bitbucketPullRequest.handler.ts` still broken, since it reads the key directly.

**The original key is preserved.** The spread keeps `pullRequest` alongside the normalized `pullrequest`, so nothing that might depend on the raw shape breaks and the enqueued payload still matches what Bitbucket actually sent. Happy to drop it if you would rather keep the queue message minimal.

**Scope kept deliberately narrow.** No new environment variables, nothing under `ee/`, and `pnpm-lock.yaml` untouched.

**One thing I could not verify.** I do not know whether there are active Bitbucket Data Center users today, so I cannot say how much impact this has in practice. If it helps confirm it from your side, searching production logs for `PR #undefined` on Bitbucket events should surface any affected installations, since `prId` also resolves to `undefined` on this path.

**The type change is documentation only.** `IWebhookBitbucketDataCenterPullRequestEvent` still declares `pullrequest`, which is correct for everything downstream of the controller. I added a JSDoc explaining that the raw event uses `pullRequest` and where the normalization happens, so the next person does not hit the same trap.

I am new to this codebase, so please push back on anything that does not match how you would have done it.
