### PR TITLE
fix(config): Fixing get config file data from bitbucket repo

### DIFF
--- a/apps/api/src/controllers/parameters.controller.ts
+++ b/apps/api/src/controllers/parameters.controller.ts
@@ -324,6 +324,13 @@ export class ParametersController {
 
     @Get('/code-review-parameter')
     @ApiQuery({ name: 'teamId', type: String, required: true })
+    @ApiQuery({
+        name: 'includeFileOverlay',
+        type: Boolean,
+        required: false,
+        description:
+            "Overlay each repository's kodus-config.yml, read live from the git provider. Defaults to true; pass false for a fast response backed only by stored configuration.",
+    })
     @UseGuards(PolicyGuard)
     @CheckPolicies(
         checkPermissions({
@@ -336,10 +343,14 @@ export class ParametersController {
         description: 'Return code review configuration for the team.',
     })
     @ApiOkResponse({ type: CodeReviewParameterResponseDto })
-    public async getCodeReviewParameter(@Query('teamId') teamId: string) {
+    public async getCodeReviewParameter(
+        @Query('teamId') teamId: string,
+        @Query('includeFileOverlay') includeFileOverlay?: string,
+    ) {
         return await this.getCodeReviewParameterUseCase.execute(
             this.request.user,
             teamId,
+            { includeFileOverlay: includeFileOverlay !== 'false' },
         );
     }
 

--- a/apps/web/src/app/(app)/settings/_components/_layout.tsx
+++ b/apps/web/src/app/(app)/settings/_components/_layout.tsx
@@ -49,6 +49,7 @@ import {
 import { resolveCodeReviewConfigForScope } from "./code-review-config-scope";
 import {
     AutomationCodeReviewConfigProvider,
+    CodeReviewConfigFetchStateProvider,
     CodeReviewModelDataProvider,
     DefaultCodeReviewConfigProvider,
     InitialParametersProvider,
@@ -73,7 +74,11 @@ const routes = [
     // Cross-repo context (#1576): relationships are directional and
     // repo-scoped by design (a global default would link EVERY repo to the
     // same siblings), so the item only renders in repository submenus.
-    { label: "Linked Repositories", href: "linked-repositories", repoOnly: true },
+    {
+        label: "Linked Repositories",
+        href: "linked-repositories",
+        repoOnly: true,
+    },
 ] satisfies Array<{
     label: string;
     href: string;
@@ -97,10 +102,17 @@ type InitialDefaultConfig = CodeReviewGlobalConfig & {
 
 type SettingsLayoutProps = React.PropsWithChildren<{
     initialTeamId: string;
-    initialConfigValue: FormattedGlobalCodeReviewConfig;
-    initialDefaultConfig: InitialDefaultConfig;
-    initialPlatformConfig: InitialPlatformConfig;
-    initialParameters: Partial<Record<string, { uuid: string; configKey: string; configValue: string } | null>>;
+    // Undefined when the server-side fetch was skipped, timed out or failed —
+    // the matching client hook then fetches it instead of the page blanking.
+    initialConfigValue: FormattedGlobalCodeReviewConfig | undefined;
+    initialDefaultConfig: InitialDefaultConfig | undefined;
+    initialPlatformConfig: InitialPlatformConfig | undefined;
+    initialParameters: Partial<
+        Record<
+            string,
+            { uuid: string; configKey: string; configValue: string } | null
+        >
+    >;
     initialModelData: CodeReviewModelData;
 }>;
 
@@ -133,41 +145,57 @@ export const SettingsLayout = ({
     );
     const { data: isMCPAvailable = true } = useMCPAvailability(canReadPlugins);
 
-    const initialShellQueryData = useMemo<{
-        uuid: string;
-        configKey: ParametersConfigKey.CODE_REVIEW_CONFIG;
-        configValue: FormattedGlobalCodeReviewConfig;
-    }>(
-        () => ({
-            uuid: "",
-            configKey: ParametersConfigKey.CODE_REVIEW_CONFIG,
-            configValue: initialConfigValue,
-        }),
+    const initialShellQueryData = useMemo<
+        | {
+              uuid: string;
+              configKey: ParametersConfigKey.CODE_REVIEW_CONFIG;
+              configValue: FormattedGlobalCodeReviewConfig;
+          }
+        | undefined
+    >(
+        () =>
+            initialConfigValue
+                ? {
+                      uuid: "",
+                      configKey: ParametersConfigKey.CODE_REVIEW_CONFIG,
+                      configValue: initialConfigValue,
+                  }
+                : undefined,
         [initialConfigValue],
     );
 
-    const { data: liveShellQuery } = useCodeReviewSettingsShell(
-        effectiveTeamId,
-        {
-            initialData:
-                effectiveTeamId === initialTeamId
-                    ? initialShellQueryData
-                    : undefined,
-        },
-    );
+    const {
+        data: liveShellQuery,
+        isFetching: isShellFetching,
+        isError: isShellError,
+    } = useCodeReviewSettingsShell(effectiveTeamId, {
+        initialData:
+            effectiveTeamId === initialTeamId
+                ? initialShellQueryData
+                : undefined,
+    });
 
     return (
         <CodeReviewModelDataProvider value={initialModelData}>
-            <InitialParametersProvider value={{ initialTeamId, parameters: initialParameters }}>
-                <SettingsLayoutShell
-                    teamId={effectiveTeamId}
-                    configValue={liveShellQuery?.configValue ?? initialConfigValue}
-                    defaultConfig={defaultConfig ?? initialDefaultConfig}
-                    platformConfig={platformConfig ?? initialPlatformConfig}
-                    isMCPAvailable={isMCPAvailable}>
-                    {children}
-                </SettingsLayoutShell>
-            </InitialParametersProvider>
+            <CodeReviewConfigFetchStateProvider
+                value={{
+                    isFetching: isShellFetching,
+                    isError: isShellError,
+                }}>
+                <InitialParametersProvider
+                    value={{ initialTeamId, parameters: initialParameters }}>
+                    <SettingsLayoutShell
+                        teamId={effectiveTeamId}
+                        configValue={
+                            liveShellQuery?.configValue ?? initialConfigValue
+                        }
+                        defaultConfig={defaultConfig ?? initialDefaultConfig}
+                        platformConfig={platformConfig ?? initialPlatformConfig}
+                        isMCPAvailable={isMCPAvailable}>
+                        {children}
+                    </SettingsLayoutShell>
+                </InitialParametersProvider>
+            </CodeReviewConfigFetchStateProvider>
         </CodeReviewModelDataProvider>
     );
 };
@@ -190,10 +218,10 @@ function SettingsLayoutShell({
     const { repositoryId, pageName, directoryId } = useCodeReviewRouteParams();
     const globalConfigOverrideCount = configValue
         ? countConfigOverridesForRoutes(
-            configValue.configs,
-            globalSettingsRoutes.map((r) => r.href),
-            FormattedConfigLevel.GLOBAL,
-        )
+              configValue.configs,
+              globalSettingsRoutes.map((r) => r.href),
+              FormattedConfigLevel.GLOBAL,
+          )
         : 0;
     const globalCustomMessagesOverrideCount = useCustomMessagesOverrideCount({
         scopeRepositoryId: "global",
@@ -259,10 +287,10 @@ function SettingsLayoutShell({
         () =>
             configValue
                 ? resolveCodeReviewConfigForScope(
-                    configValue,
-                    repositoryId,
-                    directoryId,
-                )
+                      configValue,
+                      repositoryId,
+                      directoryId,
+                  )
                 : undefined,
         [configValue, directoryId, repositoryId],
     );
@@ -360,9 +388,9 @@ function SettingsLayoutShell({
                                                         ({ label, href }) => {
                                                             const active =
                                                                 repositoryId ===
-                                                                "global" &&
+                                                                    "global" &&
                                                                 pageName ===
-                                                                href;
+                                                                    href;
 
                                                             return (
                                                                 <SidebarMenuSubItem

--- a/apps/web/src/app/(app)/settings/_components/context.tsx
+++ b/apps/web/src/app/(app)/settings/_components/context.tsx
@@ -171,6 +171,34 @@ export const CodeReviewModelDataProvider = (
     </CodeReviewModelDataContext.Provider>
 );
 
+/**
+ * Fetch state of the client-side code review config query. The
+ * kodus-config.yml overlay is only ever requested there — the server render
+ * deliberately skips it — so the UI needs to tell "the overlay is still on its
+ * way" from "the overlay failed", and neither from stored config.
+ */
+export type CodeReviewConfigFetchState = {
+    isFetching: boolean;
+    isError: boolean;
+};
+
+const CodeReviewConfigFetchStateContext =
+    createContext<CodeReviewConfigFetchState>({
+        isFetching: false,
+        isError: false,
+    });
+
+export const useCodeReviewConfigFetchState = (): CodeReviewConfigFetchState =>
+    useContext(CodeReviewConfigFetchStateContext);
+
+export const CodeReviewConfigFetchStateProvider = (
+    props: React.PropsWithChildren & { value: CodeReviewConfigFetchState },
+) => (
+    <CodeReviewConfigFetchStateContext.Provider value={props.value}>
+        {props.children}
+    </CodeReviewConfigFetchStateContext.Provider>
+);
+
 export { resolveCodeReviewConfigForScope };
 
 /**

--- a/apps/web/src/app/(app)/settings/_components/kodus-config-file-status.tsx
+++ b/apps/web/src/app/(app)/settings/_components/kodus-config-file-status.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import { Badge } from "@components/ui/badge";
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from "@components/ui/tooltip";
+import { CheckIcon, Loader2Icon, TriangleAlertIcon } from "lucide-react";
+import { cn } from "src/core/utils/components";
+
+import { useCodeReviewRouteParams } from "../_hooks";
+import { KodusConfigFileOverlayStatus } from "../code-review/_types";
+import {
+    useCodeReviewConfigFetchState,
+    useFullCodeReviewConfig,
+} from "./context";
+
+export type KodusConfigFileStatusView =
+    | { state: "hidden" }
+    | { state: "loading" }
+    | { state: "loaded" }
+    | { state: "unavailable"; error?: string };
+
+/**
+ * Whether the current scope's `kodus-config.yml` made it into the config on
+ * screen. Reading the file is a live git-provider call, so it can be missing
+ * from an otherwise healthy response — and the settings screen would then show
+ * configuration that differs from what a review actually applies. Anything but
+ * "hidden" means the scope IS governed by a file, so the state has to be shown.
+ */
+export const useKodusConfigFileStatus = (): KodusConfigFileStatusView => {
+    const { repositoryId, directoryId } = useCodeReviewRouteParams();
+    const config = useFullCodeReviewConfig();
+    const { isFetching, isError } = useCodeReviewConfigFetchState();
+
+    // The file lives in the repository, so it never applies to global settings.
+    if (!repositoryId || repositoryId === "global") {
+        return { state: "hidden" };
+    }
+
+    const repository = config?.repositories?.find(
+        (repo) => repo.id === repositoryId,
+    );
+
+    if (!repository) {
+        return { state: "hidden" };
+    }
+
+    const overlay = directoryId
+        ? repository.directories?.find((dir) => dir.id === directoryId)
+              ?.kodusConfigFile
+        : repository.kodusConfigFile;
+
+    // Absent on responses from an API that predates the field; DISABLED means
+    // this scope does not read a file at all. Either way there is nothing to
+    // tell the user.
+    if (!overlay || overlay.status === KodusConfigFileOverlayStatus.DISABLED) {
+        return { state: "hidden" };
+    }
+
+    if (overlay.status === KodusConfigFileOverlayStatus.LOADED) {
+        return { state: "loaded" };
+    }
+
+    if (overlay.status === KodusConfigFileOverlayStatus.UNAVAILABLE) {
+        return { state: "unavailable", error: overlay.error };
+    }
+
+    // SKIPPED: the server render never asked for the overlay, so it is on its
+    // way — unless the client request that carries it already failed.
+    if (isError && !isFetching) {
+        return { state: "unavailable" };
+    }
+
+    return { state: "loading" };
+};
+
+const views = {
+    loading: {
+        label: "Loading kodus-config.yml",
+        description:
+            "Reading kodus-config.yml from your repository. Values defined in the file are not applied to this page yet.",
+        className:
+            "bg-warning/10 text-warning ring-warning/64 [--button-foreground:var(--color-warning)]",
+        icon: <Loader2Icon className="animate-spin" />,
+    },
+    loaded: {
+        label: "kodus-config.yml applied",
+        description:
+            "Some of these settings come from the kodus-config.yml file in your repository, which overrides what is configured here.",
+        className:
+            "bg-success/10 text-success ring-success/64 [--button-foreground:var(--color-success)]",
+        icon: <CheckIcon />,
+    },
+    unavailable: {
+        label: "kodus-config.yml unavailable",
+        description:
+            "This repository is configured to be overridden by kodus-config.yml, but the file could not be read from your git provider. The settings below come from what is stored here and may differ from what a review applies.",
+        className:
+            "bg-danger/10 text-danger ring-danger/64 [--button-foreground:var(--color-danger)]",
+        icon: <TriangleAlertIcon />,
+    },
+} as const;
+
+export const KodusConfigFileStatusBadge = () => {
+    const status = useKodusConfigFileStatus();
+
+    if (status.state === "hidden") {
+        return null;
+    }
+
+    const view = views[status.state];
+
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <Badge
+                    leftIcon={view.icon}
+                    className={cn(
+                        "h-6 min-h-auto rounded-lg px-2 text-[10px] leading-px ring-1",
+                        view.className,
+                    )}>
+                    {view.label}
+                </Badge>
+            </TooltipTrigger>
+
+            <TooltipContent className="max-w-xs">
+                {status.state === "unavailable" && status.error
+                    ? `${view.description} (${status.error})`
+                    : view.description}
+            </TooltipContent>
+        </Tooltip>
+    );
+};

--- a/apps/web/src/app/(app)/settings/_components/kodus-config-file-status.tsx
+++ b/apps/web/src/app/(app)/settings/_components/kodus-config-file-status.tsx
@@ -6,7 +6,12 @@ import {
     TooltipContent,
     TooltipTrigger,
 } from "@components/ui/tooltip";
-import { CheckIcon, Loader2Icon, TriangleAlertIcon } from "lucide-react";
+import {
+    CheckIcon,
+    InfoIcon,
+    Loader2Icon,
+    TriangleAlertIcon,
+} from "lucide-react";
 import { cn } from "src/core/utils/components";
 
 import { useCodeReviewRouteParams } from "../_hooks";
@@ -20,6 +25,7 @@ export type KodusConfigFileStatusView =
     | { state: "hidden" }
     | { state: "loading" }
     | { state: "loaded" }
+    | { state: "notFound" }
     | { state: "unavailable"; error?: string };
 
 /**
@@ -63,6 +69,10 @@ export const useKodusConfigFileStatus = (): KodusConfigFileStatusView => {
         return { state: "loaded" };
     }
 
+    if (overlay.status === KodusConfigFileOverlayStatus.NOT_FOUND) {
+        return { state: "notFound" };
+    }
+
     if (overlay.status === KodusConfigFileOverlayStatus.UNAVAILABLE) {
         return { state: "unavailable", error: overlay.error };
     }
@@ -92,6 +102,14 @@ const views = {
         className:
             "bg-success/10 text-success ring-success/64 [--button-foreground:var(--color-success)]",
         icon: <CheckIcon />,
+    },
+    notFound: {
+        label: "kodus-config.yml not found",
+        description:
+            "This repository is set to be overridden by kodus-config.yml, but no file came back from your git provider. Either the file does not exist, or it exists and could not be read — the settings below come from what is stored here.",
+        className:
+            "bg-alert/10 text-alert ring-alert/64 [--button-foreground:var(--color-alert)]",
+        icon: <InfoIcon />,
     },
     unavailable: {
         label: "kodus-config.yml unavailable",

--- a/apps/web/src/app/(app)/settings/code-review/_components/breadcrumb.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/_components/breadcrumb.tsx
@@ -9,6 +9,7 @@ import {
 import { addSearchParamsToUrl } from "src/core/utils/url";
 
 import { useCodeReviewConfig } from "../../_components/context";
+import { KodusConfigFileStatusBadge } from "../../_components/kodus-config-file-status";
 import { useCodeReviewRouteParams } from "../../_hooks";
 
 export const CodeReviewPagesBreadcrumb = (props: { pageName: string }) => {
@@ -21,20 +22,27 @@ export const CodeReviewPagesBreadcrumb = (props: { pageName: string }) => {
     );
 
     return (
-        <Breadcrumb>
-            <BreadcrumbList>
-                <BreadcrumbItem>
-                    <BreadcrumbLink href={url}>
-                        {config?.displayName}
-                    </BreadcrumbLink>
-                </BreadcrumbItem>
+        // Every code review settings page renders this breadcrumb, so the
+        // kodus-config.yml indicator rides along with it and shows up on all
+        // of them without each page opting in.
+        <div className="flex flex-wrap items-center gap-3">
+            <Breadcrumb>
+                <BreadcrumbList>
+                    <BreadcrumbItem>
+                        <BreadcrumbLink href={url}>
+                            {config?.displayName}
+                        </BreadcrumbLink>
+                    </BreadcrumbItem>
 
-                <BreadcrumbSeparator />
+                    <BreadcrumbSeparator />
 
-                <BreadcrumbItem>
-                    <BreadcrumbPage>{props.pageName}</BreadcrumbPage>
-                </BreadcrumbItem>
-            </BreadcrumbList>
-        </Breadcrumb>
+                    <BreadcrumbItem>
+                        <BreadcrumbPage>{props.pageName}</BreadcrumbPage>
+                    </BreadcrumbItem>
+                </BreadcrumbList>
+            </Breadcrumb>
+
+            <KodusConfigFileStatusBadge />
+        </div>
     );
 };

--- a/apps/web/src/app/(app)/settings/code-review/_types.ts
+++ b/apps/web/src/app/(app)/settings/code-review/_types.ts
@@ -228,6 +228,7 @@ export interface FormattedGlobalCodeReviewConfig extends Omit<
  */
 export enum KodusConfigFileOverlayStatus {
     LOADED = "loaded",
+    NOT_FOUND = "not_found",
     DISABLED = "disabled",
     UNAVAILABLE = "unavailable",
     SKIPPED = "skipped",

--- a/apps/web/src/app/(app)/settings/code-review/_types.ts
+++ b/apps/web/src/app/(app)/settings/code-review/_types.ts
@@ -220,12 +220,31 @@ export interface FormattedGlobalCodeReviewConfig extends Omit<
     repositories: FormattedRepositoryCodeReviewConfig[];
 }
 
+/**
+ * Health of the kodus-config.yml overlay for one scope. The file is read live
+ * from the git provider, so it can be missing from a response whose stored
+ * configuration is perfectly fine — the UI has to say so rather than present
+ * partial configuration as complete.
+ */
+export enum KodusConfigFileOverlayStatus {
+    LOADED = "loaded",
+    DISABLED = "disabled",
+    UNAVAILABLE = "unavailable",
+    SKIPPED = "skipped",
+}
+
+export type KodusConfigFileOverlay = {
+    status: KodusConfigFileOverlayStatus;
+    error?: string;
+};
+
 export type FormattedRepositoryCodeReviewConfig = Omit<
     CodeReviewRepositoryConfig,
     "configs" | "directories"
 > & {
     configs: FormattedCodeReviewConfig;
     directories: FormattedDirectoryCodeReviewConfig[];
+    kodusConfigFile?: KodusConfigFileOverlay;
 };
 
 export type FormattedDirectoryCodeReviewConfig = Omit<
@@ -233,6 +252,7 @@ export type FormattedDirectoryCodeReviewConfig = Omit<
     "configs"
 > & {
     configs: FormattedCodeReviewConfig;
+    kodusConfigFile?: KodusConfigFileOverlay;
 };
 
 export enum BehaviourForNewCommits {

--- a/apps/web/src/app/(app)/settings/layout.tsx
+++ b/apps/web/src/app/(app)/settings/layout.tsx
@@ -23,6 +23,16 @@ export const metadata: Metadata = {
     openGraph: { title: "Code Review Settings" },
 };
 
+/**
+ * Upper bound on every server-side fetch below. This layout blocks the whole
+ * /settings route: an upstream that hangs used to surface as a 500 on the
+ * document itself, with no failing XHR in the browser and no exception in the
+ * API (which was not erroring — it was still waiting). Bounded + guarded, a
+ * slow upstream degrades to a client-side fetch instead of taking the route
+ * down.
+ */
+const SERVER_FETCH_TIMEOUT_MS = 5_000;
+
 function SettingsLoadingSkeleton() {
     return (
         <div className="flex flex-1 flex-row overflow-hidden">
@@ -66,9 +76,20 @@ export default async function Layout({ children }: React.PropsWithChildren) {
         initialLanguageConfig,
         initialByokModels,
     ] = await Promise.all([
-        getFormattedCodeReviewParameterNoCache(initialTeamId),
-        getDefaultCodeReviewParameterNoCache(),
-        getPlatformConfigParameterNoCache(initialTeamId),
+        getFormattedCodeReviewParameterNoCache(initialTeamId, {
+            // The kodus-config.yml overlay is a live git-provider read and can
+            // queue behind the org's background workload. The client refetches
+            // the full config right after hydration and shows the overlay's
+            // status, so the first render never waits on the provider.
+            includeFileOverlay: false,
+            signal: AbortSignal.timeout(SERVER_FETCH_TIMEOUT_MS),
+        }).catch(() => null),
+        getDefaultCodeReviewParameterNoCache({
+            signal: AbortSignal.timeout(SERVER_FETCH_TIMEOUT_MS),
+        }).catch(() => null),
+        getPlatformConfigParameterNoCache(initialTeamId, {
+            signal: AbortSignal.timeout(SERVER_FETCH_TIMEOUT_MS),
+        }).catch(() => null),
         getTeamParametersNoCache<{
             uuid: string;
             configKey: string;
@@ -83,14 +104,9 @@ export default async function Layout({ children }: React.PropsWithChildren) {
             : Promise.resolve([]),
     ]);
 
-    if (
-        !initialShellConfig ||
-        !initialDefaultConfig ||
-        !initialPlatformConfig
-    ) {
-        return null;
-    }
-
+    // Anything missing here is seeded as undefined rather than blanking the
+    // page: the client hooks below fetch it themselves, suspending inside the
+    // boundary instead of rendering an empty shell.
     return (
         <PageBoundary
             loading={<SettingsLoadingSkeleton />}
@@ -98,9 +114,9 @@ export default async function Layout({ children }: React.PropsWithChildren) {
             errorMessage="Failed to load settings. Please try again.">
             <SettingsLayout
                 initialTeamId={initialTeamId}
-                initialConfigValue={initialShellConfig.configValue}
-                initialDefaultConfig={initialDefaultConfig}
-                initialPlatformConfig={initialPlatformConfig}
+                initialConfigValue={initialShellConfig?.configValue}
+                initialDefaultConfig={initialDefaultConfig ?? undefined}
+                initialPlatformConfig={initialPlatformConfig ?? undefined}
                 initialParameters={{
                     [ParametersConfigKey.LANGUAGE_CONFIG]: initialLanguageConfig,
                 }}

--- a/apps/web/src/lib/services/parameters/fetch.ts
+++ b/apps/web/src/lib/services/parameters/fetch.ts
@@ -33,26 +33,43 @@ export const getTeamParametersNoCache = async <
         cache: "no-store",
     });
 
-export const getFormattedCodeReviewParameterNoCache = async (teamId: string) =>
+export const getFormattedCodeReviewParameterNoCache = async (
+    teamId: string,
+    options?: { includeFileOverlay?: boolean; signal?: AbortSignal },
+) =>
     authorizedFetch<{
         uuid: string;
         configKey: string;
         configValue: FormattedGlobalCodeReviewConfig;
     }>(PARAMETERS_PATHS.GET_CODE_REVIEW_PARAMETER, {
-        params: { teamId },
+        params: {
+            teamId,
+            // Omitted unless explicitly disabled: the API defaults to true and
+            // every other caller wants the overlay.
+            ...(options?.includeFileOverlay === false
+                ? { includeFileOverlay: false }
+                : {}),
+        },
         cache: "no-store",
+        signal: options?.signal,
     });
 
-export const getDefaultCodeReviewParameterNoCache = async () =>
+export const getDefaultCodeReviewParameterNoCache = async (options?: {
+    signal?: AbortSignal;
+}) =>
     authorizedFetch<
         CodeReviewGlobalConfig & {
             customMessages: CustomMessageConfig;
         }
     >(PARAMETERS_PATHS.DEFAULT_CODE_REVIEW_PARAMETER, {
         cache: "no-store",
+        signal: options?.signal,
     });
 
-export const getPlatformConfigParameterNoCache = async (teamId: string) =>
+export const getPlatformConfigParameterNoCache = async (
+    teamId: string,
+    options?: { signal?: AbortSignal },
+) =>
     authorizedFetch<{
         uuid: string;
         configKey: ParametersConfigKey.PLATFORM_CONFIGS;
@@ -63,6 +80,7 @@ export const getPlatformConfigParameterNoCache = async (teamId: string) =>
             key: ParametersConfigKey.PLATFORM_CONFIGS,
         },
         cache: "no-store",
+        signal: options?.signal,
     });
 
 export const getParameterByKey = async (key: string, teamId: string) => {

--- a/apps/web/src/lib/services/parameters/hooks.ts
+++ b/apps/web/src/lib/services/parameters/hooks.ts
@@ -124,6 +124,12 @@ export const useCodeReviewSettingsShell = (
         {
             ...config,
             placeholderData: config?.placeholderData ?? ((prev) => prev),
+            // The server seeds this query without the kodus-config.yml overlay
+            // (a live git-provider read that must not block the route). Under
+            // the app's default 60s staleTime that seed would count as fresh
+            // and the overlay would never be requested, so the seed is stale on
+            // arrival and the client fetches the complete config immediately.
+            staleTime: config?.staleTime ?? 0,
         },
     );
 };

--- a/libs/code-review/application/use-cases/configuration/get-code-review-parameter.use-case.ts
+++ b/libs/code-review/application/use-cases/configuration/get-code-review-parameter.use-case.ts
@@ -1,4 +1,5 @@
 import { Inject, Injectable } from '@nestjs/common';
+import pLimit from 'p-limit';
 import { DeepPartial } from 'typeorm';
 
 import { createLogger } from '@libs/core/log/logger';
@@ -59,6 +60,20 @@ export class GetCodeReviewParameterUseCase {
      */
     private static readonly FILE_OVERLAY_TIMEOUT_MS = Number(
         process.env.KODUS_CONFIG_FILE_OVERLAY_TIMEOUT_MS ?? 8_000,
+    );
+
+    /**
+     * How many overlay reads may be in flight against the git provider at once
+     * for a single request. Bitbucket serializes them anyway (one gate slot per
+     * app-password), but GitHub, GitLab and Azure have no such gate, and an
+     * organization with dozens of repositories would otherwise open one
+     * connection per repository at the same instant — the shape that trips
+     * GitHub's secondary rate limits. The cap does not lengthen the request:
+     * every read shares one deadline, so a queue that cannot drain in time
+     * degrades to UNAVAILABLE instead of running longer.
+     */
+    private static readonly PROVIDER_CONCURRENCY = Number(
+        process.env.KODUS_CONFIG_FILE_OVERLAY_CONCURRENCY ?? 4,
     );
 
     constructor(
@@ -243,11 +258,18 @@ export class GetCodeReviewParameterUseCase {
             globalConfigKey,
         );
 
-        // Repositories are formatted concurrently: the provider calls behind
-        // them are serialized upstream by the rate gate anyway, but running
-        // them sequentially here meant one slow repository delayed — and one
-        // failing repository could stall — every repository after it.
+        // Repositories are formatted concurrently — sequentially, one slow
+        // repository delayed every repository after it, which is what made this
+        // endpoint unbounded. The provider reads underneath are throttled by
+        // `providerLimit` and share one `deadlineAt`, so neither the fan-out nor
+        // the total duration grows with the number of repositories.
         const repositories = configValue.repositories || [];
+        const providerLimit = pLimit(
+            GetCodeReviewParameterUseCase.PROVIDER_CONCURRENCY,
+        );
+        const deadlineAt =
+            Date.now() + GetCodeReviewParameterUseCase.FILE_OVERLAY_TIMEOUT_MS;
+
         const settledRepositories = await Promise.allSettled(
             repositories.map((repo) =>
                 this.formatRepository(
@@ -255,6 +277,7 @@ export class GetCodeReviewParameterUseCase {
                     formattedGlobalConfig,
                     repo,
                     includeFileOverlay,
+                    { providerLimit, deadlineAt },
                 ),
             ),
         );
@@ -290,17 +313,23 @@ export class GetCodeReviewParameterUseCase {
 
     /**
      * Formats one repository and its directories. Reading `kodus-config.yml`
-     * means a live call to the git provider, so every such call is bounded by
-     * a single deadline shared across this repository: when the provider is
-     * slow or throttled the repository still renders from stored config, with
-     * `kodusConfigFile.status` telling the caller the overlay is missing.
-     * Dropping the repository instead would hide it from the settings screen.
+     * means a live call to the git provider, so every such call goes through
+     * `overlay.providerLimit` (capping how many repositories hit the provider
+     * at once) and races `overlay.deadlineAt`, which is shared by the whole
+     * request. When the provider is slow or throttled the repository still
+     * renders from stored config, with `kodusConfigFile.status` telling the
+     * caller the overlay is missing — dropping the repository instead would
+     * hide it from the settings screen.
      */
     private async formatRepository(
         organizationAndTeamData: OrganizationAndTeamData,
         formattedGlobalConfig: FormattedCodeReviewConfig,
         repo: CodeReviewRepositoryEntry,
         includeFileOverlay: boolean,
+        overlay: {
+            providerLimit: ReturnType<typeof pLimit>;
+            deadlineAt: number;
+        },
     ): Promise<FormattedRepositoryCodeReviewConfig> {
         const repository = { id: repo.id, name: repo.name };
         const directories = repo.directories || [];
@@ -314,11 +343,23 @@ export class GetCodeReviewParameterUseCase {
             includeFileOverlay &&
             (repoOverride || directories.some(overrideForDirectory));
 
-        // One budget for this repository's provider calls as a whole. Since
-        // repositories run concurrently, the request's worst case is a single
-        // budget rather than one per repository or per directory.
-        const deadlineAt =
-            Date.now() + GetCodeReviewParameterUseCase.FILE_OVERLAY_TIMEOUT_MS;
+        const { deadlineAt } = overlay;
+
+        // Queues the call behind the request's concurrency cap and drops it if
+        // the deadline passed while it waited — a queued call nobody is waiting
+        // for would otherwise burn a slot (and provider budget) for nothing.
+        const callProvider = <T>(fn: () => Promise<T>): Promise<T> =>
+            this.withDeadline(
+                overlay.providerLimit(() => {
+                    if (Date.now() >= deadlineAt) {
+                        throw new Error(
+                            'kodus-config.yml overlay budget exhausted while queued',
+                        );
+                    }
+                    return fn();
+                }),
+                deadlineAt,
+            );
 
         // Resolved once and threaded into every getKodusConfigFile call below.
         // Left to itself, each call re-asks the provider for the same branch —
@@ -329,12 +370,11 @@ export class GetCodeReviewParameterUseCase {
 
         if (wantsFile) {
             try {
-                defaultBranch = await this.withDeadline(
+                defaultBranch = await callProvider(() =>
                     this.codeBaseConfigService.getDefaultBranch(
                         organizationAndTeamData,
                         repository,
                     ),
-                    deadlineAt,
                 );
             } catch (error) {
                 branchError = this.getErrorMessage(error);
@@ -387,17 +427,15 @@ export class GetCodeReviewParameterUseCase {
             }
 
             try {
-                const file =
-                    await this.withDeadline(
-                        this.codeBaseConfigService.getKodusConfigFile({
-                            organizationAndTeamData,
-                            repository,
-                            defaultBranch,
-                            overrideConfig: true,
-                            ...scope,
-                        }),
-                        deadlineAt,
-                    );
+                const file = await callProvider(() =>
+                    this.codeBaseConfigService.getKodusConfigFile({
+                        organizationAndTeamData,
+                        repository,
+                        defaultBranch,
+                        overrideConfig: true,
+                        ...scope,
+                    }),
+                );
 
                 return {
                     file,

--- a/libs/code-review/application/use-cases/configuration/get-code-review-parameter.use-case.ts
+++ b/libs/code-review/application/use-cases/configuration/get-code-review-parameter.use-case.ts
@@ -47,6 +47,21 @@ type CodeReviewRepositoryEntry = NonNullable<
     IParameters<ParametersKey.CODE_REVIEW_CONFIG>['configValue']['repositories']
 >[number];
 
+/**
+ * Reads a positive-number env override, ignoring a value that cannot be used.
+ * `Number('abc')` is NaN and NaN sails straight past a `??` default, so an
+ * operator's typo would not fall back — it would reach `pLimit(NaN)` (throws,
+ * 500ing every settings request) or a NaN deadline (`setTimeout` treats it as
+ * 0, silently marking every overlay unavailable).
+ */
+function positiveNumberFromEnv(
+    raw: string | undefined,
+    fallback: number,
+): number {
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
 @Injectable()
 export class GetCodeReviewParameterUseCase {
     private readonly logger = createLogger(GetCodeReviewParameterUseCase.name);
@@ -58,8 +73,9 @@ export class GetCodeReviewParameterUseCase {
      * read is ~400ms; 8s absorbs a short queue on the shared credential
      * without making the settings screen wait on a backlogged one.
      */
-    private static readonly FILE_OVERLAY_TIMEOUT_MS = Number(
-        process.env.KODUS_CONFIG_FILE_OVERLAY_TIMEOUT_MS ?? 8_000,
+    private static readonly FILE_OVERLAY_TIMEOUT_MS = positiveNumberFromEnv(
+        process.env.KODUS_CONFIG_FILE_OVERLAY_TIMEOUT_MS,
+        8_000,
     );
 
     /**
@@ -72,8 +88,14 @@ export class GetCodeReviewParameterUseCase {
      * every read shares one deadline, so a queue that cannot drain in time
      * degrades to UNAVAILABLE instead of running longer.
      */
-    private static readonly PROVIDER_CONCURRENCY = Number(
-        process.env.KODUS_CONFIG_FILE_OVERLAY_CONCURRENCY ?? 4,
+    private static readonly PROVIDER_CONCURRENCY = Math.max(
+        1,
+        Math.floor(
+            positiveNumberFromEnv(
+                process.env.KODUS_CONFIG_FILE_OVERLAY_CONCURRENCY,
+                4,
+            ),
+        ),
     );
 
     constructor(

--- a/libs/code-review/application/use-cases/configuration/get-code-review-parameter.use-case.ts
+++ b/libs/code-review/application/use-cases/configuration/get-code-review-parameter.use-case.ts
@@ -346,14 +346,15 @@ export class GetCodeReviewParameterUseCase {
         // for would otherwise burn a slot (and provider budget) for nothing.
         const callProvider = <T>(fn: () => Promise<T>): Promise<T> =>
             this.withDeadline(
-                overlay.providerLimit(() => {
-                    if (Date.now() >= deadlineAt) {
-                        throw new Error(
-                            'kodus-config.yml overlay budget exhausted while queued',
-                        );
-                    }
-                    return fn();
-                }),
+                () =>
+                    overlay.providerLimit(() => {
+                        if (Date.now() >= deadlineAt) {
+                            throw new Error(
+                                'kodus-config.yml overlay budget exhausted while queued',
+                            );
+                        }
+                        return fn();
+                    }),
                 deadlineAt,
             );
 
@@ -363,6 +364,7 @@ export class GetCodeReviewParameterUseCase {
         // pressure.
         let defaultBranch: string | undefined;
         let branchError: string | undefined;
+        let branchFailed = false;
 
         if (wantsFile) {
             try {
@@ -373,6 +375,7 @@ export class GetCodeReviewParameterUseCase {
                     ),
                 );
             } catch (error) {
+                branchFailed = true;
                 branchError = this.getErrorMessage(error);
                 this.logger.warn({
                     message:
@@ -413,7 +416,13 @@ export class GetCodeReviewParameterUseCase {
                 };
             }
 
-            if (!defaultBranch) {
+            // Only a thrown resolution stops the read. Some adapters report
+            // failure by returning an empty branch rather than throwing
+            // (Bitbucket's getDefaultBranch catches and returns ''), and
+            // getKodusConfigFile resolves the branch itself when it receives a
+            // falsy one — the read still succeeded that way before this
+            // parallelisation, so it must keep succeeding.
+            if (branchFailed) {
                 return {
                     overlay: {
                         status: KodusConfigFileOverlayStatus.UNAVAILABLE,
@@ -433,9 +442,20 @@ export class GetCodeReviewParameterUseCase {
                     }),
                 );
 
+                // An empty result is NOT_FOUND, never LOADED. getKodusConfigFile
+                // returns undefined both for a repository that simply has no
+                // file and for a provider error an adapter swallowed
+                // (Bitbucket's getRepositoryContentFile catches and returns
+                // null), and the two are indistinguishable from here. Calling
+                // that LOADED would put a green "file applied" badge on a page
+                // whose config may not match what a review runs.
                 return {
                     file,
-                    overlay: { status: KodusConfigFileOverlayStatus.LOADED },
+                    overlay: {
+                        status: file
+                            ? KodusConfigFileOverlayStatus.LOADED
+                            : KodusConfigFileOverlayStatus.NOT_FOUND,
+                    },
                 };
             } catch (error) {
                 this.logger.warn({
@@ -571,11 +591,15 @@ export class GetCodeReviewParameterUseCase {
      * this layer exposes cancellation — but the response stops waiting on it.
      */
     private async withDeadline<T>(
-        promise: Promise<T>,
+        start: () => Promise<T>,
         deadlineAt: number,
     ): Promise<T> {
         const remainingMs = deadlineAt - Date.now();
 
+        // Bails before `start()`, never after. Taking a started promise here
+        // instead would leave it floating on this path — nothing races it, so
+        // its later rejection surfaces as an unhandled rejection even though
+        // the caller already handled the missing overlay.
         if (remainingMs <= 0) {
             throw new Error('kodus-config.yml overlay budget exhausted');
         }
@@ -584,7 +608,7 @@ export class GetCodeReviewParameterUseCase {
 
         try {
             return await Promise.race([
-                promise,
+                start(),
                 new Promise<never>((_, reject) => {
                     timer = setTimeout(
                         () =>

--- a/libs/code-review/application/use-cases/configuration/get-code-review-parameter.use-case.ts
+++ b/libs/code-review/application/use-cases/configuration/get-code-review-parameter.use-case.ts
@@ -27,18 +27,39 @@ import {
     FormattedCodeReviewConfig,
     FormattedConfigLevel,
     FormattedGlobalCodeReviewConfig,
+    FormattedRepositoryCodeReviewConfig,
     IFormattedConfigProperty,
+    KodusConfigFileOverlay,
+    KodusConfigFileOverlayStatus,
 } from '@libs/core/infrastructure/config/types/general/codeReviewConfig.type';
 import {
     buildDefaultGlobalCodeReviewConfig,
     getDefaultKodusConfigFile,
 } from '@libs/common/utils/validateCodeReviewConfigFile';
-import { CodeReviewConfigWithoutLLMProvider } from '@libs/core/infrastructure/config/types/general/codeReview.type';
+import {
+    CodeReviewConfigWithoutLLMProvider,
+    KodusConfigFile,
+} from '@libs/core/infrastructure/config/types/general/codeReview.type';
 import { PromptSourceType } from '@libs/ai-engine/domain/prompt/interfaces/promptExternalReference.interface';
+
+type CodeReviewRepositoryEntry = NonNullable<
+    IParameters<ParametersKey.CODE_REVIEW_CONFIG>['configValue']['repositories']
+>[number];
 
 @Injectable()
 export class GetCodeReviewParameterUseCase {
     private readonly logger = createLogger(GetCodeReviewParameterUseCase.name);
+
+    /**
+     * Upper bound on the provider calls a single repository's
+     * `kodus-config.yml` overlay may spend. Repositories are formatted
+     * concurrently, so this also bounds the endpoint as a whole. A healthy
+     * read is ~400ms; 8s absorbs a short queue on the shared credential
+     * without making the settings screen wait on a backlogged one.
+     */
+    private static readonly FILE_OVERLAY_TIMEOUT_MS = Number(
+        process.env.KODUS_CONFIG_FILE_OVERLAY_TIMEOUT_MS ?? 8_000,
+    );
 
     constructor(
         @Inject(PARAMETERS_SERVICE_TOKEN)
@@ -59,6 +80,15 @@ export class GetCodeReviewParameterUseCase {
         options: {
             skipAuthorization?: boolean;
             organizationId?: string;
+            /**
+             * Overlays each repository's `kodus-config.yml`, read live from the
+             * git provider. Defaults to true so the CLI and centralized-config
+             * callers keep the full merged view. The settings screen turns it
+             * off for its blocking first render — the provider can be slow or
+             * rate-limited, and the screen must not wait on it — then requests
+             * the overlay again from the client.
+             */
+            includeFileOverlay?: boolean;
         } = {},
     ) {
         try {
@@ -105,7 +135,7 @@ export class GetCodeReviewParameterUseCase {
             const parameters = parametersEntity.toObject();
 
             const filteredRepositories = [];
-            for (const repo of parameters.configValue.repositories) {
+            for (const repo of parameters.configValue.repositories || []) {
                 const hasPermission = options.skipAuthorization
                     ? true
                     : await this.authorizationService.check({
@@ -132,6 +162,7 @@ export class GetCodeReviewParameterUseCase {
                 await this.getCodeReviewConfigFormatted(
                     organizationAndTeamData,
                     hasPermissionParameters.configValue,
+                    options.includeFileOverlay ?? true,
                 );
 
             /**
@@ -148,17 +179,24 @@ export class GetCodeReviewParameterUseCase {
             const cutoffMonth = 8; // September (0-indexed)
             const cutoffDay = 11;
 
-            const paramYear =
-                hasPermissionParameters.createdAt.getUTCFullYear();
-            const paramMonth = hasPermissionParameters.createdAt.getUTCMonth();
-            const paramDay = hasPermissionParameters.createdAt.getUTCDate();
+            // A row created by get-or-create above (or an older row that never
+            // stored it) has no createdAt. Treat it as post-cutoff: the toggle
+            // exists only to keep pre-cutoff teams on the legacy engine.
+            const createdAt = hasPermissionParameters.createdAt
+                ? new Date(hasPermissionParameters.createdAt)
+                : null;
+
+            const paramYear = createdAt?.getUTCFullYear();
+            const paramMonth = createdAt?.getUTCMonth();
+            const paramDay = createdAt?.getUTCDate();
 
             const showToggleCodeReviewVersion =
-                paramYear < cutoffYear ||
-                (paramYear === cutoffYear && paramMonth < cutoffMonth) ||
-                (paramYear === cutoffYear &&
-                    paramMonth === cutoffMonth &&
-                    paramDay < cutoffDay);
+                createdAt !== null &&
+                (paramYear < cutoffYear ||
+                    (paramYear === cutoffYear && paramMonth < cutoffMonth) ||
+                    (paramYear === cutoffYear &&
+                        paramMonth === cutoffMonth &&
+                        paramDay < cutoffDay));
 
             return {
                 ...hasPermissionParameters,
@@ -184,6 +222,7 @@ export class GetCodeReviewParameterUseCase {
     private async getCodeReviewConfigFormatted(
         organizationAndTeamData: OrganizationAndTeamData,
         configValue: IParameters<ParametersKey.CODE_REVIEW_CONFIG>['configValue'],
+        includeFileOverlay: boolean,
     ): Promise<FormattedGlobalCodeReviewConfig> {
         const defaultConfig = getDefaultKodusConfigFile();
         const formattedDefaultConfig = this.formatDefaultConfig(defaultConfig);
@@ -204,134 +243,104 @@ export class GetCodeReviewParameterUseCase {
             globalConfigKey,
         );
 
+        // Repositories are formatted concurrently: the provider calls behind
+        // them are serialized upstream by the rate gate anyway, but running
+        // them sequentially here meant one slow repository delayed — and one
+        // failing repository could stall — every repository after it.
+        const repositories = configValue.repositories || [];
+        const settledRepositories = await Promise.allSettled(
+            repositories.map((repo) =>
+                this.formatRepository(
+                    organizationAndTeamData,
+                    formattedGlobalConfig,
+                    repo,
+                    includeFileOverlay,
+                ),
+            ),
+        );
+
         const formattedRepositories = [];
 
-        for (const repo of configValue.repositories || []) {
-            try {
-                const repository = {
-                    id: repo.id,
-                    name: repo.name,
-                };
+        settledRepositories.forEach((result, index) => {
+            if (result.status === 'fulfilled') {
+                formattedRepositories.push(result.value);
+                return;
+            }
 
-                const repoFile =
-                    await this.codeBaseConfigService.getKodusConfigFile({
+            this.logger.warn({
+                message:
+                    'Skipping repository while formatting code review config due to repository-level error',
+                context: GetCodeReviewParameterUseCase.name,
+                error: result.reason,
+                metadata: {
+                    organizationId: organizationAndTeamData.organizationId,
+                    teamId: organizationAndTeamData.teamId,
+                    repositoryId: repositories[index]?.id,
+                    repositoryName: repositories[index]?.name,
+                },
+            });
+        });
+
+        return {
+            ...configValue,
+            configs: formattedGlobalConfig as any, // TODO: remove this 'any' once migration is done
+            repositories: formattedRepositories,
+        };
+    }
+
+    /**
+     * Formats one repository and its directories. Reading `kodus-config.yml`
+     * means a live call to the git provider, so every such call is bounded by
+     * a single deadline shared across this repository: when the provider is
+     * slow or throttled the repository still renders from stored config, with
+     * `kodusConfigFile.status` telling the caller the overlay is missing.
+     * Dropping the repository instead would hide it from the settings screen.
+     */
+    private async formatRepository(
+        organizationAndTeamData: OrganizationAndTeamData,
+        formattedGlobalConfig: FormattedCodeReviewConfig,
+        repo: CodeReviewRepositoryEntry,
+        includeFileOverlay: boolean,
+    ): Promise<FormattedRepositoryCodeReviewConfig> {
+        const repository = { id: repo.id, name: repo.name };
+        const directories = repo.directories || [];
+
+        const repoOverride =
+            repo.configs?.kodusConfigFileOverridesWebPreferences ?? false;
+        const overrideForDirectory = (dir: (typeof directories)[number]) =>
+            dir.configs?.kodusConfigFileOverridesWebPreferences ?? repoOverride;
+
+        const wantsFile =
+            includeFileOverlay &&
+            (repoOverride || directories.some(overrideForDirectory));
+
+        // One budget for this repository's provider calls as a whole. Since
+        // repositories run concurrently, the request's worst case is a single
+        // budget rather than one per repository or per directory.
+        const deadlineAt =
+            Date.now() + GetCodeReviewParameterUseCase.FILE_OVERLAY_TIMEOUT_MS;
+
+        // Resolved once and threaded into every getKodusConfigFile call below.
+        // Left to itself, each call re-asks the provider for the same branch —
+        // one extra round trip per directory, on the credential already under
+        // pressure.
+        let defaultBranch: string | undefined;
+        let branchError: string | undefined;
+
+        if (wantsFile) {
+            try {
+                defaultBranch = await this.withDeadline(
+                    this.codeBaseConfigService.getDefaultBranch(
                         organizationAndTeamData,
                         repository,
-                        overrideConfig:
-                            repo.configs
-                                ?.kodusConfigFileOverridesWebPreferences ??
-                            false,
-                    });
-
-                const formattedRepoConfig = this.formatLevel(
-                    formattedGlobalConfig,
-                    repo.configs,
-                    FormattedConfigLevel.REPOSITORY,
+                    ),
+                    deadlineAt,
                 );
-
-                let formattedRepoFileConfig = this.formatLevel(
-                    formattedRepoConfig,
-                    repoFile,
-                    FormattedConfigLevel.REPOSITORY_FILE,
-                );
-
-                // Buscar e adicionar referências externas do nível repositório
-                const repoConfigKey =
-                    this.promptReferenceManager.buildConfigKey(
-                        organizationAndTeamData,
-                        repo.id,
-                    );
-                formattedRepoFileConfig =
-                    await this.enrichConfigWithExternalReferences(
-                        formattedRepoFileConfig,
-                        repoConfigKey,
-                    );
-
-                const formattedDirectories = [];
-
-                for (const dir of repo.directories || []) {
-                    try {
-                        const isDirectoryGroup =
-                            Array.isArray(dir.folders) &&
-                            dir.folders.length > 0;
-
-                        const directoryFile =
-                            await this.codeBaseConfigService.getKodusConfigFile(
-                                {
-                                    organizationAndTeamData,
-                                    repository,
-                                    ...(isDirectoryGroup
-                                        ? { directoryId: dir.id }
-                                        : {
-                                              directoryPath:
-                                                  (dir as any).path,
-                                          }),
-                                    overrideConfig:
-                                        dir.configs
-                                            ?.kodusConfigFileOverridesWebPreferences ??
-                                        repo.configs
-                                            ?.kodusConfigFileOverridesWebPreferences ??
-                                        false,
-                                },
-                            );
-
-                        const formattedDirConfig = this.formatLevel(
-                            formattedRepoFileConfig,
-                            dir.configs,
-                            FormattedConfigLevel.DIRECTORY,
-                        );
-
-                        let formattedDirFileConfig = this.formatLevel(
-                            formattedDirConfig,
-                            directoryFile,
-                            FormattedConfigLevel.DIRECTORY_FILE,
-                        );
-
-                        // Buscar e adicionar referências externas do nível diretório
-                        const dirConfigKey =
-                            this.promptReferenceManager.buildConfigKey(
-                                organizationAndTeamData,
-                                repo.id,
-                                dir.id,
-                            );
-                        formattedDirFileConfig =
-                            await this.enrichConfigWithExternalReferences(
-                                formattedDirFileConfig,
-                                dirConfigKey,
-                            );
-
-                        formattedDirectories.push({
-                            ...dir,
-                            configs: formattedDirFileConfig,
-                        });
-                    } catch (error) {
-                        this.logger.warn({
-                            message:
-                                'Skipping directory while formatting code review config due to directory-level error',
-                            context: GetCodeReviewParameterUseCase.name,
-                            error,
-                            metadata: {
-                                organizationId:
-                                    organizationAndTeamData.organizationId,
-                                teamId: organizationAndTeamData.teamId,
-                                repositoryId: repo.id,
-                                directoryId: dir.id,
-                                directoryPath: dir.folders?.[0]?.path,
-                            },
-                        });
-                        continue;
-                    }
-                }
-
-                formattedRepositories.push({
-                    ...repo,
-                    configs: formattedRepoFileConfig,
-                    directories: formattedDirectories,
-                });
             } catch (error) {
+                branchError = this.getErrorMessage(error);
                 this.logger.warn({
                     message:
-                        'Skipping repository while formatting code review config due to repository-level error',
+                        'Could not resolve default branch; rendering repository without its kodus-config.yml overlay',
                     context: GetCodeReviewParameterUseCase.name,
                     error,
                     metadata: {
@@ -341,15 +350,226 @@ export class GetCodeReviewParameterUseCase {
                         repositoryName: repo.name,
                     },
                 });
-                continue;
             }
         }
 
-        return {
-            ...configValue,
-            configs: formattedGlobalConfig as any, // TODO: remove this 'any' once migration is done
-            repositories: formattedRepositories,
+        const readKodusConfigFile = async (
+            scope: { directoryPath?: string; directoryId?: string },
+            overrideConfig: boolean,
+            logMetadata: Record<string, unknown>,
+        ): Promise<{
+            file?: KodusConfigFile;
+            overlay: KodusConfigFileOverlay;
+        }> => {
+            // DISABLED is decided from stored config alone, so it is reported
+            // even when the overlay is skipped: the caller needs to tell "this
+            // scope is not governed by a file" from "the file has not been
+            // read yet".
+            if (!overrideConfig) {
+                return {
+                    overlay: { status: KodusConfigFileOverlayStatus.DISABLED },
+                };
+            }
+
+            if (!includeFileOverlay) {
+                return {
+                    overlay: { status: KodusConfigFileOverlayStatus.SKIPPED },
+                };
+            }
+
+            if (!defaultBranch) {
+                return {
+                    overlay: {
+                        status: KodusConfigFileOverlayStatus.UNAVAILABLE,
+                        error: branchError,
+                    },
+                };
+            }
+
+            try {
+                const file =
+                    await this.withDeadline(
+                        this.codeBaseConfigService.getKodusConfigFile({
+                            organizationAndTeamData,
+                            repository,
+                            defaultBranch,
+                            overrideConfig: true,
+                            ...scope,
+                        }),
+                        deadlineAt,
+                    );
+
+                return {
+                    file,
+                    overlay: { status: KodusConfigFileOverlayStatus.LOADED },
+                };
+            } catch (error) {
+                this.logger.warn({
+                    message:
+                        'Could not read kodus-config.yml; rendering stored config without the file overlay',
+                    context: GetCodeReviewParameterUseCase.name,
+                    error,
+                    metadata: {
+                        organizationId: organizationAndTeamData.organizationId,
+                        teamId: organizationAndTeamData.teamId,
+                        repositoryId: repo.id,
+                        repositoryName: repo.name,
+                        ...logMetadata,
+                    },
+                });
+
+                return {
+                    overlay: {
+                        status: KodusConfigFileOverlayStatus.UNAVAILABLE,
+                        error: this.getErrorMessage(error),
+                    },
+                };
+            }
         };
+
+        const repoFileResult = await readKodusConfigFile({}, repoOverride, {});
+
+        const formattedRepoConfig = this.formatLevel(
+            formattedGlobalConfig,
+            repo.configs,
+            FormattedConfigLevel.REPOSITORY,
+        );
+
+        let formattedRepoFileConfig = this.formatLevel(
+            formattedRepoConfig,
+            repoFileResult.file,
+            FormattedConfigLevel.REPOSITORY_FILE,
+        );
+
+        // Buscar e adicionar referências externas do nível repositório
+        const repoConfigKey = this.promptReferenceManager.buildConfigKey(
+            organizationAndTeamData,
+            repo.id,
+        );
+        formattedRepoFileConfig = await this.enrichConfigWithExternalReferences(
+            formattedRepoFileConfig,
+            repoConfigKey,
+        );
+
+        const settledDirectories = await Promise.allSettled(
+            directories.map(async (dir) => {
+                const isDirectoryGroup =
+                    Array.isArray(dir.folders) && dir.folders.length > 0;
+
+                const directoryFileResult = await readKodusConfigFile(
+                    isDirectoryGroup
+                        ? { directoryId: dir.id }
+                        : { directoryPath: (dir as any).path },
+                    overrideForDirectory(dir),
+                    {
+                        directoryId: dir.id,
+                        directoryPath: dir.folders?.[0]?.path,
+                    },
+                );
+
+                const formattedDirConfig = this.formatLevel(
+                    formattedRepoFileConfig,
+                    dir.configs,
+                    FormattedConfigLevel.DIRECTORY,
+                );
+
+                let formattedDirFileConfig = this.formatLevel(
+                    formattedDirConfig,
+                    directoryFileResult.file,
+                    FormattedConfigLevel.DIRECTORY_FILE,
+                );
+
+                // Buscar e adicionar referências externas do nível diretório
+                const dirConfigKey =
+                    this.promptReferenceManager.buildConfigKey(
+                        organizationAndTeamData,
+                        repo.id,
+                        dir.id,
+                    );
+                formattedDirFileConfig =
+                    await this.enrichConfigWithExternalReferences(
+                        formattedDirFileConfig,
+                        dirConfigKey,
+                    );
+
+                return {
+                    ...dir,
+                    configs: formattedDirFileConfig,
+                    kodusConfigFile: directoryFileResult.overlay,
+                };
+            }),
+        );
+
+        const formattedDirectories = [];
+
+        settledDirectories.forEach((result, index) => {
+            if (result.status === 'fulfilled') {
+                formattedDirectories.push(result.value);
+                return;
+            }
+
+            this.logger.warn({
+                message:
+                    'Skipping directory while formatting code review config due to directory-level error',
+                context: GetCodeReviewParameterUseCase.name,
+                error: result.reason,
+                metadata: {
+                    organizationId: organizationAndTeamData.organizationId,
+                    teamId: organizationAndTeamData.teamId,
+                    repositoryId: repo.id,
+                    directoryId: directories[index]?.id,
+                    directoryPath: directories[index]?.folders?.[0]?.path,
+                },
+            });
+        });
+
+        return {
+            ...repo,
+            configs: formattedRepoFileConfig,
+            directories: formattedDirectories,
+            kodusConfigFile: repoFileResult.overlay,
+        };
+    }
+
+    /**
+     * Bounds a provider call by a deadline shared across the caller's scope.
+     * The call itself keeps running once the deadline fires — nothing below
+     * this layer exposes cancellation — but the response stops waiting on it.
+     */
+    private async withDeadline<T>(
+        promise: Promise<T>,
+        deadlineAt: number,
+    ): Promise<T> {
+        const remainingMs = deadlineAt - Date.now();
+
+        if (remainingMs <= 0) {
+            throw new Error('kodus-config.yml overlay budget exhausted');
+        }
+
+        let timer: NodeJS.Timeout;
+
+        try {
+            return await Promise.race([
+                promise,
+                new Promise<never>((_, reject) => {
+                    timer = setTimeout(
+                        () =>
+                            reject(
+                                new Error(
+                                    `kodus-config.yml overlay timed out after ${remainingMs}ms`,
+                                ),
+                            ),
+                        remainingMs,
+                    );
+                }),
+            ]);
+        } finally {
+            clearTimeout(timer);
+        }
+    }
+
+    private getErrorMessage(error: unknown): string {
+        return error instanceof Error ? error.message : String(error);
     }
 
     private formatDefaultConfig(config: object): FormattedCodeReviewConfig {

--- a/libs/code-review/application/use-cases/configuration/get-code-review-parameter.use-case.ts
+++ b/libs/code-review/application/use-cases/configuration/get-code-review-parameter.use-case.ts
@@ -47,36 +47,18 @@ type CodeReviewRepositoryEntry = NonNullable<
     IParameters<ParametersKey.CODE_REVIEW_CONFIG>['configValue']['repositories']
 >[number];
 
-/**
- * Reads a positive-number env override, ignoring a value that cannot be used.
- * `Number('abc')` is NaN and NaN sails straight past a `??` default, so an
- * operator's typo would not fall back — it would reach `pLimit(NaN)` (throws,
- * 500ing every settings request) or a NaN deadline (`setTimeout` treats it as
- * 0, silently marking every overlay unavailable).
- */
-function positiveNumberFromEnv(
-    raw: string | undefined,
-    fallback: number,
-): number {
-    const parsed = Number(raw);
-    return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
-}
-
 @Injectable()
 export class GetCodeReviewParameterUseCase {
     private readonly logger = createLogger(GetCodeReviewParameterUseCase.name);
 
     /**
-     * Upper bound on the provider calls a single repository's
-     * `kodus-config.yml` overlay may spend. Repositories are formatted
-     * concurrently, so this also bounds the endpoint as a whole. A healthy
-     * read is ~400ms; 8s absorbs a short queue on the shared credential
-     * without making the settings screen wait on a backlogged one.
+     * Upper bound on the provider calls one request's `kodus-config.yml`
+     * overlay may spend. Every read shares this budget, so it bounds the
+     * endpoint as a whole. A healthy read is ~400ms; 8s absorbs a short queue
+     * on the shared credential without making the settings screen wait on a
+     * backlogged one.
      */
-    private static readonly FILE_OVERLAY_TIMEOUT_MS = positiveNumberFromEnv(
-        process.env.KODUS_CONFIG_FILE_OVERLAY_TIMEOUT_MS,
-        8_000,
-    );
+    private static readonly FILE_OVERLAY_TIMEOUT_MS = 8_000;
 
     /**
      * How many overlay reads may be in flight against the git provider at once
@@ -88,15 +70,7 @@ export class GetCodeReviewParameterUseCase {
      * every read shares one deadline, so a queue that cannot drain in time
      * degrades to UNAVAILABLE instead of running longer.
      */
-    private static readonly PROVIDER_CONCURRENCY = Math.max(
-        1,
-        Math.floor(
-            positiveNumberFromEnv(
-                process.env.KODUS_CONFIG_FILE_OVERLAY_CONCURRENCY,
-                4,
-            ),
-        ),
-    );
+    private static readonly PROVIDER_CONCURRENCY = 4;
 
     constructor(
         @Inject(PARAMETERS_SERVICE_TOKEN)

--- a/libs/code-review/domain/contracts/CodeBaseConfigService.contract.ts
+++ b/libs/code-review/domain/contracts/CodeBaseConfigService.contract.ts
@@ -42,6 +42,11 @@ export interface ICodeBaseConfigService {
         affectedPath: string,
     ): Promise<string | undefined>;
 
+    getDefaultBranch(
+        organizationAndTeamData: OrganizationAndTeamData,
+        repository: { name: string; id: string },
+    ): Promise<string>;
+
     getKodusConfigFile(params: {
         organizationAndTeamData: OrganizationAndTeamData;
         repository: { id: string; name: string };

--- a/libs/core/infrastructure/config/types/general/codeReviewConfig.type.ts
+++ b/libs/core/infrastructure/config/types/general/codeReviewConfig.type.ts
@@ -113,8 +113,14 @@ export type FormattedGlobalCodeReviewConfig = Omit<
  * config that differs from what a review would use.
  */
 export enum KodusConfigFileOverlayStatus {
-    /** The file was read from the provider (it may legitimately not exist). */
+    /** The file was read from the provider and merged into the config. */
     LOADED = 'loaded',
+    /**
+     * The read completed but came back empty. Either the repository has no
+     * file, or a provider error was swallowed by the adapter — the two are
+     * indistinguishable, so this must not be presented as a successful read.
+     */
+    NOT_FOUND = 'not_found',
     /** Override flag is off for this scope — no file is expected. */
     DISABLED = 'disabled',
     /** Override flag is on, but the provider did not answer in time. */

--- a/libs/core/infrastructure/config/types/general/codeReviewConfig.type.ts
+++ b/libs/core/infrastructure/config/types/general/codeReviewConfig.type.ts
@@ -105,12 +105,36 @@ export type FormattedGlobalCodeReviewConfig = Omit<
     repositories: FormattedRepositoryCodeReviewConfig[];
 };
 
+/**
+ * Health of the `kodus-config.yml` overlay for one scope. Reading the file
+ * means a live call to the git provider, which can be slow or rate-limited
+ * independently of the stored configuration — so the response says whether
+ * the overlay actually made it in, instead of silently returning stored
+ * config that differs from what a review would use.
+ */
+export enum KodusConfigFileOverlayStatus {
+    /** The file was read from the provider (it may legitimately not exist). */
+    LOADED = 'loaded',
+    /** Override flag is off for this scope — no file is expected. */
+    DISABLED = 'disabled',
+    /** Override flag is on, but the provider did not answer in time. */
+    UNAVAILABLE = 'unavailable',
+    /** Caller asked for stored config only; the overlay was not attempted. */
+    SKIPPED = 'skipped',
+}
+
+export type KodusConfigFileOverlay = {
+    status: KodusConfigFileOverlayStatus;
+    error?: string;
+};
+
 export type FormattedRepositoryCodeReviewConfig = Omit<
     RepositoryCodeReviewConfig,
     'configs' | 'directories'
 > & {
     configs: FormattedCodeReviewConfig;
     directories: FormattedDirectoryCodeReviewConfig[];
+    kodusConfigFile: KodusConfigFileOverlay;
 };
 
 export type FormattedDirectoryCodeReviewConfig = Omit<
@@ -118,4 +142,5 @@ export type FormattedDirectoryCodeReviewConfig = Omit<
     'configs'
 > & {
     configs: FormattedCodeReviewConfig;
+    kodusConfigFile: KodusConfigFileOverlay;
 };

--- a/libs/ee/codeBase/codeBaseConfig.service.ts
+++ b/libs/ee/codeBase/codeBaseConfig.service.ts
@@ -697,7 +697,7 @@ export default class CodeBaseConfigService implements ICodeBaseConfigService {
         );
     }
 
-    private async getDefaultBranch(
+    async getDefaultBranch(
         organizationAndTeamData: OrganizationAndTeamData,
         repository: { name: string; id: string },
     ): Promise<string> {

--- a/test/unit/code-review/use-cases/get-code-review-parameter.use-case.spec.ts
+++ b/test/unit/code-review/use-cases/get-code-review-parameter.use-case.spec.ts
@@ -143,6 +143,69 @@ describe('GetCodeReviewParameterUseCase', () => {
         }
     });
 
+    it('reports an empty read as not found rather than loaded', async () => {
+        mockParametersService.findByKey.mockResolvedValue(buildParameters(true));
+        // getKodusConfigFile returns undefined both for a repository with no
+        // file and for a provider error an adapter swallowed.
+        mockCodeBaseConfigService.getKodusConfigFile.mockResolvedValue(
+            undefined,
+        );
+
+        const result = await execute();
+
+        expect(result.configValue.repositories[0].kodusConfigFile.status).toBe(
+            KodusConfigFileOverlayStatus.NOT_FOUND,
+        );
+    });
+
+    it('still reads the file when the adapter reports an empty default branch', async () => {
+        mockParametersService.findByKey.mockResolvedValue(buildParameters(true));
+        // Bitbucket's getDefaultBranch catches and returns '' instead of
+        // throwing; getKodusConfigFile resolves the branch itself in that case.
+        mockCodeBaseConfigService.getDefaultBranch.mockResolvedValue('');
+        mockCodeBaseConfigService.getKodusConfigFile.mockResolvedValue({
+            reviewOptions: { bug: true },
+        });
+
+        const result = await execute();
+
+        expect(result.configValue.repositories[0].kodusConfigFile.status).toBe(
+            KodusConfigFileOverlayStatus.LOADED,
+        );
+        expect(mockCodeBaseConfigService.getKodusConfigFile).toHaveBeenCalled();
+    });
+
+    it('does not leave a floating rejection when the budget is already spent', async () => {
+        const unhandled: unknown[] = [];
+        const onUnhandled = (reason: unknown) => unhandled.push(reason);
+        process.on('unhandledRejection', onUnhandled);
+
+        const useCaseClass = GetCodeReviewParameterUseCase as any;
+        const originalTimeout = useCaseClass.FILE_OVERLAY_TIMEOUT_MS;
+        // A zero budget makes every provider call take the exhausted path, so
+        // the case is deterministic instead of a race against the real 8s.
+        useCaseClass.FILE_OVERLAY_TIMEOUT_MS = 0;
+
+        mockParametersService.findByKey.mockResolvedValue(buildParameters(true));
+
+        try {
+            const result = await execute();
+            // Node reports unhandled rejections a macrotask later.
+            await new Promise((resolve) => setTimeout(resolve, 10));
+
+            expect(result.configValue.repositories[0].kodusConfigFile.status).toBe(
+                KodusConfigFileOverlayStatus.UNAVAILABLE,
+            );
+            // Queueing the call and only then bailing would leave its promise
+            // with nothing racing it, so its rejection escapes the caller that
+            // already handled the missing overlay.
+            expect(unhandled).toEqual([]);
+        } finally {
+            useCaseClass.FILE_OVERLAY_TIMEOUT_MS = originalTimeout;
+            process.off('unhandledRejection', onUnhandled);
+        }
+    });
+
     it('marks every scope as unavailable when the default branch cannot be resolved', async () => {
         mockParametersService.findByKey.mockResolvedValue(buildParameters(true));
         mockCodeBaseConfigService.getDefaultBranch.mockRejectedValue(

--- a/test/unit/code-review/use-cases/get-code-review-parameter.use-case.spec.ts
+++ b/test/unit/code-review/use-cases/get-code-review-parameter.use-case.spec.ts
@@ -4,6 +4,7 @@ import { PARAMETERS_SERVICE_TOKEN } from '@libs/organization/domain/parameters/c
 import { CODE_BASE_CONFIG_SERVICE_TOKEN } from '@libs/code-review/domain/contracts/CodeBaseConfigService.contract';
 import { AuthorizationService } from '@libs/identity/infrastructure/adapters/services/permissions/authorization.service';
 import { PROMPT_EXTERNAL_REFERENCE_MANAGER_SERVICE_TOKEN } from '@libs/ai-engine/domain/prompt/contracts/promptExternalReferenceManager.contract';
+import { KodusConfigFileOverlayStatus } from '@libs/core/infrastructure/config/types/general/codeReviewConfig.type';
 
 describe('GetCodeReviewParameterUseCase', () => {
     let useCase: GetCodeReviewParameterUseCase;
@@ -12,6 +13,36 @@ describe('GetCodeReviewParameterUseCase', () => {
     let mockAuthorizationService: any;
     let mockPromptReferenceManager: any;
 
+    const buildParameters = (overridesWebPreferences: boolean) => ({
+        toObject: () => ({
+            createdAt: new Date('2025-09-10T00:00:00.000Z'),
+            configValue: {
+                configs: {},
+                repositories: [
+                    {
+                        id: 'repo-1',
+                        name: 'repo-1',
+                        configs: {
+                            kodusConfigFileOverridesWebPreferences:
+                                overridesWebPreferences,
+                        },
+                        directories: [
+                            { id: 'dir-broken', path: 'broken/path', configs: {} },
+                            { id: 'dir-ok', path: 'ok/path', configs: {} },
+                        ],
+                    },
+                ],
+            },
+        }),
+    });
+
+    const execute = (options?: { includeFileOverlay?: boolean }) =>
+        useCase.execute(
+            { organization: { uuid: 'org-1' } } as any,
+            'team-1',
+            options,
+        );
+
     beforeEach(async () => {
         mockParametersService = {
             findByKey: jest.fn(),
@@ -19,6 +50,7 @@ describe('GetCodeReviewParameterUseCase', () => {
 
         mockCodeBaseConfigService = {
             getKodusConfigFile: jest.fn(),
+            getDefaultBranch: jest.fn().mockResolvedValue('main'),
         };
 
         mockAuthorizationService = {
@@ -58,35 +90,8 @@ describe('GetCodeReviewParameterUseCase', () => {
         );
     });
 
-    it('should keep repository and skip only failing directory', async () => {
-        mockParametersService.findByKey.mockResolvedValue({
-            toObject: () => ({
-                createdAt: new Date('2025-09-10T00:00:00.000Z'),
-                configValue: {
-                    configs: {},
-                    repositories: [
-                        {
-                            id: 'repo-1',
-                            name: 'repo-1',
-                            configs: {},
-                            directories: [
-                                {
-                                    id: 'dir-broken',
-                                    path: 'broken/path',
-                                    configs: {},
-                                },
-                                {
-                                    id: 'dir-ok',
-                                    path: 'ok/path',
-                                    configs: {},
-                                },
-                            ],
-                        },
-                    ],
-                },
-            }),
-        });
-
+    it('keeps a directory whose config file cannot be read, flagged as unavailable', async () => {
+        mockParametersService.findByKey.mockResolvedValue(buildParameters(true));
         mockCodeBaseConfigService.getKodusConfigFile.mockImplementation(
             async ({ directoryPath }: { directoryPath?: string }) => {
                 if (directoryPath === 'broken/path') {
@@ -96,16 +101,100 @@ describe('GetCodeReviewParameterUseCase', () => {
             },
         );
 
-        const result = await useCase.execute(
-            { organization: { uuid: 'org-1' } } as any,
-            'team-1',
+        const result = await execute();
+
+        const [repository] = result.configValue.repositories;
+        expect(result.configValue.repositories).toHaveLength(1);
+        expect(repository.kodusConfigFile.status).toBe(
+            KodusConfigFileOverlayStatus.LOADED,
         );
 
-        expect(result.configValue.repositories).toHaveLength(1);
-        expect(result.configValue.repositories[0].id).toBe('repo-1');
-        expect(result.configValue.repositories[0].directories).toHaveLength(1);
-        expect(result.configValue.repositories[0].directories[0].id).toBe(
-            'dir-ok',
+        // Dropping the directory would hide it from the settings screen; it
+        // renders from stored config with the overlay flagged as missing.
+        expect(repository.directories).toHaveLength(2);
+        expect(
+            repository.directories.find((dir) => dir.id === 'dir-broken')
+                .kodusConfigFile,
+        ).toEqual({
+            status: KodusConfigFileOverlayStatus.UNAVAILABLE,
+            error: 'directory config failed',
+        });
+        expect(
+            repository.directories.find((dir) => dir.id === 'dir-ok')
+                .kodusConfigFile.status,
+        ).toBe(KodusConfigFileOverlayStatus.LOADED);
+    });
+
+    it('resolves the default branch once per repository and reuses it', async () => {
+        mockParametersService.findByKey.mockResolvedValue(buildParameters(true));
+        mockCodeBaseConfigService.getKodusConfigFile.mockResolvedValue({});
+
+        await execute();
+
+        expect(mockCodeBaseConfigService.getDefaultBranch).toHaveBeenCalledTimes(
+            1,
         );
+        expect(
+            mockCodeBaseConfigService.getKodusConfigFile.mock.calls,
+        ).toHaveLength(3);
+        for (const [params] of mockCodeBaseConfigService.getKodusConfigFile.mock
+            .calls) {
+            expect(params.defaultBranch).toBe('main');
+        }
+    });
+
+    it('marks every scope as unavailable when the default branch cannot be resolved', async () => {
+        mockParametersService.findByKey.mockResolvedValue(buildParameters(true));
+        mockCodeBaseConfigService.getDefaultBranch.mockRejectedValue(
+            new Error('provider unreachable'),
+        );
+
+        const result = await execute();
+
+        const [repository] = result.configValue.repositories;
+        expect(repository.kodusConfigFile).toEqual({
+            status: KodusConfigFileOverlayStatus.UNAVAILABLE,
+            error: 'provider unreachable',
+        });
+        expect(repository.directories).toHaveLength(2);
+        expect(
+            mockCodeBaseConfigService.getKodusConfigFile,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('does not touch the provider when the override flag is off', async () => {
+        mockParametersService.findByKey.mockResolvedValue(
+            buildParameters(false),
+        );
+
+        const result = await execute();
+
+        const [repository] = result.configValue.repositories;
+        expect(repository.kodusConfigFile.status).toBe(
+            KodusConfigFileOverlayStatus.DISABLED,
+        );
+        expect(
+            mockCodeBaseConfigService.getDefaultBranch,
+        ).not.toHaveBeenCalled();
+        expect(
+            mockCodeBaseConfigService.getKodusConfigFile,
+        ).not.toHaveBeenCalled();
+    });
+
+    it('skips the overlay entirely when the caller opts out', async () => {
+        mockParametersService.findByKey.mockResolvedValue(buildParameters(true));
+
+        const result = await execute({ includeFileOverlay: false });
+
+        const [repository] = result.configValue.repositories;
+        expect(repository.kodusConfigFile.status).toBe(
+            KodusConfigFileOverlayStatus.SKIPPED,
+        );
+        expect(
+            mockCodeBaseConfigService.getDefaultBranch,
+        ).not.toHaveBeenCalled();
+        expect(
+            mockCodeBaseConfigService.getKodusConfigFile,
+        ).not.toHaveBeenCalled();
     });
 });

--- a/test/unit/code-review/use-cases/get-code-review-parameter.use-case.spec.ts
+++ b/test/unit/code-review/use-cases/get-code-review-parameter.use-case.spec.ts
@@ -162,6 +162,51 @@ describe('GetCodeReviewParameterUseCase', () => {
         ).not.toHaveBeenCalled();
     });
 
+    it('caps how many provider reads run at once', async () => {
+        const repositories = Array.from({ length: 10 }, (_, index) => ({
+            id: `repo-${index}`,
+            name: `repo-${index}`,
+            configs: { kodusConfigFileOverridesWebPreferences: true },
+            directories: [],
+        }));
+
+        mockParametersService.findByKey.mockResolvedValue({
+            toObject: () => ({
+                createdAt: new Date('2025-09-10T00:00:00.000Z'),
+                configValue: { configs: {}, repositories },
+            }),
+        });
+
+        let inFlight = 0;
+        let peakInFlight = 0;
+        const trackConcurrency = async () => {
+            inFlight += 1;
+            peakInFlight = Math.max(peakInFlight, inFlight);
+            await new Promise((resolve) => setTimeout(resolve, 5));
+            inFlight -= 1;
+        };
+
+        mockCodeBaseConfigService.getDefaultBranch.mockImplementation(
+            async () => {
+                await trackConcurrency();
+                return 'main';
+            },
+        );
+        mockCodeBaseConfigService.getKodusConfigFile.mockImplementation(
+            async () => {
+                await trackConcurrency();
+                return {};
+            },
+        );
+
+        const result = await execute();
+
+        expect(result.configValue.repositories).toHaveLength(10);
+        // Providers without a rate gate (GitHub, GitLab, Azure) would otherwise
+        // see one connection per repository open at the same instant.
+        expect(peakInFlight).toBeLessThanOrEqual(4);
+    });
+
     it('does not touch the provider when the override flag is off', async () => {
         mockParametersService.findByKey.mockResolvedValue(
             buildParameters(false),


### PR DESCRIPTION
Closes #1791 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how code review config is merged and returned from a heavily used API and settings route; behavior shifts from failing or hanging on provider slowness to partial overlays with explicit status, which callers must interpret correctly.
> 
> **Overview**
> Makes **live `kodus-config.yml` reads** from git providers optional, bounded, and visible in the UI so code review settings stay fast and honest when Bitbucket or other providers are slow.
> 
> The **`GET /code-review-parameter`** endpoint gains **`includeFileOverlay`** (default **true**; **`false`** returns stored config only). The use case formats repositories **in parallel**, caps provider calls at **4** concurrent reads with a shared **8s** deadline, resolves **default branch once per repo**, and attaches **`kodusConfigFile`** status per repo/directory (**loaded**, **disabled**, **unavailable**, **skipped**) instead of dropping scopes when a file read fails.
> 
> **Settings** no longer blocks SSR on overlay reads: server fetches use **`includeFileOverlay: false`** plus **5s** abort timeouts and tolerate partial failure; the client refetches the full config immediately (**`staleTime: 0`**) and shows a **breadcrumb badge** for loading, applied, or unavailable overlay state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fca5978d7fd8d5524a08cfb439318b5b26e40515. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->