### PR TITLE
fix(task-context): never stuff issue keys into closed-enum params via anyOf/const

### DIFF
--- a/libs/agents/skills/capabilities/task-context-read.ts
+++ b/libs/agents/skills/capabilities/task-context-read.ts
@@ -193,7 +193,7 @@ export async function fetchTaskContext(
             discovery.cachedTools,
         );
 
-        if (agenticFirst.value) {
+        if (agenticFirst.value && isUsableTaskContext(agenticFirst.value)) {
             return {
                 normalized: agenticFirst.value,
                 raw: agenticFirst.value.description ?? '',
@@ -260,9 +260,19 @@ export async function fetchTaskContext(
         discovery.cachedTools,
     );
 
+    // Last resort: surface whatever the agent produced, but only if it is a
+    // usable task context. Propagating an unusable value (a fetch failure
+    // string, serialized card metadata, blank description) would feed a
+    // bogus context to the downstream analyzer and generate a false
+    // 'Need Task Information' finding — treat it as empty instead.
+    const fallbackValue =
+        agenticFallback.value && isUsableTaskContext(agenticFallback.value)
+            ? agenticFallback.value
+            : undefined;
+
     return {
-        normalized: agenticFallback.value,
-        raw: agenticFallback.value?.description ?? '',
+        normalized: fallbackValue,
+        raw: fallbackValue?.description ?? '',
         traces,
     };
 }

--- a/libs/agents/skills/capabilities/task-context/arg-building.spec.ts
+++ b/libs/agents/skills/capabilities/task-context/arg-building.spec.ts
@@ -271,5 +271,84 @@ describe('buildTaskContextArgsCandidates (characterization)', () => {
                 expect(args.format).toBe('FMT-7');
             }
         });
+
+        it('still excludes issue keys from enum branches when a sibling anyOf is an open string (regression #1760)', () => {
+            // A format param surfaced as `anyOf: [{enum:['markdown','adf']},
+            // {type:'string'}]` has ONE open branch. The guard must not be
+            // disabled for the whole param: the issue key must never leak into
+            // responseContentFormat (the call would be rejected with -32602 and
+            // become a false medium finding).
+            const sig: TaskContextToolSignature = {
+                requiredParams: ['issueIdOrKey'],
+                properties: {
+                    issueIdOrKey: { type: 'string' },
+                    responseContentFormat: {
+                        anyOf: [
+                            { enum: ['markdown', 'adf'] },
+                            { type: 'string' },
+                        ],
+                    },
+                },
+                normalizedProperties: {
+                    issueidorkey: { type: 'string' },
+                    responsecontentformat: {
+                        anyOf: [
+                            { enum: ['markdown', 'adf'] },
+                            { type: 'string' },
+                        ],
+                    },
+                },
+            };
+
+            const out = buildTaskContextArgsCandidates(
+                params(),
+                hints({ issueKeys: ['DEV-5400'] }),
+                sig,
+            );
+
+            expect(out.length).toBeGreaterThan(0);
+            for (const args of out) {
+                expect(args.issueIdOrKey).toBe('DEV-5400');
+                if ('responseContentFormat' in args) {
+                    expect(['markdown', 'adf']).toContain(
+                        args.responseContentFormat,
+                    );
+                }
+            }
+        });
+
+        it('never stuffs the issue key into a closed non-string const/enum param (regression #1760)', () => {
+            // maxDepth: { const: 3 } and maxItems: { enum: [1,5,10] } fix the
+            // param to a non-string set with no parseable string candidate.
+            // Without the guard they'd fall through to free-string handling
+            // and be filled with the issue key (`maxDepth: 'DEV-5400'`), which
+            // the tool rejects. They must be omitted instead.
+            const sig: TaskContextToolSignature = {
+                requiredParams: ['issueIdOrKey'],
+                properties: {
+                    issueIdOrKey: { type: 'string' },
+                    maxDepth: { const: 3 },
+                    maxItems: { enum: [1, 5, 10] },
+                },
+                normalizedProperties: {
+                    issueidorkey: { type: 'string' },
+                    maxdepth: { const: 3 },
+                    maxitems: { enum: [1, 5, 10] },
+                },
+            };
+
+            const out = buildTaskContextArgsCandidates(
+                params(),
+                hints({ issueKeys: ['DEV-5400'] }),
+                sig,
+            );
+
+            expect(out.length).toBeGreaterThan(0);
+            for (const args of out) {
+                expect(args.issueIdOrKey).toBe('DEV-5400');
+                expect('maxDepth' in args).toBe(false);
+                expect('maxItems' in args).toBe(false);
+            }
+        });
     });
 });

