### PR TITLE
fix(e2e): repair RC harness blockers

### DIFF
--- a/.github/workflows/e2e-cloud.yml
+++ b/.github/workflows/e2e-cloud.yml
@@ -104,6 +104,10 @@ jobs:
               working-directory: tests/e2e
               run: npm install --no-audit --no-fund
 
+            - name: Install Playwright Chromium
+              working-directory: tests/e2e
+              run: npx playwright install --with-deps chromium
+
             # Seed the cloud tenant registry. The runner resolves each cloud
             # cell's tenant by (provider, license) from ~/.kodus-dev/cloud-
             # tenants.json (runner.ts:readCloudTenantsFile). Locally that file

--- a/.github/workflows/e2e-self-hosted-matrix.yml
+++ b/.github/workflows/e2e-self-hosted-matrix.yml
@@ -245,6 +245,15 @@ jobs:
               working-directory: tests/e2e
               run: npm install --no-audit --no-fund
 
+            # Browser scenarios currently apply only to the GitHub cell. The
+            # Playwright npm package does not install Chromium by itself on a
+            # fresh GitHub runner, so without this step rbac-ui-render and the
+            # Cockpit render check fail before opening a page.
+            - name: Install Playwright Chromium
+              if: matrix.cell.provider == 'github'
+              working-directory: tests/e2e
+              run: npx playwright install --with-deps chromium
+
             - name: Resolve cell-specific secrets
               id: secrets
               env:

--- a/libs/cli-review/infrastructure/adapters/__tests__/trace-decision-branch-reader.service.spec.ts
+++ b/libs/cli-review/infrastructure/adapters/__tests__/trace-decision-branch-reader.service.spec.ts
@@ -67,6 +67,7 @@ describe('TraceDecisionBranchReaderService', () => {
                     head: { ref: TRACE_BRANCH },
                     base: { ref: TRACE_BRANCH },
                 },
+                suppressNotFoundLogs: true,
             }),
         );
     });

--- a/libs/cli-review/infrastructure/adapters/trace-decision-branch-reader.service.ts
+++ b/libs/cli-review/infrastructure/adapters/trace-decision-branch-reader.service.ts
@@ -50,6 +50,10 @@ export class TraceDecisionBranchReaderService implements ITraceDecisionBranchRea
                     head: { ref: TRACE_BRANCH },
                     base: { ref: TRACE_BRANCH },
                 },
+                // A repository that has never enabled Trace legitimately has
+                // no orphan branch. Treat that 404 as an empty context rather
+                // than emitting the generic PR-file fallback/error pair.
+                suppressNotFoundLogs: true,
             });
 
         const raw = decodeContent(response);

--- a/libs/platform/infrastructure/adapters/services/github/github.service.ts
+++ b/libs/platform/infrastructure/adapters/services/github/github.service.ts
@@ -4677,18 +4677,20 @@ This is an experimental feature that generates committable changes. Review the d
                     /No commit found for the ref/i.test(
                         (error as any)?.message ?? '',
                     );
-                this.logger.warn({
-                    message: refDeleted
-                        ? 'PR head ref missing — falling back to base ref'
-                        : 'Error getting file content from pull request',
-                    context: GithubService.name,
-                    error,
-                    metadata: {
-                        ...params,
-                        prHeadMissing: refDeleted,
-                        httpStatus: status,
-                    },
-                });
+                if (!(params.suppressNotFoundLogs && status === 404)) {
+                    this.logger.warn({
+                        message: refDeleted
+                            ? 'PR head ref missing — falling back to base ref'
+                            : 'Error getting file content from pull request',
+                        context: GithubService.name,
+                        error,
+                        metadata: {
+                            ...params,
+                            prHeadMissing: refDeleted,
+                            httpStatus: status,
+                        },
+                    });
+                }
 
                 // If it fails, try to fetch from the base branch
                 const lines = (await octokit.repos.getContent({
@@ -4701,12 +4703,16 @@ This is an experimental feature that generates committable changes. Review the d
                 return lines;
             }
         } catch (error) {
-            this.logger.error({
-                message: 'Error getting file content to branch base',
-                context: GithubService.name,
-                error,
-                metadata: { ...params },
-            });
+            const status =
+                (error as any)?.status ?? (error as any)?.response?.status;
+            if (!(params.suppressNotFoundLogs && status === 404)) {
+                this.logger.error({
+                    message: 'Error getting file content to branch base',
+                    context: GithubService.name,
+                    error,
+                    metadata: { ...params },
+                });
+            }
         }
     }
 

