### PR TITLE
fix(kody-rules): soft-delete every rule matching a removed source path, not just the first

### DIFF
--- a/libs/kodyRules/infrastructure/adapters/services/kodyRulesSync.service.spec.ts
+++ b/libs/kodyRules/infrastructure/adapters/services/kodyRulesSync.service.spec.ts
@@ -1096,3 +1096,145 @@ describe('KodyRulesSyncService.getRuleId — result envelope parser (A rows)', (
         expect(getRuleId(input as any)).toBeUndefined();
     });
 });
+
+/**
+ * Guards the "every record, not just the first" contract of the
+ * sourcePath-scoped delete/depin passes. A sourcePath can carry several
+ * records (duplicates from concurrent syncs — observed live: two identical
+ * rules from one merge). `Array.find` soft-deleted ONE of them and left the
+ * survivor ACTIVE for a file that no longer existed; the same `.find` served
+ * the @kody-ignore path, so a marker added to an already-imported file left
+ * survivors too.
+ */
+describe('KodyRulesSyncService — deleteRuleBySourcePath / depinRuleBySourcePath', () => {
+    const ORG = { organizationId: 'org-1', teamId: 'team-1' };
+    const PATH = '.kody/rules/x.md';
+
+    const makeService = (rules: any[]) => {
+        const kodyRulesService = {
+            findByOrganizationId: jest
+                .fn()
+                .mockResolvedValue({ uuid: 'doc-1', rules }),
+            createOrUpdate: jest.fn().mockResolvedValue({}),
+        };
+        const deps: any[] = new Array(KodyRulesSyncService.length).fill({});
+        deps[0] = kodyRulesService;
+        const service = new (KodyRulesSyncService as any)(...deps);
+        return { service, kodyRulesService };
+    };
+
+    const rule = (uuid: string, extra: Record<string, unknown> = {}) => ({
+        uuid,
+        repositoryId: 'repo-1',
+        sourcePath: PATH,
+        status: KodyRulesStatus.ACTIVE,
+        ...extra,
+    });
+
+    const writtenDtos = (kodyRulesService: { createOrUpdate: jest.Mock }) =>
+        kodyRulesService.createOrUpdate.mock.calls.map(
+            ([, dto]: [unknown, any]) => dto,
+        );
+
+    it('soft-deletes EVERY live record for (repositoryId, sourcePath), not just the first', async () => {
+        const { service, kodyRulesService } = makeService([
+            rule('dup-1'),
+            rule('dup-2', { status: KodyRulesStatus.PAUSED }),
+            // Multi-rule files carry an anchor after '#': still the same file.
+            rule('dup-3', { sourcePath: `${PATH}#anchor` }),
+            rule('other-repo', { repositoryId: 'repo-2' }),
+            rule('other-path', { sourcePath: '.kody/rules/y.md' }),
+        ]);
+
+        await service.deleteRuleBySourcePath({
+            organizationAndTeamData: ORG,
+            repositoryId: 'repo-1',
+            sourcePath: PATH,
+        });
+
+        const written = writtenDtos(kodyRulesService);
+        expect(written.map((d) => d.uuid).sort()).toEqual([
+            'dup-1',
+            'dup-2',
+            'dup-3',
+        ]);
+        expect(written.every((d) => d.status === KodyRulesStatus.DELETED)).toBe(
+            true,
+        );
+    });
+
+    it('skips records that are already DELETED (no redundant writes)', async () => {
+        const { service, kodyRulesService } = makeService([
+            rule('gone', { status: KodyRulesStatus.DELETED }),
+            rule('live'),
+        ]);
+
+        await service.deleteRuleBySourcePath({
+            organizationAndTeamData: ORG,
+            repositoryId: 'repo-1',
+            sourcePath: PATH,
+        });
+
+        expect(writtenDtos(kodyRulesService).map((d) => d.uuid)).toEqual([
+            'live',
+        ]);
+    });
+
+    it('keeps going when one record fails to write — the rest still end DELETED', async () => {
+        const { service, kodyRulesService } = makeService([
+            rule('boom'),
+            rule('ok'),
+        ]);
+        kodyRulesService.createOrUpdate
+            .mockRejectedValueOnce(new Error('write failed'))
+            .mockResolvedValue({});
+
+        await service.deleteRuleBySourcePath({
+            organizationAndTeamData: ORG,
+            repositoryId: 'repo-1',
+            sourcePath: PATH,
+        });
+
+        expect(writtenDtos(kodyRulesService).map((d) => d.uuid)).toEqual([
+            'boom',
+            'ok',
+        ]);
+    });
+
+    it('is a no-op when nothing matches', async () => {
+        const { service, kodyRulesService } = makeService([
+            rule('other-path', { sourcePath: '.kody/rules/y.md' }),
+        ]);
+
+        await service.deleteRuleBySourcePath({
+            organizationAndTeamData: ORG,
+            repositoryId: 'repo-1',
+            sourcePath: PATH,
+        });
+
+        expect(kodyRulesService.createOrUpdate).not.toHaveBeenCalled();
+    });
+
+    it('depins EVERY pinned record for the path, even when the first match is unpinned', async () => {
+        const { service, kodyRulesService } = makeService([
+            // The old `.find` hit this one first and returned early.
+            rule('unpinned', { pinnedSync: false }),
+            rule('pinned-1', { pinnedSync: true }),
+            rule('pinned-2', { pinnedSync: true }),
+            rule('other-repo-pinned', { repositoryId: 'repo-2', pinnedSync: true }),
+        ]);
+
+        await service.depinRuleBySourcePath({
+            organizationAndTeamData: ORG,
+            repositoryId: 'repo-1',
+            sourcePath: PATH,
+        });
+
+        const written = writtenDtos(kodyRulesService);
+        expect(written.map((d) => d.uuid).sort()).toEqual([
+            'pinned-1',
+            'pinned-2',
+        ]);
+        expect(written.every((d) => d.pinnedSync === false)).toBe(true);
+    });
+});

