### PR TITLE
fix(kody-rules): thread org language into the sharded judge prompts

### DIFF
--- a/libs/code-review/infrastructure/agents/collaborators/kody-rules-sharded.judge.spec.ts
+++ b/libs/code-review/infrastructure/agents/collaborators/kody-rules-sharded.judge.spec.ts
@@ -455,6 +455,116 @@ describe('judgeKodyRulesSharded — deterministic file×rule sweep (#1449)', () 
         expect(warn.mock.calls[0][0].context).toBe('kody-rules-sharded');
     });
 
+    // ── language templating (Starian GitLab MR !16111) ───────────────────────
+    // Neither shard prompt had any language templating: a PR-scope kody-rules
+    // finding's suggestionContent shipped in raw English regardless of the
+    // org's configured Kody Language. `languageLabel` (resolved upstream via
+    // prompt-builder.ts's resolveLanguageLabel — the same helper every other
+    // review agent uses) must reach BOTH the file-shard and PR-shard user
+    // prompts, and must be a no-op (byte-identical prompt) when absent.
+    describe('languageLabel — respond-in-language instruction (Starian MR !16111)', () => {
+        it('includes a respond-in-language instruction in the FILE-shard user prompt when languageLabel is set', async () => {
+            let fileUser = '';
+            const run: RunJudge = async ({ filename, user }) => {
+                if (filename === 'src/a.ts') fileUser = user;
+                return [];
+            };
+            await judgeKodyRulesSharded({
+                changedFiles: [file('src/a.ts', '1 +const x: any = 1;')],
+                rules: [
+                    { uuid: 'r1', title: 'no any', rule: 'no any', path: '**/*.ts' },
+                ],
+                runJudge: run,
+                languageLabel: 'Portuguese (Brazil)',
+            });
+            expect(fileUser).toContain('Respond in Portuguese (Brazil)');
+            expect(fileUser).toContain('suggestionContent');
+        });
+
+        it('includes a respond-in-language instruction in the PR-shard user prompt when languageLabel is set', async () => {
+            let prUser = '';
+            const run: RunJudge = async ({ filename, user }) => {
+                if (filename === null) prUser = user;
+                return [];
+            };
+            await judgeKodyRulesSharded({
+                changedFiles: [file('src/a.ts', '1 +x')],
+                rules: [
+                    {
+                        uuid: 'pr1',
+                        title: 'must have tests',
+                        rule: 'every PR needs a test',
+                        scope: KodyRulesScope.PULL_REQUEST,
+                    },
+                ],
+                runJudge: run,
+                languageLabel: 'Portuguese (Brazil)',
+            });
+            expect(prUser).toContain('Respond in Portuguese (Brazil)');
+        });
+
+        it('FILE-shard prompt is byte-identical to no-languageLabel behavior when languageLabel is omitted', async () => {
+            let withLabelOmitted = '';
+            let withLabelUndefined = '';
+            const runA: RunJudge = async ({ user }) => {
+                withLabelOmitted = user;
+                return [];
+            };
+            const runB: RunJudge = async ({ user }) => {
+                withLabelUndefined = user;
+                return [];
+            };
+            const changedFiles = [file('src/a.ts', '1 +const x: any = 1;')];
+            const rules = [
+                { uuid: 'r1', title: 'no any', rule: 'no any', path: '**/*.ts' },
+            ];
+            await judgeKodyRulesSharded({
+                changedFiles,
+                rules,
+                runJudge: runA,
+            });
+            await judgeKodyRulesSharded({
+                changedFiles,
+                rules,
+                runJudge: runB,
+                languageLabel: undefined,
+            });
+            expect(withLabelOmitted).not.toContain('Respond in');
+            expect(withLabelOmitted).toBe(withLabelUndefined);
+        });
+
+        it('PR-shard prompt is byte-identical to no-languageLabel behavior when languageLabel is omitted', async () => {
+            let withLabelOmitted = '';
+            let withLabelUndefined = '';
+            const runA: RunJudge = async ({ filename, user }) => {
+                if (filename === null) withLabelOmitted = user;
+                return [];
+            };
+            const runB: RunJudge = async ({ filename, user }) => {
+                if (filename === null) withLabelUndefined = user;
+                return [];
+            };
+            const changedFiles = [file('src/a.ts', '1 +x')];
+            const rules = [
+                {
+                    uuid: 'pr1',
+                    title: 'must have tests',
+                    rule: 'every PR needs a test',
+                    scope: KodyRulesScope.PULL_REQUEST,
+                },
+            ];
+            await judgeKodyRulesSharded({ changedFiles, rules, runJudge: runA });
+            await judgeKodyRulesSharded({
+                changedFiles,
+                rules,
+                runJudge: runB,
+                languageLabel: null,
+            });
+            expect(withLabelOmitted).not.toContain('Respond in');
+            expect(withLabelOmitted).toBe(withLabelUndefined);
+        });
+    });
+
     it('normalizes null violation fields to absent keys (strict-provider output)', async () => {
         const run: RunJudge = async () => [
             {

--- a/libs/code-review/infrastructure/agents/collaborators/kody-rules-sharded.judge.ts
+++ b/libs/code-review/infrastructure/agents/collaborators/kody-rules-sharded.judge.ts
@@ -187,6 +187,20 @@ export interface ShardedJudgeInput {
      *  failure (e.g. a provider rejecting the response schema) is visible
      *  in the worker logs instead of only as an `N errored` counter. */
     logger?: { warn: (entry: any) => void };
+    /**
+     * Human-readable language label (e.g. "Portuguese (Brazil)"), already
+     * resolved via `resolveLanguageLabel` in prompt-builder.ts — the SAME
+     * helper every other review agent (bug/security/performance/generalist)
+     * uses to localize its output. When set, both the file-shard and
+     * PR-shard user prompts get an explicit "respond in this language"
+     * instruction; the shard's `suggestionContent`/WHAT-WHY-HOW body is
+     * otherwise LLM-generated raw English with no downstream translation
+     * guarantee for PR-scope findings (see kody-rules-agent.provider.ts).
+     * Optional and backward compatible: omitting it (evals, older callers,
+     * unit tests) leaves the shard prompts byte-identical to before this
+     * field existed.
+     */
+    languageLabel?: string | null;
 }
 
 export interface ShardedJudgeResult {
@@ -226,9 +240,30 @@ function ruleBlock(rules: Array<Partial<IKodyRule>>): string {
         .join('\n');
 }
 
+/**
+ * Extra user-prompt lines instructing the model to answer in `languageLabel`
+ * (a resolved label like "Portuguese (Brazil)", not a raw locale code). Both
+ * shard prompts have zero language templating on their own (the root cause
+ * of the Starian GitLab MR !16111 bug: a PR-scope kody-rules comment shipped
+ * in raw English despite the org's Kody Language being pt-BR), so this is
+ * the ONLY place a language instruction enters either shard's prompt.
+ * Returns `[]` when no label is given, so callers that splice this in with
+ * `...languageInstructionLines(x)` produce a BYTE-IDENTICAL prompt to before
+ * this existed whenever `languageLabel` is absent — no regression for evals
+ * or other callers that don't pass one.
+ */
+function languageInstructionLines(languageLabel?: string | null): string[] {
+    if (!languageLabel) return [];
+    return [
+        `Respond in ${languageLabel}: write "suggestionContent" and "oneSentenceSummary" in ${languageLabel}, not English. This is mandatory — do not fall back to English.`,
+        ``,
+    ];
+}
+
 function fileShardUser(
     file: FileChange,
     rules: Array<Partial<IKodyRule>>,
+    languageLabel?: string | null,
 ): string {
     const diff = (file as any).patchWithLinesStr ?? file.patch ?? '';
     return [
@@ -243,6 +278,7 @@ function fileShardUser(
         '```',
         `</File>`,
         ``,
+        ...languageInstructionLines(languageLabel),
         `Return ONLY JSON (ruleId is the rule's [n] number):`,
         `{"violations":[{"ruleId":<n>,"relevantLinesStart":<line>,"relevantLinesEnd":<line>,"existingCode":"<offending code>","suggestionContent":"WHAT/WHY/HOW","oneSentenceSummary":"<short>"}]}`,
     ].join('\n');
@@ -264,6 +300,7 @@ function prShardUser(
     rules: Array<Partial<IKodyRule>>,
     prTitle?: string,
     prBody?: string,
+    languageLabel?: string | null,
 ): string {
     let used = 0;
     const diffs: string[] = [];
@@ -299,6 +336,7 @@ function prShardUser(
         '```',
         `</PR>`,
         ``,
+        ...languageInstructionLines(languageLabel),
         `Return ONLY JSON (ruleId is the rule's [n] number): {"violations":[{"ruleId":<n>,"suggestionContent":"WHAT/WHY","oneSentenceSummary":"<short>"}]}`,
     ].join('\n');
 }
@@ -576,7 +614,15 @@ function resolveShardViolations(
 export async function judgeKodyRulesSharded(
     input: ShardedJudgeInput,
 ): Promise<ShardedJudgeResult> {
-    const { changedFiles, rules, runJudge, prTitle, prBody, logger } = input;
+    const {
+        changedFiles,
+        rules,
+        runJudge,
+        prTitle,
+        prBody,
+        logger,
+        languageLabel,
+    } = input;
     const concurrency = input.concurrency ?? 4;
 
     const fileRules = rules.filter((r) => !isPrLevel(r));
@@ -603,7 +649,7 @@ export async function judgeKodyRulesSharded(
             try {
                 const vs = await runJudge({
                     system: SHARD_SYSTEM_PROMPT,
-                    user: fileShardUser(file, applicable),
+                    user: fileShardUser(file, applicable, languageLabel),
                     filename: file.filename,
                     ruleUuids,
                 });
@@ -636,7 +682,13 @@ export async function judgeKodyRulesSharded(
         try {
             const vs = await runJudge({
                 system: SHARD_PR_SYSTEM_PROMPT,
-                user: prShardUser(changedFiles, prRules, prTitle, prBody),
+                user: prShardUser(
+                    changedFiles,
+                    prRules,
+                    prTitle,
+                    prBody,
+                    languageLabel,
+                ),
                 filename: null,
                 ruleUuids,
             });

--- a/libs/code-review/infrastructure/agents/prompts/prompt-builder.ts
+++ b/libs/code-review/infrastructure/agents/prompts/prompt-builder.ts
@@ -849,7 +849,16 @@ function formatOverrides(input: ReviewAgentInput, meta: PromptAgentMeta): string
 
 const displayNames = new Intl.DisplayNames(['en'], { type: 'language' });
 
-function resolveLanguageLabel(localeOrLabel?: string): string | null {
+/**
+ * Resolve a language code/label (e.g. `"pt-BR"`) to a human-readable label
+ * (e.g. `"Portuguese (Brazil)"`) for prompt injection. Exported so other
+ * prompt builders outside this file — e.g. the kody-rules sharded judge
+ * (`kody-rules-sharded.judge.ts`), which has its own static system prompts
+ * and previously had zero language templating (#Starian GitLab MR !16111) —
+ * can follow the SAME language-resolution mechanism instead of inventing a
+ * second one.
+ */
+export function resolveLanguageLabel(localeOrLabel?: string): string | null {
     if (!localeOrLabel || typeof localeOrLabel !== 'string') return null;
     try {
         return displayNames.of(localeOrLabel) || localeOrLabel;

--- a/libs/code-review/infrastructure/agents/providers/kody-rules-agent.provider.spec.ts
+++ b/libs/code-review/infrastructure/agents/providers/kody-rules-agent.provider.spec.ts
@@ -436,6 +436,56 @@ describe('KodyRulesAgentProvider.execute — sharded end-to-end (#1449)', () => 
         expect(out.suggestions[0].relevantFile).toBe('src/a.ts');
     });
 
+    // ── language resolution + forwarding (Starian GitLab MR !16111) ──────────
+    // The sharded judge's system prompts have zero language templating on
+    // their own; execute() must resolve `input.languageResultPrompt` via the
+    // SAME `resolveLanguageLabel` helper the other review agents use
+    // (prompt-builder.ts) and forward it into the shard user prompt that
+    // `runStructuredReviewCall` receives as `user`.
+    it('resolves languageResultPrompt and forwards a respond-in-language instruction to the shard prompt', async () => {
+        const { provider } = makeProvider([{ violations: [] }]);
+        await provider.execute(
+            input({
+                languageResultPrompt: 'pt-BR',
+                kodyRules: [
+                    {
+                        uuid: 'no-any',
+                        title: 'no any',
+                        rule: 'do not use any',
+                        status: 'active',
+                        severity: 'high',
+                        path: '**/*.ts',
+                    },
+                ],
+            }) as any,
+        );
+        expect(mockRunStructuredReviewCall).toHaveBeenCalledTimes(1);
+        const call = mockRunStructuredReviewCall.mock.calls[0][0];
+        expect(call.user).toContain('Respond in');
+        expect(call.user.toLowerCase()).toContain('portuguese');
+    });
+
+    it('does NOT add a language instruction when languageResultPrompt is absent (no regression)', async () => {
+        const { provider } = makeProvider([{ violations: [] }]);
+        await provider.execute(
+            input({
+                kodyRules: [
+                    {
+                        uuid: 'no-any',
+                        title: 'no any',
+                        rule: 'do not use any',
+                        status: 'active',
+                        severity: 'high',
+                        path: '**/*.ts',
+                    },
+                ],
+            }) as any,
+        );
+        expect(mockRunStructuredReviewCall).toHaveBeenCalledTimes(1);
+        const call = mockRunStructuredReviewCall.mock.calls[0][0];
+        expect(call.user).not.toContain('Respond in');
+    });
+
     it('mechanical path: detector regex fires with ZERO LLM calls', async () => {
         const { provider, judge } = makeProvider([]);
         const out = await provider.execute(

--- a/libs/code-review/infrastructure/agents/providers/kody-rules-agent.provider.ts
+++ b/libs/code-review/infrastructure/agents/providers/kody-rules-agent.provider.ts
@@ -21,6 +21,7 @@ import {
     type RawShardViolation,
     type ShardViolation,
 } from '@libs/code-review/infrastructure/agents/collaborators/kody-rules-sharded.judge';
+import { resolveLanguageLabel } from '@libs/code-review/infrastructure/agents/prompts/prompt-builder';
 import { ExternalReferenceLoaderService } from '@libs/kodyRules/infrastructure/adapters/services/externalReferenceLoader.service';
 import { buildDetectorViolations } from '@libs/code-review/infrastructure/agents/collaborators/kody-rules-detector.compiler';
 import {
@@ -168,6 +169,22 @@ export class KodyRulesAgentProvider extends BaseCodeReviewAgentProvider {
                 input,
                 this.permissionValidationService,
             );
+
+            // Resolve the org's Kody Language into a human-readable label
+            // (e.g. "pt-BR" -> "Portuguese (Brazil)") via the SAME helper
+            // every other review agent uses (prompt-builder.ts), and thread
+            // it into the sharded judge below. Without this, both shard
+            // prompts are static English strings with no language
+            // templating, so a PR-scope kody-rules finding's
+            // suggestionContent ships in raw English regardless of the
+            // org's configured language — the exact bug reported on
+            // Starian's GitLab MR !16111 (file-scope findings get a second
+            // chance via formatSuggestionContent downstream; PR-scope ones
+            // do not — see kody-rules-sharded.judge.ts's ShardedJudgeInput
+            // doc comment).
+            const languageLabel = resolveLanguageLabel(
+                input.languageResultPrompt,
+            );
             this.shardLogger.log({
                 message: `[AGENT] ${this.getIdentity().name} (sharded) using model: ${main.modelName} for PR#${input.prNumber} (${semanticRules.length} semantic, ${mechanicalRules.length} mechanical rules)`,
                 context: this.getIdentity().name,
@@ -256,6 +273,7 @@ export class KodyRulesAgentProvider extends BaseCodeReviewAgentProvider {
                         prTitle: input.prTitle,
                         prBody: input.prBody,
                         logger: this.shardLogger,
+                        languageLabel,
                     }),
             );
             judgeViolations = result.violations;


### PR DESCRIPTION
## Summary

Fixes a customer-reported bug (Starian, GitLab MR !16111): a PR-scope kody-rules review comment shipped in raw English despite the org's Kody Language being configured as Portuguese (Brazil).

**Root cause**: `libs/code-review/infrastructure/agents/collaborators/kody-rules-sharded.judge.ts` (the deterministic file×rule sharded judge, #1449) has two static English system prompts (`SHARD_SYSTEM_PROMPT` for file-scope rules, `SHARD_PR_SYSTEM_PROMPT` for PR-scope rules) with **zero language templating**. Unlike the other review agents (bug/security/performance/generalist), which resolve the org's Kody Language via `prompt-builder.ts`'s `resolveLanguageLabel(input.languageResultPrompt)` and inject it into their prompts, `KodyRulesAgentProvider.execute()` never read `input.languageResultPrompt` and never forwarded it into the `judgeKodyRulesSharded({...})` call.

**Why both shard prompts needed fixing**:
- **PR-scope findings** (`SHARD_PR_SYSTEM_PROMPT`) are the worse case — their `suggestionContent` is used essentially verbatim in the posted comment (`commentManager.service.ts` → `createPrLevelReviewComments`). The `language` param passed to `formatReviewCommentBody` only localizes surrounding template chrome (e.g. "Kody rule violation:"), not the LLM-generated body itself. This is the exact bug reported.
- **File-scope findings** (`SHARD_SYSTEM_PROMPT`) get a second chance downstream via `formatSuggestionContent` (`agent-review.stage.ts`), which translates/reformats suggestions into the target language — but that formatter has a documented skip mode when nothing is configured or it fails. Fixing the shard judge itself is real defense-in-depth, not just a PR-scope-only fix.

## Changes

- `prompt-builder.ts`: export `resolveLanguageLabel` so it can be reused outside this file, instead of inventing a second language-resolution mechanism.
- `kody-rules-sharded.judge.ts`: add an optional `languageLabel` field to `ShardedJudgeInput`; thread it into both `fileShardUser()` and `prShardUser()` as an explicit "Respond in `<language>`" instruction appended to the user prompt. Backward compatible — omitting `languageLabel` leaves the prompt byte-identical to before this change (verified by test).
- `kody-rules-agent.provider.ts`: `KodyRulesAgentProvider.execute()` now resolves `input.languageResultPrompt` via `resolveLanguageLabel` and forwards it as `languageLabel` to `judgeKodyRulesSharded(...)`.

Out of scope (per investigation): `kody-rule-summary.service.ts` (atomizer prompts) — internal judging artifacts never shown to the customer verbatim, covered by a separate open PR (#1746). `commentManager.service.ts`'s PR-level `language` chrome param is untouched — it already works correctly for template localization.

## Test plan

- [x] Extended `kody-rules-sharded.judge.spec.ts`: file-shard and PR-shard prompts include the language instruction when `languageLabel` is set; both are byte-identical to current behavior when omitted.
- [x] Extended `kody-rules-agent.provider.spec.ts`: `execute()` resolves and forwards `input.languageResultPrompt` to the shard call; no language instruction is added when it's absent.
- [x] `jest --testPathPatterns="kody-rules-sharded|kody-rules-agent|prompt-builder"` — 113/113 passing.
- [x] `eslint` on all changed files — 0 errors (one pre-existing, unrelated warning).
- [x] `tsc --noEmit -p tsconfig.json` — same error count (4393) with and without this change; no new errors introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)