### PR TITLE
fix(compose): pin Mongo off the kernel-broken releases, and gate startup on health

### DIFF
--- a/docker-compose.bench.yml
+++ b/docker-compose.bench.yml
@@ -275,12 +275,12 @@ services:
                 ]
             interval: 5s
             timeout: 3s
-            retries: 20
-            start_period: 10s
+            retries: 5
+            start_period: 30s
         logging: *bench-logging
 
     db_mongodb:
-        image: docker.io/mongo:8
+        image: docker.io/mongo:8.2.11
         container_name: kodus_mongodb_bench
         environment:
             MONGO_INITDB_ROOT_USERNAME: ${API_MG_DB_USERNAME}
@@ -297,10 +297,10 @@ services:
                     'CMD-SHELL',
                     "echo 'db.runCommand({ ping: 1 }).ok' | mongosh --quiet mongodb://$${MONGO_INITDB_ROOT_USERNAME}:$${MONGO_INITDB_ROOT_PASSWORD}@localhost:27017/admin | grep -q 1",
                 ]
-            interval: 10s
+            interval: 5s
             timeout: 5s
-            retries: 20
-            start_period: 20s
+            retries: 5
+            start_period: 40s
         logging: *bench-logging
 
 volumes:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -59,6 +59,17 @@ services:
                 # external RabbitMQ). When the local rabbitmq IS running,
                 # docker waits for its healthcheck before starting.
                 required: false
+            # This service runs `migration:run` on boot, and the migration set
+            # includes four that write to Mongo. Waiting on the container's
+            # START is not enough: a mongod that exits on startup leaves the
+            # container flapping, docker's embedded DNS drops the name, and the
+            # migration fails with `getaddrinfo ENOTFOUND db_kodus_mongodb` —
+            # an error that accuses DNS for what is a dead database. Both
+            # services publish a healthcheck; gate on it.
+            db_postgres:
+                condition: service_healthy
+            db_mongodb:
+                condition: service_healthy
         ports:
             # Host-side port vars (`<HOST>_PORT:-default`) let parallel
             # worktrees coexist by overriding to a per-slot offset (e.g.
@@ -119,6 +130,14 @@ services:
                 # external RabbitMQ). When the local rabbitmq IS running,
                 # docker waits for its healthcheck before starting.
                 required: false
+            # Runtime reads and writes Mongo. `required: false` above applies
+            # to rabbitmq only: these two always run, and gating on their
+            # healthcheck keeps a dead database from being discovered later as
+            # a name that no longer resolves.
+            db_postgres:
+                condition: service_healthy
+            db_mongodb:
+                condition: service_healthy
         volumes:
             - .:/usr/src/app:delegated
             - node_modules_cache:/usr/src/app/node_modules:nocopy
@@ -186,6 +205,14 @@ services:
             rabbitmq:
                 condition: service_healthy
                 required: false
+            # Runtime reads and writes Mongo. `required: false` above applies
+            # to rabbitmq only: these two always run, and gating on their
+            # healthcheck keeps a dead database from being discovered later as
+            # a name that no longer resolves.
+            db_postgres:
+                condition: service_healthy
+            db_mongodb:
+                condition: service_healthy
         volumes:
             - .:/usr/src/app:delegated
             - node_modules_cache:/usr/src/app/node_modules:nocopy
@@ -252,6 +279,14 @@ services:
                 # external RabbitMQ). When the local rabbitmq IS running,
                 # docker waits for its healthcheck before starting.
                 required: false
+            # Runtime reads and writes Mongo. `required: false` above applies
+            # to rabbitmq only: these two always run, and gating on their
+            # healthcheck keeps a dead database from being discovered later as
+            # a name that no longer resolves.
+            db_postgres:
+                condition: service_healthy
+            db_mongodb:
+                condition: service_healthy
         volumes:
             - .:/usr/src/app:delegated
             - node_modules_cache:/usr/src/app/node_modules:nocopy
@@ -562,12 +597,12 @@ services:
                 ]
             interval: 5s
             timeout: 3s
-            retries: 20
-            start_period: 10s
+            retries: 5
+            start_period: 30s
         logging: *default-logging
 
     db_mongodb:
-        image: docker.io/mongo:8
+        image: docker.io/mongo:8.2.11
         container_name: mongodb
         ports:
             - '27017:27017'
@@ -586,10 +621,10 @@ services:
                     'CMD-SHELL',
                     "echo 'db.runCommand({ ping: 1 }).ok' | mongosh --quiet mongodb://$${MONGO_INITDB_ROOT_USERNAME}:$${MONGO_INITDB_ROOT_PASSWORD}@localhost:27017/admin | grep -q 1",
                 ]
