### PR TITLE
fix(e2e): consolidate GitHub credentials and move SSO to AWS

### DIFF
--- a/.github/workflows/e2e-cloud.yml
+++ b/.github/workflows/e2e-cloud.yml
@@ -279,21 +279,18 @@ jobs:
                   # change (set it to matrix/midweek-smoke.yml to dial back).
                   MATRIX_FILE: ${{ inputs.matrix_file || (github.event_name == 'schedule' && (vars.E2E_CLOUD_NIGHTLY_MATRIX || 'matrix/fast.yml')) || 'matrix/fast.yml' }}
 
-                  # Provider tokens — cells without the right token are
-                  # skipped (target.sh passes --skip-missing-tokens).
+                  # One human PAT authors PRs/comments (the product ignores
+                  # bot-authored events) and exercises the legacy PAT canary.
                   GH_TEST_TOKEN: ${{ secrets.GH_TEST_TOKEN }}
-                  # Extra bot-account tokens for the round-robin pool (see
-                  # tests/e2e/lib/github-token-pool.ts). Optional — the pool
-                  # collapses to GH_TEST_TOKEN alone when these are unset.
-                  GH_TEST_TOKEN_2: ${{ secrets.GH_TEST_TOKEN_2 }}
-                  GH_TEST_TOKEN_3: ${{ secrets.GH_TEST_TOKEN_3 }}
-                  # GitHub App installation token (opt-in, preferred over the
-                  # PAT pool for cloud cells): 5000/h of its own budget,
-                  # immune to the bot-account abuse flags. All three unset →
-                  # PAT pool behavior unchanged. See lib/github-app-token.ts.
+                  # The product stores this only in provider=github cells.
+                  # No fallback: a missing credential must fail in preflight.
+                  GH_INTEGRATION_TOKEN: ${{ secrets.GH_INTEGRATION_TOKEN }}
+                  # GitHub App installation used by provider=github-app and
+                  # for high-volume reads/polls in the compatibility cell.
                   GH_APP_ID: ${{ secrets.GH_APP_ID }}
                   GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
                   GH_APP_INSTALLATION_ID: ${{ secrets.GH_APP_INSTALLATION_ID }}
+                  GH_APP_TEST_REPO: ${{ vars.GH_APP_TEST_REPO }}
                   GH_TEST_REPO: ${{ secrets.GH_TEST_REPO }}
                   GH_TEST_REPO_CLOUD: ${{ secrets.GH_TEST_REPO_CLOUD }}
                   GH_TEST_PR_NUMBER: ${{ secrets.GH_TEST_PR_NUMBER }}

--- a/.github/workflows/e2e-self-hosted-matrix.yml
+++ b/.github/workflows/e2e-self-hosted-matrix.yml
@@ -299,18 +299,9 @@ jobs:
 
                   DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
 
-                  # GitHub bot-account token POOL. The runner round-robins
-                  # every github scenario across GH_TEST_TOKEN + GH_TEST_TOKEN_2..N
-                  # (see lib/github-token-pool.ts), so the ~26-scenario
-                  # license-paid cell spreads its polling/content-creation load
-                  # across multiple accounts instead of draining one account's
-                  # 5,000 req/hr primary quota and cascading into ~19 misleading
-                  # rate-limit SKIPs. GH_TEST_TOKEN_2 is a second dedicated bot
-                  # (Admin on the fixture repo). Empty siblings are dropped, so
-                  # this stays a single-token pool — identical to before — until
-                  # the secret is set.
+                  # One human PAT is kept for PR/comment authorship because
+                  # product review triggers intentionally ignore bot authors.
                   GH_TEST_TOKEN: ${{ secrets.GH_TEST_TOKEN }}
-                  GH_TEST_TOKEN_2: ${{ secrets.GH_TEST_TOKEN_FREE }}
                   # GitHub App installation token: 5000/h of its own, immune to
                   # the abuse flags that cap the bot PATs at ~60/h. The cloud
                   # workflow has passed these for a while; self-hosted could not
@@ -320,25 +311,20 @@ jobs:
                   # works here too -- but the secrets were never wired in, which
                   # is why run 31270321822 still burned the PAT quota on the
                   # FIRST scenario and reported 8 P0 cells unverified.
-                  # All three unset -> the PAT pool behaves exactly as before.
+                  # All three unset -> the single human PAT remains in use.
                   GH_APP_ID: ${{ secrets.GH_APP_ID }}
                   GH_APP_PRIVATE_KEY: ${{ secrets.GH_APP_PRIVATE_KEY }}
                   GH_APP_INSTALLATION_ID: ${{ secrets.GH_APP_INSTALLATION_ID }}
                   # Dedicated account for the PRODUCT's stored GitHub
                   # integration credential, separate from the harness driver
-                  # pool above. The self-hosted product uses this for all its
+                  # credential above. The self-hosted product uses this for its
                   # own GitHub calls (read diff/files, post comments) — pinning
                   # it to GH_TEST_TOKEN meant product + harness drained one
                   # account and tripped the rate limit mid-cell.
                   #
-                  # Split by license so the two github cells don't share ONE
-                  # product account: the license-paid cell (heavy — ~13 review
-                  # scenarios, several multi-PR) gets its own bot, license-free
-                  # keeps GH_INTEGRATION_TOKEN. Falls back to GH_INTEGRATION_TOKEN
-                  # when GH_INTEGRATION_TOKEN_PAID is unset (graceful until the
-                  # secret is added), and to GH_TEST_TOKEN when both are unset
-                  # (see github.ts authToken()).
-                  GH_INTEGRATION_TOKEN: ${{ (matrix.cell.license == 'license-paid' && secrets.GH_INTEGRATION_TOKEN_PAID) || secrets.GH_INTEGRATION_TOKEN }}
+                  # One durable product credential; plans do not need distinct
+                  # GitHub identities.
+                  GH_INTEGRATION_TOKEN: ${{ secrets.GH_INTEGRATION_TOKEN }}
                   GH_TEST_REPO: ${{ secrets.GH_TEST_REPO }}
                   # Without this the centralized-config scenario self-skips as
                   # a setup gap, and the cell reports 8/9 verified forever. The
@@ -439,13 +425,14 @@ jobs:
                   # which — finding no ~/.kodus-dev/config — runs the INTERACTIVE
                   # setup.sh and aborts in ~1s on the non-TTY runner. Writing the
                   # config from the secrets we already pass lets the script find a
-                  # ready config instead. Plain values (not op:// refs) skip the
+                  # ready config instead. AWS credentials are inherited from
+                  # the job environment, just like the regular matrix VM. Plain
+                  # values (not op:// refs) skip the
                   # 1Password resolver in _common.sh. Harmless for non-SSO cells
                   # (nothing else reads it). Written to the file directly (never
                   # echoed) so secret values don't hit the log.
                   mkdir -p "$HOME/.kodus-dev"
                   {
-                      echo "DIGITALOCEAN_TOKEN=${DIGITALOCEAN_TOKEN:-}"
                       echo "SH_LICENSE_KEY=${SH_LICENSE_KEY_PAID:-}"
                       echo "GH_DEV_TOKEN=${GH_TEST_TOKEN:-}"
                       echo "API_OPEN_AI_API_KEY=${API_OPEN_AI_API_KEY:-}"

--- a/scripts/selfhosted/destroy.sh
+++ b/scripts/selfhosted/destroy.sh
@@ -43,6 +43,7 @@ SERVER_IP=$(state_get "$NAME" .server_ip)
 SSH_KEY_ID=$(state_get "$NAME" .ssh_key_id)
 SSH_KEY_PATH=$(state_get "$NAME" .ssh_key_path)
 CREATED_AT=$(state_get "$NAME" .created_at)
+AWS_REGION_E2E=$(state_get "$NAME" '.aws_region // "us-east-2"')
 
 log "About to destroy:"
 echo "  name:        $NAME"
@@ -108,6 +109,23 @@ if [ "$PROVIDER" = "digitalocean" ]; then
             ;;
     esac
 fi
+if [ "$PROVIDER" = "aws" ]; then
+    require_cmd aws
+    LIVE_FIELDS=$(aws ec2 describe-instances \
+        --region "$AWS_REGION_E2E" --instance-ids "$SERVER_ID" \
+        --query 'Reservations[0].Instances[0].[Tags[?Key==`Name`]|[0].Value,Tags[?Key==`Project`]|[0].Value]' \
+        --output text 2>/dev/null || echo "")
+    LIVE_NAME=$(printf '%s' "$LIVE_FIELDS" | awk '{print $1}')
+    LIVE_PROJECT=$(printf '%s' "$LIVE_FIELDS" | awk '{print $2}')
+    case "$LIVE_NAME:$LIVE_PROJECT" in
+        "${EXPECTED_NAME_PREFIX}"*:kodus-e2e) : ;;
+        *)
+            err "SAFETY: refusing to terminate EC2 instance $SERVER_ID."
+            err "Expected Name=${EXPECTED_NAME_PREFIX}* and Project=kodus-e2e; got '$LIVE_NAME' and '$LIVE_PROJECT'."
+            exit 1
+            ;;
+    esac
+fi
 
 # ---------- destroy server ----------
 case "$PROVIDER" in
