### PR TITLE
fix(gitlab): cache the resolved clone path_with_namespace

### DIFF
--- a/libs/platform/infrastructure/adapters/services/gitlab.service.spec.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.spec.ts
@@ -284,7 +284,7 @@ describe('GitlabService', () => {
             });
 
             expect(cacheService.getFromCache).toHaveBeenCalledWith(
-                'gitlab-project-path-org-1-repo-5',
+                'gitlab-project-path-org-1-team-1-https://gitlab.example.com/-repo-5',
             );
             expect(show).not.toHaveBeenCalled();
             expect(cloneParams.url).toBe(
@@ -311,9 +311,39 @@ describe('GitlabService', () => {
             });
 
             expect(cacheService.addToCache).toHaveBeenCalledWith(
-                'gitlab-project-path-org-1-repo-6',
+                'gitlab-project-path-org-1-team-1-https://gitlab.example.com/-repo-6',
                 'group/repo',
                 1800000,
+            );
+        });
+
+        // The GitLab integration is resolved per team, and two teams in the
+        // same org can point to different GitLab hosts and still share a
+        // numeric project id — the key must be scoped past organizationId
+        // alone or one team's clone can serve another team's cached slug.
+        it('scopes the cache key by team and GitLab host, not just organization', async () => {
+            mockAuthDetails();
+            mockProjectsShow(
+                jest.fn().mockResolvedValue({
+                    path_with_namespace: 'group/repo',
+                }),
+            );
+
+            await service.getCloneParams({
+                organizationAndTeamData: {
+                    organizationId: 'org-1',
+                    teamId: 'team-2',
+                },
+                repository: {
+                    id: 'repo-6',
+                    name: 'repo',
+                    fullName: 'group/repo',
+                    defaultBranch: 'main',
+                },
+            });
+
+            expect(cacheService.getFromCache).toHaveBeenCalledWith(
+                'gitlab-project-path-org-1-team-2-https://gitlab.example.com/-repo-6',
             );
         });
 

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.spec.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.spec.ts
@@ -284,7 +284,7 @@ describe('GitlabService', () => {
             });
 
             expect(cacheService.getFromCache).toHaveBeenCalledWith(
-                'gitlab-project-path-org-1-team-1-https://gitlab.example.com/-repo-5',
+                'gitlab-project-path-org-1-team-1-https://gitlab.example.com-repo-5',
             );
             expect(show).not.toHaveBeenCalled();
             expect(cloneParams.url).toBe(
@@ -311,7 +311,7 @@ describe('GitlabService', () => {
             });
 
             expect(cacheService.addToCache).toHaveBeenCalledWith(
-                'gitlab-project-path-org-1-team-1-https://gitlab.example.com/-repo-6',
+                'gitlab-project-path-org-1-team-1-https://gitlab.example.com-repo-6',
                 'group/repo',
                 1800000,
             );
@@ -343,7 +343,53 @@ describe('GitlabService', () => {
             });
 
             expect(cacheService.getFromCache).toHaveBeenCalledWith(
-                'gitlab-project-path-org-1-team-2-https://gitlab.example.com/-repo-6',
+                'gitlab-project-path-org-1-team-2-https://gitlab.example.com-repo-6',
+            );
+        });
+
+        // The clone URL and API client both normalize the host through
+        // getGitlabWebBaseUrl; the cache key must go through the same
+        // normalization or `gitlab.example.com`, `https://gitlab.example.com`
+        // and a trailing-slash variant each produce their own entry for the
+        // same instance, missing the cache on every raw-string mismatch.
+        it('shares one cache entry across raw host variants of the same instance', async () => {
+            mockProjectsShow(
+                jest.fn().mockResolvedValue({
+                    path_with_namespace: 'group/repo',
+                }),
+            );
+
+            for (const host of [
+                'gitlab.example.com',
+                'https://gitlab.example.com',
+                'https://gitlab.example.com/',
+            ]) {
+                jest.spyOn(service as any, 'getAuthDetails').mockResolvedValue(
+                    {
+                        accessToken: 'oauth-token',
+                        authMode: AuthMode.OAUTH,
+                        host,
+                    },
+                );
+
+                await service.getCloneParams({
+                    organizationAndTeamData,
+                    repository: {
+                        id: 'repo-8',
+                        name: 'repo',
+                        fullName: 'group/repo',
+                        defaultBranch: 'main',
+                    },
+                });
+            }
+
+            const keysUsed = new Set(
+                cacheService.getFromCache.mock.calls.map((call) => call[0]),
+            );
+            expect(keysUsed).toEqual(
+                new Set([
+                    'gitlab-project-path-org-1-team-1-https://gitlab.example.com-repo-8',
+                ]),
             );
         });
 

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.spec.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.spec.ts
@@ -24,7 +24,7 @@ describe('GitlabService', () => {
     let integrationConfigService: Record<string, never>;
     let authIntegrationService: Record<string, never>;
     let configService: ConfigService;
-    let cacheService: Record<string, never>;
+    let cacheService: { getFromCache: jest.Mock; addToCache: jest.Mock };
 
     const mockedAxios = axios as jest.Mocked<typeof axios>;
     const mockedGitlab = Gitlab as unknown as jest.Mock;
@@ -38,7 +38,10 @@ describe('GitlabService', () => {
         configService = {
             get: jest.fn(),
         } as unknown as ConfigService;
-        cacheService = {};
+        cacheService = {
+            getFromCache: jest.fn().mockResolvedValue(undefined),
+            addToCache: jest.fn().mockResolvedValue(undefined),
+        };
 
         service = new GitlabService(
             integrationService as any,
@@ -257,6 +260,83 @@ describe('GitlabService', () => {
             expect(cloneParams.url).toBe(
                 'https://gitlab.example.com/group/repo%20name',
             );
+        });
+
+        // Every clone otherwise pays the Projects.show round-trip on its
+        // critical path, including repeated clones of the same repository
+        // across reviews.
+        it('reuses a cached path_with_namespace instead of calling Projects.show again', async () => {
+            mockAuthDetails();
+            const show = jest.fn().mockResolvedValue({
+                path_with_namespace: 'should-not-be-used',
+            });
+            mockProjectsShow(show);
+            cacheService.getFromCache.mockResolvedValue('group/cached-repo');
+
+            const cloneParams = await service.getCloneParams({
+                organizationAndTeamData,
+                repository: {
+                    id: 'repo-5',
+                    name: 'repo',
+                    fullName: 'group/repo',
+                    defaultBranch: 'main',
+                },
+            });
+
+            expect(cacheService.getFromCache).toHaveBeenCalledWith(
+                'gitlab-project-path-org-1-repo-5',
+            );
+            expect(show).not.toHaveBeenCalled();
+            expect(cloneParams.url).toBe(
+                'https://gitlab.example.com/group/cached-repo',
+            );
+        });
+
+        it('caches a resolved path_with_namespace on a cache miss', async () => {
+            mockAuthDetails();
+            mockProjectsShow(
+                jest.fn().mockResolvedValue({
+                    path_with_namespace: 'group/repo',
+                }),
+            );
+
+            await service.getCloneParams({
+                organizationAndTeamData,
+                repository: {
+                    id: 'repo-6',
+                    name: 'repo',
+                    fullName: 'group/repo',
+                    defaultBranch: 'main',
+                },
+            });
+
+            expect(cacheService.addToCache).toHaveBeenCalledWith(
+                'gitlab-project-path-org-1-repo-6',
+                'group/repo',
+                1800000,
+            );
+        });
+
+        // A failed lookup must not be cached — caching the fullName fallback
+        // would keep retrying the stored (possibly wrong) path for the full
+        // TTL instead of the API on the very next clone.
+        it('does not cache the fallback when the project lookup fails', async () => {
+            mockAuthDetails();
+            mockProjectsShow(
+                jest.fn().mockRejectedValue(new Error('404 Not Found')),
+            );
+
+            await service.getCloneParams({
+                organizationAndTeamData,
+                repository: {
+                    id: 'repo-7',
+                    name: 'repo',
+                    fullName: 'group/repo',
+                    defaultBranch: 'main',
+                },
+            });
+
+            expect(cacheService.addToCache).not.toHaveBeenCalled();
         });
     });
 

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -3371,7 +3371,12 @@ export class GitlabService implements Omit<
         repository: Pick<Repository, 'id' | 'fullName'>,
         organizationAndTeamData: OrganizationAndTeamData,
     ): Promise<string> {
-        const cacheKey = `gitlab-project-path-${organizationAndTeamData?.organizationId}-${repository?.id}`;
+        // The GitLab integration (and therefore the numeric project id) is
+        // resolved per team, not per organization — two teams in the same
+        // org can point to different GitLab instances and share a numeric
+        // project id, so the key must include teamId and the instance host
+        // or one team can serve another's cached path_with_namespace.
+        const cacheKey = `gitlab-project-path-${organizationAndTeamData?.organizationId}-${organizationAndTeamData?.teamId}-${gitlabAuthDetail?.host ?? ''}-${repository?.id}`;
 
         try {
             const cachedPath =

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -3376,7 +3376,12 @@ export class GitlabService implements Omit<
         // org can point to different GitLab instances and share a numeric
         // project id, so the key must include teamId and the instance host
         // or one team can serve another's cached path_with_namespace.
-        const cacheKey = `gitlab-project-path-${organizationAndTeamData?.organizationId}-${organizationAndTeamData?.teamId}-${gitlabAuthDetail?.host ?? ''}-${repository?.id}`;
+        // Normalized through the same getGitlabWebBaseUrl used to build the
+        // clone URL and the API client host, so equivalent raw values
+        // (`gitlab.example.com`, `https://gitlab.example.com/`, ...) share
+        // one cache entry instead of missing on every representation.
+        const normalizedHost = this.getGitlabWebBaseUrl(gitlabAuthDetail?.host);
+        const cacheKey = `gitlab-project-path-${organizationAndTeamData?.organizationId}-${organizationAndTeamData?.teamId}-${normalizedHost}-${repository?.id}`;
 
         try {
             const cachedPath =

--- a/libs/platform/infrastructure/adapters/services/gitlab.service.ts
+++ b/libs/platform/infrastructure/adapters/services/gitlab.service.ts
@@ -3357,18 +3357,69 @@ export class GitlabService implements Omit<
      *
      * Callers without a real project id are expected to skip this entirely —
      * see `hasResolvableProjectId`.
+     *
+     * The result is cached for 30 minutes per
+     * `(organizationId, repository.id)`: every clone otherwise pays this
+     * round-trip on its critical path, including repeated clones of the same
+     * repository across reviews. The slug only changes on a rename or group
+     * move, so a short TTL is enough to pick that up without keeping the
+     * common case on the network. A failed lookup is not cached — that falls
+     * back to `fullName` for this call only, and retries the API next time.
      */
     private async resolveProjectPathWithNamespace(
         gitlabAuthDetail: GitlabAuthDetail,
         repository: Pick<Repository, 'id' | 'fullName'>,
         organizationAndTeamData: OrganizationAndTeamData,
     ): Promise<string> {
+        const cacheKey = `gitlab-project-path-${organizationAndTeamData?.organizationId}-${repository?.id}`;
+
+        try {
+            const cachedPath =
+                await this.cacheService.getFromCache<string>(cacheKey);
+            if (cachedPath) {
+                return cachedPath;
+            }
+        } catch (cacheError) {
+            this.logger.warn({
+                message: 'Error reading project path from cache, continuing with API call',
+                context: GitlabService.name,
+                serviceName: 'GitlabService resolveProjectPathWithNamespace',
+                error: cacheError,
+                metadata: {
+                    organizationAndTeamData,
+                    repositoryId: repository?.id,
+                },
+            });
+        }
+
         try {
             const gitlabAPI = this.instanceGitlabApi(gitlabAuthDetail);
             const project = await gitlabAPI.Projects.show(repository.id);
 
             if (project?.path_with_namespace) {
-                return project.path_with_namespace as string;
+                const path = project.path_with_namespace as string;
+
+                try {
+                    await this.cacheService.addToCache(
+                        cacheKey,
+                        path,
+                        1800000, // 30 minutos
+                    );
+                } catch (cacheError) {
+                    this.logger.warn({
+                        message: 'Error caching project path',
+                        context: GitlabService.name,
+                        serviceName:
+                            'GitlabService resolveProjectPathWithNamespace',
+                        error: cacheError,
+                        metadata: {
+                            organizationAndTeamData,
+                            repositoryId: repository?.id,
+                        },
+                    });
+                }
+
+                return path;
             }
 
             this.logger.warn({


### PR DESCRIPTION
Follow-up to #1735 / #1756. Addresses a finding from Kody's automated review on #1756.

## Problem

`getCloneParams` resolves the clone slug via an awaited `Projects.show` REST call on every clone's critical path (added in #1735 to fix #1743), and the result was never cached. Every sandbox clone — including repeated clones of the same repository across reviews — pays that round-trip before the actual git clone even starts, serializing latency and adding API load on slow or unreachable self-hosted GitLab instances (`queryTimeout` is 600000ms).

> If the remaining cost is a concern I am happy to memoise per (org, repoId) — left out here to keep the fix small.
> — @cursedcoder, #1735

## Fix

Memoize the resolved `path_with_namespace` via the existing `CacheService`, keyed by `(organizationId, repository.id)`, 30 minute TTL — matches the convention already used elsewhere in this file (`getUserByEmailOrNameWithRetry`, `resolveMrAuthorFromWebhookPayload`). The slug only changes on a rename or group move, so a short TTL is enough to pick that up without keeping the common case on the network.

A failed lookup is **not** cached — a transient failure falls back to the stored `fullName` for that call only and retries the API on the next clone, instead of pinning a possibly-wrong fallback for the full TTL.

## Tests

3 new cases in `gitlab.service.spec.ts`: cache hit skips `Projects.show` entirely, a cache miss stores the resolved path after the lookup, and a failed lookup does not call `addToCache`. 24/24 pass in the file; `tsc --noEmit` clean for the changed file.