### PR TITLE
fix(conversation): resolve @kody mentions on new Azure DevOps threads + extend conversation e2e coverage

### DIFF
--- a/.github/workflows/e2e-self-hosted-matrix.yml
+++ b/.github/workflows/e2e-self-hosted-matrix.yml
@@ -367,14 +367,7 @@ jobs:
                   # adapter fix — until that release it runs red, not skip.
                   VERTEX_SA_JSON: ${{ secrets.VERTEX_SA_JSON }}
                   VERTEX_REGION: global
-                  # TEMP (this branch only, not for main): claude-haiku-4-5 is
-                  # stuck on a 0-quota partner-model wall on the current
-                  # VERTEX_SA_JSON project. Gemini is first-party (no partner
-                  # quota) and routes through the OTHER v2 adapter
-                  # (VertexAdapter, not VertexAnthropicAdapter) — enough to
-                  # validate the gitlab/bitbucket/azure provider wiring, not
-                  # the Claude-on-Vertex routing itself.
-                  VERTEX_MODEL: gemini-3.5-flash-lite
+                  VERTEX_MODEL: claude-haiku-4-5
                   CONVERSATION_USER_TOKEN: ${{ secrets.CONVERSATION_USER_TOKEN }}
 
                   # LLM provider — vm.sh expects these to write to the VM's .env.

--- a/.github/workflows/e2e-self-hosted-matrix.yml
+++ b/.github/workflows/e2e-self-hosted-matrix.yml
@@ -367,7 +367,14 @@ jobs:
                   # adapter fix — until that release it runs red, not skip.
                   VERTEX_SA_JSON: ${{ secrets.VERTEX_SA_JSON }}
                   VERTEX_REGION: global
-                  VERTEX_MODEL: claude-haiku-4-5
+                  # TEMP (this branch only, not for main): claude-haiku-4-5 is
+                  # stuck on a 0-quota partner-model wall on the current
+                  # VERTEX_SA_JSON project. Gemini is first-party (no partner
+                  # quota) and routes through the OTHER v2 adapter
+                  # (VertexAdapter, not VertexAnthropicAdapter) — enough to
+                  # validate the gitlab/bitbucket/azure provider wiring, not
+                  # the Claude-on-Vertex routing itself.
+                  VERTEX_MODEL: gemini-3.5-flash-lite
                   CONVERSATION_USER_TOKEN: ${{ secrets.CONVERSATION_USER_TOKEN }}
 
                   # LLM provider — vm.sh expects these to write to the VM's .env.

--- a/.github/workflows/e2e-self-hosted-matrix.yml
+++ b/.github/workflows/e2e-self-hosted-matrix.yml
@@ -367,13 +367,7 @@ jobs:
                   # adapter fix — until that release it runs red, not skip.
                   VERTEX_SA_JSON: ${{ secrets.VERTEX_SA_JSON }}
                   VERTEX_REGION: global
-                  # TEMP (this branch only, not for main): claude-haiku-4-5 is
-                  # stuck on a 0-quota partner-model wall on the current
-                  # VERTEX_SA_JSON project. Gemini is first-party (no partner
-                  # quota) and routes through the OTHER v2 adapter
-                  # (VertexAdapter, not VertexAnthropicAdapter) — enough to
-                  # validate the Bitbucket ack-filter fix end to end.
-                  VERTEX_MODEL: gemini-3.5-flash-lite
+                  VERTEX_MODEL: claude-haiku-4-5
                   CONVERSATION_USER_TOKEN: ${{ secrets.CONVERSATION_USER_TOKEN }}
 
                   # LLM provider — vm.sh expects these to write to the VM's .env.

--- a/.github/workflows/e2e-self-hosted-matrix.yml
+++ b/.github/workflows/e2e-self-hosted-matrix.yml
@@ -367,7 +367,13 @@ jobs:
                   # adapter fix — until that release it runs red, not skip.
                   VERTEX_SA_JSON: ${{ secrets.VERTEX_SA_JSON }}
                   VERTEX_REGION: global
-                  VERTEX_MODEL: claude-haiku-4-5
+                  # TEMP (this branch only, not for main): claude-haiku-4-5 is
+                  # stuck on a 0-quota partner-model wall on the current
+                  # VERTEX_SA_JSON project. Gemini is first-party (no partner
+                  # quota) and routes through the OTHER v2 adapter
+                  # (VertexAdapter, not VertexAnthropicAdapter) — enough to
+                  # validate the Bitbucket ack-filter fix end to end.
+                  VERTEX_MODEL: gemini-3.5-flash-lite
                   CONVERSATION_USER_TOKEN: ${{ secrets.CONVERSATION_USER_TOKEN }}
 
                   # LLM provider — vm.sh expects these to write to the VM's .env.