@@ -126,6 +144,12 @@ case "$PROVIDER" in
             "https://api.hetzner.cloud/v1/servers/$SERVER_ID" >/dev/null \
             && ok "Destroyed Hetzner server $SERVER_ID" \
             || warn "Could not destroy server $SERVER_ID — check at hetzner.cloud"
+        ;;
+    aws)
+        aws ec2 terminate-instances \
+            --region "$AWS_REGION_E2E" --instance-ids "$SERVER_ID" >/dev/null \
+            && ok "Terminated EC2 instance $SERVER_ID" \
+            || warn "Could not terminate $SERVER_ID — check EC2 in $AWS_REGION_E2E"
         ;;
     *)
         err "Unknown provider in state file: $PROVIDER"
@@ -149,6 +173,12 @@ if [ -n "$SSH_KEY_ID" ]; then
                 "https://api.hetzner.cloud/v1/ssh_keys/$SSH_KEY_ID" >/dev/null \
                 && ok "Removed Hetzner SSH key $SSH_KEY_ID" \
                 || warn "Could not remove SSH key — clean up at hetzner.cloud/ssh-keys"
+            ;;
+        aws)
+            aws ec2 delete-key-pair \
+                --region "$AWS_REGION_E2E" --key-name "$SSH_KEY_ID" >/dev/null \
+                && ok "Removed EC2 key pair $SSH_KEY_ID" \
+                || warn "Could not remove EC2 key pair $SSH_KEY_ID"
             ;;
     esac
 fi

--- a/scripts/selfhosted/provision.sh
+++ b/scripts/selfhosted/provision.sh
@@ -7,12 +7,12 @@
 #   pnpm run selfhosted:provision --name wellington   # named instance (multi-tenant)
 #
 # Required env (or scripts/selfhosted/.env):
-#   DIGITALOCEAN_TOKEN     DO API token        (default provider)
+#   Provider credentials   standard AWS CLI credentials, or a DO/Hetzner token
 #   KODUS_INSTALLER_PATH   path to kodus-installer checkout
 #                           default: ../kodus-installer
 #
 # Optional env:
-#   TEST_VM_PROVIDER       digitalocean (default) | hetzner
+#   TEST_VM_PROVIDER       digitalocean (default) | aws | hetzner
 #   HCLOUD_TOKEN           Hetzner token (if TEST_VM_PROVIDER=hetzner)
 #   SH_LICENSE_KEY         License key to inject (paid features); if absent
 #                           the stack runs without API_KODUS_LICENSE_KEY set,
@@ -62,6 +62,10 @@ if state_exists "$NAME"; then
     exit 1
 fi
 
+# Resolve this before first-time setup: AWS uses the standard CLI credential
+# chain and does not need the DigitalOcean-oriented interactive config.
+TEST_VM_PROVIDER="${TEST_VM_PROVIDER:-digitalocean}"
+
 # First-time UX: if the global config doesn't exist yet, run setup
 # interactively before doing anything else. This way the dev only thinks
 # about secrets ONCE — every subsequent command (destroy, deploy, ssh,
@@ -69,7 +73,7 @@ fi
 #
 # Any env vars already exported in the caller's shell are used as defaults
 # in the prompts — they just press Enter to save them. No retyping.
-if [ ! -f "$GLOBAL_CONFIG" ]; then
+if [ ! -f "$GLOBAL_CONFIG" ] && [ "$TEST_VM_PROVIDER" != "aws" ]; then
     log "First-time setup: no config at $GLOBAL_CONFIG yet."
     log "Running 'pnpm run selfhosted:setup' so you only type secrets once."
     echo ""
@@ -85,7 +89,6 @@ if [ ! -f "$GLOBAL_CONFIG" ]; then
     fi
 fi
 
-TEST_VM_PROVIDER="${TEST_VM_PROVIDER:-digitalocean}"
 IMAGE_TAG="${IMAGE_TAG:-latest}"
 KODUS_INSTALLER_PATH="${KODUS_INSTALLER_PATH:-$REPO_ROOT/../kodus-installer}"
 
