### PR TITLE
chore: add runo workspace recipe

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -259,3 +259,6 @@ evals/kody-rules/prod-rules.json
 
 .tessl
 .claude/skills/tlc-spec-driven
+
+# runo: validation evidence downloaded per-run (see .kodus/workspace.yaml)
+.kodus/evidence/

--- a/.kodus/workspace.yaml
+++ b/.kodus/workspace.yaml
@@ -1,0 +1,28 @@
+version: 1
+setup:
+  - docker network create kodus-backend-services 2>/dev/null || true
+  - docker network create shared-network 2>/dev/null || true
+  # build sequencial da imagem compartilhada (api/worker/webhooks usam a MESMA
+  # tag; build paralelo do compose up tem race de export — igual aos scripts do repo)
+  - docker compose -f docker-compose.dev.yml build kodus-api
+  - pnpm install
+files:
+  copy: [.env]
+services:
+  compose:
+    file: docker-compose.dev.yml
+    public: kodus-api
+    health: /health/simple
+    health_timeout: 1200
+data:
+  migrate: pnpm run migration:run
+  seed: pnpm run seed
+validate:
+  - name: lint
+    run: pnpm run lint
+  - name: test-rbac
+    run: pnpm run test:rbac
+limits:
+  instance: m7i-flex.xlarge  # nao-burstavel: build sem throttling de creditos
+  disk: 100gb
+  idle_suspend: 10m


### PR DESCRIPTION
## What

Adds `.kodus/workspace.yaml` — the [runo](https://github.com/kodustech/runo) recipe that materializes a **full remote environment for any branch** of this repo: `docker-compose.dev.yml` up on a dedicated EC2 VM, migrations + seed, public URL with health check, and `lint`/`test:rbac` validation with downloadable evidence. Also ignores `.kodus/evidence/` (per-run artifacts).

With this committed, onboarding is:

```bash
# one-time: install runo + claude setup-token (see the runo README)
cp <your dev .env> .          # in your worktree
runo up --here                # or: runo new <task-name>
runo agent claude             # agent working ON the VM
runo ship "feat: ..." --validate
```

## Why these specific settings (learned the hard way, on real runs)

- **`setup` creates the external networks** (`kodus-backend-services`, `shared-network`) — the compose declares them `external: true`; they exist on dev laptops but not on a fresh VM.
- **`setup` builds the shared image sequentially** (`docker compose build kodus-api`) before `up`: kodus-api/worker/webhooks all tag `kodus-ai-dev:latest`, and parallel builds race on the export (`ERROR: image already exists`) — same reason the repo's own `docker:build` scripts are sequential.
- **`health: /health/simple` with `health_timeout: 1200`**: first boot of the dev stack (deps sync + Nest watch build) exceeds any default timeout.
- **`m7i-flex.xlarge`**: non-burstable CPU — Nest builds on t3 exhaust burst credits and crawl at 40% mid-build.
- `idle_suspend: 10m`: the VM stops itself when idle (EBS persists; `runo resume` brings it back in ~1min).

Tested end to end on real environments (env up ~30min first boot with image builds, then cached; validation evidence generated per schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)