### PR TITLE
fix(gitlab): build clone URL from path_with_namespace, not stored fullName

### DIFF
--- a/libs/platform/infrastructure/adapters/services/gitlab.service.spec.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.spec.ts
@@ -97,27 +97,166 @@ describe('GitlabService', () => {
         });
     });
 
-    it('does not duplicate the protocol when building clone params for self-hosted GitLab', async () => {
-        jest.spyOn(service as any, 'getAuthDetails').mockResolvedValue({
-            accessToken: 'oauth-token',
-            authMode: AuthMode.OAUTH,
-            host: 'https://gitlab.example.com/',
+    describe('getCloneParams', () => {
+        const mockAuthDetails = () =>
+            jest.spyOn(service as any, 'getAuthDetails').mockResolvedValue({
+                accessToken: 'oauth-token',
+                authMode: AuthMode.OAUTH,
+                host: 'https://gitlab.example.com/',
+            });
+
+        const mockProjectsShow = (show: jest.Mock) =>
+            mockedGitlab.mockReturnValue({ Projects: { show } });
+
+        it('does not duplicate the protocol when building clone params for self-hosted GitLab', async () => {
+            mockAuthDetails();
+            mockProjectsShow(
+                jest.fn().mockResolvedValue({
+                    path_with_namespace: 'group/repo',
+                }),
+            );
+
+            const cloneParams = await service.getCloneParams({
+                organizationAndTeamData,
+                repository: {
+                    id: 'repo-1',
+                    name: 'repo',
+                    fullName: 'group/repo',
+                    defaultBranch: 'main',
+                },
+            });
+
+            expect(cloneParams.url).toBe(
+                'https://gitlab.example.com/group/repo',
+            );
+            expect(cloneParams.auth).toMatchObject({
+                type: AuthMode.OAUTH,
+                token: 'oauth-token',
+            });
         });
 
-        const cloneParams = await service.getCloneParams({
-            organizationAndTeamData,
-            repository: {
-                id: 'repo-1',
-                name: 'repo',
-                fullName: 'group/repo',
-                defaultBranch: 'main',
+        // A stored fullName can hold the display form. Encoding it verbatim
+        // produces `My Group/My%20Project`, which GitLab answers with a 302
+        // to /users/sign_in and git reports as
+        // `unable to update url base from redirection`.
+        it('builds the URL from path_with_namespace when fullName holds the display form', async () => {
+            mockAuthDetails();
+            const show = jest.fn().mockResolvedValue({
+                path_with_namespace: 'my-group/my-project',
+            });
+            mockProjectsShow(show);
+
+            const cloneParams = await service.getCloneParams({
+                organizationAndTeamData,
+                repository: {
+                    id: '326',
+                    name: 'My Project',
+                    fullName: 'My Group/My Project',
+                    defaultBranch: 'main',
+                },
+            });
+
+            expect(show).toHaveBeenCalledWith('326');
+            expect(cloneParams.url).toBe(
+                'https://gitlab.example.com/my-group/my-project',
+            );
+            expect(cloneParams.url).not.toContain('%20');
+        });
+
+        // The numeric id survives a move between groups; the stored path does
+        // not, and silently loses the new parent subgroup.
+        it('picks up a subgroup the stored fullName predates', async () => {
+            mockAuthDetails();
+            mockProjectsShow(
+                jest.fn().mockResolvedValue({
+                    path_with_namespace: 'parent/group/repo',
+                }),
+            );
+
+            const cloneParams = await service.getCloneParams({
+                organizationAndTeamData,
+                repository: {
+                    id: 'repo-2',
+                    name: 'repo',
+                    fullName: 'group/repo',
+                    defaultBranch: 'main',
+                },
+            });
+
+            expect(cloneParams.url).toBe(
+                'https://gitlab.example.com/parent/group/repo',
+            );
+        });
+
+        // CLI mode passes the placeholder id '0' with a fullName parsed from the
+        // local remote. '0' is a truthy string, so this needs an explicit check
+        // or every CLI clone burns a guaranteed-failing round-trip.
+        it.each(['0', '', undefined])(
+            'skips the project lookup when the id is the placeholder %p',
+            async (id) => {
+                mockAuthDetails();
+                const show = jest.fn();
+                mockProjectsShow(show);
+
+                const cloneParams = await service.getCloneParams({
+                    organizationAndTeamData,
+                    repository: {
+                        id: id as string,
+                        name: 'repo',
+                        fullName: 'group/repo',
+                        defaultBranch: 'main',
+                    },
+                });
+
+                expect(show).not.toHaveBeenCalled();
+                expect(cloneParams.url).toBe(
+                    'https://gitlab.example.com/group/repo',
+                );
             },
+        );
+
+        it('falls back to the stored fullName when the project lookup fails', async () => {
+            mockAuthDetails();
+            mockProjectsShow(
+                jest.fn().mockRejectedValue(new Error('404 Not Found')),
+            );
+
+            const cloneParams = await service.getCloneParams({
+                organizationAndTeamData,
+                repository: {
+                    id: 'repo-3',
+                    name: 'repo',
+                    fullName: 'group/repo',
+                    defaultBranch: 'main',
+                },
+            });
+
+            expect(cloneParams.url).toBe(
+                'https://gitlab.example.com/group/repo',
+            );
         });
 
-        expect(cloneParams.url).toBe('https://gitlab.example.com/group/repo');
-        expect(cloneParams.auth).toMatchObject({
-            type: AuthMode.OAUTH,
-            token: 'oauth-token',
+        it('still encodes path segments that need it', async () => {
+            mockAuthDetails();
+            mockProjectsShow(
+                jest.fn().mockResolvedValue({
+                    path_with_namespace: 'group/repo name',
+                }),
+            );
+
+            const cloneParams = await service.getCloneParams({
+                organizationAndTeamData,
+                repository: {
+                    id: 'repo-4',
+                    name: 'repo name',
+                    fullName: 'group/repo name',
+                    defaultBranch: 'main',
+                },
+            });
+
+            expect(cloneParams.url).toBe(
+                'https://gitlab.example.com/group/repo%20name',
+            );
         });
     });
 

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -3337,6 +3337,80 @@ export class GitlabService implements Omit<
         }
     }
 
+    /**
+     * The current `path_with_namespace` for a project, looked up by its numeric
+     * id.
+     *
+     * `repository.fullName` is whatever was persisted when the repository was
+     * first selected, and it is not reliably the URL slug: it can hold the
+     * display form (`My Group/My Project` rather than `my-group/my-project`)
+     * and it goes stale when a project is renamed or moved between groups, which
+     * also drops any subgroup added along the way (`group/project` where the
+     * project now lives at `parent/group/project`). Cloning such a URL fails
+     * with a 302 to `/users/sign_in` — git reports it as
+     * `unable to update url base from redirection`, which reads like an auth
+     * problem but is really a path that GitLab won't resolve.
+     *
+     * The numeric id survives renames and moves, which is why every REST call in
+     * this service keeps working while only the clone breaks. Falls back to the
+     * stored `fullName` so a lookup failure is no worse than the old behaviour.
+     *
+     * Callers without a real project id are expected to skip this entirely —
+     * see `hasResolvableProjectId`.
+     */
+    private async resolveProjectPathWithNamespace(
+        gitlabAuthDetail: GitlabAuthDetail,
+        repository: Pick<Repository, 'id' | 'fullName'>,
+        organizationAndTeamData: OrganizationAndTeamData,
+    ): Promise<string> {
+        try {
+            const gitlabAPI = this.instanceGitlabApi(gitlabAuthDetail);
+            const project = await gitlabAPI.Projects.show(repository.id);
+
+            if (project?.path_with_namespace) {
+                return project.path_with_namespace as string;
+            }
+
+            this.logger.warn({
+                message: `Project ${repository?.id} returned no path_with_namespace; falling back to the stored fullName`,
+                context: GitlabService.name,
+                metadata: {
+                    organizationAndTeamData,
+                    repositoryId: repository?.id,
+                    fullName: repository?.fullName,
+                },
+            });
+        } catch (error) {
+            this.logger.warn({
+                message: `Could not resolve path_with_namespace for project ${repository?.id}; falling back to the stored fullName`,
+                context: GitlabService.name,
+                error,
+                metadata: {
+                    organizationAndTeamData,
+                    repositoryId: repository?.id,
+                    fullName: repository?.fullName,
+                },
+            });
+        }
+
+        return repository?.fullName || '';
+    }
+
+    /**
+     * Whether `repository.id` is a real GitLab project id worth a lookup.
+     *
+     * CLI mode has no project id to give — it builds its params straight from
+     * the local git remote and passes the placeholder `'0'` with a `fullName`
+     * parsed from that remote, which is already the authoritative slug. Note
+     * `'0'` is a truthy string, so a plain truthiness check does not catch it
+     * and every CLI clone would spend a guaranteed-failing round-trip.
+     */
+    private hasResolvableProjectId(id?: string | number): boolean {
+        const normalized = String(id ?? '').trim();
+
+        return normalized !== '' && normalized !== '0';
+    }
+
     async getCloneParams(params: {
         repository: Pick<
             Repository,
@@ -3359,7 +3433,21 @@ export class GitlabService implements Omit<
                 throw new Error('GitLab authentication details not found');
             }
 
-            const encodedPath = (params?.repository?.fullName || '')
+            // Resolve the slug from the numeric project id instead of trusting
+            // the stored `fullName`. See resolveProjectPathWithNamespace. With
+            // no real id (CLI mode) `fullName` came straight from the local
+            // remote and is already authoritative, so skip the round-trip.
+            const projectPath = this.hasResolvableProjectId(
+                params.repository?.id,
+            )
+                ? await this.resolveProjectPathWithNamespace(
+                      gitlabAuthDetail,
+                      params.repository,
+                      params.organizationAndTeamData,
+                  )
+                : params.repository?.fullName || '';
+
+            const encodedPath = projectPath
                 .split('/')
                 .map(encodeURIComponent)
                 .join('/');


### PR DESCRIPTION
Closes #1743
Re-submits the fix from #1735 (same diff) on a same-repo branch — see why below.

## Problem

`GitlabService.getCloneParams` builds the clone URL by URL-encoding `repository.fullName`. That value is whatever was persisted when the repository was first selected and is not reliably the GitLab URL slug:

1. **Display form** — `My Group/My Project` encodes to `My%20Group/My%20Project` instead of resolving to `my-group/my-project`.
2. **Stale after a rename or group move** — the stored value keeps the old path, silently dropping a parent subgroup added later.

GitLab answers the bad path with a 302 to `/users/sign_in`, so git reports `unable to update url base from redirection` — which reads like an auth failure but isn't. Every other call in `GitlabService` goes by numeric project id and stays healthy, so the integration looks fine while only cloning breaks. Downstream, `createSandboxWithRepo` burns its retry budget and the review silently degrades to self-contained mode (diff-only, no tools) with no signal to the user.

## Fix

Resolve the slug via `Projects.show(id)` and use `path_with_namespace`, falling back to the stored `fullName` if the lookup fails or the id isn't resolvable (CLI mode passes a placeholder `'0'` with a `fullName` already parsed from the local remote, which is authoritative — `hasResolvableProjectId` skips the round-trip there).

## Why this PR exists alongside #1735

**Root-cause diagnosis and the fix itself are [@cursedcoder](https://github.com/cursedcoder)'s (#1735, closes #1743).** That PR runs from a fork (`cursedcoder/kodus-ai`), and three required checks fail there with 403s regardless of the diff's correctness:

- `eligibility` — `gh api POST .../statuses` needs write scope
- `Comment preview URLs` — needs `issues:write`/`pull_requests:write`
- `Deploy web preview` — needs the `RAILWAY_TOKEN` secret

None of these are repo-issues, they're the standard read-only `GITHUB_TOKEN` GitHub Actions gives `pull_request` events from forks. Re-running doesn't change it. This branch carries the identical fix from inside the repo so it can pass full CI and actually be merged.

## Independent verification (TDD split, see commits)

1. `test(gitlab): reproduce the fullName clone-URL bug (#1743)` — adds only the two bug-reproducing tests against **unmodified** `main`. Confirmed red: `builds the URL from path_with_namespace when fullName holds the display form` and `picks up a subgroup the stored fullName predates` fail; the other 19 cases in the file pass.
2. `fix(gitlab): resolve clone URL from path_with_namespace, not stored fullName` — adds the fix. Confirmed green: 21/21 pass.

Verified twice — once against a reconstructed patch, once against `cursedcoder`'s actual commit (`b7863c3e6`, same SHA CI tested on #1735) checked out byte-for-byte — both runs identical.

## Tests

`gitlab.service.spec.ts` — 21 cases (8 new/restructured for this bug): display form, subgroup move, CLI placeholder-id skip, lookup-failure fallback, and existing self-hosted-protocol behavior.