### PR TITLE
fix(token-usage): Fix token saving when an error occurs

### DIFF
--- a/libs/core/log/observability.service.spec.ts
+++ b/libs/core/log/observability.service.spec.ts
@@ -74,3 +74,92 @@ describe('ObservabilityService Mongo exporter toggle', () => {
         expect(cfg.mongodb).toBeDefined();
     });
 });
+
+/**
+ * A structured call billed by the provider but rejected by the output parse
+ * (AI_NoObjectGeneratedError) used to leave the span with `error: true` and no
+ * `gen_ai.usage.*` at all — the spend appeared in Langfuse and never in the
+ * Mongo cost dataset.
+ */
+describe('ObservabilityService.runAiSdkLLMInSpan', () => {
+    function buildService() {
+        const service = new ObservabilityService({ get: jest.fn() } as any);
+        const span = { setAttributes: jest.fn() };
+        (service as any).getObsInstance = () => ({
+            startSpan: () => span,
+            withSpan: (_span: any, fn: () => any) => fn(),
+            getContext: () => ({ correlationId: 'corr_test' }),
+        });
+        // Attributes the span carries from the start (org/team/type) are applied
+        // by runInSpan; only the usage projection is under test here.
+        const usageAttrs = () =>
+            span.setAttributes.mock.calls
+                .map(([attrs]) => attrs)
+                .filter((attrs) => 'gen_ai.usage.total_tokens' in attrs);
+        return { service, span, usageAttrs };
+    }
+
+    const usage = {
+        inputTokens: 766,
+        outputTokens: 2503,
+        totalTokens: 3269,
+    };
+
+    it('records usage on success', async () => {
+        const { service, usageAttrs } = buildService();
+
+        await service.runAiSdkLLMInSpan({
+            spanName: 'code-review-generalist-recovery',
+            model: 'accounts/fireworks/models/deepseek-v4-flash-0731',
+            attrs: { organizationId: 'org-1', type: 'system' },
+            exec: async () => ({ usage }),
+        });
+
+        expect(usageAttrs()).toHaveLength(1);
+        expect(usageAttrs()[0]['gen_ai.usage.total_tokens']).toBe(3269);
+        // The success span must stay exactly what it was before the error path
+        // existed — `finishReason` is stamped only from a failed call.
+        expect(usageAttrs()[0]).not.toHaveProperty('finishReason');
+    });
+
+    it('records the billed usage when the call throws after the provider answered', async () => {
+        const { service, usageAttrs } = buildService();
+        const err = Object.assign(
+            new Error('No object generated: response did not match schema.'),
+            { name: 'AI_NoObjectGeneratedError', finishReason: 'stop', usage },
+        );
+
+        await expect(
+            service.runAiSdkLLMInSpan({
+                spanName: 'code-review-generalist-recovery',
+                model: 'accounts/fireworks/models/deepseek-v4-flash-0731',
+                attrs: { organizationId: 'org-1', type: 'system' },
+                exec: async () => {
+                    throw err;
+                },
+            }),
+        ).rejects.toBe(err);
+
+        const [attrs] = usageAttrs();
+        expect(attrs['gen_ai.usage.total_tokens']).toBe(3269);
+        expect(attrs.finishReason).toBe('stop');
+        // tu is what the billing aggregation reads — an error span still has to
+        // carry it, else the tokens stay invisible to the cost pipeline.
+        expect(attrs.tu).toMatchObject({ total: 3269 });
+    });
+
+    it('writes no cost span when the call failed before any generation', async () => {
+        const { service, usageAttrs } = buildService();
+
+        await expect(
+            service.runAiSdkLLMInSpan({
+                spanName: 'code-review-generalist',
+                exec: async () => {
+                    throw new Error('fetch failed');
+                },
+            }),
+        ).rejects.toThrow('fetch failed');
+
+        expect(usageAttrs()).toHaveLength(0);
+    });
+});

--- a/libs/core/log/observability.service.ts
+++ b/libs/core/log/observability.service.ts
@@ -12,7 +12,11 @@ import { DatabaseConnection } from '@libs/core/infrastructure/config/types';
 import { createLogger } from '@libs/core/log/logger';
 import { deriveTu } from './token-usage-tu';
 import { setLlmObservability } from '@libs/llm/llm-observability';
