### PR TITLE
fix(fine-tuning): ingest ObjectId suggestion ids alongside UUIDs

### DIFF
--- a/libs/kodyFineTuning/infrastructure/adapters/services/suggestionEmbedded/suggestionEmbedded.service.spec.ts
+++ b/libs/kodyFineTuning/infrastructure/adapters/services/suggestionEmbedded/suggestionEmbedded.service.spec.ts
@@ -249,10 +249,19 @@ describe('SuggestionEmbeddedService deterministic logic', () => {
             );
         });
 
-        it('rejects an id that is a string but not a UUID', () => {
+        it('rejects an id that is neither a UUID nor an ObjectId', () => {
             expect(
                 isValidSuggestion({ ...validBase(), id: 'not-a-uuid' }),
             ).toBe(false);
+        });
+
+        it('accepts a 24-char Mongo ObjectId hex id', () => {
+            expect(
+                isValidSuggestion({
+                    ...validBase(),
+                    id: '6a4fe1f32a96eaa5460394b9',
+                }),
+            ).toBe(true);
         });
 
         it('rejects when suggestionContent is missing', () => {

--- a/libs/kodyFineTuning/infrastructure/adapters/services/suggestionEmbedded/suggestionEmbedded.service.ts
+++ b/libs/kodyFineTuning/infrastructure/adapters/services/suggestionEmbedded/suggestionEmbedded.service.ts
@@ -17,9 +17,7 @@ import { SuggestionEmbeddedEntity } from '@libs/kodyFineTuning/domain/suggestion
 import { getOpenAIEmbedding } from '@libs/common/utils/document';
 import { FeedbackType } from '@libs/kodyFineTuning/domain/enums/feedbackType.enum';
 import { SuggestionEmbeddedDatabaseRepository } from '../../repositories/suggestionEmbedded.repository';
-
-const UUID_REGEX =
-    /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+import { isSuggestionId } from '@libs/platformData/domain/pullRequests/suggestion-id';
 
 @Injectable()
 export class SuggestionEmbeddedService implements ISuggestionEmbeddedService {
@@ -354,8 +352,7 @@ export class SuggestionEmbeddedService implements ISuggestionEmbeddedService {
     ): s is ISuggestionToEmbed {
         return (
             !!s &&
-            typeof s.id === 'string' &&
-            UUID_REGEX.test(s.id) &&
+            isSuggestionId(s.id) &&
             !!s.suggestionContent &&
             !!s.oneSentenceSummary &&
             !!s.label &&

--- a/libs/platformData/domain/pullRequests/suggestion-id.spec.ts
+++ b/libs/platformData/domain/pullRequests/suggestion-id.spec.ts
@@ -1,0 +1,32 @@
+import { isSuggestionId, SUGGESTION_ID_REGEX } from './suggestion-id';
+
+describe('isSuggestionId', () => {
+    it('accepts an RFC-4122 UUID', () => {
+        expect(isSuggestionId('123e4567-e89b-12d3-a456-426614174000')).toBe(
+            true,
+        );
+    });
+
+    it('accepts a 24-char Mongo ObjectId hex string', () => {
+        expect(isSuggestionId('6a4fe1f32a96eaa5460394b9')).toBe(true);
+    });
+
+    it('rejects a non-string', () => {
+        expect(isSuggestionId(12345)).toBe(false);
+        expect(isSuggestionId(null)).toBe(false);
+        expect(isSuggestionId(undefined)).toBe(false);
+    });
+
+    it('rejects strings that are neither UUID nor ObjectId', () => {
+        expect(isSuggestionId('not-a-uuid')).toBe(false);
+        expect(isSuggestionId('6a4fe1f32a96eaa5460394b')).toBe(false);
+        expect(isSuggestionId('')).toBe(false);
+    });
+
+    it('exports a regex whose source matches the same ids', () => {
+        expect(SUGGESTION_ID_REGEX.test('6a4fe1f32a96eaa5460394b9')).toBe(true);
+        expect(
+            SUGGESTION_ID_REGEX.test('123e4567-e89b-12d3-a456-426614174000'),
+        ).toBe(true);
+    });
+});

--- a/libs/platformData/domain/pullRequests/suggestion-id.ts
+++ b/libs/platformData/domain/pullRequests/suggestion-id.ts
@@ -1,0 +1,14 @@
+/**
+ * Suggestion subdocument ids are written as Mongo ObjectIds
+ * (`newSubDocumentId`) and historically also as RFC-4122 UUIDs.
+ * Fine-tuning ingest and issue-sync aggregations must accept both.
+ */
+export const SUGGESTION_ID_PATTERN =
+    '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' +
+    '[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$|^[0-9a-fA-F]{24}$';
+
+export const SUGGESTION_ID_REGEX = new RegExp(SUGGESTION_ID_PATTERN);
+
+export function isSuggestionId(id: unknown): id is string {
+    return typeof id === 'string' && SUGGESTION_ID_REGEX.test(id);
+}

--- a/libs/platformData/infrastructure/adapters/repositories/pullRequests.repository.spec.ts
+++ b/libs/platformData/infrastructure/adapters/repositories/pullRequests.repository.spec.ts
@@ -1,5 +1,6 @@
 import { PullRequestsRepository } from './pullRequests.repository';
 import type { OrganizationAndTeamData } from '@libs/core/infrastructure/config/types/general/organizationAndTeamData';
+import { SUGGESTION_ID_PATTERN } from '@libs/platformData/domain/pullRequests/suggestion-id';
 
 /**
  * Regression coverage for the cross-organization data leak that allowed
@@ -232,6 +233,38 @@ describe('PullRequestsRepository — multi-tenant filter coverage', () => {
             expect(findOneAndUpdate.mock.calls[1][0].organizationId).toBe(
                 'org-B',
             );
+        });
+    });
+
+    describe('findByOrganizationAndRepositoryWithStatusAndSyncedFlag', () => {
+        it('filters suggestion ids with UUID-or-ObjectId pattern', async () => {
+            let capturedPipeline: unknown[] | undefined;
+            const cursor = {
+                async *[Symbol.asyncIterator]() {
+                    /* no PRs */
+                },
+            };
+            model.aggregate = jest.fn((pipeline: unknown[]) => {
+                capturedPipeline = pipeline;
+                return {
+                    allowDiskUse: () => ({
+                        cursor: () => cursor,
+                    }),
+                };
+            });
+
+            await repo.findByOrganizationAndRepositoryWithStatusAndSyncedFlag(
+                'org-A',
+                { id: 'repo-1', fullName: 'org/repo' },
+                undefined,
+                false,
+            );
+
+            const regexes = JSON.stringify(capturedPipeline).match(
+                /"regex":"([^"]+)"/g,
+            );
+            expect(regexes).toEqual([`"regex":"${SUGGESTION_ID_PATTERN}"`]);
+            expect(SUGGESTION_ID_PATTERN).toContain('[0-9a-fA-F]{24}');
         });
     });
 });