@@ -115,6 +118,7 @@ save_state() {
         --arg dashboard_url "http://$SERVER_IP:3000" \
         --arg api_url "http://$SERVER_IP:3001" \
         --arg image_tag "$IMAGE_TAG" \
+        --arg aws_region "${AWS_REGION_E2E:-}" \
         --arg user_email "${DEV_USER_EMAIL:-}" \
         --arg user_password "${DEV_USER_PASSWORD:-}" \
         --argjson gh_configured "${GH_CONFIGURED:-false}" \
@@ -131,6 +135,7 @@ save_state() {
             dashboard_url: $dashboard_url,
             api_url: $api_url,
             image_tag: $image_tag,
+            aws_region: $aws_region,
             tenant: { email: $user_email, password: $user_password },
             gh_integration_configured: $gh_configured,
             created_at: $created_at
@@ -147,6 +152,12 @@ HCLOUD_API="https://api.hetzner.cloud/v1"
 HCLOUD_LOCATION="${HCLOUD_LOCATION:-nbg1}"
 HCLOUD_SERVER_TYPE="${HCLOUD_SERVER_TYPE:-cx22}"
 HCLOUD_IMAGE="${HCLOUD_IMAGE:-ubuntu-24.04}"
+
+AWS_REGION_E2E="${AWS_REGION_E2E:-us-east-2}"
+AWS_INSTANCE_TYPE="${AWS_INSTANCE_TYPE:-t3.large}"
+AWS_AMI_ID="${AWS_AMI_ID:-}"
+AWS_SECURITY_GROUP="${AWS_SECURITY_GROUP_E2E:-kodus-e2e-ssh}"
+AWS_SG_ID=""
 
 # ---------- provider abstractions ----------
 provision_ssh_key() {
@@ -172,7 +183,55 @@ provision_ssh_key() {
             SSH_KEY_ID=$(echo "$resp" | jq -r '.ssh_key.id // empty')
             [ -n "$SSH_KEY_ID" ] || { err "Hetzner key upload failed: $resp"; exit 1; }
             ;;
+        aws)
+            aws ec2 import-key-pair \
+                --region "$AWS_REGION_E2E" \
+                --key-name "$label" \
+                --public-key-material "fileb:///dev/stdin" <<< "$pubkey" \
+                >/dev/null || { err "AWS key import failed for $label"; exit 1; }
+            SSH_KEY_ID="$label"
+            ;;
     esac
+}
+
+aws_ensure_security_group() {
+    AWS_SG_ID=$(aws ec2 describe-security-groups \
+        --region "$AWS_REGION_E2E" \
+        --filters "Name=group-name,Values=$AWS_SECURITY_GROUP" \
+        --query 'SecurityGroups[0].GroupId' --output text 2>/dev/null || echo "None")
+    if [ -z "${AWS_SG_ID:-}" ] || [ "$AWS_SG_ID" = "None" ]; then
+        log "Creating security group $AWS_SECURITY_GROUP..."
+        AWS_SG_ID=$(aws ec2 create-security-group \
+            --region "$AWS_REGION_E2E" \
+            --group-name "$AWS_SECURITY_GROUP" \
+            --description "Kodus e2e ephemeral VMs" \
+            --query 'GroupId' --output text) \
+            || { err "Could not create security group $AWS_SECURITY_GROUP"; exit 1; }
+    fi
+    # 80/443 are required by the SSO Caddy overlay. The other ports serve
+    # the base stack and its readiness probes.
+    for port in 22 80 443 3000 3001 3332; do
+        aws ec2 authorize-security-group-ingress \
+            --region "$AWS_REGION_E2E" \
+            --group-id "$AWS_SG_ID" \
+            --protocol tcp --port "$port" --cidr 0.0.0.0/0 >/dev/null 2>&1 || true
+    done
+}
+
+aws_resolve_ami() {
+    [ -n "$AWS_AMI_ID" ] && return 0
+    local arch="amd64"
+    case "$AWS_INSTANCE_TYPE" in t4g.*) arch="arm64" ;; esac
+    AWS_AMI_ID=$(aws ec2 describe-images \
+        --region "$AWS_REGION_E2E" \
+        --owners 099720109477 \
+        --filters "Name=name,Values=ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-${arch}-server-*" \
+                  "Name=state,Values=available" \
+        --query 'sort_by(Images,&CreationDate)[-1].ImageId' --output text) \
+        || { err "Could not resolve an Ubuntu 24.04 $arch AMI in $AWS_REGION_E2E"; exit 1; }
+    [ -n "$AWS_AMI_ID" ] && [ "$AWS_AMI_ID" != "None" ] \
+        || { err "No Ubuntu 24.04 $arch AMI found in $AWS_REGION_E2E"; exit 1; }
+    log "AMI $AWS_AMI_ID (ubuntu 24.04 $arch)"
 }
 
 provision_server() {
@@ -241,6 +300,36 @@ provision_server() {
             [ -n "$SERVER_ID" ] && [ -n "$SERVER_IP" ] \
                 || { err "Hetzner server create failed: $resp"; exit 1; }
             ;;
+        aws)
+            aws_resolve_ami
+            aws_ensure_security_group
+            local tagspec
+            tagspec="ResourceType=instance,Tags=[{Key=Name,Value=$label},{Key=Project,Value=kodus-e2e},{Key=CreatedAt,Value=$(date -u +%Y-%m-%dT%H:%M:%SZ)}]"
+            SERVER_ID=$(aws ec2 run-instances \
+                --region "$AWS_REGION_E2E" \
+                --image-id "$AWS_AMI_ID" \
+                --instance-type "$AWS_INSTANCE_TYPE" \
+                --key-name "$SSH_KEY_ID" \
+                --security-group-ids "$AWS_SG_ID" \
+                --associate-public-ip-address \
+                --user-data "$user_data" \
+                --tag-specifications "$tagspec" \
+                --block-device-mappings 'DeviceName=/dev/sda1,Ebs={VolumeSize=40,VolumeType=gp3,DeleteOnTermination=true}' \
+                --instance-initiated-shutdown-behavior terminate \
+                --query 'Instances[0].InstanceId' --output text) \
+                || { err "AWS run-instances failed"; exit 1; }
+            [ -n "$SERVER_ID" ] && [ "$SERVER_ID" != "None" ] \
+                || { err "AWS run-instances returned no instance id"; exit 1; }
+            log "Instance $SERVER_ID starting..."
+            aws ec2 wait instance-running \
+                --region "$AWS_REGION_E2E" --instance-ids "$SERVER_ID" \
+                || { err "Instance $SERVER_ID never reached running"; exit 1; }
+            SERVER_IP=$(aws ec2 describe-instances \
+                --region "$AWS_REGION_E2E" --instance-ids "$SERVER_ID" \
+                --query 'Reservations[0].Instances[0].PublicIpAddress' --output text)
+            [ -n "$SERVER_IP" ] && [ "$SERVER_IP" != "None" ] \
+                || { err "Instance $SERVER_ID has no public IP"; exit 1; }
+            ;;
     esac
 }
 
@@ -270,7 +359,7 @@ rollback_on_failure() {
         warn "  Status:  pnpm run selfhosted:status${NAME:+ --name $NAME}"
         warn "  Destroy: pnpm run selfhosted:destroy${NAME:+ --name $NAME}"
         warn ""
-        warn "  Remember: this droplet costs ~\$1/day. Destroy it when you're done."
+        warn "  Remember: this cloud VM incurs charges. Destroy it when you're done."
         exit "$exit_code"
     fi
 
@@ -296,6 +385,12 @@ rollback_on_failure() {
                     && ok "Destroyed orphan Hetzner server $SERVER_ID" \
                     || warn "Could not destroy server $SERVER_ID"
                 ;;
+            aws)
+                aws ec2 terminate-instances \
+                    --region "$AWS_REGION_E2E" --instance-ids "$SERVER_ID" >/dev/null 2>&1 \
+                    && ok "Terminated EC2 instance $SERVER_ID" \
+                    || warn "Could not terminate $SERVER_ID in $AWS_REGION_E2E"
+                ;;
         esac
     fi
     if [ -n "$SSH_KEY_ID" ]; then
@@ -309,6 +404,10 @@ rollback_on_failure() {
                 curl -sS -X DELETE \
                     -H "Authorization: Bearer ${HCLOUD_TOKEN}" \
                     "$HCLOUD_API/ssh_keys/$SSH_KEY_ID" >/dev/null 2>&1 || true
+                ;;
+            aws)
+                aws ec2 delete-key-pair \
+                    --region "$AWS_REGION_E2E" --key-name "$SSH_KEY_ID" >/dev/null 2>&1 || true
                 ;;
         esac
     fi
@@ -332,6 +431,7 @@ for c in curl jq ssh ssh-keygen rsync openssl; do require_cmd "$c"; done
 case "$TEST_VM_PROVIDER" in
     digitalocean) require_env DIGITALOCEAN_TOKEN ;;
     hetzner)      require_env HCLOUD_TOKEN ;;
+    aws)          require_cmd aws ;;
     *) err "Unknown TEST_VM_PROVIDER=$TEST_VM_PROVIDER"; exit 1 ;;
 esac
 
