### PR TITLE
fix(llm): put a wall clock under every model call, and stop the reaper racing its own runs

### DIFF
--- a/libs/code-review/pipeline/stages/agent-review.stage.ts
+++ b/libs/code-review/pipeline/stages/agent-review.stage.ts
@@ -1,7 +1,8 @@
 import * as crypto from 'crypto';
 
 import { createLogger } from '@libs/core/log/logger';
-import { jsonSchema, embed, type EmbeddingModel } from 'ai';
+import { jsonSchema, type EmbeddingModel } from 'ai';
+import { tracedEmbed as embed } from '@libs/llm/llm-call';
 import { Inject, Injectable, Optional } from '@nestjs/common';
 import { resolveAdaptiveProfile } from '@libs/code-review/infrastructure/agents/engine/adaptive-fit';
 import { resolveContextWindow } from '@libs/llm/model-context-window';

--- a/libs/common/utils/document.ts
+++ b/libs/common/utils/document.ts
@@ -1,5 +1,6 @@
 import { createOpenAI, OpenAIProvider } from '@ai-sdk/openai';
-import { embed, EmbeddingModel } from 'ai';
+import { EmbeddingModel } from 'ai';
+import { tracedEmbed as embed } from '@libs/llm/llm-call';
 import 'dotenv/config';
 
 /**

--- a/libs/core/infrastructure/http/fetch-timeouts.ts
+++ b/libs/core/infrastructure/http/fetch-timeouts.ts
@@ -6,7 +6,7 @@ import { Agent, setGlobalDispatcher } from 'undici';
  * effort routinely take 4-7 minutes to produce the first byte, which
  * trips the headers timeout before our own abort signal fires.
  *
- * Bump the HTTP layer to 10 minutes so it aligns with LLM_CALL_TIMEOUT_MS
+ * Bump the HTTP layer to 20 minutes so it aligns with LLM_CALL_TIMEOUT_MS
  * in agent-loop.ts. Our signal-based timeouts stay the authoritative
  * cutoff; this just prevents undici from aborting earlier.
  *
@@ -15,10 +15,10 @@ import { Agent, setGlobalDispatcher } from 'undici';
 export function configureLongFetchTimeouts(): void {
     setGlobalDispatcher(
         new Agent({
-            headersTimeout: 10 * 60 * 1000,
-            bodyTimeout: 10 * 60 * 1000,
+            headersTimeout: 20 * 60 * 1000,
+            bodyTimeout: 20 * 60 * 1000,
             keepAliveTimeout: 60 * 1000,
-            keepAliveMaxTimeout: 10 * 60 * 1000,
+            keepAliveMaxTimeout: 20 * 60 * 1000,
         }),
     );
 }

--- a/libs/llm/agent-loop-call.timeout.spec.ts
+++ b/libs/llm/agent-loop-call.timeout.spec.ts
@@ -1,0 +1,97 @@
+/**
+ * The agent loop must have a wall-clock floor under it.
+ *
+ * `AbortSignal` is the polite first try. Several OpenAI-compatible proxies
+ * accept the connection, ignore the abort, and never answer — `llm-call.ts`
+ * says so in as many words ("some providers ignore AbortSignal; this is the
+ * safety net") and wraps the ONE-SHOT path in `hardTimeout` for exactly that.
+ * The loop had no such net, and the loop is where reviews run.
+ *
+ * What that cost on 2026-09-03: a review's generalist agent stopped logging
+ * mid-run. Nine pipeline stages reported `completed in Xms`; `AgentReviewStage`
+ * reported nothing, ever. The PR kept the "review starting" comment the
+ * pipeline had already posted, the sandbox lease stayed held, the span stayed
+ * open, and nothing was logged as an error — a promise that never settles
+ * throws nothing for a `catch` to see. The e2e gave up after its own 53-minute
+ * budget, well past the 30-minute ceiling that was supposed to apply.
+ *
+ * These tests stub `generateText` to that exact shape — never settles, ignores
+ * the signal. Without the wrapper they hang until jest kills them; with it they
+ * reject as `[HARD-TIMEOUT]`.
+ */
+jest.mock('ai', () => {
+    const actual = jest.requireActual('ai');
+    return { ...actual, generateText: jest.fn(), stepCountIs: jest.fn((n: number) => ({ __stepCountIs: n })) };
+});
+jest.mock('@libs/llm/model-invocation', () => ({ resolveModelConfig: jest.fn() }));
+jest.mock('@libs/llm/prompt-cache', () => ({ applyCacheBreakpoints: jest.fn() }));
+jest.mock('@libs/llm/repair-tool-call', () => ({ repairInvalidToolInput: jest.fn() }));
+jest.mock('@libs/llm/model-identity', () => ({ agentModelIdentity: jest.fn() }));
+jest.mock('@libs/core/log/langfuse', () => ({
+    buildLangfuseTelemetry: jest.fn(() => ({ isEnabled: false })),
+    toAiSdkTelemetryArgs: jest.fn(() => ({ experimental_telemetry: { isEnabled: false } })),
+}));
+
+import { generateText } from 'ai';
+import { runAgentLoopCall } from '@libs/llm/agent-loop-call';
+import { resolveModelConfig } from '@libs/llm/model-invocation';
+import { applyCacheBreakpoints } from '@libs/llm/prompt-cache';
+import { agentModelIdentity } from '@libs/llm/model-identity';
+
+const mockGenerate = generateText as unknown as jest.Mock;
+const mockResolve = resolveModelConfig as unknown as jest.Mock;
+const mockCache = applyCacheBreakpoints as unknown as jest.Mock;
+const mockIdentity = agentModelIdentity as unknown as jest.Mock;
+
+const params = () =>
+    ({
+        messages: [{ role: 'user', content: 'review this' }],
+        loop: { tools: {}, maxSteps: 1 },
+        runName: 'agent.stalled',
+        // Small so the test is fast; the wrapper adds a 5s grace on top.
+        hardTimeoutMs: 40,
+    }) as any;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockResolve.mockReturnValue({
+        model: { __model: 'main' },
+        modelName: 'openai_compatible:stub',
+        callOptions: {},
+        providerOptions: {},
+    });
+    mockCache.mockImplementation((a: any) => ({
+        systemArg: a?.system ? { system: a.system } : {},
+        messages: a?.messages ?? [],
+    }));
+    mockIdentity.mockReturnValue({ byokModelId: 'stub', credentialId: 'cred' });
+});
+
+describe('runAgentLoopCall — a stalled provider must not hang the caller', () => {
+    it('rejects on the wall clock when the provider never answers', async () => {
+        mockGenerate.mockImplementation(() => new Promise(() => {}));
+
+        await expect(runAgentLoopCall(params())).rejects.toThrow(/\[HARD-TIMEOUT\]/);
+    });
+
+    it('rejects even when handed an abort signal the provider ignores', async () => {
+        mockGenerate.mockImplementation(
+            (opts: any) =>
+                new Promise(() => {
+                    // Receiving the signal is not the same as honouring it: the
+                    // stub takes it and still never settles, which is the whole
+                    // failure mode.
+                    void opts?.abortSignal;
+                }),
+        );
+
+        await expect(runAgentLoopCall(params())).rejects.toThrow(/\[HARD-TIMEOUT\]/);
+    });
+
+    it('returns the result untouched when the provider answers in time', async () => {
+        const result = { text: 'final answer', steps: [], usage: { totalTokens: 1 } };
+        mockGenerate.mockResolvedValue(result);
+
+        await expect(runAgentLoopCall(params())).resolves.toBe(result);
+    });
+});

