### PR TITLE
fix(byok): extract task taxonomy into zero-dep leaf so the web prod build resolves

### DIFF
--- a/apps/web/src/features/ee/byok/_components/routing/task-override-grid.tsx
+++ b/apps/web/src/features/ee/byok/_components/routing/task-override-grid.tsx
@@ -19,7 +19,7 @@ import {
     TooltipContent,
     TooltipTrigger,
 } from "@components/ui/tooltip";
-import { TASK_ROUTING_FALLBACK } from "@libs/llm/byok-config";
+import { TASK_ROUTING_FALLBACK } from "@libs/llm/llm-tasks";
 import {
     AlertTriangleIcon,
     ChevronsUpDownIcon,

--- a/apps/web/src/features/ee/byok/_components/tabs/routing-tab.tsx
+++ b/apps/web/src/features/ee/byok/_components/tabs/routing-tab.tsx
@@ -23,7 +23,7 @@ import {
     SlidersHorizontalIcon,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { TASK_ROUTING_FALLBACK } from "@libs/llm/byok-config";
+import { TASK_ROUTING_FALLBACK } from "@libs/llm/llm-tasks";
 
 import { useCatalog } from "../../_data/catalog-context";
 import type { BYOKConfig, BYOKRouting, LlmTask } from "../../_types";

--- a/apps/web/src/features/ee/byok/_types.ts
+++ b/apps/web/src/features/ee/byok/_types.ts
@@ -1,5 +1,3 @@
-export type ReasoningEffort = "none" | "low" | "medium" | "high";
-
 // ─── web mirror ──────────────────────────────────────────────────────────────
 //
 // Web-side mirror of the persisted shape in libs/llm/byok-config.ts, kept
@@ -13,7 +11,10 @@ export type ReasoningEffort = "none" | "low" | "medium" | "high";
  *  so the union has ONE source of truth across front and back (type-only import
  *  → erased at build, no runtime coupling). Imported for local use in this file
  *  AND re-exported so existing `import { LlmTask } from "../../_types"` keep working. */
-import type { LlmTask } from "@libs/llm/byok-config";
+import type { LlmTask } from '@libs/llm/llm-tasks';
+
+export type ReasoningEffort = 'none' | 'low' | 'medium' | 'high';
+
 export type { LlmTask };
 
 /**
@@ -54,7 +55,7 @@ export type BYOKModelConfig = {
 
 /** Routing policy (Manual = static task→model; Auto = the future router). */
 export type BYOKRouting = {
-    mode?: "manual" | "auto";
+    mode?: 'manual' | 'auto';
     /** Model id per task (Manual policy). */
     taskOverrides?: Partial<Record<LlmTask, string>>;
     /** Default model id when a task has no explicit override. */

--- a/docker/Dockerfile.web
+++ b/docker/Dockerfile.web
@@ -39,12 +39,19 @@ RUN --mount=type=cache,target=/pnpm-store,sharing=private \
 #     this subtree is reachable from the web (the enum imports nothing;
 #     role-policies imports only the enum), so we copy just it — the rest of
 #     libs/identity pulls @nestjs/@casl and would break the isolated build.
+#   - libs/llm/llm-tasks.ts — the BYOK routing UI imports the task taxonomy
+#     (LLM_TASK / LlmTask) and the inheritance map (TASK_ROUTING_FALLBACK) from
+#     this zero-dependency leaf, the single source of truth shared with the
+#     backend resolver. It's the ONLY llm file the web reaches (it imports
+#     nothing), so we copy just the file — never the rest of libs/llm, which
+#     pulls the AI SDK / providers / kernel and would break the isolated build.
 #   - release/features-snapshot.json — read at runtime by the lib loader
 # Anything else in the repo (apps/api, libs/code-review, etc.) would just
 # bloat the build context without being touched by Next.
 COPY apps/web ./apps/web
 COPY libs/feature-gate ./libs/feature-gate
 COPY libs/identity/domain/permissions ./libs/identity/domain/permissions
+COPY libs/llm/llm-tasks.ts ./libs/llm/llm-tasks.ts
 COPY release/features-snapshot.json ./release/features-snapshot.json
 
 WORKDIR /usr/src/app/apps/web

--- a/libs/llm/byok-config.ts
+++ b/libs/llm/byok-config.ts
@@ -7,8 +7,15 @@
  * the apiKey kept as ENCRYPTED ciphertext so decryption happens once, downstream.
  * Provider ids are plain strings matching BYOKProvider values.
  */
-import { BYOKProvider } from '@libs/llm/model-providers';
+import type { BYOKProvider } from '@libs/llm/model-providers';
 import type { ReasoningEffort } from './providers/kernel/types';
+// The task taxonomy + inheritance map live in a zero-dependency leaf so the
+// isolated apps/web build can bundle them without pulling in the rest of
+// libs/llm. Re-exported here (unchanged public API) for the backend, which
+// imports them from `@libs/llm/byok-config`.
+import type { LlmTask } from './llm-tasks';
+export { LLM_TASK, TASK_ROUTING_FALLBACK } from './llm-tasks';
+export type { LlmTask } from './llm-tasks';
 
 // ─── Persisted shape ─────────────────────────────────────────────────────────
 
@@ -57,52 +64,6 @@ export interface BYOKModelConfig {
      *  sibling to rpm/tpm. */
     cooldownMs?: number;
 }
-
-/**
- * LLM task taxonomy for routing — the named source of truth for every
- * `resolveTaskSlot`/`resolveTaskModel` call. `as const` keeps the values plain
- * strings (so `routing.taskOverrides` keys, stored configs, and JSON still
- * match), while `LlmTask` is derived from it so the union can never drift from
- * the constant. Reference tasks as `LLM_TASK.codeReview`, not the bare literal.
- */
-export const LLM_TASK = {
-    codeReview: 'codeReview',
-    /** The Kody-Rules review agent (categoryLabel 'kody_rules') — enforcing the
-     *  org's authored rules on a PR. A distinct workload from the defect-finding
-     *  agents (bug/perf/security/generalist) that stay under `codeReview`, so it
-     *  can run on a different (often cheaper) model. Inherits `codeReview` when
-     *  unset (see TASK_ROUTING_FALLBACK). */
-    kodyRulesReview: 'kodyRulesReview',
-    /** Generating/learning Kody Rules (from PR history, feedback, initial scan).
-     *  Generative work, unlike per-PR detection. Inherits `codeReview` when unset. */
-    ruleGeneration: 'ruleGeneration',
-    /** The business-rules validation agent. Inherits `codeReview` when unset. */
-    businessValidation: 'businessValidation',
-    prSummary: 'prSummary',
-    conversation: 'conversation',
-} as const;
-
-export type LlmTask = (typeof LLM_TASK)[keyof typeof LLM_TASK];
-
-/**
- * Task → the task it inherits a routing target from when it has no explicit
- * `taskOverrides[task]`. The resolver applies it between the task's own override
- * and the org default (see StaticTaskStrategy); the routing UI mirrors it to
- * nest inheriting rows under their parent. Lives HERE (a bundle-safe leaf, like
- * LLM_TASK) so the backend resolver and the frontend grid import the SAME map
- * instead of hand-copying it — the inheritance graph has one source of truth.
- *
- * Each addition inherits the task it was carved out of, so an org that never
- * sets the new override keeps exactly today's behavior:
- *  - kodyRulesReview / ruleGeneration were part of the code-review flow → codeReview
- *  - businessValidation ran on the agent (chat) model → conversation
- * A single hop only (no chains).
- */
-export const TASK_ROUTING_FALLBACK: Partial<Record<LlmTask, LlmTask>> = {
-    kodyRulesReview: LLM_TASK.codeReview,
-    ruleGeneration: LLM_TASK.codeReview,
-    businessValidation: LLM_TASK.conversation,
-};
 
 /**
  * Routing policy. Persisted in Phase 2; EXECUTED in Phase 4 (Manual = static

--- a/libs/llm/llm-tasks.ts
+++ b/libs/llm/llm-tasks.ts
@@ -1,0 +1,58 @@
+/**
+ * LLM task taxonomy + the routing-inheritance map — a ZERO-dependency leaf.
+ *
+ * This file intentionally imports nothing. It is the one place the backend
+ * resolver AND the web routing UI both read the task set (`LLM_TASK` / `LlmTask`)
+ * and the inheritance graph (`TASK_ROUTING_FALLBACK`) from, so the two never
+ * drift by hand-copying. `byok-config.ts` re-exports these for the backend; the
+ * web imports them straight from here. Keeping it import-free is what lets the
+ * isolated `apps/web` production build bundle it without dragging the rest of
+ * `libs/llm` (AI SDK, providers, kernel) into the web image — see
+ * `docker/Dockerfile.web`, which copies just this leaf.
+ */
+
+/**
+ * LLM task taxonomy for routing — the named source of truth for every
+ * `resolveTaskSlot`/`resolveTaskModel` call. `as const` keeps the values plain
+ * strings (so `routing.taskOverrides` keys, stored configs, and JSON still
+ * match), while `LlmTask` is derived from it so the union can never drift from
+ * the constant. Reference tasks as `LLM_TASK.codeReview`, not the bare literal.
+ */
+export const LLM_TASK = {
+    codeReview: 'codeReview',
+    /** The Kody-Rules review agent (categoryLabel 'kody_rules') — enforcing the
+     *  org's authored rules on a PR. A distinct workload from the defect-finding
+     *  agents (bug/perf/security/generalist) that stay under `codeReview`, so it
+     *  can run on a different (often cheaper) model. Inherits `codeReview` when
+     *  unset (see TASK_ROUTING_FALLBACK). */
+    kodyRulesReview: 'kodyRulesReview',
+    /** Generating/learning Kody Rules (from PR history, feedback, initial scan).
+     *  Generative work, unlike per-PR detection. Inherits `codeReview` when unset. */
+    ruleGeneration: 'ruleGeneration',
+    /** The business-rules validation agent. Inherits `codeReview` when unset. */
+    businessValidation: 'businessValidation',
+    prSummary: 'prSummary',
+    conversation: 'conversation',
+} as const;
+
+export type LlmTask = (typeof LLM_TASK)[keyof typeof LLM_TASK];
+
+/**
+ * Task → the task it inherits a routing target from when it has no explicit
+ * `taskOverrides[task]`. The resolver applies it between the task's own override
+ * and the org default (see StaticTaskStrategy); the routing UI mirrors it to
+ * nest inheriting rows under their parent. Lives HERE (a bundle-safe leaf, like
+ * LLM_TASK) so the backend resolver and the frontend grid import the SAME map
+ * instead of hand-copying it — the inheritance graph has one source of truth.
+ *
+ * Each addition inherits the task it was carved out of, so an org that never
+ * sets the new override keeps exactly today's behavior:
+ *  - kodyRulesReview / ruleGeneration were part of the code-review flow → codeReview
+ *  - businessValidation ran on the agent (chat) model → conversation
+ * A single hop only (no chains).
+ */
+export const TASK_ROUTING_FALLBACK: Partial<Record<LlmTask, LlmTask>> = {
+    kodyRulesReview: LLM_TASK.codeReview,
+    ruleGeneration: LLM_TASK.codeReview,
+    businessValidation: LLM_TASK.conversation,
+};


### PR DESCRIPTION
## Problem

The QA Deploy image build for #1729 (already on main) failed:

```
Error: Module not found: Can't resolve '@libs/llm/byok-config'
  ./apps/web/src/features/ee/byok/_components/routing/task-override-grid.tsx
  ./apps/web/src/features/ee/byok/_components/tabs/routing-tab.tsx
```

The BYOK routing UI imports the **value** `TASK_ROUTING_FALLBACK` (and the `LlmTask` type) from `@libs/llm/byok-config`. The isolated `apps/web` Docker build (`docker/Dockerfile.web`) copies libs à la carte and never included `libs/llm`, so `next build` can't resolve it. Local dev passes (full repo on disk), which hid the break until the production image build.

## Fix

Move `LLM_TASK` / `LlmTask` / `TASK_ROUTING_FALLBACK` into a new **zero-dependency leaf** `libs/llm/llm-tasks.ts`.

- `byok-config.ts` re-exports them unchanged — all backend importers keep working (107 files reference it).
- The web imports straight from the leaf.
- `Dockerfile.web` copies just that one file — never the rest of `libs/llm` (AI SDK, providers, kernel). This mirrors the existing `libs/identity/domain/permissions` carve-out that avoids pulling `@nestjs`/`@casl` into the isolated build.
- Bonus: `BYOKProvider` in byok-config is now `import type` (it was only used in type position).

## Verification

- Real `docker build -f docker/Dockerfile.web`: **compiles the BYOK pages and produces the full production image** (488MB) — the exact step CI failed on now passes.
- Full backend suite green (6691 passed) via pre-push.

## Out of scope

A dependency bump (AI SDK `ai` 7.0.68 -> 7.0.73, posthog, e2b) was sitting uncommitted in the tree. It's **deliberately excluded** here: `ai@7.0.70` tightened the agentic tool loop (won't auto-execute a tool on an unsafe finish reason / incomplete tool call), which breaks 4 agent-harness e2e tests. That bump needs its own PR alongside the harness mock/e2e alignment.