### PR TITLE
fix(e2e): tolerate unreleased routes in the scheduled self-hosted RBAC matrix

### DIFF
--- a/.github/workflows/e2e-self-hosted-matrix.yml
+++ b/.github/workflows/e2e-self-hosted-matrix.yml
@@ -295,6 +295,12 @@ jobs:
                   IMAGE_TAG: ${{ needs.plan.outputs.image_tag }}
                   SOURCE_MATRIX_FILE: ${{ inputs.matrix_file || 'matrix/fast.yml' }}
                   LICENSE_MODE: ${{ matrix.cell.license }}
+                  # Scheduled cron runs test the newest PUBLISHED release against
+                  # a main-refreshed RBAC manifest, so endpoints added since that
+                  # release legitimately 404. PR / release-train runs test an
+                  # image built from the same commit as the manifest — there a
+                  # 404 is a real regression and must keep failing (#1696).
+                  RBAC_ALLOW_MISSING_ROUTE: ${{ github.event_name == 'schedule' && '1' || '0' }}
                   KODUS_INSTALLER_PATH: ${{ github.workspace }}/kodus-installer
                   # AWS by default: Kodus has credit there, and DigitalOcean
                   # was the direct cause of two failure classes — 504s on

--- a/tests/e2e/scenarios/rbac-authorization.ts
+++ b/tests/e2e/scenarios/rbac-authorization.ts
@@ -98,6 +98,22 @@ async function hit(
     return res.status;
 }
 