--- a/tests/e2e/providers/bitbucket.ts
+++ b/tests/e2e/providers/bitbucket.ts
@@ -351,11 +351,14 @@ export class BitbucketProvider extends BaseProvider {
                     { method: "DELETE", headers: this.headers() },
                 );
                 if (del.status === 403) {
-                    log.warn(
-                        `bitbucket:cleanupStale: cannot delete stale webhook ${h.url} — app password lacks the delete:webhook:bitbucket scope. ` +
-                            `${stale.length} dead tunnel webhook(s) remain; at Bitbucket's 50-hook cap NEW webhook registration fails silently and reviews never trigger.`,
+                    throw new Error(
+                        `bitbucket:cleanupStale: cannot delete stale webhook ${h.url} — ` +
+                            `BB_TEST_APP_PASSWORD lacks delete:webhook:bitbucket. ` +
+                            `${stale.length} dead tunnel webhook(s) remain; refusing to spend ` +
+                            `the matrix timeout on PRs whose webhook cannot be trusted. ` +
+                            `Rotate the app password with webhook read/write/delete permission, ` +
+                            `then rerun this cell to clean them automatically.`,
                     );
-                    break;
                 }
                 if (del.status >= 200 && del.status < 300) hooksDeleted += 1;
             }
@@ -364,9 +367,20 @@ export class BitbucketProvider extends BaseProvider {
                     `bitbucket:cleanupStale: deleted ${hooksDeleted} stale tunnel webhook(s)`,
                 );
             }
-        } catch {
-            // Best-effort — webhook cleanup failing must not block the run;
-            // the loud 403 warn above is the actionable signal.
+        } catch (error) {
+            // A known permission/cap problem is deterministic and must fail
+            // before a review opens. Unknown cleanup errors remain best-effort
+            // because a temporary listing failure does not prove the current
+            // webhook is unusable.
+            if (
+                error instanceof Error &&
+                error.message.includes("delete:webhook:bitbucket")
+            ) {
+                throw error;
+            }
+            log.warn(
+                `bitbucket:cleanupStale: webhook cleanup unavailable: ${error instanceof Error ? error.message : String(error)}`,
+            );
         }
         return { closed };
     }

--- a/tests/e2e/provisioning/self-hosted/vm.sh
+++ b/tests/e2e/provisioning/self-hosted/vm.sh
@@ -548,9 +548,9 @@ env_set IMAGE_TAG "$IMAGE_TAG"
 env_set API_LOG_LEVEL "info"
 # Point the web's server-side API calls (next-auth authorize → /auth/login,
 # used by rbac-frontend-routes / rbac-ui-render) at the compose SERVICE name
-# `api`, which Docker DNS always resolves on the shared network regardless of
-# container_name. The old literal `kodus-api` matched neither the service
-# (`api`) nor the actual container (`kodus_api` once GLOBAL_API_CONTAINER_NAME
+# \`api\`, which Docker DNS always resolves on the shared network regardless of
+# container_name. The old literal \`kodus-api\` matched neither the service
+# (\`api\`) nor the actual container (\`kodus_api\` once GLOBAL_API_CONTAINER_NAME
 # is set), so authorize() got ENOTFOUND → returned null → the next-auth login
 # 302'd with no session → both RBAC web scenarios failed on self-hosted only
 # (cloud passes: it reaches the API over the public URL, not a docker host).

