### PR TITLE
fix(byok): let the OpenRouter provider pin be typed, and survive its own edit

### DIFF
--- a/apps/web/src/features/ee/byok/_components/_modals/edit-key/_components/credential-forms/openrouter-advanced.spec.ts
+++ b/apps/web/src/features/ee/byok/_components/_modals/edit-key/_components/credential-forms/openrouter-advanced.spec.ts
@@ -1,0 +1,52 @@
+import { parseProviderOrder } from "./openrouter-advanced";
+
+/**
+ * The pin field documents comma-separated names and could not accept a comma.
+ *
+ * The input is controlled and its displayed value was derived from the parsed
+ * `string[]`. A person types a STRING, and the two disagree mid-word: "baseten,"
+ * parses to ["baseten"] — the empty segment after the separator is dropped — and
+ * re-renders as "baseten", erasing the comma in the same keystroke that typed
+ * it. The separator was untypeable, so a second provider could never be entered.
+ *
+ * `parseProviderOrder` still normalises; what changed is that it no longer feeds
+ * the display while the field has focus. These pin the normalisation, then the
+ * round-trip that shows why deriving the display from it cannot work.
+ */
+describe("parseProviderOrder", () => {
+    it.each([
+        ["one name", "baseten/fp4", ["baseten/fp4"]],
+        ["two names", "baseten/fp4, together", ["baseten/fp4", "together"]],
+        ["padding around names", "  a ,  b  ", ["a", "b"]],
+        ["a trailing separator", "a,", ["a"]],
+        ["repeated separators", "a,,b", ["a", "b"]],
+    ])("reads %s", (_label, raw, expected) => {
+        expect(parseProviderOrder(raw)).toEqual(expected);
+    });
+
+    it.each([
+        ["an empty field", ""],
+        ["only whitespace", "   "],
+        ["only separators", ",,,"],
+    ])("returns null for %s — no pin, not an empty pin", (_label, raw) => {
+        // null is what the write path treats as "leave OpenRouter's own routing
+        // alone"; an empty array would persist as a meaningless setting.
+        expect(parseProviderOrder(raw)).toBeNull();
+    });
+
+    it("cannot round-trip a half-typed separator — why the draft exists", () => {
+        // THE bug, stated as the property that fails. Feeding this back into the
+        // input is what deleted the user's comma on every keystroke.
+        const typed = "baseten/fp4,";
+        const shownIfDerived = (parseProviderOrder(typed) ?? []).join(", ");
+
+        expect(shownIfDerived).toBe("baseten/fp4");
+        expect(shownIfDerived).not.toBe(typed);
+
+        // Same for the space a person types after the comma.
+        const typedWithSpace = "baseten/fp4, ";
+        expect((parseProviderOrder(typedWithSpace) ?? []).join(", ")).not.toBe(
+            typedWithSpace,
+        );
+    });
+});

--- a/apps/web/src/features/ee/byok/_components/_modals/edit-key/_components/credential-forms/openrouter-advanced.tsx
+++ b/apps/web/src/features/ee/byok/_components/_modals/edit-key/_components/credential-forms/openrouter-advanced.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useState } from "react";
 import { FormControl } from "@components/ui/form-control";
 import { Input } from "@components/ui/input";
 import { Separator } from "@components/ui/separator";
