### PR TITLE
fix(agents): force the agentic task-context fallback to use known issue numbers

### DIFF
--- a/libs/agents/skills/capabilities/task-context-read.ts
+++ b/libs/agents/skills/capabilities/task-context-read.ts
@@ -792,6 +792,17 @@ USER_LANGUAGE: ${userLanguage}
 
 When calling tools that require repository data, prioritize KNOWN_REPOSITORY_OWNER and KNOWN_REPOSITORY_NAME.
 When a tool requires a tenant/site/cloud identifier, use a value from KNOWN_SITE_IDS. Never invent one; if it is (none), prefer a tool that does not require it.
+${
+    hints.issueNumbers.length > 0
+        ? 'MANDATORY: resolve ONLY the issue(s) listed in KNOWN_ISSUE_NUMBERS. ' +
+          'Use them directly as the issue ID/key argument of the fetch tool. ' +
+          'Do NOT call issue-list/search tools to "discover" an issue, and do ' +
+          'NOT return a different issue from the ones listed. If you cannot ' +
+          'fetch those exact numbers, return an empty taskContext.'
+        : 'When a tool lets you discover issues by query, prefer the issue ' +
+          'referenced by KNOWN_TOKENS / KNOWN_ISSUE_NUMBERS over an arbitrary ' +
+          'result from a list/search.'
+}
 
 Return ONLY JSON:
 {

--- a/test/unit/agents/skills/capabilities/task-context-read.spec.ts
+++ b/test/unit/agents/skills/capabilities/task-context-read.spec.ts
@@ -1040,6 +1040,12 @@ describe('fetchTaskContext capability', () => {
         expect(prompt).toContain('KNOWN_ISSUE_NUMBERS: 37');
         expect(prompt).toContain('KNOWN_REPOSITORY_OWNER: kodustech');
         expect(prompt).toContain('KNOWN_REPOSITORY_NAME: kodus-ai');
+
+        // #1770 regression: with a known issue number the agent MUST resolve
+        // exactly that issue — never a list/search "discovery" that picks an
+        // unrelated one.
+        expect(prompt).toContain('MANDATORY: resolve ONLY the issue(s)');
+        expect(prompt).toContain('Do NOT call issue-list/search tools');
     });
 
     it('uses typed candidates for optional-only tool parameters', async () => {


### PR DESCRIPTION
Fixes #1770

## Problem
The agentic fallback in `task-context-read.ts` listed `KNOWN_ISSUE_NUMBERS` but only asked the model to "Resolve task context using available MCP tools". When a task-management MCP was connected, the agent could call an issue-list/search tool and pick **any** issue from the results. Reported case: a PR referencing `#214` was validated against unrelated issue `#343`, producing false-positive `MUST_FIX: PR scope does not match the task scope` findings.

## Fix
When issue numbers are known, the fallback prompt now mandates resolving **only** those numbers:

- Forbids calling issue-list/search tools to "discover" an issue.
- Forbids returning a different issue than the ones listed.
- Uses the known numbers directly as the fetch tool's issue ID/key argument.
- If the exact numbers can't be fetched, returns an empty `taskContext` (falling through rather than guessing).

When no issue number is known, the prompt still prefers the referenced issue over an arbitrary list/search result.

## Validation
Extended `task-context-read.spec.ts` ("includes repository and issue number hints in agent fallback prompt"):
- **RED without the fix** — prompt has no mandatory-issue instruction.
- **GREEN with the fix** — 27/27 pass (26 pre-existing + strengthened assertions).

This is the deterministic phase fix for the previously-merged #1777 work on task-context resolution.