+// Guards run before handlers. With a definitely-invalid bearer token the
+// JwtAuthGuard answers 401 when a route EXISTS (it is found and rejects the
+// token) and the router answers 404 when it is ABSENT. Either way no handler
+// runs, so this probe has zero side effects — it is the mutation analogue of
+// the GET branch's owner canary, used to attribute a deny-role 404 to a
+// release gap only when the route is genuinely missing (#1696, rbac:146).
+const UNAUTHENTICATED_PROBE_TOKEN = "orca-rbac-probe-invalid-token";
+
+async function routeExists(
+    target: TargetContext,
+    entry: ManifestEntry,
+): Promise<boolean> {
+    const status = await hit(target, entry, UNAUTHENTICATED_PROBE_TOKEN);
+    return status !== 404;
+}
+
 export const rbacAuthorization: Scenario = {
     id: "rbac-authorization",
     title: "RBAC: every gated endpoint enforces the manifest verdict per role",
@@ -121,6 +137,9 @@ export const rbacAuthorization: Scenario = {
 
         const failures: string[] = [];
         const tierSkipped: string[] = [];
+        // Distinct missing endpoints (deduped — a mutation can add a 404 per
+        // deny-role, up to 3x, which must not inflate the gap ratio below).
+        const missingEndpoints = new Set<string>();
         const releaseGapSkipped: string[] = [];
         let asserted = 0;
         let mutationAllowDeferred = 0;
@@ -139,8 +158,19 @@ export const rbacAuthorization: Scenario = {
                     if (status === 404 && ALLOW_MISSING_ROUTE) {
                         // Endpoint added on main but not yet in the released
                         // image (scheduled-matrix-only narrow case #1696).
+                        // Confirm the route is genuinely absent first — a route
+                        // that EXISTS but denied a deny-role 404 instead of 403
+                        // must stay a real failure (rbac:146).
+                        if (await routeExists(ctx.target, entry)) {
+                            failures.push(
+                                `${role} should be DENIED on ${entry.httpMethod} ${entry.urlPath} (expected 403, got ${status} — route exists, this is not a release gap)`,
+                            );
+                            continue;
+                        }
+                        const key = `${entry.httpMethod} ${entry.urlPath}`;
+                        missingEndpoints.add(key);
                         releaseGapSkipped.push(
-                            `${role} DENIED ${entry.httpMethod} ${entry.urlPath} (404 — route not in tested release image)`,
+                            `${role} DENIED ${key} (404 — route not in tested release image)`,
                         );
                         continue;
                     }
@@ -160,6 +190,7 @@ export const rbacAuthorization: Scenario = {
             if (ownerStatus === 404 && ALLOW_MISSING_ROUTE) {
                 // Route added on main but absent from the released image
                 // (scheduled-matrix-only narrow case #1696).
+                missingEndpoints.add(`GET ${entry.urlPath}`);
                 releaseGapSkipped.push(
                     `GET ${entry.urlPath} (404 — route not in tested release image)`,
                 );
@@ -212,10 +243,13 @@ export const rbacAuthorization: Scenario = {
         // Safety: the release-gap tolerance exists for the NARROW case of a
         // handful of endpoints added since the last release. If most endpoints
         // 404, that's a misprovisioned image (wrong tag), not a gap — fail so
-        // the cron can't report green against a broken target (#1696).
+        // the cron can't report green against a broken target (#1696). The
+        // guard counts DISTINCT missing endpoints (one per route), not the
+        // per-deny-role 404s, so the ratio can't be inflated (rbac:170).
         ctx.assert(
-            !ALLOW_MISSING_ROUTE || releaseGapSkipped.length <= manifest.length / 2,
-            `RBAC_ALLOW_MISSING_ROUTE=1 was set but ${releaseGapSkipped.length}/${manifest.length} endpoints 404 — the tested image is likely the wrong tag, not a release gap.`,
+            !ALLOW_MISSING_ROUTE ||
+                missingEndpoints.size <= manifest.length / 2,
+            `RBAC_ALLOW_MISSING_ROUTE=1 was set but ${missingEndpoints.size}/${manifest.length} endpoints 404 — the tested image is likely the wrong tag, not a release gap.`,
         );
         ctx.assert(
             getCount > 0 && tierSkipped.length < getCount / 2,

--- a/tests/e2e/scenarios/rbac-authorization.ts
+++ b/tests/e2e/scenarios/rbac-authorization.ts
@@ -56,6 +56,18 @@ function loadManifest(): ManifestEntry[] {
     return JSON.parse(fs.readFileSync(MANIFEST_PATH, "utf8")) as ManifestEntry[];
 }
 
+// Scheduled self-hosted matrix: the tested DOCKER image is the newest
+// PUBLISHED release, but the committed RBAC manifest always reflects main.
+// Any endpoint added since the last release is absent from the image, so the
+// live probe gets 404 (route doesn't exist yet) instead of the manifest's
+// expected 403. That is a "not yet released" gap, not an RBAC regression.
+// PR / release-train runs test an image built from the same commit as the
+// manifest, where a 404 is a real mismatch and must keep failing. The cron
+// sets RBAC_ALLOW_MISSING_ROUTE=1 to permit this one narrow case; every other
+// workflow leaves it unset so genuine regressions still fail (#1696).
+const ALLOW_MISSING_ROUTE =
+    process.env.RBAC_ALLOW_MISSING_ROUTE === "1";
+
 // Replace `:param` segments with a throwaway value so the request reaches the
 // guards. PolicyGuard runs before validation, so a downstream 400/404 on a
 // dummy id still reflects "allowed by policy" (not 401/403).
@@ -109,6 +121,7 @@ export const rbacAuthorization: Scenario = {
 
         const failures: string[] = [];
         const tierSkipped: string[] = [];
+        const releaseGapSkipped: string[] = [];
         let asserted = 0;
         let mutationAllowDeferred = 0;
         let getCount = 0;
@@ -123,6 +136,14 @@ export const rbacAuthorization: Scenario = {
                         continue;
                     }
                     const status = await hit(ctx.target, entry, tokenOf(role));
+                    if (status === 404 && ALLOW_MISSING_ROUTE) {
+                        // Endpoint added on main but not yet in the released
+                        // image (scheduled-matrix-only narrow case #1696).
+                        releaseGapSkipped.push(
+                            `${role} DENIED ${entry.httpMethod} ${entry.urlPath} (404 — route not in tested release image)`,
+                        );
+                        continue;
+                    }
                     if (status !== 403) {
                         failures.push(
                             `${role} should be DENIED on ${entry.httpMethod} ${entry.urlPath} (expected 403, got ${status})`,
@@ -136,6 +157,14 @@ export const rbacAuthorization: Scenario = {
             // GET (read-only). OWNER canary skips non-RBAC (tier) guards.
             getCount++;
             const ownerStatus = await hit(ctx.target, entry, tokenOf("owner"));
+            if (ownerStatus === 404 && ALLOW_MISSING_ROUTE) {
+                // Route added on main but absent from the released image
+                // (scheduled-matrix-only narrow case #1696).
+                releaseGapSkipped.push(
+                    `GET ${entry.urlPath} (404 — route not in tested release image)`,
+                );
+                continue;
+            }
             if (ownerStatus === 401 || ownerStatus === 403) {
                 tierSkipped.push(
                     `${entry.httpMethod} ${entry.urlPath} (owner ${ownerStatus})`,
@@ -167,6 +196,11 @@ export const rbacAuthorization: Scenario = {
                 `[rbac] ${tierSkipped.length} GET endpoint(s) skipped — owner blocked by a non-RBAC guard (org not tier-unlocked?):\n  ${tierSkipped.join("\n  ")}`,
             );
         }
+        if (releaseGapSkipped.length) {
+            console.log(
+                `[rbac] ${releaseGapSkipped.length} manifest endpoint(s) 404 (not in tested release image) — tolerated because RBAC_ALLOW_MISSING_ROUTE=1 (scheduled matrix tests the last published release against a main-refreshed manifest):\n  ${releaseGapSkipped.join("\n  ")}`,
+            );
+        }
         console.log(
             `[rbac] live verdicts asserted: ${asserted} (all GET allow/deny + every mutation deny). Mutation allow-side (${mutationAllowDeferred}) is static-only, so the run stays idempotent.`,
         );
@@ -174,6 +208,14 @@ export const rbacAuthorization: Scenario = {
         ctx.assert(
             failures.length === 0,
             `RBAC mismatches (${failures.length}):\n  ${failures.join("\n  ")}`,
+        );
+        // Safety: the release-gap tolerance exists for the NARROW case of a
+        // handful of endpoints added since the last release. If most endpoints
+        // 404, that's a misprovisioned image (wrong tag), not a gap — fail so
+        // the cron can't report green against a broken target (#1696).
+        ctx.assert(
+            !ALLOW_MISSING_ROUTE || releaseGapSkipped.length <= manifest.length / 2,
+            `RBAC_ALLOW_MISSING_ROUTE=1 was set but ${releaseGapSkipped.length}/${manifest.length} endpoints 404 — the tested image is likely the wrong tag, not a release gap.`,
         );
         ctx.assert(
             getCount > 0 && tierSkipped.length < getCount / 2,


### PR DESCRIPTION
Fixes #1696

## Problem
The scheduled self-hosted matrix tests the **newest published release** image, with the harness checked out from **main** — deliberately, to answer "does what customers actually run still work?". But `rbac-authorization` asserts the committed `rbac-matrix.manifest.json`, which always reflects main. Between an endpoint landing on main and its release, the manifest lists routes the tested image doesn't have, and the cron fails with `expected 403, got 404` — a false red on a healthy release train (observed run 31526446836, 5 mismatches all `POST /license/prune-seats`).

## Fix
`tests/e2e/scenarios/rbac-authorization.ts`:
- When `RBAC_ALLOW_MISSING_ROUTE=1`, a **404** on a manifest route (route not yet in the tested image) is counted as a **release gap**, logged explicitly, and not treated as a verdict mismatch — both in the mutation-deny loop and the GET loop (owner canary 404 short-circuits the whole entry).
- Safety guard: if **over half** the manifest 404s, the run still fails — that's a misprovisioned image (wrong tag), not a release gap, and the cron must not report green against a broken target.

`.github/workflows/e2e-self-hosted-matrix.yml`:
- `RBAC_ALLOW_MISSING_ROUTE` is set only on the **scheduled trigger** (`github.event_name == 'schedule'`). PR and release-train runs test an image built from the same commit as the manifest — there a 404 is a real regression and keeps failing.

## Validation
- TypeScript: `tsc -p tests/e2e/tsconfig.json --noEmit` → 0 errors.
- Workflow YAML parses cleanly; the env diff is purely additive (no existing key touched).
- The change is a live e2e scenario (provisioned matrix), so it is validated by typecheck + logic review here and will be exercised by the scheduled run itself; the half-404 safety guard keeps the tolerance from masking a broken image.