--- a/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.spec.ts
+++ b/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.spec.ts
@@ -492,4 +492,77 @@ describe('ChatWithKodyFromGitUseCase', () => {
             PlatformType.GITLAB,
         );
     });
+
+    it('answers an @kody mention that starts a brand-new Azure DevOps thread (not a reply)', async () => {
+        // Regression test: getPullRequestReviewComment groups Azure comments
+        // by thread and puts everything AFTER the first comment into
+        // `.replies` — the thread's root comment lives on the thread object
+        // itself. getReviewThreadByCommentId used to only search `.replies`,
+        // so a brand-new `@kody <question>` (the root comment of a fresh
+        // thread, not a reply to an existing one) was never found and Kody
+        // silently never answered. Confirmed live against a real Azure
+        // DevOps PR: a single-comment thread's lone comment never got a
+        // reply.
+        const ORG_UUID = '11111111-1111-4111-8111-111111111111';
+        const TEAM_UUID = '22222222-2222-4222-8222-222222222222';
+        codeManagementService.findTeamAndOrganizationIdByConfigKey.mockResolvedValue(
+            {
+                integration: { organization: { uuid: ORG_UUID } },
+                team: { uuid: TEAM_UUID },
+            },
+        );
+        codeManagementService.getPullRequestReviewComment.mockResolvedValue([
+            {
+                id: 1,
+                threadId: 3239,
+                replies: [],
+                body: '@kody what does this pull request change?',
+                createdAt: '2026-08-18T18:19:00.000Z',
+                author: { id: 'author-1', name: 'alice' },
+            },
+        ]);
+        codeManagementService.updateResponseToComment = jest
+            .fn()
+            .mockResolvedValue({});
+        permissionValidationService.validateExecutionPermissions.mockResolvedValue(
+            { allowed: true },
+        );
+
+        await useCase.execute({
+            event: 'ms.vss-code.git-pullrequest-comment-event',
+            platformType: PlatformType.AZURE_REPOS,
+            payload: {
+                resource: {
+                    comment: {
+                        id: 1,
+                        content: '@kody what does this pull request change?',
+                        parentCommentId: 0,
+                        author: { displayName: 'alice', id: 'author-1' },
+                        _links: {
+                            threads: {
+                                href: 'https://dev.azure.com/org/proj/_apis/git/repositories/repo/pullRequests/55/threads/3239',
+                            },
+                        },
+                    },
+                    pullRequest: {
+                        pullRequestId: 55,
+                        repository: { id: 'repo-1', name: 'kodus-e2e' },
+                        sourceRefName: 'refs/heads/feature',
+                        targetRefName: 'refs/heads/main',
+                        description: 'PR description',
+                    },
+                    repository: { project: { name: 'kodus-e2e-project' } },
+                },
+                resourceContainers: { project: { id: 'project-1' } },
+            },
+        } as any);
+
+        expect(conversationAgentUseCase.execute).toHaveBeenCalledWith(
+            expect.objectContaining({
+                prepareContext: expect.objectContaining({
+                    userQuestion: '@kody what does this pull request change?',
+                }),
+            }),
+        );
+    });
 });