--- a/libs/kodyRules/infrastructure/adapters/services/kodyRulesSync.service.ts
+++ b/libs/kodyRules/infrastructure/adapters/services/kodyRulesSync.service.ts
@@ -32,6 +32,7 @@ import {
     KodyRuleSeverity,
 } from '@libs/ee/kodyRules/dtos/create-kody-rule.dto';
 import {
+    IKodyRule,
     KodyRulesOrigin,
     KodyRulesScope,
     KodyRulesStatus,
@@ -285,88 +286,128 @@ export class KodyRulesSyncService {
         }
     }
 
+    /**
+     * Every rule of `repositoryId` whose source file is `sourcePath`. A
+     * multi-rule file stores `path#anchor`, so match on the path part. A
+     * sourcePath can carry SEVERAL records (duplicates from concurrent
+     * syncs — observed live: two identical rules from one merge), which is
+     * why the passes below act on the whole list and never on `.find()`.
+     */
+    private rulesBySourcePath(
+        entity: { rules?: Partial<IKodyRule>[] } | null | undefined,
+        repositoryId: string,
+        sourcePath: string,
+    ): Partial<IKodyRule>[] {
+        return (entity?.rules ?? []).filter(
+            (r) =>
+                r?.uuid &&
+                r?.repositoryId === repositoryId &&
+                (r?.sourcePath || '').split('#')[0] === sourcePath,
+        );
+    }
+
     private async deleteRuleBySourcePath(params: {
         organizationAndTeamData: OrganizationAndTeamData;
         repositoryId: string;
         sourcePath: string;
     }): Promise<void> {
+        const { organizationAndTeamData, repositoryId, sourcePath } = params;
+        let toDelete: Partial<IKodyRule>[];
         try {
-            const { organizationAndTeamData, repositoryId, sourcePath } =
-                params;
             const entity = await this.kodyRulesService.findByOrganizationId(
                 organizationAndTeamData.organizationId,
             );
-            if (!entity) return;
-
-            const toDelete = entity.rules?.find(
-                (r) =>
-                    r?.repositoryId === repositoryId &&
-                    (r?.sourcePath || '').split('#')[0] === sourcePath,
-            );
-            if (!toDelete?.uuid) return;
-
-            // Soft-delete so the record can be restored if the source file
-            // reappears (or the @kody-ignore marker is removed).
-            await this.kodyRulesService.createOrUpdate(
-                organizationAndTeamData,
-                { ...toDelete, status: KodyRulesStatus.DELETED } as any,
-                this.systemUserInfo,
-            );
+            // Already-DELETED records are skipped: re-writing them is a
+            // no-op that only adds audit-log noise.
+            toDelete = this.rulesBySourcePath(
+                entity,
+                repositoryId,
+                sourcePath,
+            ).filter((r) => r.status !== KodyRulesStatus.DELETED);
         } catch (error) {
             this.logger.error({
-                message: 'Failed to soft-delete rule by sourcePath',
+                message: 'Failed to load rules for soft-delete by sourcePath',
                 context: KodyRulesSyncService.name,
                 error,
                 metadata: params,
             });
+            return;
+        }
+
+        // Soft-delete so the record can be restored if the source file
+        // reappears (or the @kody-ignore marker is removed). Each write has
+        // its own catch: one failure must not strand the remaining records
+        // ACTIVE for a file that no longer exists.
+        for (const rule of toDelete) {
+            try {
+                await this.kodyRulesService.createOrUpdate(
+                    organizationAndTeamData,
+                    { ...rule, status: KodyRulesStatus.DELETED } as any,
+                    this.systemUserInfo,
+                );
+            } catch (error) {
+                this.logger.error({
+                    message: 'Failed to soft-delete rule by sourcePath',
+                    context: KodyRulesSyncService.name,
+                    error,
+                    metadata: { ...params, ruleId: rule.uuid },
+                });
+            }
         }
     }
 
     /**
-     * Flips a rule's `pinnedSync` back to false. Mirrors
-     * `deleteRuleBySourcePath` but only touches the pin flag — used when
-     * the source file still exists but no longer carries `@kody-sync`
-     * (with `ideRulesSyncEnabled=false`, the force-sync path skips that
-     * file, so without this depin pass the rule would keep a stale
-     * `pinnedSync=true` and disappear from the orphan-chip count even
+     * Flips `pinnedSync` back to false on every pinned rule of the file.
+     * Used when the source file still exists but no longer carries
+     * `@kody-sync` (with `ideRulesSyncEnabled=false`, the force-sync path
+     * skips that file, so without this depin pass the rule would keep a
+     * stale `pinnedSync=true` and disappear from the orphan-chip count even
      * though the backend isn't maintaining it anymore).
      *
-     * No-op when the rule isn't found or already has `pinnedSync !== true`
-     * — avoids unnecessary writes and audit-log noise.
+     * No-op when no matching rule is still `pinnedSync === true` — avoids
+     * unnecessary writes and audit-log noise.
      */
     private async depinRuleBySourcePath(params: {
         organizationAndTeamData: OrganizationAndTeamData;
         repositoryId: string;
         sourcePath: string;
     }): Promise<void> {
+        const { organizationAndTeamData, repositoryId, sourcePath } = params;
+        let toDepin: Partial<IKodyRule>[];
         try {
-            const { organizationAndTeamData, repositoryId, sourcePath } =
-                params;
             const entity = await this.kodyRulesService.findByOrganizationId(
                 organizationAndTeamData.organizationId,
             );
-            if (!entity) return;
-
-            const toDepin = entity.rules?.find(
-                (r) =>
-                    r?.repositoryId === repositoryId &&
-                    (r?.sourcePath || '').split('#')[0] === sourcePath,
-            );
-            if (!toDepin?.uuid) return;
-            if (toDepin.pinnedSync !== true) return;
-
-            await this.kodyRulesService.createOrUpdate(
-                organizationAndTeamData,
-                { ...toDepin, pinnedSync: false } as any,
-                this.systemUserInfo,
-            );
+            toDepin = this.rulesBySourcePath(
+                entity,
+                repositoryId,
+                sourcePath,
+            ).filter((r) => r.pinnedSync === true);
         } catch (error) {
             this.logger.error({
-                message: 'Failed to depin rule by sourcePath',
+                message: 'Failed to load rules for depin by sourcePath',
                 context: KodyRulesSyncService.name,
                 error,
                 metadata: params,
             });
+            return;
+        }
+
+        for (const rule of toDepin) {
+            try {
+                await this.kodyRulesService.createOrUpdate(
+                    organizationAndTeamData,
+                    { ...rule, pinnedSync: false } as any,
+                    this.systemUserInfo,
+                );
+            } catch (error) {
+                this.logger.error({
+                    message: 'Failed to depin rule by sourcePath',
+                    context: KodyRulesSyncService.name,
+                    error,
+                    metadata: { ...params, ruleId: rule.uuid },
+                });
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

`KodyRulesSyncService.deleteRuleBySourcePath` soft-deleted only the **first** rule whose `(repositoryId, sourcePath)` matched (`Array.find`). When a sourcePath carries more than one record — which happens whenever two processes sync the same merge concurrently (self-hosted split topology: the worker's local `pull-request.closed` emit plus the `CrossProcessEventsBridge` re-emit in another process, on builds before #2683cc1ba or on mixed-version stacks) — removing the file, or adding `@kody-ignore` to it, left every record after the first `active` for a file that no longer exists. Observed live on a self-hosted instance: one merge → two identical rules; delete PR → one soft-deleted, one still firing.

`depinRuleBySourcePath` had the same shape and an extra early-return: if the *first* match happened to be unpinned, later pinned duplicates kept a stale `pinnedSync=true`.

Both passes now share one `rulesBySourcePath` match (uuid + repositoryId + anchor-stripped path) and write every match through the same `createOrUpdate` path, sequentially. Each write has its own catch, so one failed write (e.g. a `NotFoundException` from a racing UI hard-delete) cannot strand the remaining records. The delete pass skips records already `DELETED` so re-running it is a no-op instead of audit-log noise.

## Changelog routing (driven by the PR title prefix)

`fix:` → Bug fixes.

## Test plan

- [x] `libs/kodyRules/infrastructure/adapters/services/kodyRulesSync.service.spec.ts` — new `deleteRuleBySourcePath / depinRuleBySourcePath` block (5 cases): every live match is soft-deleted (including a `#anchor` sourcePath from a multi-rule file); already-`DELETED` records are skipped; one failing write does not stop the remaining records; no-op when nothing matches; every pinned record is depinned even when the first match is unpinned. Whole spec: 82/82 on this branch.
- [x] Live re-check on the self-hosted stack where the survivor was observed: rebuilt with this change, seeded a second `active` record for one `.kody/rules/*.md` (the LAB-2936 defect state), merged a PR removing the file → both records `deleted` 7 s after merge (`findOneAndUpdate` × 2, 8 ms apart), 0 `active` left for that sourcePath. Before this change the same operation left one record `active`.
## Notes for the reviewer

- Behavioural change is intentional and narrow: callers that previously deleted/depinned "the first match" now get "all matches". Every caller in `kodyRulesSync.service.ts` passes a file path and expects the file's rules to be gone/depinned, so "all" is what they meant.
- `#anchor` handling is unchanged: matching is still on `sourcePath.split('#')[0]`.