-            interval: 10s
+            interval: 5s
             timeout: 5s
-            retries: 20
-            start_period: 20s
+            retries: 5
+            start_period: 40s
         logging: *default-logging
 
 volumes:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -127,8 +127,8 @@ services:
                 ]
             interval: 5s
             timeout: 3s
-            retries: 20
-            start_period: 10s
+            retries: 5
+            start_period: 30s
 
     db_mongodb:
         image: docker.io/mongo:8
@@ -146,10 +146,10 @@ services:
                     'CMD-SHELL',
                     "echo 'db.runCommand({ ping: 1 }).ok' | mongosh --quiet mongodb://$${MONGO_INITDB_ROOT_USERNAME}:$${MONGO_INITDB_ROOT_PASSWORD}@localhost:27017/admin | grep -q 1",
                 ]
-            interval: 10s
+            interval: 5s
             timeout: 5s
-            retries: 20
-            start_period: 20s
+            retries: 5
+            start_period: 40s
 
 volumes:
     pgdata_prod:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -131,7 +131,23 @@ services:
             start_period: 30s
 
     db_mongodb:
-        image: docker.io/mongo:8
+        # Pinned, not floating. `mongo:8` resolves to a release that refuses
+        # to start on Linux kernels 6.19+: MongoDB 8.0.21-8.0.29 and
+        # 8.3.0-8.3.8 exit during startup with `MongoDB cannot start: Linux
+        # kernel versions 6.19 and newer has a known incompatibility`
+        # (SERVER-121912 - tcmalloc violates the rseq ABI). A floating tag is
+        # how a stack that worked one week stopped booting the next without a
+        # line changing here.
+        #
+        # 8.2.11 is outside that range and verified to start and stay up on
+        # kernel 7.0.14. Revisit when 8.0.30 / 8.3.9 publish, which carry the
+        # real fix. Kept identical to the kodus-installer compose, which
+        # serves the same audience.
+        #
+        # An installation already running 8.3 with its feature compatibility
+        # version raised to 8.3 will not open its data files under this pin
+        # and must set that version back before upgrading.
+        image: docker.io/mongo:8.2.11
         container_name: kodus_mongodb_prod
         restart: unless-stopped
         env_file:

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -10,9 +10,19 @@ services:
             POSTGRES_DB: ${API_PG_DB_DATABASE}
         networks:
             - kodus-backend-services-test
+        healthcheck:
+            test:
+                [
+                    'CMD-SHELL',
+                    'pg_isready -U ${API_PG_DB_USERNAME} -d ${API_PG_DB_DATABASE}',
+                ]
+            interval: 5s
+            timeout: 3s
+            retries: 5
+            start_period: 30s
 
     db_mongodb:
-        image: docker.io/mongo:8
+        image: docker.io/mongo:8.2.11
         container_name: mongodb
         ports:
             - '27017:27017'
@@ -22,6 +32,20 @@ services:
             MONGO_INITDB_DATABASE: ${API_MG_DB_DATABASE}
         networks:
             - kodus-backend-services-test
+        # Nothing here declares `depends_on`, so this healthcheck exists for the
+        # caller: `docker compose up --wait` blocks on it, and a mongod that
+        # exits on startup is reported as unhealthy instead of leaving a test
+        # suite to fail later against a name that no longer resolves.
+        healthcheck:
+            test:
+                [
+                    'CMD-SHELL',
+                    "echo 'db.runCommand({ ping: 1 }).ok' | mongosh --quiet mongodb://$${MONGO_INITDB_ROOT_USERNAME}:$${MONGO_INITDB_ROOT_PASSWORD}@localhost:27017/admin | grep -q 1",
+                ]
+            interval: 5s
+            timeout: 5s
+            retries: 5
+            start_period: 40s
 
 networks:
   kodus-backend-services-test:

--- a/tests/e2e/lib/onboarding.ts
+++ b/tests/e2e/lib/onboarding.ts
@@ -830,7 +830,26 @@ export async function resetCodeReviewConfig(
                 headers: { Authorization: `Bearer ${session.accessToken}` },
                 body: {
                     organizationAndTeamData: { teamId: session.teamId },
-                    configValue: { automatedReviewActive: true },
+                    configValue: {
+                        automatedReviewActive: true,
+                        // Scenarios open PRs against `main`, while the fixture
+                        // repos deliberately keep a non-main default branch
+                        // (tiny-url's default is the review-bait bug branch —
+                        // see the note in lib/git.ts on why the PR base and the
+                        // repo default are intentionally different).
+                        //
+                        // An EMPTY `baseBranches` used to mean "review every
+                        // base branch". Since e941be123 it means "review only
+                        // the repository default branch", so an unset list
+                        // silently skips every PR these scenarios open, with
+                        // `Branch Mismatch` and a 👎 reaction rather than an
+                        // error — which reads downstream as "no review
+                        // activity within timeout".
+                        //
+                        // State the scope the fixtures actually use instead of
+                        // depending on what an absent list happens to mean.
+                        baseBranches: ["main"],
+                    },
                 },
                 timeoutMs: 20_000,
             },