--- a/libs/agents/skills/capabilities/task-context/arg-building.spec.ts
+++ b/libs/agents/skills/capabilities/task-context/arg-building.spec.ts
@@ -155,5 +155,84 @@ describe('buildTaskContextArgsCandidates (characterization)', () => {
                 issueIdOrKey: 'CLF-1',
             });
         });
+
+        it('never stuffs the issue key into a closed-enum param exposed via anyOf (#1760)', () => {
+            // Atlassian MCP / Zod expose `responseContentFormat: 'markdown'|'adf'`
+            // as an `anyOf` of `const` branches, NOT a top-level `enum` — the
+            // closed-enum guard used to miss it, so DEV-5400 was written into
+            // responseContentFormat and the tool rejected the call with -32602.
+            const sig: TaskContextToolSignature = {
+                requiredParams: ['cloudId', 'issueIdOrKey'],
+                properties: {
+                    cloudId: { type: 'string' },
+                    issueIdOrKey: { type: 'string' },
+                    responseContentFormat: {
+                        anyOf: [
+                            { const: 'markdown' },
+                            { const: 'adf' },
+                        ],
+                    },
+                },
+                normalizedProperties: {
+                    cloudid: { type: 'string' },
+                    issueidorkey: { type: 'string' },
+                    responsecontentformat: {
+                        anyOf: [
+                            { const: 'markdown' },
+                            { const: 'adf' },
+                        ],
+                    },
+                },
+            };
+
+            const out = buildTaskContextArgsCandidates(
+                params(),
+                hints({
+                    issueKeys: ['DEV-5400'],
+                    siteIds: ['cloud-uuid'],
+                }),
+                sig,
+            );
+
+            // Every candidate must carry the real issue key in the key field,
+            // never in responseContentFormat.
+            expect(out.length).toBeGreaterThan(0);
+            for (const args of out) {
+                expect(args.issueIdOrKey).toBe('DEV-5400');
+                if ('responseContentFormat' in args) {
+                    expect(['markdown', 'adf']).toContain(
+                        args.responseContentFormat,
+                    );
+                }
+            }
+        });
+
+        it('keeps a closed enum via anyOf over a top-level enum empty (#1760)', () => {
+            // A lone `const` param is also a closed value set — must not fall
+            // through to generic string handling.
+            const sig: TaskContextToolSignature = {
+                requiredParams: ['issueKey', 'outputFormat'],
+                properties: {
+                    issueKey: { type: 'string' },
+                    outputFormat: { const: 'markdown' },
+                },
+                normalizedProperties: {
+                    issuekey: { type: 'string' },
+                    outputformat: { const: 'markdown' },
+                },
+            };
+
+            const out = buildTaskContextArgsCandidates(
+                params(),
+                hints({ issueKeys: ['WWW-2'] }),
+                sig,
+            );
+
+            expect(out.length).toBeGreaterThan(0);
+            for (const args of out) {
+                expect(args.issueKey).toBe('WWW-2');
+                expect(args.outputFormat).toBe('markdown');
+            }
+        });
     });
 });

--- a/libs/agents/skills/capabilities/task-context/arg-building.spec.ts
+++ b/libs/agents/skills/capabilities/task-context/arg-building.spec.ts
@@ -234,5 +234,42 @@ describe('buildTaskContextArgsCandidates (characterization)', () => {
                 expect(args.outputFormat).toBe('markdown');
             }
         });