--- a/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
+++ b/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
@@ -1497,6 +1497,20 @@ export class ChatWithKodyFromGitUseCase {
                         (t) => t.threadId === threadId,
                     );
                     if (thread) {
+                        // getPullRequestReviewComment groups Azure comments
+                        // by thread and only puts comments AFTER the first
+                        // one into `.replies` — the thread's root comment is
+                        // kept on `thread` itself. A brand-new `@kody
+                        // <question>` (not a reply to an existing thread) IS
+                        // that root comment, so it must be matched here too;
+                        // searching only `.replies` silently drops it.
+                        if (thread.id === commentId) {
+                            return {
+                                ...thread,
+                                thread,
+                            };
+                        }
+
                         const targetComment = thread.replies?.find(
                             (c: any) => c.id === commentId,
                         );

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -133,6 +133,8 @@ pnpm run e2e:matrix matrix/full.yml
 | `BB_TEST_REPO` | Bitbucket repo `workspace/slug` | `provider=bitbucket` |
 | `AZ_TEST_TOKEN` | Azure DevOps PAT | `provider=azure-devops` |
 | `AZ_TEST_ORG`, `AZ_TEST_PROJECT`, `AZ_TEST_REPO` | Azure DevOps coords | `provider=azure-devops` |
+| `CONVERSATION_USER_TOKEN` | GitHub PAT for a non-`kody`/`kodus`-named account with PR R/W on `GH_TEST_REPO`. Kody's `isKodyComment` filter ignores any comment whose author login contains those substrings — and `GH_TEST_TOKEN` IS such an account (`kodus-e2e-bot-N`) — so the `@kody` mention in `conversation-*` scenarios needs this separate identity. GitLab/Bitbucket/Azure DevOps don't need an equivalent var: their `GL_TEST_TOKEN`/`BB_TEST_USER`+`BB_TEST_APP_PASSWORD`/`AZ_TEST_TOKEN` are already plain human accounts (no dedicated bot was ever set up there), so `conversation-*` reuses them directly. | `scenario=conversation-*`, `provider=github` |
+| `CONVERSATION_ANTHROPIC_KEY` (or `API_ANTHROPIC_API_KEY`) | Anthropic API key used as the BYOK key under test. | `scenario=conversation-anthropic-byok` |
 | `CLOUD_TENANT_FREE_EMAIL`, `CLOUD_TENANT_FREE_PASSWORD` | Free tenant creds | `target=cloud, license=free` |
 | `CLOUD_TENANT_TRIAL_*` | Trial tenant creds | `target=cloud, license=trial` |
 | `CLOUD_TENANT_PAID_*` | Paid tenant creds | `target=cloud, license=paid` |

--- a/tests/e2e/lib/conversation-user-token.ts
+++ b/tests/e2e/lib/conversation-user-token.ts
@@ -1,0 +1,43 @@
+import type { ProviderName } from "./types.js";
+
+export interface ConversationUserToken {
+    token: string | undefined;
+    missingEnvHint: string;
+}
+
+// Resolves the "non-kody/kodus" second-identity credential the conversation
+// scenarios need to post the `@kody <question>` trigger comment as — Kody
+// ignores any comment whose author name/login contains "kody"/"kodus"
+// (isKodyComment). Only GitHub's e2e driver account (GH_TEST_TOKEN =
+// kodus-e2e-bot-N) is actually branded like that, which is why it alone
+// needs a dedicated CONVERSATION_USER_TOKEN. GitLab/Bitbucket/Azure DevOps's
+// existing driver credentials (GL_TEST_TOKEN, BB_TEST_USER/APP_PASSWORD,
+// AZ_TEST_TOKEN) are already a plain human account (verified: "Gabriel
+// Malinosqui" on all three) — no "kody"/"kodus" substring, so they already
+// pass isKodyComment and can be reused as-is. No new secrets needed there.
+export function resolveConversationUserToken(
+    providerName: ProviderName,
+): ConversationUserToken {
+    switch (providerName) {
+        case "gitlab":
+            return {
+                token: process.env.GL_TEST_TOKEN,
+                missingEnvHint: "GL_TEST_TOKEN",
+            };
+        case "bitbucket":
+            return {
+                token: process.env.BB_TEST_APP_PASSWORD,
+                missingEnvHint: "BB_TEST_APP_PASSWORD",
+            };
+        case "azure-devops":
+            return {
+                token: process.env.AZ_TEST_TOKEN,
+                missingEnvHint: "AZ_TEST_TOKEN",
+            };
+        default:
+            return {
+                token: process.env.CONVERSATION_USER_TOKEN,
+                missingEnvHint: "CONVERSATION_USER_TOKEN",
+            };
+    }
+}

--- a/tests/e2e/lib/types.ts
+++ b/tests/e2e/lib/types.ts
@@ -163,8 +163,9 @@ export interface Provider {
         token: string,
     ): Promise<{ id: string }>;
     // Optional: polls for Kody's conversational reply to an `@kody <question>`
-    // new non-trigger, non-code-review comment, or null at timeout. Only GitHub
-    // is wired; the conversation scenario gates on its presence.
+    // new non-trigger, non-code-review comment, or null at timeout. Wired on
+    // github/gitlab/bitbucket/azure-devops; the conversation scenario gates
+    // on its presence.
     pollForKodyReply?(
         pr: { number: number },
         opts: { sinceIso: string; triggerId?: string; timeoutSec?: number },

--- a/tests/e2e/providers/azure-devops.ts
+++ b/tests/e2e/providers/azure-devops.ts
@@ -492,6 +492,92 @@ export class AzureDevOpsProvider extends BaseProvider {
         };
     }
 
+    // Posts a NEW thread as a (possibly different) Azure DevOps identity —
+    // `token` overrides the auth PAT. The conversation scenario calls this
+    // with AZ_TEST_TOKEN by default: unlike GitHub's dedicated e2e bot
+    // (kodus-e2e-bot-N, filtered by isKodyComment), AZ_TEST_TOKEN is already
+    // a plain human account, so no separate non-Kody identity is needed
+    // here. Kept as a token override (not a hardcoded call to postComment)
+    // so a dedicated Azure bot account can be introduced later without
+    // touching this signature.
+    async postCommentAs(
+        prNumber: number,
+        body: string,
+        token: string,
+    ): Promise<{ id: string }> {
+        const repoId = await this.resolveRepoId();
+        const auth = `Basic ${Buffer.from(`:${token}`).toString("base64")}`;
+        const resp = await http<{
+            id: number;
+            comments: { id: number }[];
+        }>(
+            `${this.apiBase}/_apis/git/repositories/${repoId}/pullRequests/${prNumber}/threads?api-version=${this.apiVersion}`,
+            {
+                method: "POST",
+                headers: { Authorization: auth, Accept: "application/json" },
+                body: {
+                    comments: [
+                        { parentCommentId: 0, content: body, commentType: 1 },
+                    ],
+                    status: 1,
+                },
+            },
+        );
+        ensureOk(resp, "azure:postCommentAs");
+        return {
+            id: String(resp.body.comments?.[0]?.id ?? resp.body.id),
+        };
+    }
+
+    // Kody's getPullRequestReviewComment flattens ALL threads — Azure's
+    // comment model is thread-based for everything, general comments are
+    // threads too. A plain new-thread comment (unlike GitHub) is already
+    // visible there. No positioning needed.
+    async postReviewCommentAs(
+        prNumber: number,
+        body: string,
+        token: string,
+    ): Promise<{ id: string }> {
+        return this.postCommentAs(prNumber, body, token);
+    }
+
+    // Polls for Kody's conversational reply to an `@kody <question>`
+    // comment. Returns the first NEW, non-system comment that is neither
+    // ours (`@kody …`) nor a code-review finding (those carry the
+    // `<!-- kody-codereview` marker). null at timeout.
+    async pollForKodyReply(
+        pr: { number: number },
+        opts: { sinceIso: string; triggerId?: string; timeoutSec?: number },
+    ): Promise<{ id: string; body: string } | null> {
+        const repoId = await this.resolveRepoId();
+        return pollUntil(
+            async () => {
+                const resp = await http<{ value: AzureThread[] }>(
+                    `${this.apiBase}/_apis/git/repositories/${repoId}/pullRequests/${pr.number}/threads?api-version=${this.apiVersion}`,
+                    { headers: this.headers() },
+                );
+                ensureOk(resp, "azure:pollForKodyReply");
+                for (const thread of resp.body.value ?? []) {
+                    if (thread.isDeleted) continue;
+                    for (const c of thread.comments ?? []) {
+                        if (c.publishedDate <= opts.sinceIso) continue;
+                        if (opts.triggerId && String(c.id) === opts.triggerId)
+                            continue;
+                        if ((c.commentType ?? "").toLowerCase() === "system")
+                            continue;
+                        const text = c.content ?? "";
+                        if (text.toLowerCase().startsWith("@kody")) continue;
+                        if (text.includes("<!-- kody-codereview")) continue;
+                        if (!text.trim()) continue;
+                        return { id: String(c.id), body: text.slice(0, 600) };
+                    }
+                }
+                return null;
+            },
+            { timeoutSec: opts.timeoutSec ?? 300, intervalSec: 10 },
+        );
+    }
+
     authMode(): "token" {
         return "token";
     }

--- a/tests/e2e/providers/bitbucket.ts
+++ b/tests/e2e/providers/bitbucket.ts
@@ -568,6 +568,77 @@ export class BitbucketProvider extends BaseProvider {
         return { id: String(resp.body.id) };
     }
 
+    // Posts a comment as a (possibly different) Bitbucket identity —
+    // `token` overrides the app password while the username stays
+    // `this.user` (BB_TEST_USER). The conversation scenario calls this with
+    // BB_TEST_APP_PASSWORD by default: unlike GitHub's dedicated e2e bot
+    // (kody-e2e-bot-N, filtered by isKodyComment), BB_TEST_USER is already a
+    // plain human account, so no separate non-Kody identity is needed here.
+    // Kept as a token override (not a hardcoded call to postComment) so a
+    // dedicated Bitbucket bot account can be introduced later without
+    // touching this signature.
+    async postCommentAs(
+        prNumber: number,
+        body: string,
+        token: string,
+    ): Promise<{ id: string }> {
+        const auth = `Basic ${Buffer.from(`${this.user}:${token}`).toString("base64")}`;
+        const resp = await http<BitbucketComment>(
+            `${this.apiBase}/repositories/${this.workspaceSlug}/pullrequests/${prNumber}/comments`,
+            {
+                method: "POST",
+                headers: { Authorization: auth, Accept: "application/json" },
+                body: { content: { raw: body } },
+            },
+        );
+        ensureOk(resp, "bitbucket:postCommentAs");
+        return { id: String(resp.body.id) };
+    }
+
+    // Kody's getPullRequestReviewComment lists ALL PR comments
+    // (pullrequests.listComments), not diff-scoped — a plain top-level
+    // comment (unlike GitHub) is already visible there. No inline
+    // positioning needed.
+    async postReviewCommentAs(
+        prNumber: number,
+        body: string,
+        token: string,
+    ): Promise<{ id: string }> {
+        return this.postCommentAs(prNumber, body, token);
+    }
+
+    // Polls for Kody's conversational reply to an `@kody <question>`
+    // comment. Returns the first NEW comment that is neither ours
+    // (`@kody …`) nor empty. Bitbucket does NOT inject the
+    // `<!-- kody-codereview -->` marker into its comments (see
+    // classifyReviewComment above), so unlike the other providers there's
+    // nothing review-specific to filter out here. null at timeout.
+    async pollForKodyReply(
+        pr: { number: number },
+        opts: { sinceIso: string; triggerId?: string; timeoutSec?: number },
+    ): Promise<{ id: string; body: string } | null> {
+        return pollUntil(
+            async () => {
+                const resp = await http<{ values: BitbucketComment[] }>(
+                    `${this.apiBase}/repositories/${this.workspaceSlug}/pullrequests/${pr.number}/comments?pagelen=50&sort=-created_on`,
+                    { headers: this.headers() },
+                );
+                ensureOk(resp, "bitbucket:pollForKodyReply");
+                for (const c of resp.body.values ?? []) {
+                    if (c.created_on <= opts.sinceIso) continue;
+                    if (opts.triggerId && String(c.id) === opts.triggerId)
+                        continue;
+                    const raw = c.content?.raw ?? "";
+                    if (raw.toLowerCase().startsWith("@kody")) continue;
+                    if (!raw.trim()) continue;
+                    return { id: String(c.id), body: raw.slice(0, 600) };
+                }
+                return null;
+            },
+            { timeoutSec: opts.timeoutSec ?? 300, intervalSec: 10 },
+        );
+    }
+
     authMode(): "token" {
         // Bitbucket's "app password" / "API token" auth flows are both
         // routed through Kodus's AuthMode.TOKEN branch — the backend

--- a/tests/e2e/providers/bitbucket.ts
+++ b/tests/e2e/providers/bitbucket.ts
@@ -609,10 +609,14 @@ export class BitbucketProvider extends BaseProvider {
 
     // Polls for Kody's conversational reply to an `@kody <question>`
     // comment. Returns the first NEW comment that is neither ours
-    // (`@kody …`) nor empty. Bitbucket does NOT inject the
-    // `<!-- kody-codereview -->` marker into its comments (see
-    // classifyReviewComment above), so unlike the other providers there's
-    // nothing review-specific to filter out here. null at timeout.
+    // (`@kody …`), empty, nor the "Analyzing your request..." acknowledgment
+    // BitbucketResponsePolicy posts immediately after the trigger
+    // (requiresAcknowledgment()=true) — that ack has no
+    // `<!-- kody-codereview -->` marker either, so without this check a poll
+    // landing between the ack and the real answer would return the ack as
+    // if it were Kody's terminal reply (a false green: caught live —
+    // replySample came back as literally "Analyzing your request..." on a
+    // passing run). null at timeout.
     async pollForKodyReply(
         pr: { number: number },
         opts: { sinceIso: string; triggerId?: string; timeoutSec?: number },
@@ -630,6 +634,7 @@ export class BitbucketProvider extends BaseProvider {
                         continue;
                     const raw = c.content?.raw ?? "";
                     if (raw.toLowerCase().startsWith("@kody")) continue;
+                    if (raw.includes("Analyzing your request")) continue;
                     if (!raw.trim()) continue;
                     return { id: String(c.id), body: raw.slice(0, 600) };
                 }

--- a/tests/e2e/providers/bitbucket.ts
+++ b/tests/e2e/providers/bitbucket.ts
@@ -634,7 +634,8 @@ export class BitbucketProvider extends BaseProvider {
                         continue;
                     const raw = c.content?.raw ?? "";
                     if (raw.toLowerCase().startsWith("@kody")) continue;
-                    if (raw.includes("Analyzing your request")) continue;
+                    if (raw.toLowerCase().trim().startsWith("analyzing your request"))
+                        continue;
                     if (!raw.trim()) continue;
                     return { id: String(c.id), body: raw.slice(0, 600) };
                 }

--- a/tests/e2e/providers/gitlab.ts
+++ b/tests/e2e/providers/gitlab.ts
@@ -358,6 +358,77 @@ export class GitLabProvider extends BaseProvider {
         return { id: String(resp.body.id) };
     }
 
+    // Posts a note as a (possibly different) GitLab identity — `token`
+    // overrides the auth header. The conversation scenario calls this with
+    // GL_TEST_TOKEN by default: unlike GitHub's dedicated e2e bot
+    // (kodus-e2e-bot-N, filtered by isKodyComment), GL_TEST_TOKEN is already
+    // a plain human account, so no separate non-Kody identity is needed
+    // here. Kept as a token override (not a hardcoded call to postComment)
+    // so a dedicated GitLab bot account can be introduced later without
+    // touching this signature.
+    async postCommentAs(
+        prNumber: number,
+        body: string,
+        token: string,
+    ): Promise<{ id: string }> {
+        const projectId = await this.resolveProjectId();
+        const resp = await http<{ id: number }>(
+            `${this.apiBase}/projects/${projectId}/merge_requests/${prNumber}/notes`,
+            {
+                method: "POST",
+                headers: { "PRIVATE-TOKEN": token },
+                body: { body },
+            },
+        );
+        ensureOk(resp, "gitlab:postCommentAs");
+        return { id: String(resp.body.id) };
+    }
+
+    // Kody's getPullRequestReviewComment reads MergeRequestDiscussions.all()
+    // — GitLab wraps every plain note into a one-note discussion, so a plain
+    // top-level note (unlike GitHub) is already visible there. No diff
+    // position needed.
+    async postReviewCommentAs(
+        prNumber: number,
+        body: string,
+        token: string,
+    ): Promise<{ id: string }> {
+        return this.postCommentAs(prNumber, body, token);
+    }
+
+    // Polls for Kody's conversational reply to an `@kody <question>` note.
+    // Returns the first NEW note that is neither ours (`@kody …`) nor a
+    // code-review finding (those carry the `<!-- kody-codereview` marker).
+    // null at timeout.
+    async pollForKodyReply(
+        pr: { number: number },
+        opts: { sinceIso: string; triggerId?: string; timeoutSec?: number },
+    ): Promise<{ id: string; body: string } | null> {
+        const projectId = await this.resolveProjectId();
+        return pollUntil(
+            async () => {
+                const resp = await http<GitLabNote[]>(
+                    `${this.apiBase}/projects/${projectId}/merge_requests/${pr.number}/notes?per_page=100&sort=desc&order_by=updated_at`,
+                    { headers: this.headers() },
+                );
+                ensureOk(resp, "gitlab:pollForKodyReply");
+                for (const n of resp.body ?? []) {
+                    if (n.system) continue;
+                    if (n.created_at <= opts.sinceIso) continue;
+                    if (opts.triggerId && String(n.id) === opts.triggerId)
+                        continue;
+                    const body = n.body ?? "";
+                    if (body.toLowerCase().startsWith("@kody")) continue;
+                    if (body.includes("<!-- kody-codereview")) continue;
+                    if (!body.trim()) continue;
+                    return { id: String(n.id), body: body.slice(0, 600) };
+                }
+                return null;
+            },
+            { timeoutSec: opts.timeoutSec ?? 300, intervalSec: 10 },
+        );
+    }
+
     authMode(): "token" {
         return "token";
     }

--- a/tests/e2e/scenarios/conversation-anthropic-byok.ts
+++ b/tests/e2e/scenarios/conversation-anthropic-byok.ts
@@ -1,5 +1,6 @@
 import { ensureLicenseSeat } from "../lib/onboarding.js";
 import { http } from "../lib/http.js";
+import { resolveConversationUserToken } from "../lib/conversation-user-token.js";
 import type { RunContext, Scenario, KodusSession } from "../lib/types.js";
 
 // Anthropic-BYOK variant of conversation-vertex-byok: drives the REAL @kody
@@ -7,9 +8,29 @@ import type { RunContext, Scenario, KodusSession } from "../lib/types.js";
 // Sonnet → kodus-flow parser) on a real self-hosted env. Used to reproduce the
 // "Missing or invalid reasoning field" failure (old flow) and verify the fix
 // (new flow) end-to-end. Hardened: rejects the generic error fallback.
-const FIXTURE = { head: "bug/missing-null-check", base: "main" };
-const QUESTION =
-    "@kody this cron deactivates licenses daily, right? explain it to me naturally, like a colleague would, briefly.";
+//
+// FIXTURE_BRANCHES: `bug/missing-null-check` is only confirmed mirrored on
+// GitHub (see code-review-basic.ts's own placeholder comment for the other
+// providers). `refactor/use-map-storage` is the shared branch already
+// confirmed working across all 5 providers via command-review.ts — PR
+// content is irrelevant here (we only need an open PR to talk to Kody on),
+// so gitlab/bitbucket/azure-devops use that one instead.
+const FIXTURE_BRANCHES: Record<string, { head: string; base: string }> = {
+    github: { head: "bug/missing-null-check", base: "main" },
+    gitlab: { head: "refactor/use-map-storage", base: "main" },
+    bitbucket: { head: "refactor/use-map-storage", base: "main" },
+    "azure-devops": { head: "refactor/use-map-storage", base: "main" },
+};
+
+// The GitHub-specific question references the cron job that only exists on
+// `bug/missing-null-check`; the other providers point at the content-neutral
+// `refactor/use-map-storage` branch, so they get a generic question instead.
+function questionFor(providerName: string): string {
+    if (providerName === "github") {
+        return "@kody this cron deactivates licenses daily, right? explain it to me naturally, like a colleague would, briefly.";
+    }
+    return "@kody in one short sentence, what does this pull request change?";
+}
 
 async function setAnthropicByok(
     apiBaseUrl: string,
@@ -49,7 +70,7 @@ export const conversationAnthropicByok: Scenario = {
     priority: "P2",
     appliesTo: {
         target: ["self-hosted"],
-        provider: ["github"],
+        provider: ["github", "gitlab", "bitbucket", "azure-devops"],
         license: ["paid", "license-paid"],
     },
     timeoutSec: 1200,
@@ -66,9 +87,10 @@ export const conversationAnthropicByok: Scenario = {
             process.env.CONVERSATION_ANTHROPIC_MODEL ||
             "claude-sonnet-4-5-20250929";
 
-        const userToken = process.env.CONVERSATION_USER_TOKEN;
+        const { token: userToken, missingEnvHint } =
+            resolveConversationUserToken(ctx.provider.name);
         if (!userToken) {
-            ctx.skip("CONVERSATION_USER_TOKEN not set");
+            ctx.skip(`${missingEnvHint} not set`);
         }
 
         if (
@@ -89,9 +111,15 @@ export const conversationAnthropicByok: Scenario = {
 
         await setAnthropicByok(ctx.target.apiBaseUrl, session, apiKey!, model);
 
+        const fixture = FIXTURE_BRANCHES[ctx.provider.name];
+        ctx.assert(
+            fixture,
+            `No FIXTURE_BRANCHES entry for provider ${ctx.provider.name}`,
+        );
+
         const pr = await ctx.provider.openPRFromBranches({
-            head: FIXTURE.head,
-            base: FIXTURE.base,
+            head: fixture!.head,
+            base: fixture!.base,
             title: `[e2e] conversation-anthropic-byok ${ctx.runId.slice(0, 8)}`,
             body: `Automated PR (Anthropic conversation: ${model}). Auto-closed by the scenario.`,
         });
@@ -100,7 +128,7 @@ export const conversationAnthropicByok: Scenario = {
             const sinceIso = new Date().toISOString();
             const trigger = await ctx.provider.postReviewCommentAs(
                 pr.number,
-                QUESTION,
+                questionFor(ctx.provider.name),
                 userToken!,
             );
 

--- a/tests/e2e/scenarios/conversation-vertex-byok.ts
+++ b/tests/e2e/scenarios/conversation-vertex-byok.ts
@@ -1,10 +1,20 @@
 import { ensureLicenseSeat } from '../lib/onboarding.js';
 import { readVertexByokEnv, setVertexByok } from '../lib/vertex-byok.js';
+import { resolveConversationUserToken } from '../lib/conversation-user-token.js';
 import type { RunContext, Scenario } from '../lib/types.js';
 
 // Standing-branch fixture (same repo as code-review-vertex-byok). The PR
 // content is irrelevant here — we only need an open PR to talk to Kody on.
-const FIXTURE = { head: 'bug/missing-null-check', base: 'main' };
+// `bug/missing-null-check` is only confirmed mirrored on GitHub (see
+// code-review-basic.ts's own placeholder comment for the other providers);
+// `refactor/use-map-storage` is the shared branch already confirmed working
+// across all 5 providers via command-review.ts.
+const FIXTURE_BRANCHES: Record<string, { head: string; base: string }> = {
+    github: { head: 'bug/missing-null-check', base: 'main' },
+    gitlab: { head: 'refactor/use-map-storage', base: 'main' },
+    bitbucket: { head: 'refactor/use-map-storage', base: 'main' },
+    'azure-devops': { head: 'refactor/use-map-storage', base: 'main' },
+};
 
 // `@kody <question>` (NOT `@kody review`) is what the webhook handlers match
 // with KODY_MENTION_NON_REVIEW_PATTERN to route the comment to the
@@ -25,7 +35,7 @@ export const conversationVertexByok: Scenario = {
     priority: 'P2',
     appliesTo: {
         target: ['self-hosted'],
-        provider: ['github'],
+        provider: ['github', 'gitlab', 'bitbucket', 'azure-devops'],
         license: ['paid', 'license-paid'],
     },
     timeoutSec: 1200,
@@ -44,14 +54,15 @@ export const conversationVertexByok: Scenario = {
             );
         }
 
-        // Kody ignores any comment whose author login contains "kody"/"kodus"
-        // (isKodyComment, LOGIN_KEYWORDS=['kody','kodus']) — and the e2e bots
-        // are all `kodus-e2e-bot-N`. So the `@kody` mention MUST be posted by a
-        // separate, non-Kody GitHub account.
-        const userToken = process.env.CONVERSATION_USER_TOKEN;
+        // Kody ignores any comment whose author login/name contains
+        // "kody"/"kodus" (isKodyComment, LOGIN_KEYWORDS=['kody','kodus']) —
+        // and every provider's own e2e bot account is named like that. So
+        // the `@kody` mention MUST be posted by a separate, non-Kody account.
+        const { token: userToken, missingEnvHint } =
+            resolveConversationUserToken(ctx.provider.name);
         if (!userToken) {
             ctx.skip(
-                "CONVERSATION_USER_TOKEN not set — needs a GitHub token for an account whose login does NOT contain 'kody'/'kodus' (the integration bot's own comments are ignored by Kody) with Pull requests R/W on the fixture repo",
+                `${missingEnvHint} not set — needs a token for an account whose login/name does NOT contain 'kody'/'kodus' (the integration bot's own comments are ignored by Kody) with PR write access on the fixture repo`,
             );
         }
 
@@ -73,9 +84,15 @@ export const conversationVertexByok: Scenario = {
 
         await setVertexByok(ctx.target.apiBaseUrl, session, vertex!);
 
+        const fixture = FIXTURE_BRANCHES[ctx.provider.name];
+        ctx.assert(
+            fixture,
+            `No FIXTURE_BRANCHES entry for provider ${ctx.provider.name}`,
+        );
+
         const pr = await ctx.provider.openPRFromBranches({
-            head: FIXTURE.head,
-            base: FIXTURE.base,
+            head: fixture!.head,
+            base: fixture!.base,
             title: `[e2e] conversation-vertex-byok ${ctx.runId.slice(0, 8)}`,
             body: `Automated PR opened by Kodus E2E run ${ctx.runId} (Claude-on-Vertex conversation: ${vertex!.model} @ ${vertex!.region}). Auto-closed by the scenario.`,
         });


### PR DESCRIPTION
Closes #1755

## Summary

- Fixes a real bug: `getReviewThreadByCommentId` only searched an Azure DevOps thread's `.replies` array, never the thread's root comment. Since a brand-new `@kody <question>` (not a reply to an existing thread) *is* that root comment, Kody silently never answered it — confirmed live against a real Azure DevOps PR (a single-comment thread, the `@kody` mention, never got a reply). Regression from the Dec 2025 "refactor structure" commit, which dropped a check the original May 2025 fix had.
- Extends the `@kody <question>` conversation e2e coverage (`conversation-anthropic-byok`, `conversation-vertex-byok`) from GitHub-only to GitLab/Bitbucket/Azure DevOps, by implementing `postCommentAs`/`postReviewCommentAs`/`pollForKodyReply` on those three provider adapters. This is the coverage gap that let PR #1736's GitLab/Bitbucket bug ship in the first place — the only e2e scenarios that drove the real conversational flow were pinned to GitHub.
- No new secrets needed: GitLab/Bitbucket/Azure's existing driver credentials (`GL_TEST_TOKEN`, `BB_TEST_USER`/`BB_TEST_APP_PASSWORD`, `AZ_TEST_TOKEN`) are already plain human accounts (unlike GitHub's dedicated `kodus-e2e-bot-N`), so they're reused directly as the non-Kody trigger identity.
- Fixes a false-green in Bitbucket's `pollForKodyReply` (caught by Kody's own review on this PR): Bitbucket posts an "Analyzing your request..." acknowledgment before running the agent, with no `<!-- kody-codereview` marker to filter it out. The poll could return that ack as if it were Kody's terminal answer — and did, live, on the first validation run. Now explicitly skipped.

## Test plan

- [x] `chatWithKodyFromGit.use-case.spec.ts`: new regression test reproduces the exact Azure failure (0 calls to the conversation agent) without the fix, passes with it.
- [x] Full self-hosted matrix (`matrix/full.yml`, `only_provider=all`) dispatched live against this branch: `conversation-vertex-byok` passed for real (non-fallback Kody reply) on GitHub and GitLab.
- [x] Azure DevOps failed on that run — root-caused via server logs + a direct Azure DevOps API query of the actual test PR's thread (1 comment, 0 replies, matching the bug exactly) — fixed here, re-ran `only_provider=azure-devops` after the fix: now passes with a real answer.
- [x] Bitbucket "passed" on that same run, but Kody's review on this PR flagged the reply was actually the ack text, not a real answer — fixed the poll filter; re-validating.
- [x] `pnpm test --testPathPatterns=chatWithKodyFromGit.use-case.spec` — 10/10 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)