@@ -361,6 +461,10 @@ provision_ssh_key "kodus-selfhosted-$NAME" "$PUBKEY"
 log "Creating server kodus-selfhosted-$NAME..."
 USER_DATA=$(cat <<'CLOUDINIT'
 #cloud-config
+# Canonical EC2 images otherwise install the imported key for root with a
+# forced "Please login as ubuntu" command. All existing selfhosted automation
+# intentionally operates as root, matching the DO/Hetzner paths.
+disable_root: false
 package_update: true
 packages:
   - git
@@ -561,7 +665,7 @@ env_set NEXTAUTH_URL "http://$SERVER_IP:3000"
 # the Kodus API code actually reads — github/gitlab use API_*,
 # bitbucket/azure use GLOBAL_*. Setting the wrong prefix silently
 # breaks webhook auto-registration (the env var resolves to undefined
-# and Kodus tries to POST to `?token=...` with no host/path).
+# and Kodus tries to POST to ?token=... with no host/path).
 env_set API_GITHUB_CODE_MANAGEMENT_WEBHOOK "$SERVER_TUNNEL_URL/github/webhook"
 env_set API_GITLAB_CODE_MANAGEMENT_WEBHOOK "$SERVER_TUNNEL_URL/gitlab/webhook"
 env_set GLOBAL_BITBUCKET_CODE_MANAGEMENT_WEBHOOK "$SERVER_TUNNEL_URL/bitbucket/webhook"
@@ -786,6 +890,6 @@ $(echo -e "${YELLOW}⚠️  This is a PUBLISHED image, NOT your local code.${NC}
 $(echo -e "${YELLOW}    To test your current branch instead:${NC}")
 $(echo -e "${YELLOW}    →  pnpm run selfhosted:deploy${NAME:+ --name $NAME}${NC}")
 
-$(echo -e "${YELLOW}This VM is ALIVE. Cost: ~\$1/day on DO. Destroy when done.${NC}")
+$(echo -e "${YELLOW}This VM is ALIVE and incurs provider charges. Destroy when done.${NC}")
 
 EOF

--- a/scripts/sso-e2e/droplet/README.md
+++ b/scripts/sso-e2e/droplet/README.md
@@ -1,7 +1,7 @@
-# SSO E2E — droplet mode
+# SSO E2E — cloud VM mode
 
 Real-deployment regression for the SSO handoff-cookie `Domain` attribute.
-Provisions a DigitalOcean droplet, layers Caddy (Let's Encrypt) + Keycloak
+Provisions an ephemeral AWS EC2 instance, layers Caddy + Keycloak
 on top of the standard Kodus self-hosted stack, and drives the full SAML
 round-trip with Playwright against the public sslip.io hostnames.
 
@@ -10,18 +10,19 @@ Why this exists alongside the local `scripts/sso-e2e/run.sh`:
 - Local mode runs against `*.kodus.lvh.me` (which resolves to 127.0.0.1).
   Browsers happily store cookies on a loopback address, but the **public**
   cert chain, real DNS, and >4-label common-parent shapes are never exercised.
-- Droplet mode lights up a 6-label common parent (`.<IP>.sslip.io`) which
+- Cloud VM mode lights up a 6-label common parent (`.<IP>.sslip.io`) which
   is the deepest production-realistic shape — strictly stricter than the
   3-label `.kodus.io` (SaaS) and 4-label `.web.scorpion.co` (Dmitry) cases.
 
 ## What you need before running
 
-Already-required for the existing self-hosted droplet scripts. **No new
+Already required by the self-hosted release matrix. **No new
 secrets**:
 
 | Variable                       | Where it lives             | What it's used for                  |
 |--------------------------------|----------------------------|-------------------------------------|
-| `DIGITALOCEAN_TOKEN`           | `~/.kodus-dev/config`      | Provision the droplet               |
+| Standard AWS CLI credentials   | environment / AWS profile  | Provision the EC2 instance in `us-east-2` |
+| `AWS_INSTANCE_TYPE`            | environment (optional)     | Instance size; defaults to `t3.large` |
 | `API_OPEN_AI_API_KEY`          | `~/.kodus-dev/config`      | Boot the Kodus API                  |
 | `API_OPENAI_FORCE_BASE_URL`    | `~/.kodus-dev/config`      | Moonshot / other proxies (optional) |
 | `API_LLM_PROVIDER_MODEL`       | `~/.kodus-dev/config`      | Default Kimi K2.6 (optional)        |
@@ -41,10 +42,10 @@ pnpm run sso-e2e:droplet:provision
 # Provision only (no Playwright)
 pnpm run sso-e2e:droplet:provision --skip-test
 
-# Reuse an existing droplet (skip the 5-min provision)
+# Reuse an existing VM (skip the 5-min provision)
 pnpm run sso-e2e:droplet:provision --reuse
 
-# Re-run Playwright against the already-provisioned droplet
+# Re-run Playwright against the already-provisioned VM
 pnpm run sso-e2e:droplet:run                # headless
 pnpm run sso-e2e:droplet:run --headed       # visible Chromium
 

--- a/scripts/sso-e2e/droplet/destroy.sh
+++ b/scripts/sso-e2e/droplet/destroy.sh
@@ -1,9 +1,9 @@
 #!/usr/bin/env bash
-# Tear down a Kodus SSO E2E droplet provisioned by provision.sh.
+# Tear down a Kodus SSO E2E VM provisioned by provision.sh.
 #
 # Thin wrapper around scripts/selfhosted/destroy.sh — the droplet is
 # just a self-hosted instance with the SSO E2E overlay layered on top.
-# Removing the droplet wipes the overlay containers + Caddy + Keycloak
+# Removing the VM wipes the overlay containers + Caddy + Keycloak
 # alongside the base stack.
 #
 # Usage:
@@ -34,4 +34,6 @@ rm -f \
     "${REPO_ROOT}/.tmp/sso-e2e-droplet-keycloak.json" \
     "${REPO_ROOT}/.tmp/sso-e2e-org-id.txt"
 
-exec "${REPO_ROOT}/scripts/selfhosted/destroy.sh" --name "${NAME_RAW}"
+# This wrapper is itself the explicit destructive command. Keep it
+# non-interactive so CI teardown cannot stop at a confirmation prompt.
+exec "${REPO_ROOT}/scripts/selfhosted/destroy.sh" --name "${NAME_RAW}" --yes

--- a/scripts/sso-e2e/droplet/provision.sh
+++ b/scripts/sso-e2e/droplet/provision.sh
@@ -5,7 +5,7 @@
 # What this script does:
 #   1. Re-uses scripts/selfhosted/provision.sh to provision the base
 #      stack (api/web/worker/webhooks/mcp/postgres/mongo/rabbit) on a
-#      DigitalOcean droplet — same path as every other E2E droplet,
+#      ephemeral AWS EC2 VM — the same provider as the release matrix,
 #      so secrets live in one place (~/.kodus-dev/config).
 #   2. Layers Caddy + Keycloak on top via docker/sso-e2e/droplet/compose.yml.
 #      Caddy fronts three sslip.io hostnames:
@@ -26,7 +26,7 @@
 #
 # Variables you need to have set BEFORE running (all already used by
 # the existing selfhosted scripts — nothing new):
-#   DIGITALOCEAN_TOKEN          DO API token         (via ~/.kodus-dev/config)
+#   AWS credentials            standard AWS CLI credentials
 #   API_OPEN_AI_API_KEY         LLM key              (via ~/.kodus-dev/config)
 #   API_OPENAI_FORCE_BASE_URL   (optional, e.g. Moonshot)
 #   API_LLM_PROVIDER_MODEL      (optional)
@@ -49,6 +49,10 @@ REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
 # ~/.kodus-dev/config and scripts/selfhosted/.env in the right order.
 # shellcheck disable=SC1091
 . "${REPO_ROOT}/scripts/selfhosted/_common.sh"
+
+# SSO release validation follows the matrix's EC2 provider even though the
+# general-purpose developer provisioner retains its legacy provider default.
+export TEST_VM_PROVIDER="aws"
 
 # ---------- args ----------
 NAME_RAW="${SSO_E2E_DROPLET_NAME:-sso-e2e}"
@@ -86,32 +90,30 @@ CADDY_ACME_CA="${CADDY_ACME_CA:-https://acme-v02.api.letsencrypt.org/directory}"
 # Playwright/bootstrap tolerate them. Override with SSO_E2E_TLS_MODE=acme.
 SSO_E2E_TLS_MODE="${SSO_E2E_TLS_MODE:-internal}"
 
-# ---------- step 1: base droplet ----------
+# ---------- step 1: base VM ----------
 if [ "${REUSE}" = "1" ] && state_exists "${NAME}"; then
-    log "Reusing existing droplet '${NAME}'"
+    log "Reusing existing VM '${NAME}'"
     SERVER_IP=$(state_get "${NAME}" .server_ip)
 else
     if state_exists "${NAME}"; then
-        warn "Droplet '${NAME}' already exists (IP $(state_get "${NAME}" .server_ip))."
+        warn "VM '${NAME}' already exists (IP $(state_get "${NAME}" .server_ip))."
         warn "Pass --reuse to reuse it, or destroy first: pnpm run sso-e2e:droplet:destroy --name ${NAME}"
         exit 1
     fi
-    log "Provisioning base Kodus stack on a fresh droplet (~5 min)…"
-    # This droplet runs the full Kodus stack PLUS Keycloak (Quarkus/Java,
-    # memory-hungry) PLUS local image builds/extracts. The default
-    # s-2vcpu-4gb OOM/thrashes during the rabbitmq build + image extraction
-    # and hangs the provision. Default to 8GB here (overridable via DO_SIZE).
-    export DO_SIZE="${DO_SIZE:-s-4vcpu-8gb}"
-    log "  droplet size: ${DO_SIZE}"
+    log "Provisioning base Kodus stack on a fresh EC2 instance (~5 min)…"
+    # The full stack plus Keycloak needs 8GB. t3.large matches the release
+    # matrix default and remains overridable for local debugging.
+    export AWS_INSTANCE_TYPE="${AWS_INSTANCE_TYPE:-t3.large}"
+    log "  EC2 instance type: ${AWS_INSTANCE_TYPE}"
     "${REPO_ROOT}/scripts/selfhosted/provision.sh" --name "${NAME}"
     SERVER_IP=$(state_get "${NAME}" .server_ip)
 fi
 
 if [ -z "${SERVER_IP}" ]; then
-    err "Failed to resolve droplet IP from state file ${STATE_FILE}"
+    err "Failed to resolve VM IP from state file ${STATE_FILE}"
     exit 1
 fi
-ok "Droplet '${NAME}' at ${SERVER_IP}"
+ok "VM '${NAME}' at ${SERVER_IP}"
 
 # Hostnames derived from the droplet's public IP via sslip.io wildcard DNS.
 # sslip.io resolves *.<ip>.sslip.io → <ip> for any prefix — no DNS setup
@@ -189,9 +191,9 @@ env_set NEXTAUTH_URL "${APP_BASE_URL}"
 # sign-in form's /auth/sso/check call). The public API origin lives
 # in API_URL above for cookie-domain / SAML purposes — those code
 # paths read API_URL directly, not WEB_HOSTNAME_API.
-# Use the compose SERVICE name `api` (Docker DNS always resolves it on the
-# shared network) — NOT the literal `kodus-api`, which matches neither the
-# service (`api`) nor the container (`kodus_api`, GLOBAL_API_CONTAINER_NAME's
+# Use the compose SERVICE name "api" (Docker DNS always resolves it on the
+# shared network) — NOT the literal "kodus-api", which matches neither the
+# service ("api") nor the container ("kodus_api", GLOBAL_API_CONTAINER_NAME's
 # installer default) and so 502s every web→API server-side call.
 env_set WEB_HOSTNAME_API "api"
 env_set WEB_PORT_API "3001"
@@ -374,6 +376,7 @@ STATE_JSON="$(jq -n \
     --arg app "${APP_BASE_URL}" \
     --arg kc "${KC_BASE_URL}" \
     --arg org "${ORG_ID}" \
+    --arg ssh_key "${LOCAL_SSH_KEY}" \
     --arg ignore_tls "${IGNORE_TLS}" \
     '{
         base: $base,
@@ -381,6 +384,7 @@ STATE_JSON="$(jq -n \
         app_url: $app,
         kc_url: $kc,
         org_id: $org,
+        ssh_key: $ssh_key,
         ignore_tls: $ignore_tls
     }')"
 echo "${STATE_JSON}" > "${REPO_ROOT}/.tmp/sso-e2e-droplet.json"

--- a/scripts/sso-e2e/droplet/run-multi-user.sh
+++ b/scripts/sso-e2e/droplet/run-multi-user.sh
@@ -43,6 +43,7 @@ API_URL=$(jq -r .api_url "${STATE}")
 APP_URL=$(jq -r .app_url "${STATE}")
 BASE=$(jq -r .base "${STATE}")
 ORG_ID=$(jq -r .org_id "${STATE}")
+SSH_KEY=$(jq -r .ssh_key "${STATE}")
 IGNORE_TLS=$(jq -r .ignore_tls "${STATE}")
 NEWBIE=$(jq -r .newbie "${MULTI_STATE}")
 REMOVED=$(jq -r .removed "${MULTI_STATE}")
@@ -67,6 +68,7 @@ env \
     SSO_E2E_APP_URL="${APP_URL}" \
     SSO_E2E_BASE="${BASE}" \
     SSO_E2E_ORG_ID="${ORG_ID}" \
+    SSO_E2E_SSH_KEY="${SSH_KEY}" \
     SSO_E2E_NEWBIE_EMAIL="${NEWBIE}" \
     SSO_E2E_REMOVED_EMAIL="${REMOVED}" \
     SSO_E2E_USER_PASSWORD="${USER_PASSWORD}" \

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -119,7 +119,10 @@ pnpm run e2e:matrix matrix/full.yml
 | `TARGET_BASE_URL` | URL of the API to test against | Always |
 | `TARGET_WEB_URL` | URL of the dashboard | Always |
 | `TARGET_TUNNEL_URL` | Public tunnel URL for webhooks (self-hosted only) | `target=self-hosted` |
-| `GH_TEST_TOKEN` | GitHub PAT, `repo` + `admin:repo_hook`. Must be a token whose FIRST org is `kodus-e2e` (a fine-grained PAT with resource owner `kodus-e2e`, Repository access = All repositories) — the Kodus integration binds to `orgs[0]` (github.service.ts), so a personal token whose first org is `kodustech` binds the wrong org. | `provider=github` |
+| `GH_TEST_TOKEN` | Single human GitHub PAT used by the harness only for PR/comment authorship; high-volume reads and polling use the GitHub App. | `provider=github`, `provider=github-app` |
+| `GH_INTEGRATION_TOKEN` | Durable PAT stored by Kodus only in the explicit legacy token-auth cells. There is no fallback to `GH_TEST_TOKEN`. | `provider=github` |
+| `GH_APP_ID`, `GH_APP_PRIVATE_KEY`, `GH_APP_INSTALLATION_ID` | Existing E2E GitHub App credentials used to mint short-lived installation tokens. | GitHub cells |
+| `GH_APP_TEST_REPO` | Public fixture name where the App is installed (currently `kodus-e2e/tiny-url-app`); configure as a repository variable, not a secret. | `provider=github-app` |
 | `GH_REPO_ADMIN_TOKEN` | Token with org Administration on `kodus-e2e` (create + delete repos). Used ONLY by `trial-managed-review` to mint/delete its throwaway repo per run; everything else stays on `GH_TEST_TOKEN`. Falls back to `GH_TEST_TOKEN` if unset (a single fully-privileged token also works). | `scenario=trial-managed-review` |
 | `GH_TEST_REPO` | GitHub test repo `owner/repo` | `provider=github` |
 | `CENTRALIZED_CONFIG_TEST_REPO` (+ `_CLOUD`) | Writable centralized-config source repo `owner/repo`, per target (self-hosted: `kodus-e2e/kodus-config-e2e`, cloud: `kodus-e2e/kodus-config-e2e-cloud`) — the scenario seeds it via the GitHub API each run | scenario `centralized-config-sync` (else it skips) |

--- a/tests/e2e/cli/run-matrix.ts
+++ b/tests/e2e/cli/run-matrix.ts
@@ -81,17 +81,12 @@ function parseArgs(): {
 // filter cells locally before any provisioning happens. Keep in sync with
 // `requireEnv` calls in tests/e2e/providers/*.ts.
 const PROVIDER_REQUIRED_ENV: Record<string, string[]> = {
-    github: ["GH_TEST_TOKEN", "GH_TEST_REPO"],
+    github: ["GH_TEST_TOKEN", "GH_INTEGRATION_TOKEN", "GH_TEST_REPO"],
     // GitHub App variant: shares GH_TEST_TOKEN with `github` (used for
     // PR open / comment posting / webhook listing — those code paths
     // still run as a user, not as the App). The App-specific bits are
     // GH_APP_TEST_REPO (where the App is installed, scope-limited) and
     // GH_APP_INSTALLATION_ID (the numeric id captured after install).
-    // NOT COVERED TODAY -- tracked in issue #1695. These two are unset, so
-    // every github-app cell is dropped here as a non-gating setup skip. The
-    // cell is deliberately NOT deleted: reporting it as unverified keeps the
-    // gap visible, and deleting it would make the matrix look complete while
-    // the path customers are meant to use goes untested.
     "github-app": [
         "GH_TEST_TOKEN",
         "GH_APP_TEST_REPO",

--- a/tests/e2e/lib/__tests__/github-quota.test.ts
+++ b/tests/e2e/lib/__tests__/github-quota.test.ts
@@ -82,34 +82,39 @@ test("authToken: the integration credential stays the durable PAT even when the 
     // for harness-side quota. That token must NEVER become the credential
     // Kodus stores on the integration — the product would be left with an
     // expired secret mid-run.
-    const saved = process.env.GH_TEST_TOKEN;
+    const savedTestToken = process.env.GH_TEST_TOKEN;
+    const savedIntegrationToken = process.env.GH_INTEGRATION_TOKEN;
     process.env.GH_TEST_TOKEN = "ghp_durable_pat";
+    process.env.GH_INTEGRATION_TOKEN = "ghp_integration_pat";
     process.env.GH_TEST_REPO = "kodustech/qa-fixture";
     try {
         const provider = new GitHubProvider({
             target: "self-hosted",
             tokenOverride: "ghs_expiring_app_token",
         });
-        assert.equal(provider.authToken(), "ghp_durable_pat");
+        assert.equal(provider.authToken(), "ghp_integration_pat");
         // Without the durable PAT, an App-token provider must fail loudly
         // rather than hand the backend a ~1h credential.
-        delete process.env.GH_TEST_TOKEN;
+        delete process.env.GH_INTEGRATION_TOKEN;
         assert.throws(
             () => provider.authToken(),
-            /GH_TEST_TOKEN.*required/,
+            /GH_INTEGRATION_TOKEN.*required/,
             "App token without durable PAT must throw, not be stored",
         );
         // A misconfigured GH_TEST_TOKEN holding an installation token must
         // also be rejected — no ghs_ in the durable slot, ever.
-        process.env.GH_TEST_TOKEN = "ghs_misconfigured_secret";
+        process.env.GH_INTEGRATION_TOKEN = "ghs_misconfigured_secret";
         assert.throws(
             () => provider.authToken(),
             /ghs_.*durable PAT/,
-            "ghs_ GH_TEST_TOKEN must throw, not be stored",
+            "ghs_ GH_INTEGRATION_TOKEN must throw, not be stored",
         );
     } finally {
-        if (saved === undefined) delete process.env.GH_TEST_TOKEN;
-        else process.env.GH_TEST_TOKEN = saved;
+        if (savedTestToken === undefined) delete process.env.GH_TEST_TOKEN;
+        else process.env.GH_TEST_TOKEN = savedTestToken;
+        if (savedIntegrationToken === undefined)
+            delete process.env.GH_INTEGRATION_TOKEN;
+        else process.env.GH_INTEGRATION_TOKEN = savedIntegrationToken;
     }
 });
 

--- a/tests/e2e/lib/__tests__/github-token-pool.test.ts
+++ b/tests/e2e/lib/__tests__/github-token-pool.test.ts
@@ -12,27 +12,16 @@ test("collapses to a single token when only GH_TEST_TOKEN is set", () => {
     assert.deepEqual(githubTokenPool(env({ GH_TEST_TOKEN: "a" })), ["a"]);
 });
 
-test("collects numbered siblings GH_TEST_TOKEN_2..N in order", () => {
+test("ignores obsolete token-pool variables", () => {
     assert.deepEqual(
         githubTokenPool(
-            env({ GH_TEST_TOKEN: "a", GH_TEST_TOKEN_2: "b", GH_TEST_TOKEN_3: "c" }),
+            env({
+                GH_TEST_TOKEN: "a",
+                GH_TEST_TOKEN_2: "b",
+                GH_TEST_TOKEN_3: "c",
+                GH_TEST_TOKENS: "x,y,z",
+            }),
         ),
-        ["a", "b", "c"],
-    );
-});
-
-test("GH_TEST_TOKENS list takes precedence and splits on comma/space/newline", () => {
-    assert.deepEqual(
-        githubTokenPool(
-            env({ GH_TEST_TOKENS: "x, y\nz", GH_TEST_TOKEN: "ignored" }),
-        ),
-        ["x", "y", "z"],
-    );
-});
-
-test("dedupes repeated tokens (same secret pasted twice)", () => {
-    assert.deepEqual(
-        githubTokenPool(env({ GH_TEST_TOKEN: "a", GH_TEST_TOKEN_2: "a" })),
         ["a"],
     );
 });
@@ -46,12 +35,12 @@ test("empty env yields an empty pool (picker returns no token)", () => {
     });
 });
 
-test("picker round-robins tokens and reports a 1-based slot", () => {
+test("picker always returns the single human author token", () => {
     const pick = makeGithubTokenPicker(
         env({ GH_TEST_TOKEN: "a", GH_TEST_TOKEN_2: "b", GH_TEST_TOKEN_3: "c" }),
     );
     assert.deepEqual(
         [pick(), pick(), pick(), pick()].map((a) => `${a.token}:${a.slot}/${a.size}`),
-        ["a:1/3", "b:2/3", "c:3/3", "a:1/3"],
+        ["a:1/1", "a:1/1", "a:1/1", "a:1/1"],
     );
 });

--- a/tests/e2e/lib/__tests__/integration-license.test.ts
+++ b/tests/e2e/lib/__tests__/integration-license.test.ts
@@ -212,6 +212,7 @@ async function runLicenseScenario(opts: RunOpts): Promise<{
             }
         }
         process.env.GH_TEST_TOKEN = "fake-token";
+        process.env.GH_INTEGRATION_TOKEN = "fake-integration-token";
         process.env.GH_TEST_REPO = TEST_REPO;
         process.env.GH_TEST_PR_NUMBER = String(TEST_PR_NUMBER);
 

--- a/tests/e2e/lib/__tests__/integration.test.ts
+++ b/tests/e2e/lib/__tests__/integration.test.ts
@@ -244,6 +244,7 @@ test("integration: code-review-basic runs end-to-end against mocked Kodus + GitH
         process.env.E2E_POLL_TIMEOUT_OVERRIDE_SEC = "3";
         process.env.E2E_SETTLE_OVERRIDE_SEC = "0";
         process.env.GH_TEST_TOKEN = "fake-token";
+        process.env.GH_INTEGRATION_TOKEN = "fake-integration-token";
         process.env.GH_TEST_REPO = TEST_REPO;
         process.env.GH_TEST_PR_NUMBER = String(TEST_PR_NUMBER);
 
@@ -470,6 +471,7 @@ test("integration: scenario fails clearly when Kody does NOT respond", async () 
         process.env.E2E_POLL_TIMEOUT_OVERRIDE_SEC = "3";
         process.env.E2E_SETTLE_OVERRIDE_SEC = "0";
         process.env.GH_TEST_TOKEN = "fake-token";
+        process.env.GH_INTEGRATION_TOKEN = "fake-integration-token";
         process.env.GH_TEST_REPO = TEST_REPO;
         process.env.GH_TEST_PR_NUMBER = String(TEST_PR_NUMBER);
 

--- a/tests/e2e/lib/__tests__/providers.test.ts
+++ b/tests/e2e/lib/__tests__/providers.test.ts
@@ -23,6 +23,7 @@ test("makeProvider github constructs with required env", () => {
     withEnv(
         {
             GH_TEST_TOKEN: "test-token",
+            GH_INTEGRATION_TOKEN: "integration-token",
             GH_TEST_REPO: "owner/repo",
         },
         () => {
@@ -31,7 +32,7 @@ test("makeProvider github constructs with required env", () => {
             assert.equal(p.integrationType, "GITHUB");
             assert.equal(p.webhookPath, "/github/webhook");
             assert.equal(p.authMode(), "token");
-            assert.equal(p.authToken(), "test-token");
+            assert.equal(p.authToken(), "integration-token");
             assert.equal(p.licenseGitTool(), "github");
         },
     );

--- a/tests/e2e/lib/github-token-pool.ts
+++ b/tests/e2e/lib/github-token-pool.ts
@@ -1,5 +1,5 @@
 /**
- * GitHub e2e token pool.
+ * GitHub e2e harness credential.
  *
  * GitHub's rate limits — both the 5k/h primary budget and (worse for us) the
  * per-account *secondary* limits on content creation (branches/PRs/comments) —
@@ -7,41 +7,16 @@
  * single bot token, so one account's budget is the ceiling for the whole run;
  * when it trips we get `HTTP 403` / opaque `items is not iterable` failures.
  *
- * Spreading the cells across several bot accounts multiplies both budgets
- * linearly. This module just resolves the available tokens; the runner does
- * the round-robin assignment per GitHub cell.
- *
- * Sources, in priority order:
- *   1. `GH_TEST_TOKENS` — a single secret holding a comma/space/newline list
- *      (easiest to manage as one secret).
- *   2. `GH_TEST_TOKEN` + `GH_TEST_TOKEN_2..N` — the base token plus numbered
- *      siblings, one per extra bot account.
- *
- * Always backward compatible: with only `GH_TEST_TOKEN` set, the pool is a
- * single token and behaviour is identical to before.
+ * High-volume traffic now uses the GitHub App installation token. A single
+ * human PAT remains solely for PR/comment authorship because Kodus ignores
+ * bot-authored review triggers. Keeping this resolver's array shape avoids a
+ * broad runner rewrite while deliberately rejecting token pools.
  */
-
-const MAX_NUMBERED = 9;
-
-function dedupe(tokens: string[]): string[] {
-    return [...new Set(tokens.map((t) => t.trim()).filter(Boolean))];
-}
 
 export function githubTokenPool(
     env: NodeJS.ProcessEnv = process.env,
 ): string[] {
-    const list = env.GH_TEST_TOKENS?.split(/[\s,]+/);
-    if (list && dedupe(list).length > 0) {
-        return dedupe(list);
-    }
-
-    const numbered: string[] = [];
-    if (env.GH_TEST_TOKEN) numbered.push(env.GH_TEST_TOKEN);
-    for (let i = 2; i <= MAX_NUMBERED; i++) {
-        const v = env[`GH_TEST_TOKEN_${i}`];
-        if (v) numbered.push(v);
-    }
-    return dedupe(numbered);
+    return env.GH_TEST_TOKEN ? [env.GH_TEST_TOKEN.trim()].filter(Boolean) : [];
 }
 
 export interface GithubTokenAssignment {
@@ -102,15 +77,13 @@ export interface RateLimitInfo {
  * validate it against GitHub, and the stored credential has to outlive the
  * run, so an installation token (~1h) is rejected there.
  *
- * The fallback is the trap. With GH_INTEGRATION_TOKEN unset this silently
- * becomes GH_TEST_TOKEN -- the same abuse-flagged bot account the harness is
- * already draining -- and the two consumers share one penalised budget. That
- * is what exhausted run 31270321822 on its FIRST scenario, in a call that no
- * amount of App migration would have covered.
+ * There is deliberately no fallback. The harness author and the credential
+ * stored by the product have different permission and lifetime contracts;
+ * conflating them caused opaque onboarding HTTP 400 failures.
  */
 export function integrationTokenInfo(env: NodeJS.ProcessEnv = process.env): {
     token?: string;
-    source: 'GH_INTEGRATION_TOKEN' | 'GH_TEST_TOKEN' | 'none';
+    source: 'GH_INTEGRATION_TOKEN' | 'none';
     sharedWithDriverPool: boolean;
 } {
     if (env.GH_INTEGRATION_TOKEN) {
@@ -120,13 +93,6 @@ export function integrationTokenInfo(env: NodeJS.ProcessEnv = process.env): {
             sharedWithDriverPool: githubTokenPool(env).includes(
                 env.GH_INTEGRATION_TOKEN,
             ),
-        };
-    }
-    if (env.GH_TEST_TOKEN) {
-        return {
-            token: env.GH_TEST_TOKEN,
-            source: 'GH_TEST_TOKEN',
-            sharedWithDriverPool: true,
         };
     }
     return { source: 'none', sharedWithDriverPool: false };
@@ -201,17 +167,11 @@ export async function preflightIntegrationToken(
     const info = integrationTokenInfo(env);
     if (!info.token) {
         log.warn(
-            '[preflight] no GitHub integration credential (GH_INTEGRATION_TOKEN / GH_TEST_TOKEN) - the product cannot register its integration',
+            '[preflight] GH_INTEGRATION_TOKEN is missing - provider=github cannot register its integration',
         );
         return undefined;
     }
-    if (info.source === 'GH_TEST_TOKEN') {
-        log.warn(
-            "[preflight] GH_INTEGRATION_TOKEN is UNSET - the product's stored GitHub credential falls back to GH_TEST_TOKEN, " +
-                'so the harness and the product drain the SAME account. Set GH_INTEGRATION_TOKEN (and GH_INTEGRATION_TOKEN_PAID) ' +
-                'to a separate, non-abuse-flagged account.',
-        );
-    } else if (info.sharedWithDriverPool) {
+    if (info.sharedWithDriverPool) {
         log.warn(
             '[preflight] GH_INTEGRATION_TOKEN is ALSO in the driver pool - the product and the harness share one budget. ' +
                 'Use a dedicated account for the integration credential.',

--- a/tests/e2e/lib/runner.ts
+++ b/tests/e2e/lib/runner.ts
@@ -615,9 +615,7 @@ export async function runMatrix(opts: RunOptions): Promise<RunOutcome> {
                 repo,
             });
         }
-        // Spread cleanup's repo/PR listing across the bot-account pool too —
-        // otherwise every fixture lists on the single default account and helps
-        // exhaust its per-account GitHub rate limit before the cells even run.
+        // Cleanup uses the single human credential before cells start.
         const pickCleanupToken = makeGithubTokenPicker();
         for (const { provider: providerName, repo } of fixtures.values()) {
             const label = `${providerName}${repo ? ` (${repo})` : ''}`;
@@ -649,8 +647,8 @@ export async function runMatrix(opts: RunOptions): Promise<RunOutcome> {
         }
     }
 
-    // Round-robins GitHub cells across the bot-account token pool so no single
-    // account's rate limit caps the run (no-op with a single token).
+    // Single human author credential. High-volume scenario traffic is moved
+    // to the App installation token below.
     const pickGithubToken = makeGithubTokenPicker();
 
     // Report each bot account's remaining GitHub budget up front (free — GET
@@ -658,9 +656,8 @@ export async function runMatrix(opts: RunOptions): Promise<RunOutcome> {
     // visible before the cells run instead of as an opaque mid-run 403 cascade.
     if (!opts.dryRun && opts.cells.some((c) => c.provider === "github")) {
         await preflightGithubRateLimits(log);
-        // …and the credential the PRODUCT stores, which the pool preflight
-        // never looked at. It is a DIFFERENT account (or, when
-        // GH_INTEGRATION_TOKEN is unset, silently the same one), and it is the
+        // …and the credential the PRODUCT stores, which the driver preflight
+        // never looked at. It is a DIFFERENT account, and it is the
         // one /code-management/auth-integration validates against GitHub —
         // the exact call that exhausted run 31270321822 on its first scenario.
         await preflightIntegrationToken(log);
@@ -786,9 +783,8 @@ export async function runMatrix(opts: RunOptions): Promise<RunOutcome> {
 
             log.info(`RUN   ${cellLabel}`);
 
-            // Assign this GitHub run a token from the bot-account pool
-            // (round-robin). Same token across both attempts so a retry stays
-            // on the same account; other cells keep draining the other tokens.
+            // Resolve the one human author credential before replacing the
+            // high-volume driver token with an App installation token below.
             const ghAssignment =
                 cell.provider === "github" ? pickGithubToken() : undefined;
             let githubToken = ghAssignment?.token;
@@ -809,16 +805,17 @@ export async function runMatrix(opts: RunOptions): Promise<RunOutcome> {
             // provider.currentUserId() now resolves that ONE call from the
             // durable PAT, so both targets can put their heavy traffic on
             // the App budget — which is where the quota SKIPs came from.
-            if (cell.provider === "github") {
+            if (cell.provider === "github" || cell.provider === "github-app") {
                 try {
                     const appToken = await githubAppToken();
                     if (appToken) {
                         githubToken = appToken;
-                        log.info("  github → App installation token");
+                        log.info(`  ${cell.provider} → App installation token`);
                     }
                 } catch (err) {
+                    if (cell.provider === "github-app") throw err;
                     log.err(
-                        `  github → App token mint FAILED (${(err as Error).message.slice(0, 160)}) — falling back to PAT pool`,
+                        `  github → App token mint FAILED (${(err as Error).message.slice(0, 160)}) — using the single human PAT`,
                     );
                 }
             }

--- a/tests/e2e/playwright/sso-multi-user.mjs
+++ b/tests/e2e/playwright/sso-multi-user.mjs
@@ -24,6 +24,7 @@
 //   SSO_E2E_APP_URL       https://app.<IP>.sslip.io
 //   SSO_E2E_BASE          <IP>.sslip.io
 //   SSO_E2E_ORG_ID        org uuid from provision.sh
+//   SSO_E2E_SSH_KEY       private key for the provisioned VM
 //   SSO_E2E_ADMIN_EMAIL   (default: sso-user@kodus-test.com)
 //   SSO_E2E_ADMIN_PASSWORD (default: TestSso!2026)
 //   SSO_E2E_NEWBIE_EMAIL  (default: newbie-sso@kodus-test.com)
@@ -45,6 +46,7 @@ const {
     SSO_E2E_APP_URL,
     SSO_E2E_BASE,
     SSO_E2E_ORG_ID,
+    SSO_E2E_SSH_KEY,
     SSO_E2E_ADMIN_EMAIL = "sso-user@kodus-test.com",
     SSO_E2E_ADMIN_PASSWORD = "TestSso!2026",
     SSO_E2E_NEWBIE_EMAIL = "newbie-sso@kodus-test.com",
@@ -59,6 +61,7 @@ for (const [k, v] of Object.entries({
     SSO_E2E_APP_URL,
     SSO_E2E_BASE,
     SSO_E2E_ORG_ID,
+    SSO_E2E_SSH_KEY,
 })) {
     if (!v) {
         console.error(`error: env ${k} is required`);
@@ -396,7 +399,7 @@ async function subFlow4() {
         "ssh",
         [
             "-i",
-            ".kodus-dev/ssh-keys/sso-e2e",
+            SSO_E2E_SSH_KEY,
             "-o",
             "StrictHostKeyChecking=no",
             "-o",

--- a/tests/e2e/providers/github-app.ts
+++ b/tests/e2e/providers/github-app.ts
@@ -18,15 +18,10 @@ import { GitHubProvider } from "./github.js";
 //                             (e.g. kodus-e2e/tiny-url-app)
 //   GH_APP_INSTALLATION_ID    numeric installation id captured after the
 //                             one-time install on github.com
-//   GH_TEST_TOKEN             still required — used for opening PRs,
-//                             posting comments, listing webhooks, etc.
-//                             from a *user* viewpoint. The App's
-//                             installation token is short-lived and
-//                             can't easily drive a deterministic PR-open
-//                             flow from outside the integration. Reusing
-//                             the user PAT here keeps the E2E surface
-//                             identical to github (PAT) for everything
-//                             except the auth-integration step.
+//   GH_TEST_TOKEN             one human PAT used only for PR/comment
+//                             authorship because Kodus intentionally ignores
+//                             bot-authored review triggers. Reads and polling
+//                             use the short-lived App installation token.
 //
 // Backend prerequisites (cloud only): API_GITHUB_APP_ID,
 // API_GITHUB_APP_PRIVATE_KEY, GLOBAL_GITHUB_CLIENT_ID, API_GITHUB_CLIENT_SECRET.
@@ -37,11 +32,14 @@ export class GitHubAppProvider extends GitHubProvider {
 
     private readonly installationId: string;
 
-    constructor() {
+    constructor(tokenOverride?: string) {
         // Redirect the whole surface (clone URL, /repos/* calls,
         // webhook listing) to the App-bound repo via the parent's
         // repoOverride hook.
-        super({ repoOverride: requireEnv("GH_APP_TEST_REPO") });
+        super({
+            repoOverride: requireEnv("GH_APP_TEST_REPO"),
+            tokenOverride,
+        });
         this.installationId = requireEnv("GH_APP_INSTALLATION_ID");
     }
 

--- a/tests/e2e/providers/github.ts
+++ b/tests/e2e/providers/github.ts
@@ -94,9 +94,8 @@ export class GitHubProvider extends BaseProvider {
         tokenOverride?: string;
     }) {
         super();
-        // tokenOverride is the round-robin token the matrix runner assigns
-        // from the bot-account pool (see lib/github-token-pool.ts). Falls back
-        // to the single GH_TEST_TOKEN when no pool is configured.
+        // tokenOverride is normally a freshly minted App installation token.
+        // GH_TEST_TOKEN remains the fallback for human-authored events.
         this.token = opts?.tokenOverride || requireEnv('GH_TEST_TOKEN');
         // Subclasses (notably GitHubAppProvider) need to target a
         // DIFFERENT repo than the PAT-driven default — the GitHub App
@@ -915,34 +914,31 @@ export class GitHubProvider extends BaseProvider {
     // long-lived base PAT; the assigned token keeps serving the harness's
     // own API calls (clone, PRs, polling).
     //
-    // Prefer a DEDICATED integration account (GH_INTEGRATION_TOKEN) so the
+    // Use a DEDICATED integration account (GH_INTEGRATION_TOKEN) so the
     // product's own GitHub calls (read diff/files, post comments, resolve
     // threads) draw on a separate 5,000 req/hr budget from the harness
-    // driver pool. Without it, the product and the harness both hammer
+    // driver credential. Without it, the product and the harness both hammer
     // GH_TEST_TOKEN — that single account's quota was tripping mid-cell and
-    // cascading scenarios into rate-limit SKIPs. Falls back to GH_TEST_TOKEN
-    // when the dedicated secret is unset, so this is a no-op until wired.
+    // cascading scenarios into rate-limit SKIPs. There is intentionally no
+    // fallback: storing the harness credential caused opaque HTTP 400s when
+    // that credential had different scopes.
     authToken(): string {
         // Installation tokens are prefixed ghs_ and die in ~1h. NOTHING with
         // that prefix may become the stored integration credential — not the
         // runner-assigned token, and not a misconfigured secret either (a
         // silent 1h credential in CI config would fail mid-run).
-        const durable =
-            process.env.GH_INTEGRATION_TOKEN || process.env.GH_TEST_TOKEN;
-        if (durable) {
-            if (durable.startsWith('ghs_')) {
-                throw new Error(
-                    'The GitHub integration credential (GH_INTEGRATION_TOKEN / GH_TEST_TOKEN) is a GitHub App installation token (ghs_) — it must be a durable PAT',
-                );
-            }
-            return durable;
-        }
-        if (this.token.startsWith('ghs_')) {
+        const durable = process.env.GH_INTEGRATION_TOKEN;
+        if (!durable) {
             throw new Error(
-                'GH_TEST_TOKEN (durable PAT) is required when the harness runs on a GitHub App installation token — the integration credential must not expire',
+                'GH_INTEGRATION_TOKEN is required for provider=github; it is the durable PAT stored by the product',
             );
         }
-        return this.token;
+        if (durable.startsWith('ghs_')) {
+            throw new Error(
+                'GH_INTEGRATION_TOKEN is a GitHub App installation token (ghs_) — it must be a durable PAT',
+            );
+        }
+        return durable;
     }
 
     // Identity, not traffic — and the two need DIFFERENT credentials.

--- a/tests/e2e/providers/index.ts
+++ b/tests/e2e/providers/index.ts
@@ -15,10 +15,10 @@ import { GitLabProvider } from "./gitlab.js";
 // shared repo never fans a webhook out across multiple orgs. Only the
 // GitHub PAT provider honours it; the others are already 1 org : 1 repo
 // on cloud and ignore it, and github-app is pinned to its App-bound repo.
-// `githubToken` overrides the GitHub PAT for this provider instance — the
-// matrix runner round-robins it across the bot-account pool so no single
-// account's rate limit caps the whole run (see lib/github-token-pool.ts).
-// Ignored by the non-GitHub providers and by github-app (installation auth).
+// `githubToken` overrides the GitHub PAT for this provider instance — normally
+// with the short-lived App installation token minted by the runner.
+// Ignored by non-GitHub providers. For github-app it is the freshly minted
+// installation token; authorship writes still use the one human PAT.
 export function makeProvider(
     name: ProviderName,
     target: Target = "self-hosted",
@@ -35,7 +35,7 @@ export function makeProvider(
         case "github-app":
             // App variant is cloud-only and pinned to its own App-bound repo
             // (GH_APP_TEST_REPO), so it's already repo-independent.
-            return new GitHubAppProvider();
+            return new GitHubAppProvider(githubToken);
         case "gitlab":
             return new GitLabProvider(target);
         case "bitbucket":

--- a/tests/e2e/scenarios/sso-cookie-domain.ts
+++ b/tests/e2e/scenarios/sso-cookie-domain.ts
@@ -43,11 +43,10 @@ function runScript(script: string, args: string[]): Promise<ScriptResult> {
             cwd: REPO_ROOT,
             env: {
                 ...process.env,
-                // The release matrix provisions its regular cells on AWS,
-                // but the dedicated SSO topology still uses the standalone
-                // selfhosted provisioner, which supports DigitalOcean and
-                // Hetzner only. Do not leak TEST_VM_PROVIDER=aws into it.
-                TEST_VM_PROVIDER: "digitalocean",
+                // Use the same EC2 provider and credentials as the release
+                // matrix. The dedicated topology is still needed for Caddy +
+                // Keycloak, but it no longer depends on DigitalOcean.
+                TEST_VM_PROVIDER: "aws",
                 // Force headless — the matrix runner has no display.
                 // The standalone script defaults to headless too, but
                 // we set it explicitly so a stray --headed in someone's

--- a/tests/e2e/scenarios/sso-multi-user.ts
+++ b/tests/e2e/scenarios/sso-multi-user.ts
@@ -45,9 +45,8 @@ function runScript(script: string): Promise<ScriptResult> {
             env: {
                 ...process.env,
                 SSO_E2E_HEADLESS: "1",
-                // See sso-cookie-domain: this dedicated topology has not been
-                // migrated to the matrix's AWS provisioner.
-                TEST_VM_PROVIDER: "digitalocean",
+                // See sso-cookie-domain: the shared SSO topology runs on EC2.
+                TEST_VM_PROVIDER: "aws",
             },
             stdio: ["ignore", "pipe", "pipe"],
         });


### PR DESCRIPTION
Consolida a automação GitHub em uma App existente + um único PAT humano, remove fallbacks silenciosos e migra o SSO E2E para AWS. Validação local: 175/175 testes; matriz fast 12/12 coerente; SSO real na AWS aprovado. Secrets redundantes só serão removidos depois do gate cloud verde na main.