-import { readAiSdkUsage } from '@libs/llm/ai-sdk-usage';
+import {
+    readAiSdkUsage,
+    readAiSdkUsageFromError,
+    type AiSdkUsage,
+} from '@libs/llm/ai-sdk-usage';
 
 export type TokenUsage = {
     input_tokens?: number;
@@ -426,34 +430,52 @@ export class ObservabilityService implements OnModuleInit {
         // Measure the call duration here (parity with the old recordAgentRunUsage
         // durationMs, which the agent loop used to record by hand).
         const startedAt = Date.now();
+        const usageAttrs = (usage: AiSdkUsage, finishReason?: string) =>
+            buildUsageSpanAttributes({
+                runName: params.runName,
+                model: params.model,
+                byokModelId: params.byokModelId,
+                credentialId: params.credentialId,
+                route: params.route,
+                usedFallback: params.usedFallback,
+                agentName: (a.agentName as string) ?? spanAgent,
+                phase: (a.phase as string) ?? spanPhase,
+                type: a.type as string | undefined,
+                organizationId: a.organizationId as string | undefined,
+                teamId: a.teamId as string | undefined,
+                prNumber: a.prNumber as number | undefined,
+                source: a.source as string | undefined,
+                durationMs: Date.now() - startedAt,
+                finishReason,
+                usage,
+            });
         return this.runInSpan(
             params.spanName,
             async (span) => {
-                const result = await params.exec();
-                const usage = result?.usage;
-                span?.setAttributes?.(
-                    buildUsageSpanAttributes({
-                        runName: params.runName,
-                        model: params.model,
-                        byokModelId: params.byokModelId,
-                        credentialId: params.credentialId,
-                        route: params.route,
-                        usedFallback: params.usedFallback,
-                        agentName: (a.agentName as string) ?? spanAgent,
-                        phase: (a.phase as string) ?? spanPhase,
-                        type: a.type as string | undefined,
-                        organizationId: a.organizationId as string | undefined,
-                        teamId: a.teamId as string | undefined,
-                        prNumber: a.prNumber as number | undefined,
-                        source: a.source as string | undefined,
-                        durationMs: Date.now() - startedAt,
+                try {
+                    const result = await params.exec();
+                    span?.setAttributes?.(
                         // Single shared reader — same mapping the agent harness
                         // uses, so cache-read/write + reasoning can't be captured
                         // in one path and dropped in the other.
-                        usage: readAiSdkUsage(usage),
-                    }),
-                );
-                return result;
+                        usageAttrs(readAiSdkUsage(result?.usage)),
+                    );
+                    return result;
+                } catch (err) {
+                    // A call that died AFTER the provider answered (structured
+                    // output parse / schema mismatch) was still billed, and the
+                    // SDK hands its usage back on the error. Record it before
+                    // rethrowing, else the span lands in Mongo with the error
+                    // flag and zero tokens while Langfuse shows the real spend.
+                    // runInSpan's own catch still stamps `error`/`exception.*`.
+                    const failed = readAiSdkUsageFromError(err);
+                    if (failed) {
+                        span?.setAttributes?.(
+                            usageAttrs(failed.usage, failed.finishReason),
+                        );
+                    }
+                    throw err;
+                }
             },
             params.attrs,
         );

--- a/libs/llm/ai-sdk-usage.spec.ts
+++ b/libs/llm/ai-sdk-usage.spec.ts
@@ -1,4 +1,4 @@
-import { readAiSdkUsage } from './ai-sdk-usage';
+import { readAiSdkUsage, readAiSdkUsageFromError } from './ai-sdk-usage';
 
 /**
  * The single AI SDK usage reader (shared by the agent harness and
@@ -149,5 +149,73 @@ describe('readAiSdkUsage', () => {
             reasoningTokens: undefined,
         });
         expect(readAiSdkUsage(null)).toEqual(readAiSdkUsage(undefined));
+    });
+});
+
+/**
+ * A structured call that dies in the output parse (AI_NoObjectGeneratedError)
+ * was answered — and billed — by the provider. Before this reader the wrapper
+ * span recorded the error and zero tokens, so the spend showed up in Langfuse
+ * and never in `observability_telemetry` (the `structuredRecovery` leak).
+ */
+describe('readAiSdkUsageFromError', () => {
+    const noObjectGenerated = (usage: unknown) =>
+        Object.assign(
+            new Error('No object generated: response did not match schema.'),
+            {
+                name: 'AI_NoObjectGeneratedError',
+                finishReason: 'stop',
+                usage,
+            },
+        );
+
+    it('recovers the billed usage from a NoObjectGeneratedError', () => {
+        const got = readAiSdkUsageFromError(
+            noObjectGenerated({
+                inputTokens: 766,
+                outputTokens: 2503,
+                totalTokens: 3269,
+                outputTokenDetails: { reasoningTokens: 2100 },
+            }),
+        );
+
+        expect(got?.finishReason).toBe('stop');
+        expect(got?.usage).toMatchObject({
+            inputTokens: 766,
+            outputTokens: 2503,
+            totalTokens: 3269,
+            reasoningTokens: 2100,
+        });
+    });
+
+    it('unwraps usage carried on the error cause', () => {
+        const err = Object.assign(new Error('wrapped'), {
+            cause: noObjectGenerated({
+                inputTokens: 10,
+                outputTokens: 5,
+                totalTokens: 15,
+            }),
+        });
+
+        expect(readAiSdkUsageFromError(err)?.usage.totalTokens).toBe(15);
+    });
+
+    it('returns undefined when nothing was billed', () => {
+        // Transport failures (timeout, 429, reset): no response, no usage — must
+        // not write a zero-token cost span.
+        expect(
+            readAiSdkUsageFromError(new Error('fetch failed')),
+        ).toBeUndefined();
+        expect(
+            readAiSdkUsageFromError(
+                noObjectGenerated({
+                    inputTokens: 0,
+                    outputTokens: 0,
+                    totalTokens: 0,
+                }),
+            ),
+        ).toBeUndefined();
+        expect(readAiSdkUsageFromError(undefined)).toBeUndefined();
+        expect(readAiSdkUsageFromError(null)).toBeUndefined();
     });
 });

--- a/libs/llm/ai-sdk-usage.ts
+++ b/libs/llm/ai-sdk-usage.ts
@@ -44,9 +44,44 @@ interface LegacyUsageFallbacks {
 // the reader chains defensively with `?.` — so accept any subset. A real ai@7
 // `LanguageModelUsage` is still assignable (more specific → deep-partial).
 export type AiSdkUsageInput =
-    | (DeepPartial<LanguageModelUsage> & LegacyUsageFallbacks)
-    | null
-    | undefined;
+    (DeepPartial<LanguageModelUsage> & LegacyUsageFallbacks) | null | undefined;
+
+/** Shape of the AI SDK errors that carry the usage of a call the provider
+ *  already answered (and billed) — `NoObjectGeneratedError` and its wrappers. */
+interface UsageCarryingError {
+    usage?: AiSdkUsageInput;
+    finishReason?: string;
+    cause?: unknown;
+}
+
+/**
+ * Usage hanging off a FAILED AI SDK call. A structured call that dies in the
+ * output parse (`AI_NoObjectGeneratedError`: schema mismatch, unparseable
+ * object) was still answered by the provider and still billed — the SDK hands
+ * the usage back on the error. Dropping it is spend that exists in Langfuse and
+ * nowhere in the cost pipeline (the `structuredRecovery` leak).
+ *
+ * Returns undefined when the error carries no usage or an all-zero one, so a
+ * transport failure (timeout, 429, connection reset — nothing was generated)
+ * never writes a zero-token cost span.
+ */
+export function readAiSdkUsageFromError(
+    err: unknown,
+): { usage: AiSdkUsage; finishReason?: string } | undefined {
+    const e = (err ?? {}) as UsageCarryingError;
+    const cause = (e.cause ?? {}) as UsageCarryingError;
+    const raw = e.usage ?? cause.usage;
+    if (!raw) return undefined;
+
+    const usage = readAiSdkUsage(raw);
+    const billed =
+        (usage.inputTokens ?? 0) +
+        (usage.outputTokens ?? 0) +
+        (usage.totalTokens ?? 0);
+    if (billed <= 0) return undefined;
+
+    return { usage, finishReason: e.finishReason ?? cause.finishReason };
+}
 
 /** Map an AI SDK usage object onto {@link AiSdkUsage}. Null/undefined-safe. */
 export function readAiSdkUsage(usage: AiSdkUsageInput): AiSdkUsage {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches billing-critical telemetry attributes on the error path; behavior is narrowly scoped and guarded so only errors with non-zero billed usage get cost spans.
> 
> **Overview**
> Fixes **missing Mongo cost data** when an AI SDK call is billed by the provider but fails during structured output parsing (`AI_NoObjectGeneratedError`). Those spans used to be marked errored with **no** `gen_ai.usage.*` or `tu`, so spend showed in Langfuse but not in `observability_telemetry`.
> 
> Adds **`readAiSdkUsageFromError`** in `ai-sdk-usage.ts` to pull usage (and optional `finishReason`) from the error or its `cause`, reusing `readAiSdkUsage` and ignoring transport failures and all-zero usage. **`runAiSdkLLMInSpan`** now wraps `exec` in try/catch: on success behavior is unchanged; on throw it stamps usage attributes before rethrowing so billing aggregation still sees tokens. Failed calls with no generation still write **no** cost attributes.
> 
> Tests cover the new reader and the three span paths (success, post-provider error with usage, pre-generation failure).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc5ed4d7b5cda7de2dd0c5f09a38a332f496db74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->