### PR TITLE
fix(code-review): fixing branch validation

### DIFF
--- a/libs/code-review/pipeline/stages/validate-config.stage.spec.ts
+++ b/libs/code-review/pipeline/stages/validate-config.stage.spec.ts
@@ -268,3 +268,105 @@ describe('ValidateConfigStage — v2 routing', () => {
         expect(result.codeReviewConfig.byokConfig).toBeUndefined();
     });
 });
+
+describe('ValidateConfigStage — base branch scope', () => {
+    let stage: ValidateConfigStage;
+
+    const orgAndTeam = { organizationId: 'org-1', teamId: 'team-1' } as any;
+
+    const validate = (
+        configBaseBranches: string[] | undefined,
+        apiBaseBranch: string | undefined,
+        targetBranch: string,
+        sourceBranch = 'feature/x',
+    ) =>
+        stage['_isBranchLogicValid'](
+            sourceBranch,
+            targetBranch,
+            configBaseBranches,
+            apiBaseBranch,
+            'github' as any,
+            orgAndTeam,
+        );
+
+    beforeEach(async () => {
+        const module: TestingModule = await Test.createTestingModule({
+            providers: [
+                ValidateConfigStage,
+                {
+                    provide: AUTOMATION_EXECUTION_SERVICE_TOKEN,
+                    useValue: { findLatestExecutionByFilters: jest.fn() },
+                },
+                {
+                    provide: ORGANIZATION_PARAMETERS_SERVICE_TOKEN,
+                    useValue: { findByKey: jest.fn() },
+                },
+                {
+                    provide: CodeManagementService,
+                    useValue: { createSingleIssueComment: jest.fn() },
+                },
+            ],
+        }).compile();
+
+        stage = module.get<ValidateConfigStage>(ValidateConfigStage);
+    });
+
+    describe('missing config (undefined / not an array)', () => {
+        it('does not block when baseBranches is undefined', () => {
+            expect(validate(undefined, 'main', 'develop').canProceed).toBe(true);
+        });
+
+        it('does not block when baseBranches is corrupt', () => {
+            expect(validate('main' as any, 'main', 'develop').canProceed).toBe(
+                true,
+            );
+        });
+    });
+
+    describe('empty list — scope is the repository default branch', () => {
+        it('reviews a PR targeting the default branch', () => {
+            expect(validate([], 'main', 'main').canProceed).toBe(true);
+        });
+
+        it('skips a PR targeting a non-default branch', () => {
+            const result = validate([], 'main', 'develop');
+
+            expect(result.canProceed).toBe(false);
+            expect(result.details?.message).toContain('develop');
+        });
+
+        it('falls back to reviewing when the default branch is unknown', () => {
+            expect(validate([], undefined, 'develop').canProceed).toBe(true);
+        });
+    });
+
+    describe('non-empty list — scope is the configured patterns', () => {
+        it('reviews a PR targeting a configured branch', () => {
+            expect(validate(['develop'], 'main', 'develop').canProceed).toBe(
+                true,
+            );
+        });
+
+        it('still reviews a PR targeting the default branch', () => {
+            expect(validate(['develop'], 'main', 'main').canProceed).toBe(true);
+        });
+
+        it('skips a PR targeting a branch outside the patterns', () => {
+            expect(validate(['develop'], 'main', 'staging').canProceed).toBe(
+                false,
+            );
+        });
+
+        it('lets an explicit exclusion opt the default branch out', () => {
+            expect(
+                validate(['develop', '!main'], 'main', 'main').canProceed,
+            ).toBe(false);
+        });
+
+        it('matches wildcard patterns', () => {
+            expect(
+                validate(['release/*'], 'main', 'release/2.0').canProceed,
+            ).toBe(true);
+        });
+    });
+});

--- a/libs/code-review/pipeline/stages/validate-config.stage.ts
+++ b/libs/code-review/pipeline/stages/validate-config.stage.ts
@@ -37,7 +37,6 @@ import {
     shouldReviewBranches,
 } from '@libs/code-review/infrastructure/adapters/services/branchReview.service';
 import { isByokConfig, LLM_TASK } from '@libs/llm/byok-config';
-import type { NormalizedModel } from '@libs/llm/byok-config';
 import { resolveTaskSlot } from '@libs/llm/resolve-task-model';
 
 @Injectable()
@@ -596,11 +595,12 @@ export class ValidateConfigStage extends BasePipelineStage<CodeReviewPipelineCon
         platformType: PlatformType,
         organizationAndTeamData: OrganizationAndTeamData,
     ): IStageValidationResult {
-        if (
-            !configBaseBranches ||
-            !Array.isArray(configBaseBranches) ||
-            configBaseBranches.length === 0
-        ) {
+
+        // A missing/corrupt list means we have no scope to enforce, so we let the
+        // review through. An empty list is a real configuration: it narrows the
+        // scope to the repository default branch, which mergeBaseBranches injects
+        // below. Collapsing the two is what made every base branch reviewable.
+        if (!configBaseBranches || !Array.isArray(configBaseBranches)) {
             return { canProceed: true };
         }
 
@@ -643,12 +643,16 @@ export class ValidateConfigStage extends BasePipelineStage<CodeReviewPipelineCon
             return { canProceed: true };
         }
 
+        const reason = configBaseBranches.length
+            ? `Target branch '${targetBranch}' does not match configured patterns: [${expression}]`
+            : `Target branch '${targetBranch}' is not the repository default branch, and no base branches are configured`;
+
         return {
             canProceed: false,
             details: {
                 message: StageMessageHelper.skippedWithReason(
                     PipelineReasons.CONFIG.BRANCH_MISMATCH,
-                    `Target branch '${targetBranch}' does not match configured patterns: [${expression}]`,
+                    reason,
                 ),
                 reasonCode: AutomationMessage.SKIPPED_BY_BASIC_RULES,
             },


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes when automated code reviews run for teams with empty `baseBranches` config—fewer PRs will be reviewed, which is intentional but affects production automation behavior.
> 
> **Overview**
> Fixes automated review **base-branch gating** so an empty `baseBranches` list is enforced instead of being treated like “no config.”
> 
> **Before**, missing, invalid, and **empty** `baseBranches` all short-circuited to allow every PR target branch. **Now**, only missing or non-array config is ignored; an empty array narrows reviews to the repository default branch (via `mergeBaseBranches`), and PRs targeting other bases are skipped with a clearer skip reason.
> 
> Adds a dedicated spec suite for undefined/corrupt config, empty-list default-branch behavior, pattern lists, exclusions (`!main`), and wildcards. Drops an unused `NormalizedModel` import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e941be123ae60d233032b10541cf6eb652992212. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->