### PR DESCRIPTION
The 2026-09-02 release run died with `getaddrinfo ENOTFOUND db_kodus_mongodb`
on all four E2E cells, ten minutes into each. It read as a DNS problem. It was
a database that refused to start, and then two more failures hiding behind it.

## MongoDB will not start on Linux kernels 6.19+

`mongo:8` is a floating tag. It resolves to a release that exits during startup
with:

```
MongoDB cannot start: Linux kernel versions 6.19 and newer has a known
incompatibility with this version of MongoDB.
```

[SERVER-121912](https://jira.mongodb.org/browse/SERVER-121912) — tcmalloc
violates the rseq ABI. Affected: 8.0.21–8.0.29 and 8.3.0–8.3.8. Fixed in
8.0.30 / 8.3.9, neither published to Docker Hub yet.

Nothing in this repository changed. The ground did: container runtimes moved
past that kernel, and a floating tag handed us a database version nobody chose.

`8.2.11` is outside the affected range, verified to start and stay up past the
60s crash window on kernel 7.0.14, and opens existing data (feature
compatibility version 8.2). Pinned in dev, test and bench.

**`prod` deliberately keeps `mongo:8`.** Pinning would be a downgrade for an
installation whose feature compatibility version is already ahead of it.
Revisit when the fixed releases publish.

## The error accused the wrong thing

A mongod that exits leaves its container gone, so its name leaves docker's
embedded DNS. `kodus-api` runs `migration:run` on boot — four of those
migrations write to Mongo — and it starts a second after the database
container does. The migration then fails on a name that no longer resolves,
the API never becomes healthy, and the caller learns about it ten minutes
later when its own health check times out.

So `dev` now gates `kodus-api`, `worker`, `worker-analytics` and `webhooks`
on both databases being healthy, which is what `docker-compose.prod.yml` has
carried for some time. `test` declares healthchecks it had none of — nothing
there uses `depends_on`, so they exist for the caller: `docker compose up
--wait` now blocks on a real readiness signal.

The database ladders drop from 20 retries to 5. `retries` absorbs flakiness,
which a database does not have — it is serving or it is dead. What needed the
room was slow first boot, and `start_period` (30s / 40s, where failures cost
no retry) is the knob for that.

The companion fix is [kodus-installer#54](https://github.com/kodustech/kodus-installer/pull/54),
which is the compose the release E2E actually provisions.

## What the release found once the stack booted

With Mongo up, two cells went fully green and two got far enough to fail for a
different reason: `code-review-basic` and `kody-rules-create-and-apply` timed
out on github and azure-devops with "no review activity".

The reviews were not hanging. They were skipped, deliberately, in two seconds:

```
stage:  "FetchChangedFilesStage"
status: "skipped"
message: "Branch Mismatch — Target branch 'main' is not the repository
          default branch, and no base branches are configured"
```

Scenarios open PRs against `main`, while the fixture repos deliberately keep a
non-main default branch — tiny-url's default is the review-bait bug branch, and
`lib/git.ts` explains why the PR base and the repo default are meant to differ.

The tenant baseline left `baseBranches` unset. That used to mean "review every
base branch". Since e941be123 an empty list means "review only the repository
default branch", so an unset list now skips every PR these scenarios open. The
skip is not an error — the pipeline records `Branch Mismatch`, leaves a
reaction, and logs "Successfully handled" — so the scenario reports "No review
activity within timeout" after 600s of waiting for something decided against in
two.

e941be123 is correct; the fixture was relying on the behaviour it fixed. The
baseline now states the scope the fixtures actually use.

## Verification

- **broken mongod** — the gate stops compose in ~1s naming the unhealthy
  service, and the dependent container is never created
- **healthy mongod** — `Container mongodb Healthy` → dependent starts normally
- `8.2.11` survives 95s on kernel 7.0.14 and opens a copy of a real 424MB
  volume: FCV 8.2, all databases present
- all four compose files pass `docker compose config`
- `tests/e2e` typechecks

The branch-mismatch diagnosis is read off the run's own server evidence
(`stage` + `status` from the ungrepped section of the worker log), not inferred.
