### PR TITLE
test(llm): fix false-positive truncation failure in Fireworks contract test

### DIFF
--- a/libs/llm/fireworks-structured-output.contract.spec.ts
+++ b/libs/llm/fireworks-structured-output.contract.spec.ts
@@ -62,7 +62,11 @@ describeIfKey('Fireworks structured-output support (contract)', () => {
                             'Say the word "hello" and rate your confidence from 0 to 1.',
                     },
                 ],
-                max_tokens: 64,
+                // deepseek-v4-flash is a reasoning model: reasoning tokens
+                // count against max_tokens, so a small budget truncates the
+                // JSON content mid-object (finish_reason: length) and reads
+                // as a false "Fireworks dropped json_schema" drift.
+                max_tokens: 2048,
                 response_format: {
                     type: 'json_schema',
                     json_schema: {
@@ -97,6 +101,14 @@ describeIfKey('Fireworks structured-output support (contract)', () => {
         }
 
         const body = JSON.parse(raw);
+        const finishReason = body?.choices?.[0]?.finish_reason;
+        if (finishReason === 'length') {
+            throw new Error(
+                `Response hit the max_tokens cap before the JSON closed (finish_reason: length) — ` +
+                    'this is token-budget truncation, NOT Fireworks dropping json_schema support. ' +
+                    'Raise max_tokens in this test.',
+            );
+        }
         const content = body?.choices?.[0]?.message?.content;
         if (typeof content !== 'string') {
             throw new Error(


### PR DESCRIPTION
## Why

The scheduled [contract-tests run](https://github.com/kodustech/kodus-ai/actions/runs/32341486477) failed with:

```
Model output was not valid JSON despite a json_schema request: {"word": "hello", "confidence
```

This was **not** real API drift. `deepseek-v4-flash-0731` is a reasoning model — its reasoning tokens count against `max_tokens`, so the test's 64-token budget was exhausted mid-object (`finish_reason: length`), truncating the JSON and masquerading as "Fireworks stopped honoring strict json_schema".

## What

- Raise `max_tokens` from 64 to 2048 so the reasoning budget can't starve the content (single request, negligible cost)
- Fail explicitly when `finish_reason === 'length'`, so budget truncation is never again mistaken for real API drift

## Testing

Ran the contract spec 3x against the live Fireworks API with a real key — 3/3 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)