+
+        it('keeps issue keys flowing into a param with const + open string branches', () => {
+            // A union like `anyOf: [{type:'string'}, {const:'default'}]` is an
+            // OPEN text param (free-form text with a suggested default), not a
+            // closed enum. The issue key must still flow through it — treating
+            // it as closed would replace the real value with the const.
+            const sig: TaskContextToolSignature = {
+                requiredParams: ['issueKey', 'format'],
+                properties: {
+                    issueKey: { type: 'string' },
+                    format: {
+                        anyOf: [{ type: 'string' }, { const: 'default' }],
+                    },
+                },
+                normalizedProperties: {
+                    issuekey: { type: 'string' },
+                    format: {
+                        anyOf: [{ type: 'string' }, { const: 'default' }],
+                    },
+                },
+            };
+
+            const out = buildTaskContextArgsCandidates(
+                params(),
+                hints({ issueKeys: ['FMT-7'] }),
+                sig,
+            );
+
+            expect(out.length).toBeGreaterThan(0);
+            for (const args of out) {
+                expect(args.issueKey).toBe('FMT-7');
+                // Open string param: the const must NOT replace the real
+                // value. The issue key flows through because the param is
+                // treated as free-form, not narrowed to the const.
+                expect(args.format).toBe('FMT-7');
+            }
+        });
     });
 });

