### PR TITLE
fix(centralized-config): don't stale-delete rules waiting on an open PR

### DIFF
--- a/libs/centralized-config/infrastructure/adapters/services/__tests__/centralized-config.service.spec.ts
+++ b/libs/centralized-config/infrastructure/adapters/services/__tests__/centralized-config.service.spec.ts
@@ -1623,6 +1623,173 @@ describe('CentralizedConfigService', () => {
             );
         });
 
+        it('should resurrect a DELETED rule when the YAML file is present again', async () => {
+            // Stale cleanup can soft-delete a rule whose file is only on an
+            // open PR. After that PR merges, git is source of truth: the
+            // file is on the default branch, so sync must restore ACTIVE
+            // instead of preserving DELETED (which hid the rule in the UI).
+            const ruleFiles: any[] = [
+                {
+                    centralizedDirectoryPath: '.kody-rules/review',
+                    repositoryId: undefined,
+                    directoryPath: undefined,
+                    ruleType: 'standard' as any,
+                    ruleFilePath: '.kody-rules/review/docs.yml',
+                    path: '.kody-rules/review/docs.yml',
+                },
+            ];
+
+            const mockRuleContent = {
+                title: 'Docs must not contradict the change',
+                rule: 'Flag contradictions, not missing docs',
+                examples: [],
+                inheritance: { inheritable: true, exclude: [], include: [] },
+            };
+
+            mockCodeManagementService.getRepositoryTree.mockResolvedValue([]);
+            mockCodeManagementService.getDefaultBranch.mockResolvedValue(
+                'main',
+            );
+            mockCodeManagementService.getRepositoryContentFile.mockResolvedValue(
+                {
+                    data: {
+                        content: Buffer.from(
+                            yaml.dump(mockRuleContent),
+                        ).toString('base64'),
+                        encoding: 'base64',
+                    },
+                },
+            );
+
+            mockParametersService.findByKey.mockResolvedValue({
+                configValue: {
+                    repository: { name: 'central-repo', id: 'central-repo-id' },
+                },
+            });
+
+            mockIntegrationConfigService.findIntegrationConfigFormatted.mockResolvedValue(
+                [],
+            );
+            mockKodyRulesService.findByOrganizationId.mockResolvedValue({
+                rules: [
+                    {
+                        uuid: 'deleted-rule-uuid',
+                        status: 'deleted',
+                        origin: 'user',
+                        centralizedConfig: {
+                            path: '.kody-rules/review/docs.yml',
+                            status: 'synced',
+                        },
+                    },
+                ],
+            });
+            mockCreateOrUpdateKodyRulesUseCase.execute.mockResolvedValue({
+                uuid: 'deleted-rule-uuid',
+            });
+
+            await service.synchronizeKodyRules({
+                organizationAndTeamData,
+                ruleFiles,
+                actor,
+            });
+
+            expect(
+                mockCreateOrUpdateKodyRulesUseCase.execute,
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    uuid: 'deleted-rule-uuid',
+                    status: 'active',
+                    origin: 'user',
+                    centralizedConfig: {
+                        path: '.kody-rules/review/docs.yml',
+                        status: 'synced',
+                    },
+                }),
+                'org-1',
+                expect.any(Object),
+                true,
+            );
+        });
+
+        it('should resurrect a DELETED rule as PAUSED when YAML enabled is false', async () => {
+            const ruleFiles: any[] = [
+                {
+                    centralizedDirectoryPath: '.kody-rules/review',
+                    repositoryId: undefined,
+                    directoryPath: undefined,
+                    ruleType: 'standard' as any,
+                    ruleFilePath: '.kody-rules/review/paused.yml',
+                    path: '.kody-rules/review/paused.yml',
+                },
+            ];
+
+            const mockRuleContent = {
+                title: 'Paused after restore',
+                rule: 'Stay paused',
+                enabled: false,
+                examples: [],
+                inheritance: { inheritable: true, exclude: [], include: [] },
+            };
+
+            mockCodeManagementService.getRepositoryTree.mockResolvedValue([]);
+            mockCodeManagementService.getDefaultBranch.mockResolvedValue(
+                'main',
+            );
+            mockCodeManagementService.getRepositoryContentFile.mockResolvedValue(
+                {
+                    data: {
+                        content: Buffer.from(
+                            yaml.dump(mockRuleContent),
+                        ).toString('base64'),
+                        encoding: 'base64',
+                    },
+                },
+            );
+
+            mockParametersService.findByKey.mockResolvedValue({
+                configValue: {
+                    repository: { name: 'central-repo', id: 'central-repo-id' },
+                },
+            });
+
+            mockIntegrationConfigService.findIntegrationConfigFormatted.mockResolvedValue(
+                [],
+            );
+            mockKodyRulesService.findByOrganizationId.mockResolvedValue({
+                rules: [
+                    {
+                        uuid: 'deleted-paused-uuid',
+                        status: 'deleted',
+                        centralizedConfig: {
+                            path: '.kody-rules/review/paused.yml',
+                            status: 'synced',
+                        },
+                    },
+                ],
+            });
+            mockCreateOrUpdateKodyRulesUseCase.execute.mockResolvedValue({
+                uuid: 'deleted-paused-uuid',
+            });
+
+            await service.synchronizeKodyRules({
+                organizationAndTeamData,
+                ruleFiles,
+                actor,
+            });
+
+            expect(
+                mockCreateOrUpdateKodyRulesUseCase.execute,
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    uuid: 'deleted-paused-uuid',
+                    status: 'paused',
+                }),
+                'org-1',
+                expect.any(Object),
+                true,
+            );
+        });
+
         it('should handle YAML parsing errors gracefully', async () => {
             const ruleFiles: any[] = [
                 {
@@ -1748,6 +1915,161 @@ describe('CentralizedConfigService', () => {
             expect(result.success).toBe(true);
             // The synced rule is still present in the files → not deleted.
             // None of the path-less rules are deleted either.
+            expect(
+                mockDeleteRuleInOrganizationByIdKodyRulesUseCase.execute,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('should NOT delete PENDING_ADD rules whose file is only on an open PR', async () => {
+            // Sync reads the default branch. A newly created rule is exported
+            // to a mutation PR first, so its YAML is not in discovery yet.
+            // Treating that as "stale" is what made existing rules vanish
+            // from the UI when adding another rule with centralized config.
+            mockKodyRulesService.findByOrganizationId.mockResolvedValue({
+                toJson: () => ({
+                    rules: [
+                        {
+                            uuid: 'pending-add-rule',
+                            title: 'Docs must not contradict the change',
+                            status: 'active',
+                            centralizedConfig: {
+                                path: '.kody-rules/review/docs.yml',
+                                status: 'pending_add',
+                            },
+                        },
+                        {
+                            uuid: 'synced-rule',
+                            title: 'Keep me',
+                            status: 'active',
+                            centralizedConfig: {
+                                path: '.kody-rules/review/kept.yml',
+                                status: 'synced',
+                            },
+                        },
+                    ],
+                }),
+            });
+
+            const result = await service.removeStaleKodyRules({
+                organizationAndTeamData,
+                actor,
+                ruleFiles: [
+                    { path: '.kody-rules/review/kept.yml' } as any,
+                ],
+            });
+
+            expect(result.success).toBe(true);
+            expect(
+                mockDeleteRuleInOrganizationByIdKodyRulesUseCase.execute,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('should NOT delete PENDING_EDIT rules whose file is only on an open PR', async () => {
+            mockKodyRulesService.findByOrganizationId.mockResolvedValue({
+                toJson: () => ({
+                    rules: [
+                        {
+                            uuid: 'pending-edit-rule',
+                            title: 'Renamed on the PR',
+                            status: 'active',
+                            centralizedConfig: {
+                                path: '.kody-rules/review/renamed.yml',
+                                status: 'pending_edit',
+                            },
+                        },
+                    ],
+                }),
+            });
+
+            const result = await service.removeStaleKodyRules({
+                organizationAndTeamData,
+                actor,
+                ruleFiles: [
+                    { path: '.kody-rules/review/other.yml' } as any,
+                ],
+            });
+
+            expect(result.success).toBe(true);
+            expect(
+                mockDeleteRuleInOrganizationByIdKodyRulesUseCase.execute,
+            ).not.toHaveBeenCalled();
+        });
+
+        it('should still delete a truly removed synced rule while keeping PENDING_ADD', async () => {
+            mockKodyRulesService.findByOrganizationId.mockResolvedValue({
+                toJson: () => ({
+                    rules: [
+                        {
+                            uuid: 'pending-add-rule',
+                            status: 'active',
+                            centralizedConfig: {
+                                path: '.kody-rules/review/new.yml',
+                                status: 'pending_add',
+                            },
+                        },
+                        {
+                            uuid: 'removed-synced-rule',
+                            status: 'active',
+                            centralizedConfig: {
+                                path: '.kody-rules/review/gone.yml',
+                                status: 'synced',
+                            },
+                        },
+                    ],
+                }),
+            });
+
+            mockDeleteRuleInOrganizationByIdKodyRulesUseCase.execute.mockResolvedValue(
+                true,
+            );
+
+            const result = await service.removeStaleKodyRules({
+                organizationAndTeamData,
+                actor,
+                ruleFiles: [
+                    { path: '.kody-rules/review/other.yml' } as any,
+                ],
+            });
+
+            expect(result.success).toBe(true);
+            expect(result.removedRuleCount).toBe(1);
+            expect(
+                mockDeleteRuleInOrganizationByIdKodyRulesUseCase.execute,
+            ).toHaveBeenCalledTimes(1);
+            expect(
+                mockDeleteRuleInOrganizationByIdKodyRulesUseCase.execute,
+            ).toHaveBeenCalledWith('removed-synced-rule', actor);
+        });
+
+        it('should NOT delete PENDING_ADD when discovery is empty but the tree read is proven', async () => {
+            // First production incident: only the new rule existed (pending_add),
+            // default-branch discovery found kodus-config.yml and zero rule
+            // files, and #1518 treated that as "user deleted the last rule".
+            mockKodyRulesService.findByOrganizationId.mockResolvedValue({
+                toJson: () => ({
+                    rules: [
+                        {
+                            uuid: 'pending-add-only',
+                            title: 'Docs must not contradict the change',
+                            status: 'active',
+                            centralizedConfig: {
+                                path: '.kody-rules/review/docs.yml',
+                                status: 'pending_add',
+                            },
+                        },
+                    ],
+                }),
+            });
+
+            const result = await service.removeStaleKodyRules({
+                organizationAndTeamData,
+                actor,
+                ruleFiles: [],
+                configFiles: [{ path: 'kodus-config.yml' } as any],
+            });
+
+            expect(result.success).toBe(true);
+            expect(result.removedRuleCount).toBe(0);
             expect(
                 mockDeleteRuleInOrganizationByIdKodyRulesUseCase.execute,
             ).not.toHaveBeenCalled();

--- a/libs/centralized-config/infrastructure/adapters/services/centralized-config.service.ts
+++ b/libs/centralized-config/infrastructure/adapters/services/centralized-config.service.ts
@@ -2282,15 +2282,25 @@ export class CentralizedConfigService implements ICentralizedConfigService {
                     // `enabled` flag. A rule in any other lifecycle state
                     // (PENDING approval, REJECTED, ...) keeps its status, so
                     // merging the centralized-config PR can't silently approve
-                    // a pending rule or resurrect a rejected one. Likewise,
-                    // keep an existing rule's origin instead of reclassifying
-                    // it as a repo-file sync.
+                    // a pending rule or resurrect a rejected one.
+                    //
+                    // DELETED is not an approval state — stale cleanup
+                    // soft-deletes rules whose files are missing from the
+                    // default branch. If git has the file again, restore
+                    // ACTIVE/PAUSED from `enabled` instead of leaving the
+                    // rule hidden in the UI.
+                    // Likewise, keep an existing rule's origin instead of
+                    // reclassifying it as a repo-file sync.
                     const existingStatus = existingMatch?.status;
                     const isExistingApproved =
                         existingStatus === KodyRulesStatus.ACTIVE ||
                         existingStatus === KodyRulesStatus.PAUSED;
+                    const isStaleDeleted =
+                        existingStatus === KodyRulesStatus.DELETED;
                     const resolvedStatus =
-                        existingStatus && !isExistingApproved
+                        existingStatus &&
+                        !isExistingApproved &&
+                        !isStaleDeleted
                             ? existingStatus
                             : enabled === false
                               ? KodyRulesStatus.PAUSED
@@ -2531,6 +2541,22 @@ export class CentralizedConfigService implements ICentralizedConfigService {
                 }
 
                 if (!currentSourcePaths.has(sourcePath)) {
+                    const centralizedStatus = rule.centralizedConfig?.status;
+                    // The file for an in-flight mutation lives on the open
+                    // PR, not the default branch that sync reads. Deleting
+                    // it here is what made rules disappear from the UI when
+                    // another rule was added. PENDING_DELETE is the opposite:
+                    // after the delete PR merges the file is gone and this
+                    // cleanup must still run.
+                    if (
+                        centralizedStatus ===
+                            KodyRuleCentralizedStatus.PENDING_ADD ||
+                        centralizedStatus ===
+                            KodyRuleCentralizedStatus.PENDING_EDIT
+                    ) {
+                        continue;
+                    }
+
                     try {
                         await this.deleteRuleInOrganizationByIdKodyRulesUseCase.execute(
                             rule.uuid,


### PR DESCRIPTION
<!--
  Thanks for sending a PR! The PR title MUST follow Conventional Commits, e.g.
    feat(code-review): add agent-first reviewer
    fix(web): block app.kodus.io from search-engine indexing
    chore(deps): bump posthog-node to 4.x
  CI will fail otherwise.
-->

## Summary
  With centralized config enabled, adding a new Kody Rule could hide existing rules in the UI. Sync reads the default branch, so a `pending_add` /  `pending_edit` file that only exists on the open mutation PR looked stale and was soft-deleted. After the PR merged, sync found the YAML again but kept  `DELETED`, so the rules stayed hidden.
  This change:
  - Skips stale cleanup for `pending_add` / `pending_edit` (the file lives on the open PR, not the default branch). True removals and `pending_delete`  after a delete PR merges still run. Last-rule delete with a proven tree read (`kodus-config.yml` present, zero rule files) is unchanged.
  - Restores a `DELETED` rule to `ACTIVE` / `PAUSED` from YAML `enabled` when git has the file again. IDE `pending` / `rejected` are still not  auto-approved on merge.

  ## Test plan
  - [x] `removeStaleKodyRules` does not delete `pending_add` / `pending_edit` when the file is absent from default-branch discovery
  - [x] `pending_add` is kept when discovery is empty but the tree read is proven (`kodus-config.yml` present)
  - [x] A truly removed **synced** rule is still deleted; `pending_delete` still cleans up after merge
  - [x] Last-rule delete still works when `configFiles` proves the read (`centralized-config.service.stale-1579.spec.ts`)
  - [x] `synchronizeKodyRules` resurrects `DELETED` to `ACTIVE`, or `PAUSED` when YAML `enabled: false`
  - [x] IDE `pending` / `rejected` are still not auto-approved
  - [ ] Enable centralized config, add a new rule (mutation PR still open), confirm existing rules stay visible
  - [ ] Merge the mutation PR, run Sync, confirm the new rule is active and previously deleted-by-stale rules come back if their YAML is on the default  branch
  
  ## Notes for the reviewer
  `DELETED` was lumped in with approval lifecycle states (`PENDING` / `REJECTED`) so merge could not silently approve a rule. Stale cleanup uses  `DELETED` as a sync state, not an approval decision — if the file is on the tree again, git should win.

<!-- Anything non-obvious. Risks, follow-ups, screenshots for UX work. -->
