### PR TITLE
fix(code-review): searchDocs says backend unavailable instead of faking no docs

### DIFF
--- a/libs/code-review/infrastructure/adapters/services/documentation-search-exa.service.ts
+++ b/libs/code-review/infrastructure/adapters/services/documentation-search-exa.service.ts
@@ -78,6 +78,15 @@ export class DocumentationSearchExaService {
         this.exaClient = apiKey ? new Exa(apiKey) : null;
     }
 
+    /**
+     * The search backend is usable only when an Exa API key is configured.
+     * Exposed so the agent-facing tool can say "search is unavailable" instead
+     * of "no documentation found" when it never ran (#1762).
+     */
+    isSearchAvailable(): boolean {
+        return this.exaClient !== null;
+    }
+
     async searchByFilePlan(
         planByFile: Record<string, DocumentationQueryPlanByFile>,
         options?: {

--- a/libs/code-review/infrastructure/agents/engine/agent-tools.factory.ts
+++ b/libs/code-review/infrastructure/agents/engine/agent-tools.factory.ts
@@ -1509,7 +1509,13 @@ fi
 
                     const docs = results['agent'] || [];
                     if (docs.length === 0) {
-                        return `No documentation found for "${packageName}" with query "${query}".`;
+                        // A successful Exa search always returns a doc item
+                        // (even a 0-result query yields url:"unknown" + a
+                        // fallback snippet), so empty docs with a configured
+                        // backend means every query failed at runtime (#1762
+                        // cause b) — NOT "the library has no docs". Say so,
+                        // matching the unconfigured-backend branch above.
+                        return `Documentation search ran but returned no documentation for "${packageName}" with query "${query}" (the search backend answered nothing). Do NOT conclude the package has no documentation: this usually means the backend is failing at runtime. If the finding depends on framework documentation, state that verification is unavailable.`;
                     }
 
                     const formatted = docs

--- a/libs/code-review/infrastructure/agents/engine/agent-tools.factory.ts
+++ b/libs/code-review/infrastructure/agents/engine/agent-tools.factory.ts
@@ -47,6 +47,13 @@ export interface DocumentationSearchAdapter {
             }>
         >
     >;
+    /**
+     * True when the search backend is actually usable (e.g. an Exa API key is
+     * configured). Lets the agent-visible tool distinguish "no docs exist"
+     * from "search is not available right now" instead of silently reporting
+     * the former for the latter (#1762).
+     */
+    isSearchAvailable?: () => boolean;
 }
 
 /**
@@ -1479,6 +1486,18 @@ fi
                 }
 
                 try {
+                    // Distinguish "search cannot run" from "no docs exist".
+                    // Previously an unconfigured/broken backend produced the
+                    // same "No documentation found" as a genuine empty result,
+                    // so the agent could not tell "tool unavailable" from "the
+                    // library has no docs" and fell back to its prior (#1762).
+                    const available =
+                        documentationSearchService.isSearchAvailable?.() ??
+                        true;
+                    if (!available) {
+                        return `Documentation search is not available right now (no configured search backend). Do NOT conclude the package has no documentation: this means the tool did not run. If the finding depends on framework documentation, state that verification is unavailable.`;
+                    }
+
                     const planByFile = {
                         agent: { queryTasks: [{ packageName, query }] },
                     };

--- a/libs/code-review/infrastructure/agents/engine/agent-tools.sandbox-errors.spec.ts
+++ b/libs/code-review/infrastructure/agents/engine/agent-tools.sandbox-errors.spec.ts
@@ -151,4 +151,33 @@ describe('searchDocs — distinguishes "backend unavailable" from "no docs"', ()
             'Do NOT conclude the package has no documentation',
         );
     });
+
+    it('says the search ran but returned nothing when a configured backend yields empty docs', async () => {
+        // #1762 cause (b): the backend has a key (isSearchAvailable => true)
+        // but every query fails at runtime, so searchByFilePlan returns empty.
+        // A successful Exa search always returns a doc item, so empty docs here
+        // means "backend failing", not "no docs" — the tool must not fabricate
+        // a definitive "No documentation found".
+        const failingDocs: any = {
+            isSearchAvailable: () => true,
+            searchByFilePlan: async () => ({}),
+        };
+        const tools = buildAgentTools(
+            makeRemote(),
+            undefined,
+            undefined,
+            failingDocs,
+        );
+
+        const out = await tools.searchDocs.execute({
+            packageName: 'jest',
+            query: 'v30 renamed --testPathPattern to --testPathPatterns',
+        });
+
+        expect(out).toContain('search ran but returned no documentation');
+        expect(out).not.toContain('No documentation found');
+        expect(out).toContain(
+            'Do NOT conclude the package has no documentation',
+        );
+    });
 });

--- a/libs/code-review/infrastructure/agents/engine/agent-tools.sandbox-errors.spec.ts
+++ b/libs/code-review/infrastructure/agents/engine/agent-tools.sandbox-errors.spec.ts
@@ -117,3 +117,38 @@ describe('readFile — clear signal when a read produces no content', () => {
         expect(out.toLowerCase()).toMatch(/empty/);
     });
 });
+
+// REGRESSION (issue #1762): the searchDocs tool must not claim "No
+// documentation found" when the search backend is actually unavailable — the
+// model then treats "tool broken" as "there is no documentation for this
+// library" and falls back to its prior, which produced false-positive findings
+// on third-party API claims. When the service reports it is unavailable, the
+// tool must say so explicitly.
+describe('searchDocs — distinguishes "backend unavailable" from "no docs"', () => {
+    it('says the search backend is unavailable instead of fabricating a "no docs" result', async () => {
+        const unavailableDocs: any = {
+            isSearchAvailable: () => false,
+            searchByFilePlan: async () => ({}),
+        };
+        const tools = buildAgentTools(
+            makeRemote(),
+            undefined,
+            undefined,
+            unavailableDocs,
+        );
+
+        const out = await tools.searchDocs.execute({
+            packageName: 'jest',
+            query: 'v30 renamed --testPathPattern to --testPathPatterns',
+        });
+
+        expect(out).toContain(
+            'Documentation search is not available right now',
+        );
+        expect(out).not.toContain('No documentation found');
+        // The agent must not conflate "tool down" with "no docs exist".
+        expect(out).toContain(
+            'Do NOT conclude the package has no documentation',
+        );
+    });
+});


### PR DESCRIPTION
Fixes #1762

## Problem
`DocumentationSearchExaService` returns `{}` when no `API_EXA_KEY` is configured (backend never built) and `null` per-query when an Exa call throws (backend broken). Either way the `searchDocs` VERIFY tool rewrote it to **"No documentation found for «pkg» with query «q»"** — semantically *"I searched and there is nothing"*.

The agent could not tell **"tool unavailable/broken"** from **"the library has no docs"**, so every third-party-API claim fell back to the model's prior. In prod this produced false positives (e.g. a valid Jest `--testPathPatterns` flag flagged as invalid) — 100/100 sampled `searchDocs` calls had returned "No documentation found" for weeks.

## Fix
- `DocumentationSearchExaService` exposes `isSearchAvailable()` (backend usable ⟺ an API key is configured).
- Wired through the factory's `DocumentationSearchAdapter` (optional — call sites without a search service are unaffected).
- When unavailable, `searchDocs` returns an explicit **"Documentation search is not available right now… do not conclude the package has no documentation"** instead of a fabricated empty result. Backend-unavailable stays distinct from a genuine empty search.

This addresses the deterministic root-cause (a) — "client never constructed" — which the issue's 8-week data shows is the dominant cause.

## Validation
Regression test in `agent-tools.sandbox-errors.spec.ts`:
- **RED without the fix** — mock backend returns `{}` + claims unavailable → tool reports `No documentation found for "jest"...` (the exact bug).
- **GREEN with the fix** — tool reports `Documentation search is not available right now`.
- 11/11 pass across the sandbox-errors + service specs.