--- a/libs/agents/skills/capabilities/task-context/arg-building.ts
+++ b/libs/agents/skills/capabilities/task-context/arg-building.ts
@@ -259,6 +259,40 @@ function resolveEnumParamCandidates(
 }
 
 /**
+ * A parameter is only a *closed* enum when every possible value is fixed.
+ * A `const` or an `anyOf`/`oneOf` of `const` branches is closed; but if any
+ * `anyOf`/`oneOf` variant is an open `type: 'string'` (no `const`/`enum`),
+ * the parameter accepts free-form text, so treating it as a closed enum
+ * would replace a legitimate issue-key/query-token value with the const (or
+ * drop it) — the exact class of bug we are guarding against.
+ */
+function hasOpenStringBranch(
+    paramSchema: Record<string, unknown> | undefined,
+): boolean {
+    if (!paramSchema) {
+        return false;
+    }
+
+    return (['anyOf', 'oneOf'] as const).some((key) => {
+        const variants = paramSchema[key];
+        return (
+            Array.isArray(variants) &&
+            variants.some((variant) => {
+                if (!variant || typeof variant !== 'object') {
+                    return false;
+                }
+                const branch = variant as Record<string, unknown>;
+                return (
+                    branch.type === 'string' &&
+                    !('const' in branch) &&
+                    !Array.isArray(branch.enum)
+                );
+            })
+        );
+    });
+}
+
+/**
  * Extract the concrete value set of a closed-enum parameter.
  *
  * Reads a top-level JSON-schema `enum` array AND the two other shapes a
@@ -268,7 +302,12 @@ function resolveEnumParamCandidates(
  *     `enum`), e.g. `'markdown' | 'adf'` surfaced as
  *     `anyOf: [{ const: 'markdown' }, { const: 'adf' }]`.
  *
- * Without this, a param declared via `anyOf`/`oneOf`/`const` evades the
+ * A top-level `enum` is always closed. `const` / `anyOf` / `oneOf` extraction
+ * is skipped when any variant is an open `type: 'string'` — those params take
+ * free-form values and must NOT be treated as closed (their value comes from
+ * the issue-key/query-token pipeline, not a fixed set).
+ *
+ * Without this, a param declared via `const`/`anyOf`/`oneOf` evades the
  * closed-enum guard in `resolveEnumParamCandidates` and gets treated as a
  * generic string, so issue keys / query tokens are stuffed into it and the
  * tool's own validator rejects the call (#1760).
@@ -288,7 +327,7 @@ function extractEnumValues(
         }
     };
 
-    // 1. Top-level `enum: ['a', 'b']`.
+    // 1. Top-level `enum: ['a', 'b']` is always a closed set.
     const rawEnum = paramSchema.enum;
     if (Array.isArray(rawEnum)) {
         for (const value of rawEnum) {
@@ -296,28 +335,33 @@ function extractEnumValues(
         }
     }
 
-    // 2. Lone `const: 'a'`.
-    pushConc(paramSchema.const);
+    // 2. `const` / `anyOf` / `oneOf` are only closed when no branch is an
+    //    open string. An open string branch means the param accepts
+    //    free-form values, so don't narrow it.
+    if (!hasOpenStringBranch(paramSchema)) {
+        // Lone `const: 'a'`.
+        pushConc(paramSchema.const);
 
-    // 3. `anyOf` / `oneOf` branches — each branch may declare `const` or a
-    //    nested `enum`. Recursively walk them.
-    for (const key of ['anyOf', 'oneOf'] as const) {
-        const variants = paramSchema[key];
-        if (!Array.isArray(variants)) {
-            continue;
-        }
-        for (const variant of variants) {
-            if (!variant || typeof variant !== 'object') {
+        // `anyOf` / `oneOf` branches — each branch may declare `const` or a
+        // nested `enum`.
+        for (const key of ['anyOf', 'oneOf'] as const) {
+            const variants = paramSchema[key];
+            if (!Array.isArray(variants)) {
                 continue;
             }
-            const branch = variant as Record<string, unknown>;
-            if ('const' in branch) {
-                pushConc(branch.const);
-                continue;
-            }
-            if (Array.isArray(branch.enum)) {
-                for (const value of branch.enum) {
-                    pushConc(value);
+            for (const variant of variants) {
+                if (!variant || typeof variant !== 'object') {
+                    continue;
+                }
+                const branch = variant as Record<string, unknown>;
+                if ('const' in branch) {
+                    pushConc(branch.const);
+                    continue;
+                }
+                if (Array.isArray(branch.enum)) {
+                    for (const value of branch.enum) {
+                        pushConc(value);
+                    }
                 }
             }
         }

--- a/libs/agents/skills/capabilities/task-context/arg-building.ts
+++ b/libs/agents/skills/capabilities/task-context/arg-building.ts
@@ -258,6 +258,21 @@ function resolveEnumParamCandidates(
     return [];
 }
 
+/**
+ * Extract the concrete value set of a closed-enum parameter.
+ *
+ * Reads a top-level JSON-schema `enum` array AND the two other shapes a
+ * tool's runtime schema (Zod-generated / MCP / Atlassian) commonly emits:
+ *   - a lone `const` (frozen single value),
+ *   - `anyOf` / `oneOf` where each branch is `{ const: 'x' }` (or has its own
+ *     `enum`), e.g. `'markdown' | 'adf'` surfaced as
+ *     `anyOf: [{ const: 'markdown' }, { const: 'adf' }]`.
+ *
+ * Without this, a param declared via `anyOf`/`oneOf`/`const` evades the
+ * closed-enum guard in `resolveEnumParamCandidates` and gets treated as a
+ * generic string, so issue keys / query tokens are stuffed into it and the
+ * tool's own validator rejects the call (#1760).
+ */
 function extractEnumValues(
     paramSchema: Record<string, unknown> | undefined,
 ): string[] {
@@ -265,14 +280,50 @@ function extractEnumValues(
         return [];
     }
 
-    const raw = paramSchema.enum;
-    if (Array.isArray(raw)) {
-        return raw
-            .filter((value): value is string => typeof value === 'string')
-            .map((value) => value);
+    const collected: string[] = [];
+
+    const pushConc = (value: unknown): void => {
+        if (typeof value === 'string') {
+            collected.push(value);
+        }
+    };
+
+    // 1. Top-level `enum: ['a', 'b']`.
+    const rawEnum = paramSchema.enum;
+    if (Array.isArray(rawEnum)) {
+        for (const value of rawEnum) {
+            pushConc(value);
+        }
     }
 
-    return [];
+    // 2. Lone `const: 'a'`.
+    pushConc(paramSchema.const);
+
+    // 3. `anyOf` / `oneOf` branches — each branch may declare `const` or a
+    //    nested `enum`. Recursively walk them.
+    for (const key of ['anyOf', 'oneOf'] as const) {
+        const variants = paramSchema[key];
+        if (!Array.isArray(variants)) {
+            continue;
+        }
+        for (const variant of variants) {
+            if (!variant || typeof variant !== 'object') {
+                continue;
+            }
+            const branch = variant as Record<string, unknown>;
+            if ('const' in branch) {
+                pushConc(branch.const);
+                continue;
+            }
+            if (Array.isArray(branch.enum)) {
+                for (const value of branch.enum) {
+                    pushConc(value);
+                }
+            }
+        }
+    }
+
+    return [...new Set(collected)];
 }
 
 type ParamIntent = 'issue' | 'query' | 'context' | 'url' | 'ari' | 'generic';

--- a/libs/agents/skills/capabilities/task-context/arg-building.ts
+++ b/libs/agents/skills/capabilities/task-context/arg-building.ts
@@ -124,6 +124,16 @@ function getCandidateValuesForParam(
         return enumCandidates;
     }
 
+    // A parameter fixed to a closed non-string value set (e.g. { const: 3 },
+    // { enum: [1,2,3] }, { const: true }) yields no parseable string candidate
+    // from extractEnumValues and would otherwise fall through to free-string
+    // handling here — letting an issue key / query token be stuffed into it
+    // (the -32602 / false-finding class the guard exists to prevent). Treat it
+    // as "don't fill" instead of "free text".
+    if (hasOnlyNonStringClosedConstraint(paramSchema)) {
+        return [];
+    }
+
     if (!supportsStringParam(paramSchema)) {
         return [];
     }
@@ -335,15 +345,78 @@ function extractEnumValues(
         }
     }
 
