### PR TITLE
fix(ci): allow release cloud gate history writes

### DIFF
--- a/.github/workflows/selfhosted-build-push.yml
+++ b/.github/workflows/selfhosted-build-push.yml
@@ -78,6 +78,14 @@ jobs:
     cloud-gate:
         name: Cloud gate (full matrix vs QA)
         if: ${{ github.event_name == 'schedule' }}
+        # The reusable workflow's `history` job appends results to the
+        # e2e-history branch and therefore requests `contents: write`.
+        # GitHub validates reusable-workflow permissions even when this job is
+        # skipped on a manual dispatch; without this ceiling the entire release
+        # workflow fails at startup before creating any jobs. The called
+        # `cloud-matrix` job remains explicitly pinned to `contents: read`.
+        permissions:
+            contents: write
         uses: ./.github/workflows/e2e-cloud.yml
         with:
             matrix_file: matrix/fast.yml


### PR DESCRIPTION
## Summary
- grants the release cloud-gate caller the contents: write ceiling required by the reusable E2E history job
- keeps the cloud-matrix job explicitly read-only inside the called workflow
- prevents release runs from failing during workflow validation before any job starts

## Context
Release run 31841562694 failed with startup_failure and created zero jobs. This is the same reusable-workflow permission mismatch fixed for the QA caller in #1708; the release caller was missed.

## Validation
- actionlint -shellcheck= .github/workflows/selfhosted-build-push.yml .github/workflows/e2e-cloud.yml
- git diff --check

## Note
The local pre-push repository hook still reports unrelated existing env-schema coverage errors for API_CRON_LICENSE_INACTIVITY and RUN_ID.