### PR TITLE
fix(ci): allow release matrix history writes

### DIFF
--- a/.github/workflows/selfhosted-build-push.yml
+++ b/.github/workflows/selfhosted-build-push.yml
@@ -469,8 +469,12 @@ jobs:
         # See create-rc-tag: without this the matrix is skipped on every
         # manual dispatch — the exact symptom that surfaced this bug.
         if: ${{ !cancelled() && needs.build-and-push.result == 'success' }}
+        # The reusable workflow's `history` job appends results to the
+        # e2e-history branch and requests `contents: write`. GitHub validates
+        # that permission against this caller before creating any jobs. The
+        # matrix job inside the reusable workflow remains pinned to read-only.
         permissions:
-            contents: read
+            contents: write
             packages: read
         uses: ./.github/workflows/e2e-self-hosted-matrix.yml
         with:


### PR DESCRIPTION
## Summary
- raises the release e2e-matrix caller ceiling from contents: read to contents: write
- matches the reusable self-hosted matrix history job permission
- keeps packages read-only and the token-bearing matrix job read-only

## Root cause
Release run 31842484772 failed at startup with zero jobs because e2e-self-hosted-matrix.yml contains a history job requiring contents: write, while this caller granted only contents: read. GitHub validates every reusable call before evaluating job conditions.

## Full audit
All six reusable workflow calls in selfhosted-build-push.yml were compared against their callees. After this change, their permission ceilings match. All other local reusable-workflow call sites in the repository were also checked; no additional permission mismatch was found.

## Validation
- actionlint -shellcheck= .github/workflows/selfhosted-build-push.yml .github/workflows/e2e-self-hosted-matrix.yml
- git diff --check