-    // 2. `const` / `anyOf` / `oneOf` are only closed when no branch is an
-    //    open string. An open string branch means the param accepts
-    //    free-form values, so don't narrow it.
-    if (!hasOpenStringBranch(paramSchema)) {
-        // Lone `const: 'a'`.
-        pushConc(paramSchema.const);
+    const openStringBranch = hasOpenStringBranch(paramSchema);
 
-        // `anyOf` / `oneOf` branches — each branch may declare `const` or a
-        // nested `enum`.
+    // 2. A lone `const: 'a'` is only a closed value set when the param has no
+    //    open string branch; next to an open string it is a suggested default,
+    //    not a restriction, so it must not narrow the free-form param.
+    if (!openStringBranch) {
+        pushConc(paramSchema.const);
+    }
+
+    // 3. `anyOf` / `oneOf` branches — each branch may declare `const` or a
+    //    nested `enum`.
+    for (const key of ['anyOf', 'oneOf'] as const) {
+        const variants = paramSchema[key];
+        if (!Array.isArray(variants)) {
+            continue;
+        }
+        for (const variant of variants) {
+            if (!variant || typeof variant !== 'object') {
+                continue;
+            }
+            const branch = variant as Record<string, unknown>;
+            if ('const' in branch) {
+                // A const branch next to an open string sibling is just a
+                // default suggestion — keep it out of the closed set so the
+                // param stays free-form (e.g. anyOf:[{type:'string'},{const:'default'}]).
+                if (!openStringBranch) {
+                    pushConc(branch.const);
+                }
+                continue;
+            }
+            // An enum branch is ALWAYS a closed set, even when the param also
+            // carries an open string branch. Collecting it keeps the
+            // closed-enum guard active, so an issue key can't leak into a
+            // format param like anyOf:[{enum:['markdown','adf']},{type:'string'}]
+            // (#1760).
+            if (Array.isArray(branch.enum)) {
+                for (const value of branch.enum) {
+                    pushConc(value);
+                }
+            }
+        }
+    }
+
+    return [...new Set(collected)];
+}
+
+/**
+ * Collect every value a schema fixes via `enum` / `const`, regardless of type,
+ * using the same "closed" rules as extractEnumValues but WITHOUT the string
+ * filter. This lets a closed non-string set (e.g. { const: 3 }) be detected
+ * even though it yields no parseable string candidate.
+ */
+function collectClosedSchemaValues(
+    paramSchema: Record<string, unknown> | undefined,
+): unknown[] {
+    if (!paramSchema) {
+        return [];
+    }
+
+    const collected: unknown[] = [];
+
+    const rawEnum = paramSchema.enum;
+    if (Array.isArray(rawEnum)) {
+        for (const value of rawEnum) {
+            collected.push(value);
+        }
+    }
+
+    if (!hasOpenStringBranch(paramSchema)) {
+        if ('const' in paramSchema) {
+            collected.push(paramSchema.const);
+        }
         for (const key of ['anyOf', 'oneOf'] as const) {
             const variants = paramSchema[key];
             if (!Array.isArray(variants)) {
@@ -355,19 +428,36 @@ function extractEnumValues(
                 }
                 const branch = variant as Record<string, unknown>;
                 if ('const' in branch) {
-                    pushConc(branch.const);
+                    collected.push(branch.const);
                     continue;
                 }
                 if (Array.isArray(branch.enum)) {
                     for (const value of branch.enum) {
-                        pushConc(value);
+                        collected.push(value);
                     }
                 }
             }
         }
     }
 
-    return [...new Set(collected)];
+    return collected;
+}
+
+/**
+ * True when the parameter is fixed to a closed `const`/`enum` set whose values
+ * are all non-string (e.g. { const: 3 }, { enum: [1,2,3] }, { const: true }).
+ * Such a parameter must never be treated as a free-form string via
+ * supportsStringParam — stuffing an issue key into it is exactly the -32602
+ * class of bug — so it should yield no candidates instead.
+ */
+function hasOnlyNonStringClosedConstraint(
+    paramSchema: Record<string, unknown> | undefined,
+): boolean {
+    const closedValues = collectClosedSchemaValues(paramSchema);
+    if (!closedValues.length) {
+        return false;
+    }
+    return closedValues.every((value) => typeof value !== 'string');
 }
 
 type ParamIntent = 'issue' | 'query' | 'context' | 'url' | 'ari' | 'generic';