--- a/libs/platformData/infrastructure/adapters/repositories/pullRequests.repository.ts
+++ b/libs/platformData/infrastructure/adapters/repositories/pullRequests.repository.ts
@@ -29,6 +29,7 @@ import { PullRequestsEntity } from '@libs/platformData/domain/pullRequests/entit
 import { DeliveryStatus } from '@libs/platformData/domain/pullRequests/enums/deliveryStatus.enum';
 import { ImplementationStatus } from '@libs/platformData/domain/pullRequests/enums/implementationStatus.enum';
 import { UNRESOLVED_RANK_BONUS } from '@libs/platformData/domain/pullRequests/deep-link-rank';
+import { SUGGESTION_ID_PATTERN } from '@libs/platformData/domain/pullRequests/suggestion-id';
 
 @Injectable()
 export class PullRequestsRepository implements IPullRequestsRepository {
@@ -1188,11 +1189,6 @@ export class PullRequestsRepository implements IPullRequestsRepository {
             matchStage.status = status;
         }
 
-        /* ---------- regex para validar UUID no $expr/$regexMatch ---------- */
-        const UUID_REGEX =
-            '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' +
-            '[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$';
-
         const pipeline = [
             { $match: matchStage },
             {
@@ -1240,7 +1236,7 @@ export class PullRequestsRepository implements IPullRequestsRepository {
                                                 {
                                                     $regexMatch: {
                                                         input: '$$s.id',
-                                                        regex: UUID_REGEX,
+                                                        regex: SUGGESTION_ID_PATTERN,
                                                     },
                                                 },
                                             ],
@@ -1305,11 +1301,6 @@ export class PullRequestsRepository implements IPullRequestsRepository {
             matchStage.status = status;
         }
 
-        /* ---------- regex para validar UUID no $expr/$regexMatch ---------- */
-        const UUID_REGEX =
-            '^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-' +
-            '[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$';
-
         const pipeline = [
             { $match: matchStage },
             {
@@ -1350,7 +1341,7 @@ export class PullRequestsRepository implements IPullRequestsRepository {
                                                 {
                                                     $regexMatch: {
                                                         input: '$$s.id',
-                                                        regex: UUID_REGEX,
+                                                        regex: SUGGESTION_ID_PATTERN,
                                                     },
                                                 },
                                             ],


### PR DESCRIPTION
## Summary

Self-hosted (and any Mongo-backed) suggestion ids are 24-character ObjectIds from `newSubDocumentId`, but fine-tuning ingest and issue-sync aggregations only accepted RFC-4122 UUIDs. Every closed PR therefore stayed `syncedEmbeddedSuggestions: false` and `suggestion_embedded` never filled.

This change treats a suggestion id as valid when it is either a UUID or a 24-hex ObjectId, in:

- `findByOrganizationAndRepositoryWithStatusAndSyncedFlag`
- `findByOrganizationAndRepositoryWithStatusAndSyncedWithIssuesFlag`
- `SuggestionEmbeddedService.isValidSuggestion`

Fixes https://github.com/kodustech/kodus-ai/issues/1846

## Changelog routing (driven by the PR title prefix)

The prefix in your PR title decides where this change appears in the public changelog. No labels needed — the title is the source of truth.

| Prefix     | Public changelog                              |
| ---------- | --------------------------------------------- |
| `feat:`    | **Improvements** section (or tied to a tracked feature, see below) |
| `fix:`     | **Bug fixes** section                         |
| `perf:`    | **Performance** section                       |
| `docs:`, `style:`, `refactor:`, `test:`, `chore:`, `ci:`, `build:` | Hidden from public changelog |

## Test plan

- [x] Unit: `suggestion-id.spec.ts` accepts ObjectId and UUID, rejects garbage
- [x] Unit: `suggestionEmbedded.service.spec.ts` ObjectId path
- [x] Unit: `pullRequests.repository.spec.ts` pipeline uses `SUGGESTION_ID_PATTERN`
- [x] `SKIP_INTEGRATION=true pnpm test` (860 suites, 12569 tests)
- [ ] After merge: a review that reaches `KodyFineTuningStage` should create `suggestion_embedded` rows for ObjectId ids (needs `API_OPEN_AI_API_KEY`)

## Notes for the reviewer

Embeddings still go to OpenAI `text-embedding-3-small` (`libs/common/utils/document.ts`); this PR does not change that. The 50-embedding smart-filter gate is unchanged (repo+language first, then org+language).