### PR TITLE
fix(gitlab): build clone URL from path_with_namespace, not stored fullName

### DIFF
--- a/libs/platform/infrastructure/adapters/services/gitlab.service.spec.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.spec.ts
@@ -97,27 +97,139 @@ describe('GitlabService', () => {
         });
     });
 
-    it('does not duplicate the protocol when building clone params for self-hosted GitLab', async () => {
-        jest.spyOn(service as any, 'getAuthDetails').mockResolvedValue({
-            accessToken: 'oauth-token',
-            authMode: AuthMode.OAUTH,
-            host: 'https://gitlab.example.com/',
+    describe('getCloneParams', () => {
+        const mockAuthDetails = () =>
+            jest.spyOn(service as any, 'getAuthDetails').mockResolvedValue({
+                accessToken: 'oauth-token',
+                authMode: AuthMode.OAUTH,
+                host: 'https://gitlab.example.com/',
+            });
+
+        const mockProjectsShow = (show: jest.Mock) =>
+            mockedGitlab.mockReturnValue({ Projects: { show } });
+
+        it('does not duplicate the protocol when building clone params for self-hosted GitLab', async () => {
+            mockAuthDetails();
+            mockProjectsShow(
+                jest.fn().mockResolvedValue({
+                    path_with_namespace: 'group/repo',
+                }),
+            );
+
+            const cloneParams = await service.getCloneParams({
+                organizationAndTeamData,
+                repository: {
+                    id: 'repo-1',
+                    name: 'repo',
+                    fullName: 'group/repo',
+                    defaultBranch: 'main',
+                },
+            });
+
+            expect(cloneParams.url).toBe(
+                'https://gitlab.example.com/group/repo',
+            );
+            expect(cloneParams.auth).toMatchObject({
+                type: AuthMode.OAUTH,
+                token: 'oauth-token',
+            });
         });
 
-        const cloneParams = await service.getCloneParams({
-            organizationAndTeamData,
-            repository: {
-                id: 'repo-1',
-                name: 'repo',
-                fullName: 'group/repo',
-                defaultBranch: 'main',
-            },
+        // A stored fullName can hold the display form. Encoding it verbatim
+        // produces `My Group/My%20Project`, which GitLab answers with a 302
+        // to /users/sign_in and git reports as
+        // `unable to update url base from redirection`.
+        it('builds the URL from path_with_namespace when fullName holds the display form', async () => {
+            mockAuthDetails();
+            const show = jest.fn().mockResolvedValue({
+                path_with_namespace: 'my-group/my-project',
+            });
+            mockProjectsShow(show);
+
+            const cloneParams = await service.getCloneParams({
+                organizationAndTeamData,
+                repository: {
+                    id: '326',
+                    name: 'My Project',
+                    fullName: 'My Group/My Project',
+                    defaultBranch: 'main',
+                },
+            });
+
+            expect(show).toHaveBeenCalledWith('326');
+            expect(cloneParams.url).toBe(
+                'https://gitlab.example.com/my-group/my-project',
+            );
+            expect(cloneParams.url).not.toContain('%20');
         });
 
-        expect(cloneParams.url).toBe('https://gitlab.example.com/group/repo');
-        expect(cloneParams.auth).toMatchObject({
-            type: AuthMode.OAUTH,
-            token: 'oauth-token',
+        // The numeric id survives a move between groups; the stored path does
+        // not, and silently loses the new parent subgroup.
+        it('picks up a subgroup the stored fullName predates', async () => {
+            mockAuthDetails();
+            mockProjectsShow(
+                jest.fn().mockResolvedValue({
+                    path_with_namespace: 'parent/group/repo',
+                }),
+            );
+
+            const cloneParams = await service.getCloneParams({
+                organizationAndTeamData,
+                repository: {
+                    id: 'repo-2',
+                    name: 'repo',
+                    fullName: 'group/repo',
+                    defaultBranch: 'main',
+                },
+            });
+
+            expect(cloneParams.url).toBe(
+                'https://gitlab.example.com/parent/group/repo',
+            );
+        });
+
+        it('falls back to the stored fullName when the project lookup fails', async () => {
+            mockAuthDetails();
+            mockProjectsShow(
+                jest.fn().mockRejectedValue(new Error('404 Not Found')),
+            );
+
+            const cloneParams = await service.getCloneParams({
+                organizationAndTeamData,
+                repository: {
+                    id: 'repo-3',
+                    name: 'repo',
+                    fullName: 'group/repo',
+                    defaultBranch: 'main',
+                },
+            });
+
+            expect(cloneParams.url).toBe(
+                'https://gitlab.example.com/group/repo',
+            );
+        });
+
+        it('still encodes path segments that need it', async () => {
+            mockAuthDetails();
+            mockProjectsShow(
+                jest.fn().mockResolvedValue({
+                    path_with_namespace: 'group/repo name',
+                }),
+            );
+
+            const cloneParams = await service.getCloneParams({
+                organizationAndTeamData,
+                repository: {
+                    id: 'repo-4',
+                    name: 'repo name',
+                    fullName: 'group/repo name',
+                    defaultBranch: 'main',
+                },
+            });
+
+            expect(cloneParams.url).toBe(
+                'https://gitlab.example.com/group/repo%20name',
+            );
         });
     });
 

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.spec.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.spec.ts
@@ -188,6 +188,33 @@ describe('GitlabService', () => {
             );
         });
 
+        // CLI mode passes the placeholder id '0' with a fullName parsed from the
+        // local remote. '0' is a truthy string, so this needs an explicit check
+        // or every CLI clone burns a guaranteed-failing round-trip.
+        it.each(['0', '', undefined])(
+            'skips the project lookup when the id is the placeholder %p',
+            async (id) => {
+                mockAuthDetails();
+                const show = jest.fn();
+                mockProjectsShow(show);
+
+                const cloneParams = await service.getCloneParams({
+                    organizationAndTeamData,
+                    repository: {
+                        id: id as string,
+                        name: 'repo',
+                        fullName: 'group/repo',
+                        defaultBranch: 'main',
+                    },
+                });
+
+                expect(show).not.toHaveBeenCalled();
+                expect(cloneParams.url).toBe(
+                    'https://gitlab.example.com/group/repo',
+                );
+            },
+        );
+
         it('falls back to the stored fullName when the project lookup fails', async () => {
             mockAuthDetails();
             mockProjectsShow(

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -3354,10 +3354,14 @@ export class GitlabService implements Omit<
      * The numeric id survives renames and moves, which is why every REST call in
      * this service keeps working while only the clone breaks. Falls back to the
      * stored `fullName` so a lookup failure is no worse than the old behaviour.
+     *
+     * Callers without a real project id are expected to skip this entirely —
+     * see `hasResolvableProjectId`.
      */
     private async resolveProjectPathWithNamespace(
         gitlabAuthDetail: GitlabAuthDetail,
         repository: Pick<Repository, 'id' | 'fullName'>,
+        organizationAndTeamData: OrganizationAndTeamData,
     ): Promise<string> {
         try {
             const gitlabAPI = this.instanceGitlabApi(gitlabAuthDetail);
@@ -3371,6 +3375,7 @@ export class GitlabService implements Omit<
                 message: `Project ${repository?.id} returned no path_with_namespace; falling back to the stored fullName`,
                 context: GitlabService.name,
                 metadata: {
+                    organizationAndTeamData,
                     repositoryId: repository?.id,
                     fullName: repository?.fullName,
                 },
@@ -3381,6 +3386,7 @@ export class GitlabService implements Omit<
                 context: GitlabService.name,
                 error,
                 metadata: {
+                    organizationAndTeamData,
                     repositoryId: repository?.id,
                     fullName: repository?.fullName,
                 },
@@ -3388,6 +3394,21 @@ export class GitlabService implements Omit<
         }
 
         return repository?.fullName || '';
+    }
+
+    /**
+     * Whether `repository.id` is a real GitLab project id worth a lookup.
+     *
+     * CLI mode has no project id to give — it builds its params straight from
+     * the local git remote and passes the placeholder `'0'` with a `fullName`
+     * parsed from that remote, which is already the authoritative slug. Note
+     * `'0'` is a truthy string, so a plain truthiness check does not catch it
+     * and every CLI clone would spend a guaranteed-failing round-trip.
+     */
+    private hasResolvableProjectId(id?: string | number): boolean {
+        const normalized = String(id ?? '').trim();
+
+        return normalized !== '' && normalized !== '0';
     }
 
     async getCloneParams(params: {
@@ -3413,11 +3434,18 @@ export class GitlabService implements Omit<
             }
 
             // Resolve the slug from the numeric project id instead of trusting
-            // the stored `fullName`. See resolveProjectPathWithNamespace.
-            const projectPath = await this.resolveProjectPathWithNamespace(
-                gitlabAuthDetail,
-                params.repository,
-            );
+            // the stored `fullName`. See resolveProjectPathWithNamespace. With
+            // no real id (CLI mode) `fullName` came straight from the local
+            // remote and is already authoritative, so skip the round-trip.
+            const projectPath = this.hasResolvableProjectId(
+                params.repository?.id,
+            )
+                ? await this.resolveProjectPathWithNamespace(
+                      gitlabAuthDetail,
+                      params.repository,
+                      params.organizationAndTeamData,
+                  )
+                : params.repository?.fullName || '';
 
             const encodedPath = projectPath
                 .split('/')

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -3337,6 +3337,59 @@ export class GitlabService implements Omit<
         }
     }
 
+    /**
+     * The current `path_with_namespace` for a project, looked up by its numeric
+     * id.
+     *
+     * `repository.fullName` is whatever was persisted when the repository was
+     * first selected, and it is not reliably the URL slug: it can hold the
+     * display form (`My Group/My Project` rather than `my-group/my-project`)
+     * and it goes stale when a project is renamed or moved between groups, which
+     * also drops any subgroup added along the way (`group/project` where the
+     * project now lives at `parent/group/project`). Cloning such a URL fails
+     * with a 302 to `/users/sign_in` — git reports it as
+     * `unable to update url base from redirection`, which reads like an auth
+     * problem but is really a path that GitLab won't resolve.
+     *
+     * The numeric id survives renames and moves, which is why every REST call in
+     * this service keeps working while only the clone breaks. Falls back to the
+     * stored `fullName` so a lookup failure is no worse than the old behaviour.
+     */
+    private async resolveProjectPathWithNamespace(
+        gitlabAuthDetail: GitlabAuthDetail,
+        repository: Pick<Repository, 'id' | 'fullName'>,
+    ): Promise<string> {
+        try {
+            const gitlabAPI = this.instanceGitlabApi(gitlabAuthDetail);
+            const project = await gitlabAPI.Projects.show(repository.id);
+
+            if (project?.path_with_namespace) {
+                return project.path_with_namespace as string;
+            }
+
+            this.logger.warn({
+                message: `Project ${repository?.id} returned no path_with_namespace; falling back to the stored fullName`,
+                context: GitlabService.name,
+                metadata: {
+                    repositoryId: repository?.id,
+                    fullName: repository?.fullName,
+                },
+            });
+        } catch (error) {
+            this.logger.warn({
+                message: `Could not resolve path_with_namespace for project ${repository?.id}; falling back to the stored fullName`,
+                context: GitlabService.name,
+                error,
+                metadata: {
+                    repositoryId: repository?.id,
+                    fullName: repository?.fullName,
+                },
+            });
+        }
+
+        return repository?.fullName || '';
+    }
+
     async getCloneParams(params: {
         repository: Pick<
             Repository,
@@ -3359,7 +3412,14 @@ export class GitlabService implements Omit<
                 throw new Error('GitLab authentication details not found');
             }
 
-            const encodedPath = (params?.repository?.fullName || '')
+            // Resolve the slug from the numeric project id instead of trusting
+            // the stored `fullName`. See resolveProjectPathWithNamespace.
+            const projectPath = await this.resolveProjectPathWithNamespace(
+                gitlabAuthDetail,
+                params.repository,
+            );
+
+            const encodedPath = projectPath
                 .split('/')
                 .map(encodeURIComponent)
                 .join('/');


### PR DESCRIPTION
Closes #1743

## Problem

`GitlabService.getCloneParams` builds the clone URL by URL-encoding `repository.fullName`:

```ts
const encodedPath = (params?.repository?.fullName || '')
    .split('/')
    .map(encodeURIComponent)
    .join('/');
const fullGitlabUrl = `${this.getGitlabWebBaseUrl(gitlabAuthDetail.host)}/${encodedPath}`;
```

`fullName` holds whatever was persisted when the repository was first selected, and it is not reliably the URL slug. Two ways it diverges:

1. **Display form.** It can carry the human-readable namespace and project name, so `My Group/My Project` gets encoded to `My%20Group/My%20Project` instead of resolving to `my-group/my-project`.
2. **Stale after a move.** When a project is renamed or moved between groups, the stored value keeps the old path — and if the project gained a parent subgroup, that segment is missing entirely (`group/project` where the project now lives at `parent/group/project`).

## Why it is easy to misdiagnose

GitLab answers an unresolvable path with a 302 to `/users/sign_in`, and git reports:

```
fatal: unable to update url base from redirection:
  asked for: https://gitlab.example.com/My%20Group/My%20Project/info/refs?service=git-upload-pack
   redirect: https://gitlab.example.com/users/sign_in
```

That looks like an auth failure, so the natural first guess is an expired token or a missing permission grant. It isn't — the credential is fine. Every other call in `GitlabService` goes through the REST API by **numeric project id**, which is immune to renames, so the integration appears healthy while only cloning breaks.

Downstream the failure is quiet: `createSandboxWithRepo` retries on its full backoff schedule and then `CreateSandboxStage` logs `all retries exhausted, continuing without it`, so the review silently degrades to self-contained mode (no tools, diff-only analysis) with no signal to the user.

## Fix

Resolve the path from `Projects.show(id)` and use `path_with_namespace`. The numeric id survives renames and group moves, and `Projects.show` is already the idiom elsewhere in this service (`getDefaultBranch`, `getRepositories`).

Falls back to the stored `fullName` if the lookup fails, so the error path is no worse than before.

## Cost

One extra API call per clone, on a code path that is about to fetch the repository over the network anyway. Callers with no real project id skip it entirely (see below). If the remaining cost is a concern I am happy to memoise per `(org, repoId)` — left out here to keep the fix small.

## Review feedback addressed

- **CLI mode placeholder id.** `clone-params-resolver.service.ts` passes `id: '0'` with a `fullName` parsed from the local remote, which is already authoritative — so those calls now skip the lookup rather than spending a guaranteed-failing round-trip. Worth noting `'0'` is a truthy string, so the guard is an explicit `hasResolvableProjectId` check rather than a truthiness test.
- **Log traceability.** The fallback warns now carry `organizationAndTeamData`.

## Tests

Eight cases in `gitlab.service.spec.ts`, covering the display form, a subgroup the stored path predates, the placeholder-id skip, the fallback when the lookup fails, that genuine encoding still happens, and the existing self-hosted-protocol behaviour.

The two new bug-specific tests fail on `main` and pass with this change:

```
✕ builds the URL from path_with_namespace when fullName holds the display form
✕ picks up a subgroup the stored fullName predates
```

## Note on verification

I could not get a full dependency install in my environment (private `@kodus` registry), so I ran `gitlab.service.spec.ts` against a borrowed `node_modules` from an older checkout — 10/10 pass. Two neighbouring suites (`clone-params-no-integration`, `clone-params-resolver.contract`) fail to load there on a missing `@octokit/plugin-enterprise-server`, but they fail identically on a pristine `main` with the same setup, so that is my environment rather than this change. Worth a clean CI run to confirm.

Opened as a draft — happy to adjust the approach if you would rather fix this by correcting `fullName` at the point it is persisted instead.