--- a/tests/e2e/scenarios/cockpit-analytics.ts
+++ b/tests/e2e/scenarios/cockpit-analytics.ts
@@ -72,11 +72,14 @@ export const cockpitAnalytics: Scenario = {
         await ensureLicenseSeat(ctx.target, session, ctx.provider);
 
         // ---- Layer 1: cockpit eligibility + warehouse reachability ----
-        // Routed through the web's generic API proxy (/api/proxy/api/* →
-        // apps/api). The cockpit endpoint's own tier guard tells us whether the
-        // org is eligible — no separate (cloud-only) billing call.
+        // Call apps/api directly. The web proxy deliberately discards a
+        // caller-supplied Authorization header and derives its Bearer from a
+        // NextAuth cookie. This non-browser probe has an API JWT but no
+        // NextAuth cookie, so routing it through the proxy deterministically
+        // turns an authenticated request into a 401. The browser layer below
+        // still exercises the real same-origin proxy and page rendering.
         const validateUrl =
-            `${ctx.target.webBaseUrl}/api/proxy/api/cockpit/validate` +
+            `${ctx.target.apiBaseUrl}/cockpit/validate` +
             `?organizationId=${encodeURIComponent(session.organizationId)}`;
         // apps/api wraps controller returns in the global TransformInterceptor
         // envelope `{ data, statusCode, type }`, so the cockpit payload lives

--- a/tests/e2e/scenarios/sso-cookie-domain.ts
+++ b/tests/e2e/scenarios/sso-cookie-domain.ts
@@ -43,6 +43,11 @@ function runScript(script: string, args: string[]): Promise<ScriptResult> {
             cwd: REPO_ROOT,
             env: {
                 ...process.env,
+                // The release matrix provisions its regular cells on AWS,
+                // but the dedicated SSO topology still uses the standalone
+                // selfhosted provisioner, which supports DigitalOcean and
+                // Hetzner only. Do not leak TEST_VM_PROVIDER=aws into it.
+                TEST_VM_PROVIDER: "digitalocean",
                 // Force headless — the matrix runner has no display.
                 // The standalone script defaults to headless too, but
                 // we set it explicitly so a stray --headed in someone's

--- a/tests/e2e/scenarios/sso-multi-user.ts
+++ b/tests/e2e/scenarios/sso-multi-user.ts
@@ -24,6 +24,13 @@ const RUNNER = resolve(
     "droplet",
     "run-multi-user.sh",
 );
+const DESTROY = resolve(
+    REPO_ROOT,
+    "scripts",
+    "sso-e2e",
+    "droplet",
+    "destroy.sh",
+);
 
 interface ScriptResult {
     code: number;
@@ -35,7 +42,13 @@ function runScript(script: string): Promise<ScriptResult> {
     return new Promise((done) => {
         const child = spawn("bash", [script], {
             cwd: REPO_ROOT,
-            env: { ...process.env, SSO_E2E_HEADLESS: "1" },
+            env: {
+                ...process.env,
+                SSO_E2E_HEADLESS: "1",
+                // See sso-cookie-domain: this dedicated topology has not been
+                // migrated to the matrix's AWS provisioner.
+                TEST_VM_PROVIDER: "digitalocean",
+            },
             stdio: ["ignore", "pipe", "pipe"],
         });
         let stdout = "";
@@ -68,7 +81,18 @@ export const ssoMultiUser: Scenario = {
     async run(ctx: RunContext) {
         ctx.assert(existsSync(RUNNER), `runner not found at ${RUNNER}`);
 
-        const result = await runScript(RUNNER);
+        let result: ScriptResult;
+        try {
+            result = await runScript(RUNNER);
+        } finally {
+            // The cookie-domain scenario intentionally leaves the shared SSO
+            // droplet alive so this scenario can reuse it. CI has no human
+            // follow-up, so the last SSO scenario owns teardown even on
+            // failure. Local/manual runs preserve the existing debug flow.
+            if (process.env.CI === "true" && existsSync(DESTROY)) {
+                await runScript(DESTROY);
+            }
+        }
 
         // Each sub-flow logs `[sso-multi-user] PASS sub-flow-N: …`.
         // We require all 4 PASS lines AND a zero exit code.
@@ -92,7 +116,10 @@ export const ssoMultiUser: Scenario = {
             droplet: "sso-e2e",
             subFlowsPassed: passLines.length,
             evidence: passLines.map((l) => l.trim()),
-            note: "Droplet kept alive for follow-up debugging. Tear down with `pnpm run sso-e2e:droplet:destroy --name sso-e2e`.",
+            note:
+                process.env.CI === "true"
+                    ? "Dedicated SSO droplet cleaned up after the final SSO scenario."
+                    : "Droplet kept alive for follow-up debugging. Tear down with `pnpm run sso-e2e:droplet:destroy --name sso-e2e`.",
         };
     },
 };


### PR DESCRIPTION
## What changed

- install Playwright Chromium before browser-backed E2E scenarios
- authenticate the Cockpit API probe directly instead of sending a JWT through the cookie-only web proxy
- isolate the dedicated SSO topology on DigitalOcean and tear it down after CI
- fail Bitbucket cells early when stale tunnel webhooks cannot be deleted
- suppress expected 404 noise when the optional Trace branch does not exist
- prevent shell command substitution from backticks inside the VM heredoc

## Why

The RC run `31842820287` exposed deterministic harness failures that obscured the product signal and consumed the full Bitbucket timeout.

## Validation

- `npm test` in `tests/e2e`: 177 passed
- focused Trace reader Jest suite: 5 passed
- `actionlint` on the two changed workflows: passed
- `git diff --check`: passed
- `bash -n` on the VM provisioner: passed

The E2E typecheck remains blocked by the pre-existing untracked `tests/e2e/benchmark/tp-lost.ts` (`TS18046`). The repository pre-push env coverage hook is also blocked by unrelated untracked work referencing `API_CRON_LICENSE_INACTIVITY` and `RUN_ID`.