--- a/test/unit/agents/skills/capabilities/task-context-read.spec.ts
+++ b/test/unit/agents/skills/capabilities/task-context-read.spec.ts
@@ -220,6 +220,114 @@ describe('fetchTaskContext capability', () => {
         ).toBe(true);
     });
 
+    it('ignores an unusable agent-first result and falls through to deterministic', async () => {
+        // The agent returned a fetch-failure string as taskContext — the same
+        // class isUsableTaskContext already filters on the deterministic path.
+        // It must not be propagated as resolved context; we fall through to the
+        // deterministic path instead.
+        const callAgent: CallAgentMock = jest.fn().mockResolvedValue({
+            result: JSON.stringify({
+                taskContext: 'Failed to fetch (status 404)',
+                title: 'Agent title',
+                id: 'AG-1',
+                toolsUsed: ['search'],
+            }),
+        });
+
+        const callTool: CallToolMock = jest.fn().mockResolvedValue({
+            result: {
+                data: {
+                    key: 'TASK-1',
+                    fields: {
+                        summary: 'Task title',
+                        description: 'Real deterministic description',
+                    },
+                },
+            },
+        });
+
+        const toolCaller: ToolCaller = {
+            callTool,
+            callAgent,
+            getRegisteredTools: () => [{ name: 'searchTasks' }],
+            getToolsForLLM: () => [
+                {
+                    name: 'searchTasks',
+                    parameters: {
+                        required: ['query'],
+                        properties: { query: { type: 'string' } },
+                    },
+                },
+            ],
+        };
+
+        const hooks = {
+            getSeedTaskContextTools: jest.fn(async () => ['searchTasks']),
+            getCachedTaskContextTools: jest.fn(async () => []),
+            saveCachedTaskContextTools: jest.fn(async () => undefined),
+            resolvePreferredTool: jest.fn(async () => undefined),
+            recordExecution: jest.fn(async () => undefined),
+        };
+
+        const result = await fetchTaskContext(
+            toolCaller,
+            createCapabilityRuntime('jira'),
+            {
+                ...createBaseParams(),
+                taskContextResolutionMode: 'agent_first',
+            },
+            hooks,
+        );
+
+        expect(result.normalized).toMatchObject({
+            id: 'TASK-1',
+            title: 'Task title',
+            description: 'Real deterministic description',
+            sourceProvider: 'jira',
+        });
+        expect(callTool).toHaveBeenCalled();
+        expect(callAgent).toHaveBeenCalled();
+    });
+
+    it('treats an unusable agent fallback result as empty instead of propagating it', async () => {
+        // Last-resort agent fallback also goes through isUsableTaskContext: a
+        // fetch-failure string must not become the surfaced task context.
+        const callAgent: CallAgentMock = jest.fn().mockResolvedValue({
+            result: JSON.stringify({
+                taskContext: 'Failed to fetch (status 404)',
+                title: 'Agent title',
+                id: 'AG-1',
+                toolsUsed: ['search'],
+            }),
+        });
+
+        const toolCaller: ToolCaller = {
+            callTool: jest.fn(),
+            callAgent,
+            getRegisteredTools: () => [{ name: 'searchTasks' }],
+            getToolsForLLM: () => [],
+        };
+
+        const hooks = {
+            getSeedTaskContextTools: jest.fn(async () => []),
+            getCachedTaskContextTools: jest.fn(async () => []),
+            saveCachedTaskContextTools: jest.fn(async () => undefined),
+            resolvePreferredTool: jest.fn(async () => undefined),
+            recordExecution: jest.fn(async () => undefined),
+        };
+
+        const result = await fetchTaskContext(
+            toolCaller,
+            createCapabilityRuntime('notion'),
+            createBaseParams(),
+            hooks,
+        );
+
+        expect(result.normalized).toBeUndefined();
+        expect(result.raw).toBe('');
+        expect(callAgent).toHaveBeenCalled();
+    });
+
     it('explores registered deterministic tools when no seed boundary is available', async () => {
         const callTool: CallToolMock = jest.fn().mockResolvedValue({
             result: {


### PR DESCRIPTION
Fixes #1760

### Problem
On a Bitbucket PR with a Jira key (`DEV-5400`), `getJiraIssue` (Atlassian MCP) was invoked with the issue key written into `responseContentFormat`. The tool rejected it with `-32602` (Invalid enum value. Expected 'markdown' | 'adf'), and that error text was then treated as PARTIAL task context, producing a false medium-severity `business_logic` "Need Task Information" finding — the diff was never compared to the ticket.

Root cause: `arg-building.ts` has a closed-enum guard (`resolveEnumParamCandidates`) whose job is to never stuff issue keys/query tokens into an enum-valued parameter. But `extractEnumValues()` only read a **top-level JSON-schema `enum` array**. The Atlassian MCP / Zod exposes `responseContentFormat: 'markdown'|'adf'` as an **`anyOf` of `const` branches** — so the guard never fired, the param was treated as a generic string, and issue-intent inference (`descriptor.includes('issue')`) wrote `DEV-5400` into it.

### Fix
`extractEnumValues()` now also detects the two other closed-value shapes a tool's runtime schema commonly emits:
- a lone `const`,
- `anyOf` / `oneOf` branches that declare `const` or their own nested `enum` (deduplicated).

With the guard firing, a closed-enum param only ever carries a declared value (or is omitted so the tool default applies) — never an issue key / query token. Applies to the whole class of `responseContentFormat`/`searchResultMode`-style params, not just Atlassian.

### What this PR does
- `libs/agents/skills/capabilities/task-context/arg-building.ts`: broaden `extractEnumValues()` to `const` + `anyOf`/`oneOf`.
- 2 regression tests in `arg-building.spec.ts`: a `getJiraIssue`-shaped signature proves `DEV-5400` lands in `issueIdOrKey` and never in `responseContentFormat`; a `const`-typed required param keeps its declared value.

### How did I verify
- Ran the whole `arg-building` suite: 11 passed (9 existing + 2 new).
- Confirmed the 2 new tests **fail on current main** (`outputFormat` received the issue key `WWW-2` instead of `markdown`) and pass with the fix.
- The pushed clone fails the repo's full pre-push suite for infra reasons (Docker/DB-dependent integration tests in a bare clone), not because of this change — pre-commit passed and the targeted unit suites (task-context: 73/73) are green.