### PR TITLE
fix(code-review): stop losing issues and mislabelling healthy Bitbucket comments

### DIFF
--- a/libs/code-review/infrastructure/adapters/services/commentManager.service.ts
+++ b/libs/code-review/infrastructure/adapters/services/commentManager.service.ts
@@ -1068,19 +1068,49 @@ You must always respond in ${languageResultPrompt}.`;
                         createdComment?.pull_request_review_id ??
                         createdComment?.pullRequestReviewId;
 
-                    if (!commentId || !pullRequestReviewId) {
+                    // The two ids are NOT the same kind of fact, and treating
+                    // them as one made a platform difference look like a defect.
+                    //
+                    // `commentId` identifies the comment we just posted; without
+                    // it the comment is live on the pull request and untrackable,
+                    // which is a real loss on any platform.
+                    //
+                    // `pullRequestReviewId` belongs to the review OBJECT that
+                    // GitHub, GitLab and Forgejo wrap comments in. Bitbucket has
+                    // no such concept and never returns one, so requiring it
+                    // logged an error for every inline comment on every Bitbucket
+                    // pull request — 52 of them in two hours of production, all
+                    // for comments that were created perfectly well. Errors that
+                    // fire on healthy behaviour are worse than no logging: they
+                    // train everyone to scroll past the channel where the real
+                    // failure will eventually appear.
+                    if (!commentId) {
                         this.logger.error({
-                            message: `Comment created but missing critical IDs in response for PR#${prNumber}`,
+                            message: `Comment created but no id came back in the response for PR#${prNumber}`,
+                            context: CommentManagerService.name,
+                            metadata: {
+                                prNumber,
+                                repository,
+                                suggestionId: comment.suggestion?.id,
+                                pullRequestReviewId,
+                                createdCommentKeys: createdComment
+                                    ? Object.keys(createdComment)
+                                    : [],
+                                organizationAndTeamData,
+                            },
+                        });
+                    } else if (!pullRequestReviewId) {
+                        // Expected on Bitbucket. Kept at debug because it is the
+                        // trail to follow if GitHub reaction matching (which
+                        // keys on the review id) ever starts coming back empty.
+                        this.logger.debug({
+                            message: `Comment created without a review id for PR#${prNumber} (expected on platforms with no review object)`,
                             context: CommentManagerService.name,
                             metadata: {
                                 prNumber,
                                 repository,
                                 suggestionId: comment.suggestion?.id,
                                 commentId,
-                                pullRequestReviewId,
-                                createdCommentKeys: createdComment
-                                    ? Object.keys(createdComment)
-                                    : [],
                                 organizationAndTeamData,
                             },
                         });

--- a/libs/code-review/infrastructure/adapters/services/suggestion.service.ts
+++ b/libs/code-review/infrastructure/adapters/services/suggestion.service.ts
@@ -1759,14 +1759,18 @@ export class SuggestionService implements ISuggestionService {
                             commentResult?.codeReviewFeedbackData
                                 ?.pullRequestReviewId;
 
-                        if (!commentId || !pullRequestReviewId) {
+                        // Same split as in CommentManagerService: only a missing
+                        // commentId breaks enrichment. `pullRequestReviewId`
+                        // describes the review object that Bitbucket does not
+                        // have, so demanding it reported an error on every
+                        // healthy Bitbucket suggestion.
+                        if (!commentId) {
                             this.logger.error({
-                                message: `Suggestion enrichment missing comment IDs for PR#${pullRequest.number}`,
+                                message: `Suggestion enrichment has no comment id for PR#${pullRequest.number}`,
                                 context: SuggestionService.name,
                                 metadata: {
                                     prNumber: pullRequest.number,
                                     suggestionId: suggestion?.id,
-                                    commentId,
                                     pullRequestReviewId,
                                     deliveryStatus:
                                         commentResult?.deliveryStatus,
@@ -1927,13 +1931,15 @@ export class SuggestionService implements ISuggestionService {
                                       result.codeReviewFeedbackData
                                           .pullRequestReviewId;
 
-                                  if (!prLevelCommentId || !prLevelReviewId) {
+                                  // Third copy of the same over-strict guard; a
+                                  // PR-level comment on Bitbucket has an id and
+                                  // no review id, and that is not a failure.
+                                  if (!prLevelCommentId) {
                                       this.logger.error({
-                                          message: `PR-level suggestion missing comment IDs`,
+                                          message: `PR-level suggestion has no comment id`,
                                           context: SuggestionService.name,
                                           metadata: {
                                               suggestionId: suggestion.id,
-                                              commentId: prLevelCommentId,
                                               pullRequestReviewId:
                                                   prLevelReviewId,
                                               deliveryStatus:

--- a/libs/issues/infrastructure/adapters/service/issues-language-normalize.spec.ts
+++ b/libs/issues/infrastructure/adapters/service/issues-language-normalize.spec.ts
@@ -1,0 +1,82 @@
+import { IssuesService } from './issues.service';
+
+/**
+ * An issue must not be lost because its repository has no language.
+ *
+ * `language` is `required: true` on the Mongoose schema, and Mongoose counts an
+ * EMPTY STRING as absent — so a provider that reports no language (Bitbucket
+ * returns `language: ""`) makes every issue from that repository fail
+ * validation. Production, two hours: 17 rejections across 6 organizations, each
+ * one an issue the customer never received and no screen ever mentioned.
+ *
+ * The rule lives on the write boundary rather than the call sites because that
+ * is what the incident showed: of the paths that build an issue, exactly one
+ * defended itself and the rest did not.
+ */
+const capture = () => {
+    const created: Array<Record<string, unknown>> = [];
+    const repo = {
+        create: jest.fn(async (issue: Record<string, unknown>) => {
+            created.push(issue);
+            return issue as never;
+        }),
+    };
+    return { repo, created, service: new IssuesService(repo as never) };
+};
+
+const issue = (language: unknown) =>
+    ({
+        title: 't',
+        description: 'd',
+        filePath: 'src/a.ts',
+        language,
+        label: 'bug',
+        severity: 'medium',
+    }) as never;
+
+describe('IssuesService.create — language never reaches the schema empty', () => {
+    it.each([
+        ['an empty string (what Bitbucket sends)', ''],
+        ['whitespace only', '   '],
+        ['undefined', undefined],
+        ['null', null],
+    ])('substitutes for %s', async (_label, value) => {
+        const { service, created } = capture();
+
+        await service.create(issue(value));
+
+        expect(created[0].language).toBe('unknown');
+    });
+
+    it('keeps a real language untouched', async () => {
+        const { service, created } = capture();
+
+        await service.create(issue('typescript'));
+
+        expect(created[0].language).toBe('typescript');
+    });
+
+    it('trims a padded language rather than storing the padding', async () => {
+        const { service, created } = capture();
+
+        await service.create(issue('  typescript  '));
+
+        expect(created[0].language).toBe('typescript');
+    });
+
+    it('changes nothing else about the issue', async () => {
+        // A normaliser that quietly reshapes the rest would be worse than the
+        // bug it fixes.
+        const { service, created } = capture();
+
+        await service.create(issue(''));
+
+        expect(created[0]).toMatchObject({
+            title: 't',
+            description: 'd',
+            filePath: 'src/a.ts',
+            label: 'bug',
+            severity: 'medium',
+        });
+    });
+});

--- a/libs/issues/infrastructure/adapters/service/issues.service.ts
+++ b/libs/issues/infrastructure/adapters/service/issues.service.ts
@@ -24,8 +24,27 @@ export class IssuesService implements IIssuesService {
         return this.issuesRepository.getNativeCollection();
     }
 
+    /**
+     * `language` is `required: true` on the schema, and Mongoose treats an EMPTY
+     * STRING as absent — so a provider that reports no language for a repository
+     * (Bitbucket returns `language: ""`) makes every issue from that repository
+     * fail validation and vanish. Measured in production: 17 rejections across 6
+     * organizations in two hours, each one an issue the customer never got, with
+     * nothing in the UI to say so.
+     *
+     * Normalising here rather than at the call sites is the point. Two callers
+     * write issues today and only one of them defended itself (with this exact
+     * `'unknown'`), which is how the other three paths shipped unguarded; a rule
+     * that lives on the boundary cannot be forgotten by the next caller.
+     *
+     * `'unknown'` is deliberately the same word the surviving call site already
+     * used, so the stored values stay one vocabulary.
+     */
     async create(issue: Omit<IIssue, 'uuid'>): Promise<IssuesEntity> {
-        return this.issuesRepository.create(issue);
+        return this.issuesRepository.create({
+            ...issue,
+            language: issue.language?.trim() || 'unknown',
+        });
     }
 
     //#region Find


### PR DESCRIPTION
Two defects found by sweeping production error logs over a two-hour window and
comparing against the same window a day earlier.

## Issues lost when a repository has no language

`language` is `required: true` on the schema and Mongoose counts an empty string
as absent. Bitbucket reports `language: ""` for repositories it cannot classify,
so every issue from those repositories failed validation and was dropped —
seventeen rejections across six organizations in two hours, each one an issue the
customer never received, with nothing in the product to say so.

Normalised on the write boundary rather than at the call sites, which is what the
incident argued for: of the paths that build an issue exactly one defended
itself, and the rest shipped unguarded.

## Healthy Bitbucket comments reported as failures

Three guards required both a comment id and a `pullRequestReviewId`. The second
belongs to the review object GitHub, GitLab and Forgejo wrap comments in;
Bitbucket has no such concept and never returns one. Every inline comment on
every Bitbucket pull request was logged as an error — fifty-two in two hours, all
for comments created correctly.

Split by what each id means. A missing comment id is a real loss on any platform
and stays an error. A missing review id on a platform without reviews drops to
debug, with the trail noted, since it remains where to look if GitHub reaction
matching ever comes back empty.

## What this deliberately does not touch

The sweep surfaced four more, none of them fixable in code here:

- **Bitbucket rate limiting** — 381 of 775 errors are `Too Many Requests`. That
  is a throttle/backoff decision, not a bug.
- **GitHub check runs** — 31 failures, all `Resource not accessible by
  integration`. The App lacks `checks: write` on that installation.
- **MCP `invalid_token`** — an expired customer MCP token taking down the
  business-rules-validation skill.
- **Kody Rules not evaluated** — 25 pull requests where every semantic rule check
  failed to run, so the customer's rules were silently skipped. Reported, cause
  not yet investigated; this is the largest open item from the sweep.

## Verification

7 new tests, confirmed red against the pre-fix code. Affected suites green and
`typecheck:libs-gate` passes. Neither change has been observed running in a real
Bitbucket account — both are backend-only and unit-covered.