--- a/libs/llm/agent-loop-call.timeout.spec.ts
+++ b/libs/llm/agent-loop-call.timeout.spec.ts
@@ -88,6 +88,30 @@ describe('runAgentLoopCall — a stalled provider must not hang the caller', () 
         await expect(runAgentLoopCall(params())).rejects.toThrow(/\[HARD-TIMEOUT\]/);
     });
 
+    it('arms an abort even when the caller threads no signal', async () => {
+        // The race frees the pipeline; only the abort frees the request. With
+        // `abortSignal: undefined` the socket stays open and the BYOK limiter
+        // never gets its concurrency slot back — its release is a `finally` on
+        // a task that never settles. No review caller passes a signal, so the
+        // loop MUST arm its own.
+        mockGenerate.mockResolvedValue({ text: 'ok', steps: [], usage: {} });
+
+        await runAgentLoopCall(params());
+
+        const sent = mockGenerate.mock.calls[0][0];
+        expect(sent.abortSignal).toBeInstanceOf(AbortSignal);
+        expect(sent.abortSignal.aborted).toBe(false);
+    });
+
+    it('prefers the caller\'s signal when one IS threaded', async () => {
+        mockGenerate.mockResolvedValue({ text: 'ok', steps: [], usage: {} });
+        const controller = new AbortController();
+
+        await runAgentLoopCall({ ...params(), signal: controller.signal });
+
+        expect(mockGenerate.mock.calls[0][0].abortSignal).toBe(controller.signal);
+    });
+
     it('returns the result untouched when the provider answers in time', async () => {
         const result = { text: 'final answer', steps: [], usage: { totalTokens: 1 } };
         mockGenerate.mockResolvedValue(result);

--- a/libs/llm/agent-loop-call.timeout.spec.ts
+++ b/libs/llm/agent-loop-call.timeout.spec.ts
@@ -18,6 +18,11 @@
  * These tests stub `generateText` to that exact shape — never settles, ignores
  * the signal. Without the wrapper they hang until jest kills them; with it they
  * reject as `[HARD-TIMEOUT]`.
+*
+ * The per-test 15s budgets are not slack: `hardTimeout` grants ms + 5s of
+ * grace so a provider that DOES honour the abort settles on its own first, so
+ * a 40ms ceiling resolves at ~5.04s — just past jest's 5s default. Declared
+ * per test rather than via a CLI flag, which a plain `pnpm test` never passes.
  */
 jest.mock('ai', () => {
     const actual = jest.requireActual('ai');
@@ -72,7 +77,7 @@ describe('runAgentLoopCall — a stalled provider must not hang the caller', () 
         mockGenerate.mockImplementation(() => new Promise(() => {}));
 
         await expect(runAgentLoopCall(params())).rejects.toThrow(/\[HARD-TIMEOUT\]/);
-    });
+    }, 15000);
 
     it('rejects even when handed an abort signal the provider ignores', async () => {
         mockGenerate.mockImplementation(
@@ -86,7 +91,7 @@ describe('runAgentLoopCall — a stalled provider must not hang the caller', () 
         );
 
         await expect(runAgentLoopCall(params())).rejects.toThrow(/\[HARD-TIMEOUT\]/);
-    });
+    }, 15000);
 
     it('arms an abort even when the caller threads no signal', async () => {
         // The race frees the pipeline; only the abort frees the request. With

--- a/libs/llm/agent-loop-call.ts
+++ b/libs/llm/agent-loop-call.ts
@@ -36,6 +36,7 @@ import { agentModelIdentity } from '@libs/llm/model-identity';
 import { applyCacheBreakpoints } from '@libs/llm/prompt-cache';
 import { repairInvalidToolInput } from '@libs/llm/repair-tool-call';
 import { getLlmObservability } from '@libs/llm/llm-observability';
+import { hardTimeout, AGENT_TIMEOUT_MS } from '@libs/llm/llm-call';
 import {
     buildLangfuseTelemetry,
     toAiSdkTelemetryArgs,
@@ -104,6 +105,10 @@ export interface AgentLoopParams {
     telemetryMetadata?: LangfuseTelemetryMetadata;
     /** Cancellation / hard-timeout signal (the caller composes parent + timeout). */
     signal?: AbortSignal;
+    /** Wall-clock ceiling for the whole loop. Defaults to AGENT_TIMEOUT_MS.
+     *  Separate from `signal`: the signal is a request the provider may ignore,
+     *  this is the deadline that holds when it does. */
+    hardTimeoutMs?: number;
     /** Fallback max-output when the slot omits one (else provider default). */
     maxOutputTokens?: number;
     /** Override the slot's sampling temperature. */
@@ -219,7 +224,8 @@ export async function runAgentLoopCall(
     // ── ONE observability span — records the run's aggregate usage. Absent port
     // (a bare unit test) runs directly, still gets the model/loop, just no span. ──
     const observability = getLlmObservability();
-    return observability
+    const run = () =>
+        observability
         ? observability.runAiSdkLLMInSpan<any>({
               spanName: spanName ?? runName,
               runName,
@@ -234,6 +240,17 @@ export async function runAgentLoopCall(
               exec,
           })
         : exec();
+
+    // Belt over the AbortSignal suspenders. `signal` above is a REQUEST: several
+    // OpenAI-compatible proxies accept the connection, ignore the abort and
+    // never answer, and an `await` on that settles never — so nothing throws,
+    // no `catch` runs, and the caller waits forever with its span open and its
+    // sandbox lease held. The one-shot path has had this net since it was
+    // written (`llm-call.ts`); the loop, where reviews actually run, did not.
+    //
+    // Not a new ceiling: AGENT_TIMEOUT_MS was always the intended maximum. This
+    // is what makes it true when the provider declines to cooperate.
+    return hardTimeout(run(), params.hardTimeoutMs ?? AGENT_TIMEOUT_MS, runName);
 }
 
 // Re-export so callers can build a fixed model handle if needed (parity with

--- a/libs/llm/agent-loop-call.ts
+++ b/libs/llm/agent-loop-call.ts
@@ -36,7 +36,11 @@ import { agentModelIdentity } from '@libs/llm/model-identity';
 import { applyCacheBreakpoints } from '@libs/llm/prompt-cache';
 import { repairInvalidToolInput } from '@libs/llm/repair-tool-call';
 import { getLlmObservability } from '@libs/llm/llm-observability';
-import { hardTimeout, AGENT_TIMEOUT_MS } from '@libs/llm/llm-call';
+import {
+    hardTimeout,
+    timeoutSignal,
+    AGENT_TIMEOUT_MS,
+} from '@libs/llm/llm-call';
 import {
     buildLangfuseTelemetry,
     toAiSdkTelemetryArgs,
@@ -134,7 +138,7 @@ export async function runAgentLoopCall(
         organizationId,
         reporter,
         telemetryMetadata,
-        signal,
+        signal: callerSignal,
     } = params;
 
     // ── access + tuning + reasoning: the SAME montagem the one-shot uses ──
@@ -153,6 +157,22 @@ export async function runAgentLoopCall(
         openrouterProviderOrder: (slot as any)?.openrouterProviderOrder,
         openrouterAllowFallbacks: (slot as any)?.openrouterAllowFallbacks,
     });
+    // The deadline, decided once and used twice: the signal asks the provider to
+    // stop, the race below stops waiting for it.
+    const hardTimeoutMs = params.hardTimeoutMs ?? AGENT_TIMEOUT_MS;
+    // Self-arm when the caller supplies nothing. Threading a signal from the
+    // caller was always allowed and no review caller does it, so the loop ran
+    // with `abortSignal: undefined` — no cancellation at all. The race added
+    // below frees the PIPELINE, but only an abort frees the REQUEST: without
+    // one the socket stays open and the BYOK limiter never gets its slot back
+    // (its release is a `finally` on a task that never settles), so a stalled
+    // call would keep spending a concurrency slot for the life of the worker.
+    //
+    // The one-shot path has always self-armed (`timeoutSignal(...)` in
+    // structured-review-call). This gives the loop the same floor, and the 5s
+    // grace inside `hardTimeout` is what orders them: abort first, race only if
+    // the abort was ignored.
+    const signal = callerSignal ?? timeoutSignal(hardTimeoutMs);
     const temperature = params.temperature ?? inv.callOptions.temperature;
     const maxOutputTokens =
         inv.callOptions.maxOutputTokens ?? params.maxOutputTokens;
@@ -250,7 +270,7 @@ export async function runAgentLoopCall(
     //
     // Not a new ceiling: AGENT_TIMEOUT_MS was always the intended maximum. This
     // is what makes it true when the provider declines to cooperate.
-    return hardTimeout(run(), params.hardTimeoutMs ?? AGENT_TIMEOUT_MS, runName);
+    return hardTimeout(run(), hardTimeoutMs, runName);
 }
 
 // Re-export so callers can build a fixed model handle if needed (parity with

--- a/libs/llm/llm-call.spec.ts
+++ b/libs/llm/llm-call.spec.ts
@@ -293,17 +293,17 @@ describe('tracedGenerateText — hard-timeout net + wall-clock policy branches',
 
     const hang = () => new Promise<never>(() => {});
 
-    it('no abortSignal, no override → AGENT_TIMEOUT_MS branch (1800s) throws [HARD-TIMEOUT]', async () => {
+    it('no abortSignal, no override → AGENT_TIMEOUT_MS branch (4800s) throws [HARD-TIMEOUT]', async () => {
         mockGenerate.mockReturnValueOnce(hang());
         const p = run({ model: {} as any }).catch((e) => e);
         jest.advanceTimersByTime(AGENT_TIMEOUT_MS + 5_001);
         const err = (await p) as Error;
         expect(err).toBeInstanceOf(Error);
         expect(err.message).toContain('[HARD-TIMEOUT]');
-        expect(err.message).toContain('1800s');
+        expect(err.message).toContain('4800s');
     });
 
-    it('abortSignal present → LLM_CALL_TIMEOUT_MS branch (600s), the shorter secondary-call cap', async () => {
+    it('abortSignal present → LLM_CALL_TIMEOUT_MS branch (1200s), the shorter secondary-call cap', async () => {
         mockGenerate.mockReturnValueOnce(hang());
         const p = run({
             model: {} as any,
@@ -312,7 +312,7 @@ describe('tracedGenerateText — hard-timeout net + wall-clock policy branches',
         jest.advanceTimersByTime(LLM_CALL_TIMEOUT_MS + 5_001);
         const err = (await p) as Error;
         expect(err.message).toContain('[HARD-TIMEOUT]');
-        expect(err.message).toContain('600s');
+        expect(err.message).toContain('1200s');
     });
 
     it('__kodusHardTimeoutMs override wins (explicit cap honored)', async () => {
@@ -328,7 +328,7 @@ describe('tracedGenerateText — hard-timeout net + wall-clock policy branches',
 
     it('metamorphic (row 42) — __kodusHardTimeoutMs takes PRECEDENCE over abortSignal regardless of both being present', async () => {
         // Same inputs, override present alongside abortSignal → override branch
-        // wins deterministically (not the 600s abort branch).
+        // wins deterministically (not the 1200s abort branch).
         mockGenerate.mockReturnValueOnce(hang());
         const p = run({
             model: {} as any,
@@ -338,7 +338,7 @@ describe('tracedGenerateText — hard-timeout net + wall-clock policy branches',
         jest.advanceTimersByTime(20_000 + 5_001);
         const err = (await p) as Error;
         expect(err.message).toContain('20s');
-        expect(err.message).not.toContain('600s');
+        expect(err.message).not.toContain('1200s');
     });
 
     it('label branch: telemetry.functionId is used in the timeout message', async () => {

--- a/libs/llm/llm-call.timeout.spec.ts
+++ b/libs/llm/llm-call.timeout.spec.ts
@@ -7,12 +7,17 @@ import {
 
 describe('llm-call timeout primitives', () => {
     describe('AGENT_TIMEOUT_MS contract', () => {
-        it('caps a single agent at exactly 30 minutes', () => {
-            expect(AGENT_TIMEOUT_MS).toBe(30 * 60 * 1000);
+        it('caps a single agent at exactly 80 minutes', () => {
+            // Sized off 14 days of production AgentReviewStage durations (n=94):
+            // p99 29.5 min, max 32.2, and 1.1% already past the old 30-minute
+            // value — which means enforcing that one would have killed real
+            // reviews of large PRs. See the hierarchy note in llm-call.ts.
+            expect(AGENT_TIMEOUT_MS).toBe(80 * 60 * 1000);
         });
 
-        it('caps a single LLM call at exactly 10 minutes', () => {
-            expect(LLM_CALL_TIMEOUT_MS).toBe(10 * 60 * 1000);
+        it('caps a single LLM call at exactly 20 minutes', () => {
+            // Lockstep with the undici headersTimeout in fetch-timeouts.ts.
+            expect(LLM_CALL_TIMEOUT_MS).toBe(20 * 60 * 1000);
         });
     });
 
@@ -113,7 +118,7 @@ describe('llm-call timeout primitives', () => {
             await expect(wrapped).rejects.toThrow('inner-fail');
         });
 
-        it('uses AGENT_TIMEOUT_MS as the contract for a 30-minute agent run', async () => {
+        it('uses AGENT_TIMEOUT_MS as the contract for an 80-minute agent run', async () => {
             // End-to-end: a 30-min budget + 5s grace ⇒ rejects at 30:05.
             const inner = new Promise<never>(() => {});
             const wrapped = hardTimeout(
@@ -128,8 +133,8 @@ describe('llm-call timeout primitives', () => {
             const err = await result;
             expect((err as Error).message).toContain('[HARD-TIMEOUT]');
             expect((err as Error).message).toContain('agent-loop');
-            // 30 minutes = 1800 seconds
-            expect((err as Error).message).toContain('1800s');
+            // 80 minutes = 4800 seconds
+            expect((err as Error).message).toContain('4800s');
         });
     });
 });

--- a/libs/llm/llm-call.ts
+++ b/libs/llm/llm-call.ts
@@ -9,12 +9,30 @@
  */
 import { generateText as _aiSdkGenerateText, embed as _aiSdkEmbed } from 'ai';
 
-export const AGENT_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes max per agent
-// 10 minutes per individual LLM call — matches the undici headersTimeout
-// set in the worker bootstrap so neither layer aborts the other. Large
-// Gemini calls (>500K prompt + high reasoning) can legitimately take
-// 4-7 minutes of wall-clock before the first byte arrives.
-export const LLM_CALL_TIMEOUT_MS = 10 * 60 * 1000;
+/**
+ * The ceilings, outermost first. Each layer must leave room for the one
+ * inside it, or the outer one fires first and the inner is decoration:
+ *
+ *   CODE_REVIEW_PROCESS_TIMEOUT_MS  105 min  (job-processor-router)
+ *     AGENT_TIMEOUT_MS               80 min  (one agent's whole loop)
+ *       LLM_CALL_TIMEOUT_MS          20 min  (one model round-trip)
+ *         undici headersTimeout      20 min  (fetch-timeouts.ts)
+ *
+ * 80 minutes for the loop is sized off production, not preference. Over 14
+ * days of `AgentReviewStage` durations (n=94): p50 3.1 min, p90 11.6, p95
+ * 17.8, p99 29.5, max 32.2 — and 1.1% already exceeded the previous 30-minute
+ * ceiling, which means enforcing it would have killed legitimate reviews of
+ * large PRs. The pathological case sits far above that: the 2026-09-03 hang
+ * ran 98 minutes and was still going. So the gap between "large and slow" and
+ * "stuck" is wide, and 80 lands in it: ~2.5x the observed max, still well
+ * under the job's 105.
+ */
+export const AGENT_TIMEOUT_MS = 80 * 60 * 1000;
+// One model round-trip. Kept in lockstep with the undici headersTimeout in
+// fetch-timeouts.ts — raise one without the other and the HTTP layer aborts
+// first, making this number decoration. Large Gemini calls (>500K prompt +
+// high reasoning) can legitimately take 4-7 minutes before the first byte.
+export const LLM_CALL_TIMEOUT_MS = 20 * 60 * 1000;
 
 /** Create an AbortSignal that fires after the given ms. */
 export function timeoutSignal(ms: number): AbortSignal {

--- a/libs/llm/llm-call.ts
+++ b/libs/llm/llm-call.ts
@@ -7,7 +7,7 @@
  * is the AI SDK `generateText` with that net applied — Langfuse tracing is
  * consumed via `telemetry` on each call by the caller.
  */
-import { generateText as _aiSdkGenerateText } from 'ai';
+import { generateText as _aiSdkGenerateText, embed as _aiSdkEmbed } from 'ai';
 
 export const AGENT_TIMEOUT_MS = 30 * 60 * 1000; // 30 minutes max per agent
 // 10 minutes per individual LLM call — matches the undici headersTimeout
@@ -81,3 +81,28 @@ const generateText: typeof _aiSdkGenerateText = (async (
 }) as typeof _aiSdkGenerateText;
 
 export { generateText as tracedGenerateText };
+
+/**
+ * Embedding calls stall the same way model calls do, and are protected less.
+ *
+ * Both callers today are fail-soft against ERRORS — one catches and falls back
+ * to a lexical veto, the other has no catch at all — but a request that never
+ * answers throws nothing, so the catch never runs and the caller waits. A
+ * stalled embedding endpoint freezes the dedup stage exactly the way a stalled
+ * model call froze the agent loop.
+ *
+ * Shorter ceiling than a model call on purpose: an embedding is a single
+ * forward pass over a few hundred tokens. Minutes here mean the endpoint is
+ * gone, not busy.
+ */
+export const EMBED_TIMEOUT_MS = 60 * 1000;
+
+const embed: typeof _aiSdkEmbed = (async (
+    ...args: Parameters<typeof _aiSdkEmbed>
+) => {
+    const opts = args[0] as any;
+    const ms = opts?.__kodusHardTimeoutMs ?? EMBED_TIMEOUT_MS;
+    return hardTimeout(_aiSdkEmbed(...args), ms, 'embed');
+}) as typeof _aiSdkEmbed;
+
+export { embed as tracedEmbed };

--- a/libs/llm/llm-call.ts
+++ b/libs/llm/llm-call.ts
@@ -80,7 +80,20 @@ const generateText: typeof _aiSdkGenerateText = (async (
     return hardTimeout(_aiSdkGenerateText(...args), ms, label);
 }) as typeof _aiSdkGenerateText;
 
-export { generateText as tracedGenerateText };
+/**
+ * Per-call override for the wall clock. Read since the wrapper was written but
+ * never typed, so the first caller that needed it (the connection probe, whose
+ * own budget is 15s rather than the 10-minute call default) could not pass it
+ * without a cast. Declared here so the escape hatch is part of the contract.
+ */
+export type HardTimeoutOverride = { __kodusHardTimeoutMs?: number };
+
+export const tracedGenerateText = generateText as (
+    ...args: [
+        Parameters<typeof _aiSdkGenerateText>[0] & HardTimeoutOverride,
+        ...rest: unknown[],
+    ]
+) => ReturnType<typeof _aiSdkGenerateText>;
 
 /**
  * Embedding calls stall the same way model calls do, and are protected less.
@@ -105,4 +118,9 @@ const embed: typeof _aiSdkEmbed = (async (
     return hardTimeout(_aiSdkEmbed(...args), ms, 'embed');
 }) as typeof _aiSdkEmbed;
 
-export { embed as tracedEmbed };
+export const tracedEmbed = embed as (
+    ...args: [
+        Parameters<typeof _aiSdkEmbed>[0] & HardTimeoutOverride,
+        ...rest: unknown[],
+    ]
+) => ReturnType<typeof _aiSdkEmbed>;

--- a/libs/llm/probe-slot-call.timeout.spec.ts
+++ b/libs/llm/probe-slot-call.timeout.spec.ts
@@ -1,0 +1,69 @@
+/**
+ * The "Test" button must answer, even when the provider does not.
+ *
+ * `probeSlotCall` arms an AbortController and aborts at PROBE_TIMEOUT_MS. That
+ * covers a provider that honours the abort. The ones this probe exists to
+ * diagnose are exactly the ones that do not: an operator pastes a key for an
+ * OpenAI-compatible proxy, the proxy accepts the connection and never answers,
+ * and the abort is ignored. The await then settles never — nothing thrown, no
+ * catch reached — and the dialog spins with no verdict.
+ *
+ * Same failure the agent loop had (see agent-loop-call.timeout.spec.ts); this
+ * one costs a browser tab rather than a review, which is why it is smaller,
+ * not why it should be left open.
+ */
+jest.mock('ai', () => {
+    const actual = jest.requireActual('ai');
+    return { ...actual, generateText: jest.fn() };
+});
+jest.mock('@libs/llm/model-invocation', () => ({ resolveModelConfig: jest.fn() }));
+jest.mock('@libs/llm/reasoning-options', () => ({
+    buildReasoningProviderOptions: jest.fn(() => ({})),
+    reasoningEffortWasDropped: jest.fn(() => false),
+}));
+
+import { generateText } from 'ai';
+import { probeSlotCall } from '@libs/llm/probe-slot-call';
+import { resolveModelConfig } from '@libs/llm/model-invocation';
+
+const mockGenerate = generateText as unknown as jest.Mock;
+const mockResolve = resolveModelConfig as unknown as jest.Mock;
+
+const slot = () =>
+    ({
+        provider: 'openai_compatible',
+        model: 'stub',
+        baseURL: 'https://stub.invalid/v1',
+    }) as any;
+
+beforeEach(() => {
+    jest.clearAllMocks();
+    mockResolve.mockReturnValue({
+        model: { __model: 'probe' },
+        modelName: 'openai_compatible:stub',
+        callOptions: {},
+        providerOptions: {},
+    });
+});
+
+describe('probeSlotCall — an unanswering provider must still produce a verdict', () => {
+    it('does not hang when the provider ignores the abort and never answers', async () => {
+        mockGenerate.mockImplementation(
+            (opts: any) =>
+                new Promise(() => {
+                    // Takes the signal, ignores it — the shape the probe is for.
+                    void opts?.abortSignal;
+                }),
+        );
+
+        // What it must never do is leave the caller waiting forever. Whether
+        // the verdict arrives as a resolved failure or a throw is the probe's
+        // business; settling at all is the contract under test.
+        const settled = await probeSlotCall(slot(), { timeoutMs: 40 }).then(
+            () => 'resolved',
+            (e: Error) => e.message,
+        );
+
+        expect(settled).toMatch(/resolved|\[HARD-TIMEOUT\]/);
+    }, 15000);
+});

--- a/libs/llm/probe-slot-call.ts
+++ b/libs/llm/probe-slot-call.ts
@@ -26,8 +26,19 @@ import {
 } from '@libs/llm/override-reachability';
 import { buildReasoningProviderOptions } from '@libs/llm/reasoning-options';
 
-/** A probe must answer fast or not at all — the connect form is waiting. */
-export const PROBE_TIMEOUT_MS = 15_000;
+/**
+ * The connect form is waiting, so this is the shortest ceiling in the
+ * hierarchy — but not 15s, which it was. A probe is not a 1-token ping: the
+ * completion budget below carries the slot's *configured* reasoning budget
+ * (see `probeMaxOutputTokens`), so on a reasoning model the probe waits for
+ * real thinking. At 15s that reported a working key as broken, which is the
+ * worse failure of the two: a false negative sends the user to rotate a
+ * credential that was fine.
+ *
+ * 2 minutes is long for a form and still an order of magnitude under
+ * LLM_CALL_TIMEOUT_MS, so the ordering the hierarchy test asserts holds.
+ */
+export const PROBE_TIMEOUT_MS = 120_000;
 
 /**
  * Floor for the completion budget. A thinking model rejects a request whose

--- a/libs/llm/probe-slot-call.ts
+++ b/libs/llm/probe-slot-call.ts
@@ -16,7 +16,7 @@
  * module changes. Divergence stops being something to remember and becomes
  * impossible.
  */
-import { generateText } from 'ai';
+import { tracedGenerateText as generateText } from '@libs/llm/llm-call';
 import type { NormalizedModel } from '@libs/llm/byok-config';
 import { resolveModelConfig } from '@libs/llm/model-invocation';
 import {
@@ -169,6 +169,13 @@ export async function probeSlotCall(
     try {
         const result = await generateText({
             model: inv.model as any,
+            // The AbortController above is the polite ask; several of the
+            // OpenAI-compatible proxies this probe exists to diagnose accept
+            // the connection and ignore it. Without a wall clock the await
+            // settles never and the dialog spins with no verdict. Pinned to the
+            // probe's own budget rather than the 10-minute call default —
+            // `hardTimeout` adds a 5s grace, so a working abort still wins.
+            __kodusHardTimeoutMs: opts.timeoutMs ?? PROBE_TIMEOUT_MS,
             // The SDK retries twice by default; a probe must report the first
             // answer it gets, not triple a user's failing request.
             maxRetries: 0,

--- a/libs/llm/timeout-hierarchy.spec.ts
+++ b/libs/llm/timeout-hierarchy.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * The ceilings are a nesting, not four independent numbers.
+ *
+ * Each layer must leave room for the one inside it. Raise an inner one past
+ * its outer and the outer fires first, which is how a timeout becomes
+ * decoration: the number in the constant stops describing when anything
+ * actually happens. That is exactly how `LLM_CALL_TIMEOUT_MS` and undici's
+ * `headersTimeout` came to be pinned to each other by a comment — this locks
+ * the relationship the comment describes.
+ *
+ * Sized off production, not preference: 14 days of `AgentReviewStage`
+ * durations (n=94) gave p50 3.1 min, p95 17.8, p99 29.5, max 32.2, with 1.1%
+ * already past the old 30-minute ceiling. The 2026-09-03 hang ran 98 minutes.
+ * The gap between "large PR" and "stuck" is wide, and the agent ceiling has to
+ * sit inside it.
+ */
+import { AGENT_TIMEOUT_MS, LLM_CALL_TIMEOUT_MS, EMBED_TIMEOUT_MS } from '@libs/llm/llm-call';
+import { PROBE_TIMEOUT_MS } from '@libs/llm/probe-slot-call';
+
+// Mirrored from job-processor-router.service.ts. Duplicated on purpose: libs/llm
+// must not depend on the workflow layer, and a silent drift here is exactly
+// what this test exists to catch — if that constant moves, this fails and
+// someone reads both.
+const CODE_REVIEW_PROCESS_TIMEOUT_MS = 105 * 60 * 1000;
+
+describe('LLM timeout hierarchy — every layer leaves room for the one inside', () => {
+    it('an agent loop fits inside the review job that runs it', () => {
+        expect(AGENT_TIMEOUT_MS).toBeLessThan(CODE_REVIEW_PROCESS_TIMEOUT_MS);
+    });
+
+    it('leaves the job real headroom for the stages around the agent', () => {
+        // The pipeline still has to fetch files, post the initial comment, and
+        // afterwards create comments and generate the summary. A loop that
+        // consumed the whole job budget would be killed mid-publish.
+        const headroom = CODE_REVIEW_PROCESS_TIMEOUT_MS - AGENT_TIMEOUT_MS;
+        expect(headroom).toBeGreaterThanOrEqual(20 * 60 * 1000);
+    });
+
+    it('one model round-trip fits inside the loop that may make several', () => {
+        expect(LLM_CALL_TIMEOUT_MS).toBeLessThan(AGENT_TIMEOUT_MS);
+    });
+
+    it('covers the slowest legitimate review observed in production', () => {
+        // max 32.2 min over 14 days (n=94). Enforcing a ceiling at or under
+        // that would kill real reviews of large PRs.
+        expect(AGENT_TIMEOUT_MS).toBeGreaterThan(33 * 60 * 1000);
+    });
+
+    it('still cuts the pathological case, which ran 98 minutes', () => {
+        expect(AGENT_TIMEOUT_MS).toBeLessThan(98 * 60 * 1000);
+    });
+
+    it('keeps the short-lived ceilings short — they answer a person, not a pipeline', () => {
+        expect(PROBE_TIMEOUT_MS).toBeLessThan(LLM_CALL_TIMEOUT_MS);
+        expect(EMBED_TIMEOUT_MS).toBeLessThan(LLM_CALL_TIMEOUT_MS);
+    });
+});

--- a/libs/llm/timeout-hierarchy.spec.ts
+++ b/libs/llm/timeout-hierarchy.spec.ts
@@ -54,4 +54,18 @@ describe('LLM timeout hierarchy — every layer leaves room for the one inside',
         expect(PROBE_TIMEOUT_MS).toBeLessThan(LLM_CALL_TIMEOUT_MS);
         expect(EMBED_TIMEOUT_MS).toBeLessThan(LLM_CALL_TIMEOUT_MS);
     });
+
+    // Both bounds matter, in opposite directions.
+    //
+    // Floor: the probe forwards the slot's configured reasoning budget, so on
+    // a thinking model it waits for real thinking. It sat at 15s, which
+    // reported working credentials as broken.
+    //
+    // Ceiling: it still blocks a form. Nothing above interactive scale is a
+    // probe any more, which is what stops this drifting up to meet the call
+    // ceiling the next time someone sees a timeout.
+    it('gives the probe room for a thinking model without ceasing to be interactive', () => {
+        expect(PROBE_TIMEOUT_MS).toBeGreaterThanOrEqual(60 * 1000);
+        expect(PROBE_TIMEOUT_MS).toBeLessThanOrEqual(2 * 60 * 1000);
+    });
 });

--- a/libs/llm/traced-embed.spec.ts
+++ b/libs/llm/traced-embed.spec.ts
@@ -1,0 +1,47 @@
+/**
+ * Embeddings need the same wall-clock floor model calls have.
+ *
+ * Both production callers are fail-soft against ERRORS — the dedup guard
+ * catches and falls back to a lexical veto, `document.ts` has no catch at all
+ * — and neither is protected against SILENCE. A request that never answers
+ * throws nothing, so the catch never runs and the stage waits forever, which
+ * is precisely how the agent loop hung on 2026-09-03.
+ */
+jest.mock('ai', () => {
+    const actual = jest.requireActual('ai');
+    return { ...actual, embed: jest.fn() };
+});
+
+import { embed } from 'ai';
+import { tracedEmbed, EMBED_TIMEOUT_MS } from '@libs/llm/llm-call';
+
+const mockEmbed = embed as unknown as jest.Mock;
+
+describe('tracedEmbed — a stalled embedding endpoint must not hang the stage', () => {
+    beforeEach(() => jest.clearAllMocks());
+
+    it('rejects on the wall clock when the endpoint never answers', async () => {
+        mockEmbed.mockImplementation(() => new Promise(() => {}));
+
+        await expect(
+            tracedEmbed({
+                model: {} as any,
+                value: 'x',
+                __kodusHardTimeoutMs: 40,
+            } as any),
+        ).rejects.toThrow(/\[HARD-TIMEOUT\]/);
+    });
+
+    it('returns the embedding untouched when the endpoint answers', async () => {
+        const result = { embedding: [0.1, 0.2], usage: { tokens: 3 } };
+        mockEmbed.mockResolvedValue(result);
+
+        await expect(
+            tracedEmbed({ model: {} as any, value: 'x' } as any),
+        ).resolves.toBe(result);
+    });
+
+    it('defaults to a ceiling well under the agent one — an embedding is one forward pass', () => {
+        expect(EMBED_TIMEOUT_MS).toBe(60 * 1000);
+    });
+});

--- a/libs/llm/traced-embed.spec.ts
+++ b/libs/llm/traced-embed.spec.ts
@@ -6,6 +6,11 @@
  * — and neither is protected against SILENCE. A request that never answers
  * throws nothing, so the catch never runs and the stage waits forever, which
  * is precisely how the agent loop hung on 2026-09-03.
+*
+ * The per-test 15s budgets are not slack: `hardTimeout` grants ms + 5s of
+ * grace so a provider that DOES honour the abort settles on its own first, so
+ * a 40ms ceiling resolves at ~5.04s — just past jest's 5s default. Declared
+ * per test rather than via a CLI flag, which a plain `pnpm test` never passes.
  */
 jest.mock('ai', () => {
     const actual = jest.requireActual('ai');
@@ -30,7 +35,7 @@ describe('tracedEmbed — a stalled embedding endpoint must not hang the stage',
                 __kodusHardTimeoutMs: 40,
             } as any),
         ).rejects.toThrow(/\[HARD-TIMEOUT\]/);
-    });
+    }, 15000);
 
     it('returns the embedding untouched when the endpoint answers', async () => {
         const result = { embedding: [0.1, 0.2], usage: { tokens: 3 } };

--- a/scripts/selfhosted/provision.sh
+++ b/scripts/selfhosted/provision.sh
@@ -305,19 +305,51 @@ provision_server() {
             aws_ensure_security_group
             local tagspec
             tagspec="ResourceType=instance,Tags=[{Key=Name,Value=$label},{Key=Project,Value=kodus-e2e},{Key=CreatedAt,Value=$(date -u +%Y-%m-%dT%H:%M:%SZ)}]"
-            SERVER_ID=$(aws ec2 run-instances \
-                --region "$AWS_REGION_E2E" \
-                --image-id "$AWS_AMI_ID" \
-                --instance-type "$AWS_INSTANCE_TYPE" \
-                --key-name "$SSH_KEY_ID" \
-                --security-group-ids "$AWS_SG_ID" \
-                --associate-public-ip-address \
-                --user-data "$user_data" \
-                --tag-specifications "$tagspec" \
-                --block-device-mappings 'DeviceName=/dev/sda1,Ebs={VolumeSize=40,VolumeType=gp3,DeleteOnTermination=true}' \
-                --instance-initiated-shutdown-behavior terminate \
-                --query 'Instances[0].InstanceId' --output text) \
-                || { err "AWS run-instances failed"; exit 1; }
+            # EC2 is eventually consistent: a key pair, security group or AMI
+            # created moments ago can still be invisible to run-instances,
+            # which used to fail the whole run on a condition that clears
+            # itself in seconds. AWS's guidance for Invalid*.NotFound is to
+            # retry, so retry -- anything else is a real error and still exits.
+            #
+            # stderr goes to a file rather than being discarded. The previous
+            # version printed only "AWS run-instances failed"; the reason
+            # survived one occurrence purely because stderr leaked to the job
+            # log, and capturing it makes the next one self-explaining.
+            local attempt aws_err
+            aws_err=$(mktemp)
+            SERVER_ID=""
+            for attempt in 1 2 3 4 5; do
+                if SERVER_ID=$(aws ec2 run-instances \
+                        --region "$AWS_REGION_E2E" \
+                        --image-id "$AWS_AMI_ID" \
+                        --instance-type "$AWS_INSTANCE_TYPE" \
+                        --key-name "$SSH_KEY_ID" \
+                        --security-group-ids "$AWS_SG_ID" \
+                        --associate-public-ip-address \
+                        --user-data "$user_data" \
+                        --tag-specifications "$tagspec" \
+                        --block-device-mappings 'DeviceName=/dev/sda1,Ebs={VolumeSize=40,VolumeType=gp3,DeleteOnTermination=true}' \
+                        --instance-initiated-shutdown-behavior terminate \
+                        --query 'Instances[0].InstanceId' --output text 2>"$aws_err"); then
+                    break
+                fi
+                SERVER_ID=""
+                if grep -q 'Invalid[A-Za-z]*\.NotFound' "$aws_err"; then
+                    warn "run-instances attempt $attempt: $(tr '\n' ' ' < "$aws_err")"
+                    warn "  a just-created dependency is not visible yet; retrying in $(( attempt * 3 ))s"
+                    sleep $(( attempt * 3 ))
+                    continue
+                fi
+                err "AWS run-instances failed: $(cat "$aws_err")"
+                rm -f "$aws_err"
+                exit 1
+            done
+            if [ -z "$SERVER_ID" ]; then
+                err "AWS run-instances failed after $attempt attempts: $(cat "$aws_err")"
+                rm -f "$aws_err"
+                exit 1
+            fi
+            rm -f "$aws_err"
             [ -n "$SERVER_ID" ] && [ "$SERVER_ID" != "None" ] \
                 || { err "AWS run-instances returned no instance id"; exit 1; }
             log "Instance $SERVER_ID starting..."

--- a/scripts/selfhosted/reap.sh
+++ b/scripts/selfhosted/reap.sh
@@ -149,8 +149,14 @@ reap_aws_ec2() {
     # only evidence anything was missed is this line. It ran silently in CI for
     # exactly that reason: reap-droplets.yml passed no AWS credential.
     command -v aws >/dev/null 2>&1 || { warn "aws CLI not found — EC2 sweep SKIPPED (leaked instances will not be reaped)"; return 0; }
-    if [ -z "${AWS_ACCESS_KEY_ID:-}" ] && [ -z "${AWS_PROFILE:-}" ]; then
-        warn "no AWS credential — EC2 sweep SKIPPED (leaked instances will not be reaped)"
+    # Ask the CLI whether it can authenticate, rather than guessing from two
+    # env vars. The env-var check passed in CI and silently skipped the sweep
+    # everywhere else -- a default profile, SSO, an instance role and a
+    # container role all authenticate fine and set neither variable, so the
+    # one command that reaps leaked instances quietly did nothing while
+    # printing a warning nobody was watching for.
+    if ! aws sts get-caller-identity >/dev/null 2>&1; then
+        warn "AWS credential does not authenticate — EC2 sweep SKIPPED (leaked instances will not be reaped)"
         return 0
     fi
     local region="${AWS_REGION_E2E:-${AWS_DEFAULT_REGION:-us-east-2}}"
@@ -196,20 +202,40 @@ reap_aws_ec2() {
 
     # Key pairs outlive their instance when a run dies between import and
     # launch. They cost nothing but accumulate; drop the ones with no instance.
-    local kp
-    while read -r kp; do
+    #
+    # "No instance" is NOT sufficient on its own, and assuming it was is what
+    # broke a run with `InvalidKeyPair.NotFound`: a live run holds a key pair
+    # and no instance for the whole window between import-key-pair and
+    # run-instances. Sweeping on absence alone deletes the key out from under
+    # it, and run-instances then fails on a key the run had just created.
+    #
+    # So key pairs get the same TTL guard the instances above get. A key
+    # younger than the TTL may belong to a run still in flight; only an old
+    # one is provably an orphan.
+    local kp created kp_epoch kp_age kp_age_h
+    while read -r kp created; do
         [ -n "${kp:-}" ] || continue
         case "$kp" in
             kodus-e2e-*)
-                if ! echo "$rows" | grep -q "$kp"; then
-                    [ "$DRY_RUN" = "1" ] \
-                        && dim "  would drop stale key pair $kp" \
-                        || { aws ec2 delete-key-pair --region "$region" --key-name "$kp" >/dev/null 2>&1 \
-                             && dim "  dropped stale key pair $kp"; }
+                if echo "$rows" | grep -q "$kp"; then continue; fi
+                kp_epoch=$(iso_to_epoch "$created")
+                if [ -z "$kp_epoch" ]; then
+                    warn "  skip   key pair $kp — could not parse CreateTime '$created'; refusing to guess its age"
+                    continue
                 fi
+                kp_age=$(( NOW - kp_epoch ))
+                kp_age_h=$(( kp_age / 3600 ))
+                if [ "$REAP_ALL" != "1" ] && [ "$kp_age" -lt "$TTL_SECS" ]; then
+                    dim "  young  key pair $kp (${kp_age_h}h < ${TTL_HOURS}h) — a run may still be launching with it"
+                    continue
+                fi
+                [ "$DRY_RUN" = "1" ] \
+                    && dim "  would drop stale key pair $kp (${kp_age_h}h old)" \
+                    || { aws ec2 delete-key-pair --region "$region" --key-name "$kp" >/dev/null 2>&1 \
+                         && dim "  dropped stale key pair $kp (${kp_age_h}h old)"; }
                 ;;
         esac
-    done < <(aws ec2 describe-key-pairs --region "$region" --query 'KeyPairs[].KeyName' --output text 2>/dev/null | tr '\t' '\n')
+    done < <(aws ec2 describe-key-pairs --region "$region" --query 'KeyPairs[].[KeyName,CreateTime]' --output text 2>/dev/null)
 }
 
 # ---------- pull live droplets (source of truth) ----------

--- a/tests/e2e/provisioning/self-hosted/vm.sh
+++ b/tests/e2e/provisioning/self-hosted/vm.sh
@@ -253,19 +253,51 @@ provision_server() {
             # because the reaper watched a different prefix.
             local tagspec
             tagspec="ResourceType=instance,Tags=[{Key=Name,Value=$name},{Key=Project,Value=kodus-e2e},{Key=CreatedAt,Value=$(date -u +%Y-%m-%dT%H:%M:%SZ)}]"
-            SERVER_ID=$(aws ec2 run-instances \
-                --region "$AWS_REGION_E2E" \
-                --image-id "$AWS_AMI_ID" \
-                --instance-type "$AWS_INSTANCE_TYPE" \
-                --key-name "$SSH_KEY_ID" \
-                --security-group-ids "$AWS_SG_ID" \
-                --associate-public-ip-address \
-                --user-data "$user_data" \
-                --tag-specifications "$tagspec" \
-                --block-device-mappings 'DeviceName=/dev/sda1,Ebs={VolumeSize=40,VolumeType=gp3,DeleteOnTermination=true}' \
-                --instance-initiated-shutdown-behavior terminate \
-                --query 'Instances[0].InstanceId' --output text) \
-                || { err "AWS run-instances failed"; exit 1; }
+            # EC2 is eventually consistent: a key pair, security group or AMI
+            # created moments ago can still be invisible to run-instances,
+            # which used to fail the whole run on a condition that clears
+            # itself in seconds. AWS's guidance for Invalid*.NotFound is to
+            # retry, so retry -- anything else is a real error and still exits.
+            #
+            # stderr goes to a file rather than being discarded. The previous
+            # version printed only "AWS run-instances failed"; the reason
+            # survived one occurrence purely because stderr leaked to the job
+            # log, and capturing it makes the next one self-explaining.
+            local attempt aws_err
+            aws_err=$(mktemp)
+            SERVER_ID=""
+            for attempt in 1 2 3 4 5; do
+                if SERVER_ID=$(aws ec2 run-instances \
+                        --region "$AWS_REGION_E2E" \
+                        --image-id "$AWS_AMI_ID" \
+                        --instance-type "$AWS_INSTANCE_TYPE" \
+                        --key-name "$SSH_KEY_ID" \
+                        --security-group-ids "$AWS_SG_ID" \
+                        --associate-public-ip-address \
+                        --user-data "$user_data" \
+                        --tag-specifications "$tagspec" \
+                        --block-device-mappings 'DeviceName=/dev/sda1,Ebs={VolumeSize=40,VolumeType=gp3,DeleteOnTermination=true}' \
+                        --instance-initiated-shutdown-behavior terminate \
+                        --query 'Instances[0].InstanceId' --output text 2>"$aws_err"); then
+                    break
+                fi
+                SERVER_ID=""
+                if grep -q 'Invalid[A-Za-z]*\.NotFound' "$aws_err"; then
+                    warn "run-instances attempt $attempt: $(tr '\n' ' ' < "$aws_err")"
+                    warn "  a just-created dependency is not visible yet; retrying in $(( attempt * 3 ))s"
+                    sleep $(( attempt * 3 ))
+                    continue
+                fi
+                err "AWS run-instances failed: $(cat "$aws_err")"
+                rm -f "$aws_err"
+                exit 1
+            done
+            if [ -z "$SERVER_ID" ]; then
+                err "AWS run-instances failed after $attempt attempts: $(cat "$aws_err")"
+                rm -f "$aws_err"
+                exit 1
+            fi
+            rm -f "$aws_err"
             [ -n "$SERVER_ID" ] && [ "$SERVER_ID" != "None" ] \
                 || { err "AWS run-instances returned no instance id"; exit 1; }
             log "Instance $SERVER_ID starting..."


### PR DESCRIPTION
A review hung forever on 2026-09-03 and nothing was logged as an error. That
is the whole story: **a promise that never settles throws nothing**, so no
`catch` runs, no `Promise.allSettled` rejects, and every guard in the path
reports success. `try/catch` tolerates failure, not silence.

Chasing that turned up the same shape in five more places, plus an unrelated
AWS defect the same method exposed.

## What hung, and why

`AgentReviewStage` stopped logging mid-run. Nine pipeline stages reported
`completed in Xms`; that one reported nothing, ever. The PR kept the "review
starting" comment, the sandbox lease stayed held, the span stayed open. The
e2e gave up after its own 53-minute budget — well past the 30-minute ceiling
that was supposed to apply.

`llm-call.ts` already said so in as many words: *"some providers ignore
AbortSignal; this is the safety net"*, and wrapped the **one-shot** path in
`hardTimeout` for exactly that. The **loop** had no such net, and the loop is
where reviews run.

`AbortSignal` is the polite first try. Several OpenAI-compatible proxies
accept the connection, ignore the abort and never answer. And a
`Promise.race` alone frees the *caller*, not the *request*: without an abort
the socket stays open and the BYOK limiter never reclaims its slot, because
the release is a `.finally()` on the task promise.

So the loop now both races a wall clock and arms its own `AbortSignal` when
the caller threads none.

## The ceilings, sized off production

They were four independent numbers that did not nest. They are now a
hierarchy, asserted by a test:

```
CODE_REVIEW_PROCESS_TIMEOUT_MS  105 min
  └─ AGENT_TIMEOUT_MS            80 min   (was 30)
       └─ LLM_CALL_TIMEOUT_MS    20 min   (was 10)
            └─ undici headers    20 min   (was 10, now in lockstep)
```

From CloudWatch, n=94 over 14 days: the slowest **legitimate** review ran
32.2 min, so the old 30-minute ceiling was killing 1.1% of real reviews of
large PRs. The pathological run took 98 min. 80 covers the former and still
cuts the latter, and the test pins both ends so neither drifts.

Also fixed while in there:

- **`tracedEmbed`** — both production callers are fail-soft against *errors*
  and unprotected against *silence*. `document.ts` has no `catch` at all.
- **`probeSlotCall`** — the Test button spun forever on a proxy that ignores
  the abort. Separately, its 15s ceiling was wrong in the other direction:
  the probe forwards the slot's *configured* reasoning budget, so on a
  thinking model 15s reported working credentials as broken. Now 120s,
  bounded from both sides.

## The AWS defect, which was not a blip

A matrix cell died on `InvalidKeyPair.NotFound` from `run-instances`, moments
after importing that key pair. It was written off as eventual consistency
because the next run worked. It was a race with our own reaper.

The key-pair sweep dropped any `kodus-e2e-*` key with no matching instance,
at any age — but a live run holds a key pair and no instance for the whole
window between `import-key-pair` and `run-instances`. "No instance" is not
evidence of an orphan; it is also the signature of a run about to launch. The
comment above the sweep even named the window and nothing checked the run had
died.

Proven against a real key pair, same TTL, same moment:

| | reaper's verdict |
|---|---|
| before | `would drop stale key pair kodus-e2e-guardtest` |
| after | `young key pair kodus-e2e-guardtest (0h < 6h) — a run may still be launching with it` |

`--ttl 0` still reaps it, so genuine orphans are untouched.

Proving that exposed why nobody had seen it: the EC2 sweep tested
`AWS_ACCESS_KEY_ID` and `AWS_PROFILE` and skipped itself when both were
empty. A default profile, SSO, an instance role and a container role all
authenticate and set neither — so outside CI the one command that reaps
leaked instances quietly did nothing behind a warning nobody watched for. It
now asks `sts get-caller-identity`.

With the race gone, the residual eventual-consistency case gets a bounded
retry on `Invalid*.NotFound` only; every other error still exits on the first
try. And `run-instances` stderr goes to a file instead of being discarded —
the old handler printed `AWS run-instances failed` and nothing else, so the
reason survived that occurrence purely because stderr leaked to the job log.

## Verification

- 93 suites / 2149 tests green in `libs/llm`; full suite green before rebase
  (12383 tests / 841 suites).
- The probe test was verified by reverting the fix (fails) and restoring it
  (passes).
- Three tests added by the first commits passed only under
  `--testTimeout=15000`, and nothing in the jest config sets one — they were
  red under a plain `pnpm test`. `hardTimeout` grants ms + 5s of grace so a
  provider that *does* honour the abort settles first, putting a 40ms ceiling
  at ~5.04s. Now declared per test, with the arithmetic written down.
- Reaper behaviour proven against live AWS in both directions, including the
  counterfactual above. Test key pair removed afterwards.