@@ -10,6 +11,19 @@ import { Controller, useFormContext } from "react-hook-form";
 import type { EditKeyForm } from "../../_types";
 
 /**
+ * The typed text as the stored list: trimmed names, blanks dropped, and `null`
+ * for "no pin" (OpenRouter's own routing) rather than an empty array, which the
+ * write path would persist as a meaningless empty setting.
+ */
+export const parseProviderOrder = (raw: string): string[] | null => {
+    const parsed = raw
+        .split(",")
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+    return parsed.length > 0 ? parsed : null;
+};
+
+/**
  * OpenRouter-only advanced fields — pin upstream providers + fallback toggle.
  * Rendered inside the Advanced settings section via the ADVANCED_FIELDS registry
  * (keyed by provider), so it isn't a `provider === "open_router"` special-case in
@@ -17,6 +31,8 @@ import type { EditKeyForm } from "../../_types";
  */
 export const OpenRouterRoutingFields = () => {
     const { control } = useFormContext<EditKeyForm>();
+    // Raw text while the pin field has focus — see the note at its Controller.
+    const [draft, setDraft] = useState<string | null>(null);
 
     return (
         <>
@@ -48,6 +64,16 @@ export const OpenRouterRoutingFields = () => {
                     name="openrouterProviderOrder"
                     control={control}
                     render={({ field, fieldState }) => {
+                        // The model is a string[], but a person types a STRING —
+                        // and the two disagree mid-word. Deriving the displayed
+                        // value straight from the array meant the comma the user
+                        // typed was parsed into an empty segment, filtered out,
+                        // and re-rendered gone in the same keystroke: the
+                        // separator this field documents was literally
+                        // untypeable, so a second provider could never be
+                        // entered. `draft` holds the raw text while the field is
+                        // being edited and is dropped on blur, so the array stays
+                        // the source of truth everywhere except under the cursor.
                         const asCsv = Array.isArray(field.value)
                             ? field.value.join(", ")
                             : "";
@@ -60,19 +86,20 @@ export const OpenRouterRoutingFields = () => {
                                     <Input
                                         size="md"
                                         placeholder="e.g. moonshot, together"
-                                        value={asCsv}
+                                        value={draft ?? asCsv}
                                         error={fieldState.error}
                                         onChange={(e) => {
                                             const raw = e.target.value;
-                                            const parsed = raw
-                                                .split(",")
-                                                .map((s) => s.trim())
-                                                .filter((s) => s.length > 0);
+                                            setDraft(raw);
                                             field.onChange(
-                                                parsed.length > 0
-                                                    ? parsed
-                                                    : null,
+                                                parseProviderOrder(raw),
                                             );
+                                        }}
+                                        onBlur={() => {
+                                            // Hand display back to the array, so
+                                            // what is stored is what is shown.
+                                            setDraft(null);
+                                            field.onBlur();
                                         }}
                                     />
                                 </FormControl.Input>

--- a/apps/web/src/features/ee/byok/manual/page.client.tsx
+++ b/apps/web/src/features/ee/byok/manual/page.client.tsx
@@ -179,6 +179,24 @@ export function ByokManualPageClient({
                   typeof editSettings.awsRegion === "string"
                       ? editSettings.awsRegion
                       : undefined,
+              // OpenRouter pinning is stored under credential settings like the
+              // three above, and was the only pair this lift forgot. The form
+              // default reads `existingConfig?.openrouterProviderOrder ?? null`,
+              // so omitting it here did two things: Edit always opened with an
+              // empty field however many times the user saved, and — because
+              // the backend REPLACES credential settings with what the form
+              // sends (only the aws* secrets are carried over) — the next save
+              // wrote settings without the key and ERASED the stored pin. The
+              // value could never survive its own edit dialog.
+              openrouterProviderOrder: Array.isArray(
+                  editSettings.openrouterProviderOrder,
+              )
+                  ? (editSettings.openrouterProviderOrder as string[])
+                  : undefined,
+              openrouterAllowFallbacks:
+                  typeof editSettings.openrouterAllowFallbacks === "boolean"
+                      ? editSettings.openrouterAllowFallbacks
+                      : undefined,
           }
         : null;
 


### PR DESCRIPTION
Reported by a customer: the OpenRouter provider pin could not be entered, and whatever did get entered was gone on the next Edit — however many times it was saved.

Two defects on the same field, plus a third nobody had seen.

## The comma was untypeable

The input is controlled and its displayed value was derived from the parsed `string[]`. A person types a STRING, and the two disagree mid-word: `"baseten,"` parses to `["baseten"]` — the empty segment after the separator is dropped — and re-renders as `"baseten"`, erasing the comma in the same keystroke that typed it. The separator the helper text documents could never be held, so a second provider could never be reached.

A `draft` string now holds the raw text while the field has focus and is released on blur, so the array stays the source of truth everywhere except under the cursor.

## The value was destroyed by its own dialog

Building `existingConfig` for an edit lifts credential settings by name — `baseURL`, `vertexLocation`, `awsRegion` — and `openrouterProviderOrder` / `openrouterAllowFallbacks` were the only pair it forgot, so the form default resolved to `null` and the field opened empty.

That alone would be cosmetic. It is not: the backend REPLACES credential settings with what the form sends, carrying over only the `aws*` secrets.

```ts
const settings = { ...(nextSettings ?? {}) };
for (const field of BYOK_SECRET_SETTINGS) { ... }
result.settings = settings;
```

So the next save wrote settings without the key and ERASED the stored pin. Every attempt to fix it by saving again destroyed the previous one — exactly what the report describes.

## Evidence

Read from production: 8 of 81 OpenRouter credentials still carry a pin, so it does persist — until the credential is edited.

## Tests

`parseProviderOrder` is extracted so the normalisation is testable. The round-trip that could not hold a half-typed separator is pinned as the property that FAILED, rather than as a description of the fix.

Verified: 10 suites / 150 tests green in `apps/web/src/features/ee/byok`, tsc clean on the touched files, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)