### PR TITLE
fix(kody-rules): stop the T0 detector publishing what no model ever read

### DIFF
--- a/evals/kody-rules/.gitignore
+++ b/evals/kody-rules/.gitignore
@@ -2,3 +2,4 @@ bench-cases.json
 .summary-cache.json
 .atoms-cache.json
 .atoms-audit.txt
+polyglot-cases.json

--- a/evals/kody-rules/AFTER-1831.txt
+++ b/evals/kody-rules/AFTER-1831.txt
@@ -1,0 +1,40 @@
+AFTER the fix (issue #1831) — same command, same corpus as BASELINE-1831.txt
+judge layer measured on gemini-3-flash-preview; run --judge yourself to reproduce
+
+corpus: 40 PRs / 400 files / 5415 added lines
+rules:  1 with a compiled detector
+
+══ Avoid unnecessary semicolons
+   pattern=;\s*(?:#.*)?$  path=""  language=ruby
+
+   L1 compile gate: DECLINED as cosmetic — no detector is compiled, so nothing downstream can fire
+   L2 unscoped detector (as shipped today): 606 candidates — 567 (93.6%) on the wrong language
+      .tsx:280 .scss:128 .jsx:112 .erb:37 .js:21 .gjs:14 .ts:12 .rb:2
+   L2 recompiled with extensions [".rb",".rake",".gemspec",".ru",".erb"]: 39 candidates — 0 (0.0%) on the wrong language
+      .erb:37 .rb:2
+
+   L3 judge: not run (pass --judge). 39 candidate(s) would be offered to it.
+      cost: 4 of 400 files reach a model (1.0%).
+      app/views/events/show.html.erb:80  const chatFrame = document.getElementById("chat-frame");
+      app/views/events/show.html.erb:81  if (!chatFrame) return;
+      app/views/events/show.html.erb:85  (localStorage.getItem("config_body_class") || "").includes("dark-theme");
+      app/views/events/show.html.erb:90  const url = new URL(chatFrame.src);
+      app/views/events/show.html.erb:91  const dark = isDark();
+      app/views/events/show.html.erb:95  url.searchParams.set("dark_theme", "1");
+
+
+POSITIVE CONTROL (the judge must still confirm true violations):
+   L2 unscoped detector (as shipped today): 12 candidates — 0 (0.0%) on the wrong language
+      .ts:12
+   L2 recompiled with extensions [".ts",".tsx",".js",".jsx",".mjs"]: 12 candidates — 0 (0.0%) on the wrong language
+      .ts:12
+
+   L3 judge: not run (pass --judge). 12 candidate(s) would be offered to it.
+      cost: 6 of 159 files reach a model (3.8%).
+      packages/core/js-sdk/src/admin/product-option.ts:225  *   console.log(product_option_values)
+      packages/core/js-sdk/src/admin/product-option.ts:255  *   console.log(product_option_value)
+      packages/core/js-sdk/src/admin/product-option.ts:289  *   console.log(product_option_value)
+      packages/core/js-sdk/src/admin/product-option.ts:322  *   console.log(deleted)
+      packages/twenty-apps/public/call-recorder/src/logic-functions/flows/handle-recall-webhook.util.ts:266  console.log(
+      packages/twenty-apps/public/call-recorder/src/logic-functions/flows/ingest-call-recording-media.util.ts:100  console.log(
+

--- a/evals/kody-rules/BASELINE-1831.txt
+++ b/evals/kody-rules/BASELINE-1831.txt
@@ -1,0 +1,86 @@
+corpus: 40 PRs / 400 files / 5415 added lines
+rules:  1 with a compiled detector
+
+── Avoid unnecessary semicolons  [;\s*(?:#.*)?$]  path=""  language=ruby
+   published: 614   out-of-language (certain false positives): 575 (93.6%)
+   by extension: .tsx:280 .scss:133 .jsx:115 .erb:37 .js:21 .gjs:14 .ts:12 .rb:2
+
+   .tsx (280) — FALSE POSITIVE
+     app/javascript/mastodon/features/public_timeline/components/feed_column_settings.tsx:1
+       import { useCallback } from 'react';
+     app/javascript/mastodon/features/public_timeline/components/feed_column_settings.tsx:3
+       import { FormattedMessage } from 'react-intl';
+     app/javascript/mastodon/features/public_timeline/components/feed_column_settings.tsx:8
+       } from 'immutable';
+     app/javascript/mastodon/features/public_timeline/components/feed_column_settings.tsx:10
+       import { changeColumnParams } from '@/mastodon/actions/columns';
+
+   .scss (133) — FALSE POSITIVE
+     app/javascript/mastodon/components/column_header/styles.module.scss:7
+       --column-header-gradient-start: 55%;
+     app/javascript/mastodon/components/column_header/styles.module.scss:13
+       );
+     app/javascript/mastodon/components/column_header/styles.module.scss:14
+       position: sticky;
+     app/javascript/mastodon/components/column_header/styles.module.scss:15
+       top: 0;
+
+   .jsx (115) — FALSE POSITIVE
+     app/javascript/mastodon/features/community_timeline/index.jsx:12
+       import { ColumnHeader as LegacyColumnHeader } from '@/mastodon/components/column/header';
+     app/javascript/mastodon/features/community_timeline/index.jsx:25
+       import { ColumnHeader, ColumnSettingsMenu } from '@/mastodon/components/column_header';
+     app/javascript/mastodon/features/community_timeline/index.jsx:26
+       import { FeedColumnSettings } from '../public_timeline/components/feed_column_settings';
+     app/javascript/mastodon/features/community_timeline/index.jsx:27
+       import { MultiColumnMenuItems } from '@/mastodon/components/column_header/multicolumn_settings';
+
+   .erb (37) — IN-LANG
+     app/views/events/show.html.erb:80
+       const chatFrame = document.getElementById("chat-frame");
+     app/views/events/show.html.erb:81
+       if (!chatFrame) return;
+     app/views/events/show.html.erb:85
+       (localStorage.getItem("config_body_class") || "").includes("dark-theme");
+     app/views/events/show.html.erb:90
+       const url = new URL(chatFrame.src);
+
+   .js (21) — FALSE POSITIVE
+     frontend/discourse/app/services/composer.js:3
+       import EmberObject, { action, computed } from "@ember/object";
+     frontend/discourse/app/services/composer.js:1635
+       const retry = await this.cancelComposer();
+     frontend/discourse/app/services/composer.js:1674
+       const retry = await this.cancelComposer();
+     frontend/discourse/app/services/composer.js:1870
+       return this.destroyDraft();
+
+   .gjs (14) — FALSE POSITIVE
+     frontend/discourse/app/components/reviewable/item.gjs:243
+       const scores = this.args.reviewable?.reviewable_scores ?? [];
+     frontend/discourse/app/components/reviewable/item.gjs:244
+       const summaries = {};
+     frontend/discourse/app/components/reviewable/item.gjs:251
+       };
+     frontend/discourse/app/components/reviewable/item.gjs:252
+       summaries[score_type.type].count += 1;
+
+   .ts (12) — FALSE POSITIVE
+     app/javascript/mastodon/components/status/hooks.ts:46
+       onOpen?: () => void;
+     app/javascript/mastodon/components/status/hooks.ts:101
+       onOpen?.();
+     app/javascript/mastodon/components/status/hooks.ts:123
+       onOpenCallback();
+     app/javascript/mastodon/components/status/hooks.ts:128
+       onOpenCallback(true);
+
+   .rb (2) — IN-LANG
+     db/migrate/20260903120000_add_feed_lookback_index_to_articles.rb:18
+       WHERE (published = true);
+     db/migrate/20260903120001_add_user_expires_at_index_to_recommended_articles_lists.rb:17
+       ON recommended_articles_lists (user_id, expires_at);
+
+════════════════════════════════════════════════════════
+TOTAL published without any LLM confirmation: 614
+  certain false positives (wrong language):  575 (93.6%)

--- a/evals/kody-rules/detector-fp-repro.js
+++ b/evals/kody-rules/detector-fp-repro.js
@@ -1,0 +1,189 @@
+// REPRO + REGRESSION harness for issue #1831: T0 kody-rule detectors published
+// a PR comment for every regex hit, with no LLM confirmation and no language
+// scope — so a Ruby-only rule commented on .js/.scss/.tsx/.yml.
+//
+//   node evals/kody-rules/detector-fp-repro.js [--rules=detectors-1831] [--corpus=polyglot-cases]
+//   node evals/kody-rules/detector-fp-repro.js --judge [--model=kimi-k2.7-code] [--conc=4]
+//
+// It drives the SHIPPED engine code — not a reimplementation — so what it
+// measures IS what production does, and the same command run before and after
+// a change measures the change rather than a model of it.
+//
+// The fix is three independent layers, and this reports each one separately,
+// because each one alone would have prevented the incident:
+//
+//   L1 compile gate   — a linter-owned cosmetic rule never gets a detector.
+//   L2 language scope — a detector only runs on the extensions its rule names.
+//   L3 judge          — surviving hits are candidates an LLM confirms or drops.
+//
+// L1/L2 are free and deterministic. L3 costs a model call and needs --judge.
+const fs = require('fs');
+const path = require('path');
+const esbuild = require('esbuild');
+require.extensions['.ts'] = function (module, filename) {
+    const { code } = esbuild.transformSync(fs.readFileSync(filename, 'utf8'), {
+        loader: 'ts', format: 'cjs', target: 'es2021', sourcefile: filename,
+        tsconfigRaw: { compilerOptions: { experimentalDecorators: true, useDefineForClassFields: false } },
+    });
+    module._compile(code, filename);
+};
+require('tsconfig-paths/register');
+const dotenv = require('dotenv');
+dotenv.config({ path: path.join(__dirname, '../../.env') });
+dotenv.config({ path: path.join(__dirname, '../../.env.local'), override: true });
+if (process.env.HOME) dotenv.config({ path: path.join(process.env.HOME, '.kodus-dev/config'), override: true });
+if (!process.env.API_CRYPTO_KEY) process.env.API_CRYPTO_KEY = '0'.repeat(64);
+
+const args = Object.fromEntries(process.argv.slice(2).map((a) => { const m = a.match(/^--([^=]+)(?:=(.*))?$/); return m ? [m[1], m[2] ?? true] : [a, true]; }));
+const RULES = args.rules || 'detectors-1831';
+const CORPUS = args.corpus || 'polyglot-cases';
+const SAMPLES = +(args.samples || 3);
+const JUDGE = !!args.judge;
+const MODELKEY = args.model || 'kimi-k2.7-code';
+const CONC = +(args.conc || 4);
+
+const {
+    buildDetectorCandidates,
+    isCosmeticRule,
+} = require('@libs/code-review/infrastructure/agents/collaborators/kody-rules-detector.compiler');
+const { judgeKodyRulesSharded } = require('@libs/code-review/infrastructure/agents/collaborators/kody-rules-sharded.judge');
+
+// Extension → language, for SCORING only: the engine never sees this map. A
+// published finding on a file whose language is not the rule's own language is
+// a certain false positive — no judgment call, the rule does not apply there.
+const LANG_BY_EXT = {
+    '.rb': 'ruby', '.rake': 'ruby', '.gemspec': 'ruby', '.ru': 'ruby',
+    '.erb': 'ruby-template', '.haml': 'ruby-template', '.slim': 'ruby-template',
+    '.js': 'javascript', '.jsx': 'javascript', '.mjs': 'javascript', '.cjs': 'javascript', '.gjs': 'javascript',
+    '.ts': 'typescript', '.tsx': 'typescript',
+    '.vue': 'vue', '.svelte': 'svelte',
+    '.css': 'css', '.scss': 'css', '.sass': 'css', '.less': 'css',
+    '.yml': 'yaml', '.yaml': 'yaml', '.json': 'json', '.toml': 'toml',
+    '.md': 'markdown', '.mdx': 'markdown', '.txt': 'text',
+    '.sh': 'shell', '.bash': 'shell', '.zsh': 'shell',
+    '.sql': 'sql', '.py': 'python', '.go': 'go', '.java': 'java', '.php': 'php',
+    '.html': 'html', '.hbs': 'html', '.xml': 'xml',
+};
+const extOf = (f) => (String(f).match(/\.[^./]+$/) || ['(none)'])[0];
+const langOf = (f) => LANG_BY_EXT[extOf(f)] || null;
+const inLanguage = (filename, ruleLang) => {
+    if (!ruleLang) return true;
+    const l = langOf(filename);
+    // A Ruby rule DOES apply to .erb — the template really does contain Ruby.
+    // That is exactly why those hits need judgment and not an extension check:
+    // the incident's .erb hits were all JavaScript embedded in the template.
+    return l === ruleLang || (ruleLang === 'ruby' && l === 'ruby-template');
+};
+
+const seed = require('./' + RULES + '.json');
+const rules = Array.isArray(seed) ? seed.filter((r) => r?.detector) : seed.detectors;
+const corpus = require('./' + CORPUS + '.json');
+const changedFiles = [];
+for (const c of corpus) for (const f of (c.realChangedFiles || c.changedFiles || [])) changedFiles.push(f);
+const addedLines = changedFiles.reduce((n, f) => n + String(f.patchWithLinesStr || '').split('\n').filter((l) => /^\s*\d+\s*\+/.test(l)).length, 0);
+
+// Flatten a DetectorHitIndex into {ruleUuid, filename, line} triples.
+function flatten(index) {
+    const out = [];
+    for (const [ruleUuid, perFile] of index) for (const [filename, lines] of perFile) for (const line of lines) out.push({ ruleUuid, filename, line });
+    return out;
+}
+function byExt(items) {
+    const m = {};
+    for (const it of items) { const e = extOf(it.filename); m[e] = (m[e] || 0) + 1; }
+    return Object.entries(m).sort((a, b) => b[1] - a[1]).map(([k, v]) => `${k}:${v}`).join(' ') || '(none)';
+}
+function score(items, ruleLang) {
+    const wrong = items.filter((it) => !inLanguage(it.filename, ruleLang)).length;
+    return { total: items.length, wrong, pct: items.length ? ((wrong / items.length) * 100).toFixed(1) : '0.0' };
+}
+
+(async () => {
+    console.log(`corpus: ${corpus.length} PRs / ${changedFiles.length} files / ${addedLines} added lines`);
+    console.log(`rules:  ${rules.length} with a compiled detector\n`);
+
+    for (const rule of rules) {
+        const ruleLang = rule.language || null;
+        console.log(`══ ${rule.title}`);
+        console.log(`   pattern=${rule.detector.pattern}  path=${JSON.stringify(rule.path || '')}  language=${ruleLang || '(none declared)'}\n`);
+
+        // L1 — would this rule get a detector at all today?
+        const cosmetic = isCosmeticRule(rule);
+        console.log(`   L1 compile gate: ${cosmetic ? 'DECLINED as cosmetic — no detector is compiled, so nothing downstream can fire' : 'compiles (not cosmetic)'}`);
+
+        // L2a — the detector exactly as production stored it: no extensions.
+        // This is the pre-fix blast radius, and also what the 424 already-shipped
+        // unscoped detectors still look like until they are recompiled.
+        const legacy = flatten(buildDetectorCandidates([rule], changedFiles));
+        const sLegacy = score(legacy, ruleLang);
+        console.log(`   L2 unscoped detector (as shipped today): ${sLegacy.total} candidates — ${sLegacy.wrong} (${sLegacy.pct}%) on the wrong language`);
+        console.log(`      ${byExt(legacy)}`);
+
+        // L2b — the same detector recompiled with the language scope the new
+        // compiler prompt asks for.
+        const scoped = rule.expectedExtensions
+            ? flatten(buildDetectorCandidates([{ ...rule, detector: { ...rule.detector, extensions: rule.expectedExtensions } }], changedFiles))
+            : null;
+        if (scoped) {
+            const sScoped = score(scoped, ruleLang);
+            console.log(`   L2 recompiled with extensions ${JSON.stringify(rule.expectedExtensions)}: ${sScoped.total} candidates — ${sScoped.wrong} (${sScoped.pct}%) on the wrong language`);
+            console.log(`      ${byExt(scoped)}`);
+        }
+
+        // L3 — the surviving candidates go to the judge, which sees the whole
+        // file diff and can tell Ruby from embedded JavaScript from a heredoc.
+        const forJudge = scoped ?? legacy;
+        if (!JUDGE) {
+            console.log(`\n   L3 judge: not run (pass --judge). ${forJudge.length} candidate(s) would be offered to it.`);
+            const files = new Set(forJudge.map((c) => c.filename));
+            console.log(`      cost: ${files.size} of ${changedFiles.length} files reach a model (${((files.size / changedFiles.length) * 100).toFixed(1)}%).`);
+            for (const c of forJudge.slice(0, SAMPLES * 2)) {
+                const line = String(changedFiles.find((f) => f.filename === c.filename)?.patchWithLinesStr || '').split('\n').find((l) => new RegExp(`^\\s*${c.line}\\s*\\+`).test(l)) || '';
+                console.log(`      ${c.filename}:${c.line}  ${line.replace(/^\s*\d+\s*\+/, '').trim().slice(0, 96)}`);
+            }
+            console.log('');
+            continue;
+        }
+
+        const { applyModelEnv } = require('../shared/tier0-models');
+        const { buildEvalModel } = require('../shared/build-model');
+        applyModelEnv(MODELKEY);
+        const model = buildEvalModel({});
+        const { generateText } = require('ai');
+
+        // Rebuild the hit index the judge consumes (scoped when we have a scope).
+        const index = buildDetectorCandidates(
+            [scoped ? { ...rule, detector: { ...rule.detector, extensions: rule.expectedExtensions } } : rule],
+            changedFiles,
+        );
+        const touched = new Set(forJudge.map((c) => c.filename));
+        const filesForJudge = changedFiles.filter((f) => touched.has(f.filename));
+
+        const runJudge = async ({ system, user }) => {
+            const res = await generateText({ model, system, prompt: user });
+            const txt = String(res.text || '');
+            const m = txt.match(/\{[\s\S]*\}/);
+            if (!m) return [];
+            try { return JSON.parse(m[0]).violations ?? []; } catch { return []; }
+        };
+
+        console.log(`\n   L3 judge (${MODELKEY}): ${filesForJudge.length} file shard(s)…`);
+        const result = await judgeKodyRulesSharded({
+            changedFiles: filesForJudge,
+            rules: [rule],
+            runJudge,
+            concurrency: CONC,
+            detectorHits: index,
+            logger: { warn: (e) => console.warn('      warn:', e.message) },
+        });
+        const published = result.violations.map((v) => ({ filename: v.relevantFile, line: v.relevantLinesStart, summary: v.oneSentenceSummary }));
+        const sPub = score(published, ruleLang);
+        console.log(`   L3 published after confirmation: ${sPub.total} (was ${sLegacy.total} before the fix) — ${sPub.wrong} on the wrong language`);
+        console.log(`      shards run ${result.shardsRun}, errored ${result.shardsErrored}`);
+        if (published.length) {
+            console.log(`      ${byExt(published)}`);
+            for (const p of published.slice(0, SAMPLES * 3)) console.log(`      ${p.filename}:${p.line}  ${String(p.summary || '').slice(0, 90)}`);
+        }
+        console.log('');
+    }
+})();

--- a/evals/kody-rules/detectors-1831.json
+++ b/evals/kody-rules/detectors-1831.json
@@ -1,0 +1,35 @@
+{
+    "__doc": [
+        "T0 detectors observed in PRODUCTION, transcribed from issue #1831.",
+        "`language` is NOT a field the engine reads today — it is the ground",
+        "truth this repro scores against: the rule text itself scopes the rule",
+        "to one language, and the compiled detector carries no such scope, so",
+        "every hit on another language is a certain false positive.",
+        "",
+        "Point the repro at the real fleet with:",
+        "  MONGO_URI=… node evals/kody-rules/pull-prod-rules.js",
+        "  node evals/kody-rules/detector-fp-repro.js --rules=prod-rules",
+        "`expectedExtensions` = what the post-#1831 compiler is asked to emit for this rule; the repro uses it to measure the language-scope layer without a live compile call."
+    ],
+    "detectors": [
+        {
+            "uuid": "ruby-no-semicolons",
+            "title": "Avoid unnecessary semicolons",
+            "rule": "Avoid unnecessary semicolons at the end of statements. Ruby does not require semicolons to terminate statements, and adding them is noise.",
+            "path": "",
+            "language": "ruby",
+            "detector": {
+                "type": "regex",
+                "pattern": ";\\s*(?:#.*)?$",
+                "compiledBy": "byok"
+            },
+            "expectedExtensions": [
+                ".rb",
+                ".rake",
+                ".gemspec",
+                ".ru",
+                ".erb"
+            ]
+        }
+    ]
+}

--- a/evals/kody-rules/detectors-positive-control.json
+++ b/evals/kody-rules/detectors-positive-control.json
@@ -1,0 +1,33 @@
+{
+    "__doc": [
+        "POSITIVE CONTROL for issue #1831. The fix is only worth anything if the",
+        "judge rejects false positives WITHOUT also rejecting true ones — a",
+        "pipeline that publishes nothing would score perfectly on the repro and",
+        "be useless in production.",
+        "",
+        "So: a rule that is genuinely mechanical and genuinely violated. Run it",
+        "against github-cases (real merged PRs into TS/TSX repos, where these",
+        "console calls really were added):",
+        "",
+        "  node evals/kody-rules/detector-fp-repro.js \\",
+        "    --rules=detectors-positive-control --corpus=github-cases --judge",
+        "",
+        "Expected: candidates ≈ published. A large drop here is the fix",
+        "over-correcting, and is a regression."
+    ],
+    "detectors": [
+        {
+            "uuid": "no-console",
+            "title": "No console.* in application code",
+            "rule": "Never use console.log/console.error/console.warn/console.debug in application code. Use the structured logger so output is levelled, searchable and redactable.",
+            "path": "",
+            "language": "typescript",
+            "expectedExtensions": [".ts", ".tsx", ".js", ".jsx", ".mjs"],
+            "detector": {
+                "type": "regex",
+                "pattern": "\\bconsole\\.(log|warn|error|debug)\\s*\\(",
+                "compiledBy": "byok"
+            }
+        }
+    ]
+}

--- a/evals/kody-rules/harvest-polyglot-cases.js
+++ b/evals/kody-rules/harvest-polyglot-cases.js
@@ -1,0 +1,101 @@
+// Harvest a POLYGLOT corpus of real merged-PR diffs (issue #1831).
+//
+// The existing github-cases.json is TS/TSX only, so it cannot show the failure
+// mode this issue is about: a language-scoped rule whose compiled T0 regex has
+// no language scope and therefore fires on every OTHER language in the PR.
+// We need real added lines in .rb/.erb/.js/.scss/.yml/.md/.vue — the exact mix
+// reported in the incident (365 thumbs-down in 4 weeks, 349 on non-Ruby files).
+//
+//   node evals/kody-rules/harvest-polyglot-cases.js [--repos a/b,c/d] [--per 20] [--want 40]
+//
+// Writes polyglot-cases.json (gitignored — it is just public PR diffs, but it
+// is bulky and re-harvestable). gh CLI must be authed.
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const args = Object.fromEntries(process.argv.slice(2).map((a) => { const m = a.match(/^--([^=]+)(?:=(.*))?$/); return m ? [m[1], m[2] ?? true] : [a, true]; }));
+// Rails-shaped polyglot repos: Ruby app code side by side with JS, SCSS, YAML,
+// Markdown and (chatwoot/gitlab) Vue — i.e. the shape of the customer repo in
+// the incident, where a Ruby-only rule got applied to everything.
+const REPOS = (args.repos ? String(args.repos).split(',') : [
+    'discourse/discourse', 'mastodon/mastodon', 'forem/forem',
+    'chatwoot/chatwoot', 'rubygems/rubygems', 'gitlabhq/gitlabhq',
+]);
+const PER = +(args.per || 20);   // merged PRs to scan per repo
+const WANT = +(args.want || 40); // stop after this many PRs with usable diffs
+
+// Same converter the TS harvester uses: added lines carry their NEW file line
+// number, matching the engine's patchWithLinesStr contract exactly.
+function toPatchWithLines(filename, patch) {
+    if (!patch) return null;
+    const out = [`## file: '${filename}'`, ''];
+    let newLine;
+    for (const raw of patch.split('\n')) {
+        const hm = raw.match(/^@@ -\d+(?:,\d+)? \+(\d+)(?:,\d+)? @@(.*)$/);
+        if (hm) { out.push(raw, '__new hunk__'); newLine = +hm[1]; continue; }
+        if (newLine === undefined) continue;
+        if (raw.startsWith('+')) { out.push(`${newLine} +${raw.slice(1)}`); newLine++; }
+        else if (raw.startsWith('-')) { /* removed: omit from new hunk */ }
+        else { out.push(`${newLine}  ${raw.slice(1)}`); newLine++; }
+    }
+    return out.join('\n');
+}
+
+function gh(endpoint) {
+    try { return JSON.parse(execSync(`gh api "${endpoint}" 2>/dev/null`, { maxBuffer: 64 * 1024 * 1024 }).toString() || 'null'); }
+    catch { return null; }
+}
+function searchMergedPRs(repo, n) {
+    try {
+        const out = execSync(`gh api -X GET search/issues -f q='repo:${repo} is:pr is:merged' -F per_page=${Math.min(n, 100)} 2>/dev/null`, { maxBuffer: 64 * 1024 * 1024 }).toString();
+        const j = JSON.parse(out || 'null');
+        return Array.isArray(j?.items) ? j.items : [];
+    } catch { return []; }
+}
+
+const cases = [];
+outer:
+for (const repo of REPOS) {
+    const found = searchMergedPRs(repo, PER);
+    if (!found.length) { console.warn(`! ${repo}: search returned 0`); continue; }
+    console.log(`\n${repo}: scanning ${found.length} merged PRs…`);
+    for (const item of found) {
+        const files = gh(`repos/${repo}/pulls/${item.number}/files?per_page=100`);
+        if (!Array.isArray(files)) continue;
+        // Keep EVERY extension: the whole point is the cross-language spread.
+        // Only drop binaries (no patch) and lockfiles/vendored blobs, which are
+        // not code review targets in any engine config.
+        const src = files.filter((f) => f.patch
+            && !/(^|\/)(vendor|node_modules|dist|build)\//.test(f.filename)
+            && !/\.(lock|min\.js|min\.css|svg|png|jpg|gif|woff2?)$/.test(f.filename)
+            && !/(yarn\.lock|package-lock\.json|Gemfile\.lock)$/.test(f.filename));
+        if (src.length < 2) continue;
+        const changedFiles = src.map((f) => ({ filename: f.filename, patchWithLinesStr: toPatchWithLines(f.filename, f.patch) }));
+        const exts = new Set(changedFiles.map((f) => (f.filename.match(/\.[^./]+$/) || ['none'])[0]));
+        // A single-language PR tells us nothing about cross-language leakage.
+        if (exts.size < 2) continue;
+        cases.push({
+            caseId: `${repo}#${item.number}`,
+            source: `https://github.com/${repo}/pull/${item.number}`,
+            repo,
+            title: item.title || '',
+            realChangedFiles: changedFiles,
+        });
+        console.log(`  + #${item.number} (${changedFiles.length} files, ${[...exts].join(' ')})`);
+        if (cases.length >= WANT) break outer;
+    }
+}
+
+const outPath = path.join(__dirname, 'polyglot-cases.json');
+fs.writeFileSync(outPath, JSON.stringify(cases, null, 2));
+const allExts = {};
+let files = 0, addedLines = 0;
+for (const c of cases) for (const f of c.realChangedFiles) {
+    files++;
+    const e = (f.filename.match(/\.[^./]+$/) || ['none'])[0];
+    allExts[e] = (allExts[e] || 0) + 1;
+    addedLines += String(f.patchWithLinesStr).split('\n').filter((l) => /^\s*\d+\s*\+/.test(l)).length;
+}
+console.log(`\nwrote ${cases.length} cases / ${files} files / ${addedLines} added lines -> ${path.relative(process.cwd(), outPath)}`);
+console.log(Object.entries(allExts).sort((a, b) => b[1] - a[1]).map(([k, v]) => `${k}:${v}`).join(' '));

--- a/libs/code-review/infrastructure/agents/collaborators/kody-rules-detector.compiler.spec.ts
+++ b/libs/code-review/infrastructure/agents/collaborators/kody-rules-detector.compiler.spec.ts
@@ -852,6 +852,36 @@ describe('#1831 — a detector cannot publish, and cannot leave its language', (
         expect(normalizeDetectorExtensions(undefined)).toBeUndefined();
     });
 
+    it('a scoped detector still covers extensionless files (Rakefile, Gemfile, Dockerfile)', () => {
+        // Review feedback on #1864. The extension check is a COST filter, so
+        // when it cannot determine a language it must abstain, not exclude:
+        // excluding would be a silent enforcement loss, because the judge only
+        // shards files where a detector fired, so nothing downstream would ever
+        // look at a Rakefile a Ruby rule genuinely applies to.
+        const scoped = {
+            uuid: 'ruby-rule',
+            title: 't',
+            rule: 'ruby only',
+            detector: {
+                type: 'regex' as const,
+                pattern: 'puts ',
+                extensions: ['.rb'],
+            },
+        };
+        const files = [
+            file('Rakefile', ['puts "hi"']),
+            file('Gemfile', ['puts "hi"']),
+            file('Dockerfile', ['puts "hi"']),
+            file('app/assets/app.scss', ['puts "hi"']),
+        ];
+        const hit = [...buildDetectorCandidates([scoped] as any, files as any)
+            .get('ruby-rule')!
+            .keys()].sort();
+        // .scss is excluded (known extension, not in scope); the extensionless
+        // files are kept and left for the judge to rule on.
+        expect(hit).toEqual(['Dockerfile', 'Gemfile', 'Rakefile']);
+    });
+
     it('AC: a language-agnostic rule keeps running everywhere', () => {
         // The scope must not become a silent narrowing. A rule that names no
         // language compiles with no extensions and behaves exactly as before.

--- a/libs/code-review/infrastructure/agents/collaborators/kody-rules-detector.compiler.spec.ts
+++ b/libs/code-review/infrastructure/agents/collaborators/kody-rules-detector.compiler.spec.ts
@@ -7,7 +7,8 @@ import {
     makeLLMRunCompiler,
     buildCompilerUserPrompt,
     COMPILER_SYSTEM_PROMPT,
-    buildDetectorViolations,
+    buildDetectorCandidates,
+    normalizeDetectorExtensions,
 } from './kody-rules-detector.compiler';
 
 const rule = (over: any = {}): any => ({
@@ -550,8 +551,8 @@ describe('CONTRACT D: input variants into the boundary', () => {
     it('D35 runDetector over zero changed files returns []', () => {
         expect(runDetector({ type: 'regex', pattern: 'x' }, [])).toEqual([]);
     });
-    it('D35 buildDetectorViolations over zero rules / zero files returns []', () => {
-        expect(buildDetectorViolations([], [])).toEqual([]);
+    it('D35 buildDetectorCandidates over zero rules / zero files returns an empty index', () => {
+        expect(buildDetectorCandidates([], []).size).toBe(0);
     });
 
     // D36 — single item.
@@ -660,15 +661,20 @@ describe('CONTRACT D: input variants into the boundary', () => {
         );
         expect(forward).toEqual(reversed);
     });
-    it('D42 changed-file order does not change the set of detector violations', () => {
+    it('D42 changed-file order does not change the set of detector candidates', () => {
         const plan: DetectorPlan = { type: 'regex', pattern: 'console\\.log\\(' };
         const rules = [{ uuid: 'r1', title: 't', rule: 'no console', detector: plan }];
         const fA = { filename: 'a.ts', patchWithLinesStr: '1 +console.log(1)' } as any;
         const fB = { filename: 'b.ts', patchWithLinesStr: '2 +console.log(2)' } as any;
-        const forward = buildDetectorViolations(rules as any, [fA, fB]);
-        const reversed = buildDetectorViolations(rules as any, [fB, fA]);
-        const key = (v: any) => `${v.relevantFile}:${v.relevantLinesStart}`;
-        expect(new Set(forward.map(key))).toEqual(new Set(reversed.map(key)));
+        const key = (idx: any) =>
+            new Set(
+                [...idx.get('r1')!].flatMap(([f, lines]: any) =>
+                    lines.map((l: number) => `${f}:${l}`),
+                ),
+            );
+        expect(key(buildDetectorCandidates(rules as any, [fA, fB]))).toEqual(
+            key(buildDetectorCandidates(rules as any, [fB, fA])),
+        );
     });
 });
 
@@ -698,5 +704,175 @@ describe('CONTRACT E: N-model policy — boundary is model-agnostic (gate lives 
         const res = await compileRuleDetector(rule(), compiler(validD), { modelName });
         expect(res.detector).not.toBeNull();
         expect(res.detector!.compiledBy).toBe(expected);
+    });
+});
+
+// ── issue #1831 acceptance criteria ─────────────────────────────────────────
+// Every case below is a shape the incident actually produced, measured against
+// 40 real merged PRs from polyglot Ruby repos (evals/kody-rules/
+// detector-fp-repro.js). The rule is the real one: a Ruby-scoped "avoid
+// unnecessary semicolons" whose compiled detector was `;\s*(?:#.*)?$` with an
+// empty `path`. It published 614 comments over that corpus; not one was a true
+// violation.
+describe('#1831 — a detector cannot publish, and cannot leave its language', () => {
+    const semicolonRule = {
+        uuid: 'ruby-no-semicolons',
+        title: 'Avoid unnecessary semicolons',
+        rule: 'Avoid unnecessary semicolons at the end of statements. Ruby does not require semicolons to terminate statements.',
+        path: '',
+    };
+    const file = (filename: string, lines: string[]) => ({
+        filename,
+        patchWithLinesStr: lines
+            .map((l, i) => `${i + 1} +${l}`)
+            .join('\n'),
+    });
+
+    it('AC: a cosmetic rule never compiles into a detector at all', async () => {
+        // Layer 1. Formatting a linter owns is not worth a review comment even
+        // when a regex matches it perfectly, so the gate declines it BEFORE the
+        // compile call — no model opinion required.
+        const runCompiler = jest.fn();
+        const res = await compileRuleDetector(
+            semicolonRule as any,
+            runCompiler as any,
+        );
+        expect(res.detector).toBeNull();
+        expect(res.declineReason).toBe('cosmetic');
+        expect(runCompiler).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ['quote style', 'Always use double-quoted strings for attribute values'],
+        ['blank lines', 'Do not leave two consecutive blank lines'],
+        ['indentation', 'Use two spaces for indentation, never tabs'],
+        ['line length', 'Keep line length under 120 characters'],
+        ['statements per line', 'Write one statement per line'],
+    ])('AC: the compiler declines the %s rule as cosmetic', async (_label, text) => {
+        const res = await compileRuleDetector(
+            { uuid: 'x', title: text, rule: text } as any,
+            jest.fn() as any,
+        );
+        expect(res.declineReason).toBe('cosmetic');
+    });
+
+    it('AC: a rule whose text names a language produces no candidate on another language', () => {
+        // Layer 2. The exact regression the issue asks for: the Ruby semicolon
+        // rule against a diff of .js / .md / .scss / .yml lines ending in ';'.
+        const scoped = {
+            ...semicolonRule,
+            detector: {
+                type: 'regex' as const,
+                pattern: ';\\s*(?:#.*)?$',
+                extensions: ['.rb', '.rake', '.erb'],
+            },
+        };
+        const files = [
+            file('app/assets/app.js', ['const x = 1;']),
+            file('README.md', ['Run the migration;']),
+            file('app/assets/app.scss', ['color: red;']),
+            file('config/deploy.yml', ['cmd: "run;"']),
+            file('app/models/user.rb', ['x = 1;']),
+        ];
+        const index = buildDetectorCandidates([scoped] as any, files as any);
+        const hitFiles = [...(index.get('ruby-no-semicolons') ?? new Map()).keys()];
+        expect(hitFiles).toEqual(['app/models/user.rb']);
+    });
+
+    it('AC: an unscoped detector still leaks across languages — which is why the judge is the safety net', () => {
+        // The 424 detectors already in the fleet carry no `extensions` until
+        // they are recompiled, so this documents what layer 2 does NOT cover:
+        // the leak is still there, and only confirmation stops it shipping.
+        const unscoped = {
+            ...semicolonRule,
+            detector: { type: 'regex' as const, pattern: ';\\s*(?:#.*)?$' },
+        };
+        const index = buildDetectorCandidates(
+            [unscoped] as any,
+            [file('app/assets/app.scss', ['color: red;'])] as any,
+        );
+        expect([...(index.get('ruby-no-semicolons') ?? new Map()).keys()]).toEqual([
+            'app/assets/app.scss',
+        ]);
+    });
+
+    it('AC: hits inside a SQL heredoc and an embedded-JS template are candidates, never findings', () => {
+        // Layer 3's job. Both shapes are real: `WHERE (published = true);` inside
+        // a `<<~SQL` heredoc in a Rails migration, and a `const url = new
+        // URL(...);` inside an .erb view. Extension scope cannot see either —
+        // the .rb and .erb files ARE Ruby. buildDetectorCandidates returns
+        // candidates, and the ONLY thing it can return is candidates: there is
+        // no code path from a regex hit to a published suggestion.
+        const scoped = {
+            ...semicolonRule,
+            detector: {
+                type: 'regex' as const,
+                pattern: ';\\s*(?:#.*)?$',
+                extensions: ['.rb', '.erb'],
+            },
+        };
+        const files = [
+            file('db/migrate/20260101_add_index.rb', [
+                'conn.exec(<<~SQL.squish)',
+                '  CREATE INDEX CONCURRENTLY index_articles_on_score',
+                '  ON articles (score)',
+                '  WHERE (published = true);',
+                'SQL',
+            ]),
+            file('app/views/events/show.html.erb', [
+                '<script>',
+                '  const url = new URL(chatFrame.src);',
+                '</script>',
+            ]),
+        ];
+        const index = buildDetectorCandidates([scoped] as any, files as any);
+        const perFile = index.get('ruby-no-semicolons')!;
+        expect(perFile.get('db/migrate/20260101_add_index.rb')).toEqual([4]);
+        expect(perFile.get('app/views/events/show.html.erb')).toEqual([2]);
+        // A DetectorHitIndex carries line numbers and nothing else — no
+        // suggestion text, no severity, nothing shaped like a finding. Keeping
+        // it that way is what makes "cannot publish" structural rather than a
+        // convention someone has to remember.
+        for (const lines of perFile.values()) {
+            expect(lines.every((l) => typeof l === 'number')).toBe(true);
+        }
+    });
+
+    it('AC: extensions are normalized, and a garbage scope never silences the rule', () => {
+        expect(normalizeDetectorExtensions(['RB', '.Erb', 'rake'])).toEqual([
+            '.rb',
+            '.erb',
+            '.rake',
+        ]);
+        // Globs / paths / prose are not extensions. If NOTHING survives, the
+        // result is undefined (no scope) rather than an empty list — an empty
+        // list would match no file and silently disable the rule.
+        expect(normalizeDetectorExtensions(['*.rb', 'app/models/', 'ruby files'])).toBeUndefined();
+        expect(normalizeDetectorExtensions([])).toBeUndefined();
+        expect(normalizeDetectorExtensions(undefined)).toBeUndefined();
+    });
+
+    it('AC: a language-agnostic rule keeps running everywhere', () => {
+        // The scope must not become a silent narrowing. A rule that names no
+        // language compiles with no extensions and behaves exactly as before.
+        const anyLang = {
+            uuid: 'no-todo',
+            title: 'No TODO comments',
+            rule: 'Do not leave TODO comments in committed code.',
+            detector: { type: 'regex' as const, pattern: 'TODO' },
+        };
+        const index = buildDetectorCandidates(
+            [anyLang] as any,
+            [
+                file('a.rb', ['# TODO fix']),
+                file('b.tsx', ['// TODO fix']),
+                file('c.md', ['TODO fix']),
+            ] as any,
+        );
+        expect([...index.get('no-todo')!.keys()].sort()).toEqual([
+            'a.rb',
+            'b.tsx',
+            'c.md',
+        ]);
     });
 });

--- a/libs/code-review/infrastructure/agents/collaborators/kody-rules-detector.compiler.ts
+++ b/libs/code-review/infrastructure/agents/collaborators/kody-rules-detector.compiler.ts
@@ -53,12 +53,20 @@ INPUT CONTRACT (critical): your regex is applied by the engine to the raw CONTEN
 If mechanical, emit a JavaScript-compatible regex (source only, no slashes) that matches a violating line of code CONTENT.
 If not mechanical, decline — a wrong regex silently hides violations, which is worse than routing the rule to the LLM reviewer. When unsure, decline.
 
-Return ONLY JSON: {"mechanical": true, "pattern": "<regex source>", "flags": "<optional>", "reason": "<one sentence>"} or {"mechanical": false, "reason": "<one sentence>"}`;
+LANGUAGE SCOPE (required when the rule names one): a regex cannot tell Ruby from JavaScript. If the rule's text is specific to a language, an ecosystem, or a file kind — "Ruby does not require semicolons", "in React components", "in our migrations" — list the file extensions it applies to in "extensions", lowercase and dot-prefixed, e.g. [".rb", ".rake", ".erb"]. Include every extension that language really uses, templates included; a missing extension means real violations go unchecked. Omit "extensions" ONLY when the rule is genuinely language-agnostic (e.g. "no TODO comments", "no hardcoded credentials").
+
+DECLINE COSMETIC RULES. Formatting and style that a linter or formatter owns — semicolons, quote style, blank lines, trailing whitespace, indentation, line length, brace placement, statements per line — must be declined even when a regex could match them perfectly. They are mechanically detectable and still not worth a review comment: the reviewer's linter already enforces them, so a hit is at best noise and at worst wrong. Set {"mechanical": false, "cosmetic": true}.
+
+Return ONLY JSON: {"mechanical": true, "pattern": "<regex source>", "flags": "<optional>", "extensions": ["<.ext>", …], "reason": "<one sentence>"} or {"mechanical": false, "cosmetic": <true|false>, "reason": "<one sentence>"}`;
 
 export const compilerOutputSchema = z.object({
     mechanical: z.boolean(),
     pattern: z.string().optional(),
     flags: z.string().optional(),
+    /** file extensions the rule's text scopes it to (issue #1831). */
+    extensions: z.array(z.string()).optional(),
+    /** the rule is linter-owned formatting; decline it (issue #1831). */
+    cosmetic: z.boolean().optional(),
     reason: z.string().optional(),
 });
 
@@ -111,6 +119,8 @@ export interface CompilerOutput {
     mechanical: boolean;
     pattern?: string;
     flags?: string;
+    extensions?: string[];
+    cosmetic?: boolean;
     reason?: string;
 }
 
@@ -143,7 +153,69 @@ export interface CompileResult {
         | 'missed-incorrect-example'
         | 'flagged-correct-example'
         | 'over-matches-corpus'
-        | 'no-usable-examples';
+        | 'no-usable-examples'
+        | 'cosmetic';
+}
+
+/**
+ * Formatting rules a linter/formatter owns. Compiling these into a detector is
+ * a bad trade even when the regex is perfect: the hit is cosmetic, so its value
+ * is near zero, while its cost — a review comment on someone's PR — is the
+ * same as any other comment. Issue #1831 measured one such rule ("Ruby does not
+ * require semicolons") producing 614 comments over 40 real PRs with not one
+ * true violation among them.
+ *
+ * The compiler prompt asks the model to decline these itself; this list is the
+ * deterministic backstop, because "is this cosmetic?" is exactly the kind of
+ * judgment a weak BYOK model gets wrong, and the whole T0 safety argument rests
+ * on the gate not trusting the model.
+ */
+const COSMETIC_RULE_PATTERNS: RegExp[] = [
+    /\bsemi-?colons?\b/i,
+    /\b(single|double)[- ]quot/i,
+    /\bquote (style|marks)\b/i,
+    /\bblank lines?\b/i,
+    /\bempty lines?\b/i,
+    /\btrailing (whitespace|space|comma)\b/i,
+    /\bindent(ation|ing)?\b/i,
+    /\bline length\b/i,
+    /\bmax(imum)?[- ]len\b/i,
+    /\bbrace (style|placement)\b/i,
+    /\bstatements? per line\b/i,
+    /\btabs? (vs\.?|or) spaces?\b/i,
+];
+
+/**
+ * True when the rule is linter-owned formatting. Reads title + body: the title
+ * alone is often too terse ("Semicolons"), the body alone too discursive.
+ */
+export function isCosmeticRule(rule: Partial<IKodyRule>): boolean {
+    const text = `${rule.title ?? ''}\n${rule.rule ?? ''}`;
+    return COSMETIC_RULE_PATTERNS.some((rx) => rx.test(text));
+}
+
+/**
+ * Normalize the compiler's `extensions` into lowercase dot-prefixed entries,
+ * dropping anything that isn't a plausible extension. Returns undefined for an
+ * empty/absent list so "no scope" stays distinguishable from "scoped to
+ * nothing" — the latter would silently disable the rule.
+ */
+export function normalizeDetectorExtensions(
+    extensions?: string[],
+): string[] | undefined {
+    if (!Array.isArray(extensions)) return undefined;
+    const out = new Set<string>();
+    for (const raw of extensions) {
+        if (typeof raw !== 'string') continue;
+        const e = raw.trim().toLowerCase();
+        if (!e) continue;
+        const dotted = e.startsWith('.') ? e : `.${e}`;
+        // A real extension: dot + alphanumerics. Rejects globs ("*.rb"), paths
+        // and prose the model may have put here instead.
+        if (!/^\.[a-z0-9_+-]{1,12}$/.test(dotted)) continue;
+        out.add(dotted);
+    }
+    return out.size ? [...out] : undefined;
 }
 
 /** Longest detector pattern we persist. A compiled rule is a simple line
@@ -198,7 +270,17 @@ export async function compileRuleDetector(
     // model output and promoting a wrong regex would SILENTLY HIDE violations,
     // which is worse than declining (see the prompt: "when unsure, decline"). So
     // any off-schema shape correctly falls through to decline → semantic judge.
+    // Cosmetic rules never get a detector (issue #1831) — checked BEFORE the
+    // LLM call so a linter-owned rule costs nothing to reject, and independently
+    // of whether the model remembered to set `cosmetic`.
+    if (isCosmeticRule(rule)) {
+        return { detector: null, declineReason: 'cosmetic' };
+    }
+
     const out = await runCompiler(rule);
+    if (out?.cosmetic === true) {
+        return { detector: null, declineReason: 'cosmetic' };
+    }
     if (!out || out.mechanical !== true || !out.pattern) {
         return { detector: null, declineReason: 'not-mechanical' };
     }
@@ -272,6 +354,7 @@ export async function compileRuleDetector(
             flags: out.flags,
             compiledBy: opts.modelName,
             reason: out.reason,
+            extensions: normalizeDetectorExtensions(out.extensions),
         },
     };
 }
@@ -327,46 +410,84 @@ export function runDetector(
     return hits;
 }
 
-/** A detector-produced finding, shaped like the judge's ShardViolation so the
- *  provider can merge both streams into one mapAgentFindings call. */
-export interface DetectorViolation {
-    ruleUuid: string;
-    relevantFile: string;
-    relevantLinesStart: number;
-    relevantLinesEnd: number;
-    existingCode: string;
-    suggestionContent: string;
-    oneSentenceSummary: string;
+/**
+ * Where a compiled detector fired: ruleUuid → filename → ascending line numbers.
+ * This is the whole T0 review-time output now (issue #1831). It answers both
+ * questions the judge needs: which files a mechanical rule must be judged on
+ * (only the ones its regex fired in — everything else stays free), and which
+ * lines to put in front of the model as candidates.
+ */
+export type DetectorHitIndex = Map<string, Map<string, number[]>>;
+
+/**
+ * Does this file fall inside the detector's compiled language scope?
+ *
+ * A detector with no `extensions` is unscoped and applies everywhere — the
+ * pre-#1831 behavior, kept because a genuinely language-agnostic rule ("no
+ * hardcoded credentials") must not be silently narrowed, and because the 424
+ * detectors already in the fleet carry no scope until they are recompiled.
+ * Their false positives are now caught by the judge instead.
+ */
+export function detectorAppliesToFile(
+    filename: string,
+    detector: DetectorPlan,
+): boolean {
+    const exts = detector.extensions;
+    if (!exts?.length) return true;
+    const m = String(filename).toLowerCase().match(/\.[^./]+$/);
+    return !!m && exts.includes(m[0]);
 }
 
 /**
- * T0 review-time: for every rule that carries a compiled detector, run it over
- * the ADDED lines of the path-applicable changed files and emit one finding per
- * hit. Pure code — no LLM. (A confirm-on-hits LLM pass to filter residual false
- * positives + polish the comment is a later refinement; the compile-time gate
- * already bounds precision.)
+ * T0 REVIEW-TIME: run every compiled detector over the added lines of the
+ * path-applicable, extension-applicable changed files and return WHERE each one
+ * fired.
+ *
+ * This used to be `buildDetectorViolations`, and it published a PR comment per
+ * hit with no LLM anywhere in the path. Issue #1831 measured what that costs:
+ * one Ruby-scoped rule, run over 40 real polyglot PRs, published 614 comments —
+ * 93.6% of them on files of another language entirely (.tsx, .scss, .jsx), and
+ * of the remainder, the `.rb` hits were SQL inside heredocs and the `.erb` hits
+ * were JavaScript embedded in a template. Not one true violation. In production
+ * the same path rejected at 44.6% thumbs-down against 6.2% for the LLM judge.
+ *
+ * A regex cannot see the things that make those hits wrong — the file's
+ * language, a heredoc, a comment, an embedded second language — so the regex no
+ * longer gets to decide. It is now a ROUTER: cheap, deterministic, and its only
+ * job is to say which (rule, file) pairs are worth an LLM's attention. The
+ * judge that already handles semantic rules confirms or rejects each candidate
+ * with the whole file diff in front of it.
+ *
+ * The cost argument survives: a file where nothing matched never reaches a
+ * model, so a precise detector still costs ~nothing, and a noisy one costs in
+ * proportion to its noise — which is the right incentive.
  */
-export function buildDetectorViolations(
+export function buildDetectorCandidates(
     rules: Array<Partial<IKodyRule>>,
     changedFiles: FileChange[],
-): DetectorViolation[] {
-    const out: DetectorViolation[] = [];
+): DetectorHitIndex {
+    const index: DetectorHitIndex = new Map();
     for (const rule of rules) {
         if (!rule.detector || !rule.uuid) continue;
-        const files = changedFiles.filter((f) =>
-            ruleAppliesToFile(f.filename, rule.path),
+        const files = changedFiles.filter(
+            (f) =>
+                ruleAppliesToFile(f.filename, rule.path) &&
+                detectorAppliesToFile(f.filename, rule.detector!),
         );
         for (const h of runDetector(rule.detector, files)) {
-            out.push({
-                ruleUuid: rule.uuid,
-                relevantFile: h.filename,
-                relevantLinesStart: h.line,
-                relevantLinesEnd: h.line,
-                existingCode: h.code,
-                suggestionContent: `Violates team rule '${rule.title}': ${rule.rule}`,
-                oneSentenceSummary: `Violates '${rule.title}'`,
-            });
+            let perFile = index.get(rule.uuid);
+            if (!perFile) index.set(rule.uuid, (perFile = new Map()));
+            const lines = perFile.get(h.filename);
+            if (lines) lines.push(h.line);
+            else perFile.set(h.filename, [h.line]);
         }
     }
-    return out;
+    // Ascending, de-duplicated: the same line can match once per detector run
+    // and the prompt should list each candidate once, in file order.
+    for (const perFile of index.values()) {
+        for (const [filename, lines] of perFile) {
+            perFile.set(filename, [...new Set(lines)].sort((a, b) => a - b));
+        }
+    }
+    return index;
 }

--- a/libs/code-review/infrastructure/agents/collaborators/kody-rules-detector.compiler.ts
+++ b/libs/code-review/infrastructure/agents/collaborators/kody-rules-detector.compiler.ts
@@ -435,7 +435,15 @@ export function detectorAppliesToFile(
     const exts = detector.extensions;
     if (!exts?.length) return true;
     const m = String(filename).toLowerCase().match(/\.[^./]+$/);
-    return !!m && exts.includes(m[0]);
+    // No extension at all (Rakefile, Gemfile, Dockerfile, Makefile, LICENSE):
+    // we cannot tell the language, so we do not narrow. Excluding them would be
+    // a SILENT enforcement loss — a Ruby-scoped rule would never fire on a
+    // Rakefile, and because the judge only shards files where a detector fired,
+    // no LLM pass would catch it either. The scope is a cost filter, so when it
+    // cannot decide it must abstain and let the judge rule; the same reason
+    // `normalizeDetectorExtensions` returns undefined instead of an empty list.
+    if (!m) return true;
+    return exts.includes(m[0]);
 }
 
 /**

--- a/libs/code-review/infrastructure/agents/collaborators/kody-rules-sharded.judge.spec.ts
+++ b/libs/code-review/infrastructure/agents/collaborators/kody-rules-sharded.judge.spec.ts
@@ -1186,3 +1186,59 @@ describe('CONTRACT — boundary ALWAYS returns its declared shape', () => {
         expect(res.shardsErrored).toBe(2);
     });
 });
+
+// ── #1831: what the shard ASKS FOR determines what a finding looks like ─────
+describe('#1831 — the file-shard prompt asks for a complete, applicable finding', () => {
+    const captureUser = async (rules: any[], detectorHits?: any) => {
+        let user = '';
+        const runJudge: RunJudge = async (args) => {
+            user = args.user;
+            return [];
+        };
+        await judgeKodyRulesSharded({
+            changedFiles: [
+                {
+                    filename: 'app/models/user.rb',
+                    patchWithLinesStr: '3 +    return false if x == nil',
+                } as any,
+            ],
+            rules,
+            runJudge,
+            detectorHits,
+        });
+        return user;
+    };
+
+    it('asks for improvedCode and language, which the wire schema has always required', () => {
+        // Both keys are REQUIRED by shardViolationsWireSchema, but the return
+        // template never showed them, so models filled them with null and every
+        // sharded kody-rules finding shipped with no fix to apply and no
+        // language for the diff block. #1831 needs a detector-derived finding to
+        // carry an applicable improvedCode; those now come through this shard,
+        // so asking here fixes the whole stream.
+        return captureUser([{ uuid: 'r1', title: 't', rule: 'no nil compare' }]).then((user) => {
+            expect(user).toContain('"improvedCode"');
+            expect(user).toContain('"language"');
+            // null stays legal: a rule like "use the structured logger" has no
+            // line-level replacement the model can write without knowing the
+            // project's logger, and inventing one is worse than omitting it.
+            expect(user).toMatch(/use null only when the fix cannot be expressed/);
+        });
+    });
+
+    it('tells the model to strip the diff prefix from existingCode', () => {
+        // Without this, models copy the shard line verbatim — `266 +  console.log(`
+        // — and the '+' leaks into the published comment and into anchoring.
+        return captureUser([{ uuid: 'r1', title: 't', rule: 'no nil compare' }]).then((user) => {
+            expect(user).toMatch(/strip the line-number and '\+' prefix/);
+        });
+    });
+
+    it('keeps the candidate block out of a purely semantic shard', () => {
+        // No detector rules in the review = byte-identical prompt to before
+        // #1831, so nothing regresses for the orgs that have no T0 rules.
+        return captureUser([{ uuid: 'r1', title: 't', rule: 'no nil compare' }]).then((user) => {
+            expect(user).not.toContain('<Candidates>');
+        });
+    });
+});

--- a/libs/code-review/infrastructure/agents/collaborators/kody-rules-sharded.judge.ts
+++ b/libs/code-review/infrastructure/agents/collaborators/kody-rules-sharded.judge.ts
@@ -28,6 +28,9 @@ import {
     IKodyRule,
     KodyRulesScope,
 } from '@libs/kodyRules/domain/interfaces/kodyRules.interface';
+// Type-only: the compiler imports `ruleAppliesToFile` from THIS module, so a
+// value import back would close a runtime require cycle.
+import type { DetectorHitIndex } from '@libs/code-review/infrastructure/agents/collaborators/kody-rules-detector.compiler';
 
 /**
  * Parser schema for a shard's JSON output. The provider passes this to
@@ -201,6 +204,21 @@ export interface ShardedJudgeInput {
      * field existed.
      */
     languageLabel?: string | null;
+    /**
+     * Where each compiled T0 detector fired (issue #1831). Two effects:
+     *
+     *   1. ROUTING — a rule that carries a detector is judged ONLY in the files
+     *      its regex hit. A precise detector therefore still costs almost
+     *      nothing (most files never reach a model), while a noisy one costs in
+     *      proportion to its noise.
+     *   2. HINTING — the hit lines are shown to the judge as candidates to
+     *      confirm or reject, so recall does not rest on the model
+     *      independently rediscovering what the regex already found.
+     *
+     * Absent = no detector rules in this review; every rule shards by `path`
+     * exactly as before.
+     */
+    detectorHits?: DetectorHitIndex;
 }
 
 export interface ShardedJudgeResult {
@@ -260,10 +278,50 @@ function languageInstructionLines(languageLabel?: string | null): string[] {
     ];
 }
 
+/**
+ * The candidate block for a file shard (issue #1831): the lines a compiled
+ * regex detector already flagged, presented as questions rather than findings.
+ *
+ * The wording is the load-bearing part. Handing a model a list of pre-flagged
+ * lines invites it to rubber-stamp them, which would reproduce the very bug
+ * this replaces — so the block states plainly what the pre-filter is blind to
+ * (language, comments, embedded languages, heredocs) and names rejection as the
+ * expected outcome, not a failure. Those are not hypotheticals: they are the
+ * three shapes the incident's false positives actually took — a Ruby rule
+ * firing on .tsx/.scss, on JavaScript embedded in .erb, and on SQL inside a
+ * `<<~SQL` heredoc in a migration.
+ *
+ * Returns [] when this shard has no candidates, so a shard of purely semantic
+ * rules keeps a byte-identical prompt to before this existed.
+ */
+function candidateLines(
+    file: FileChange,
+    rules: Array<Partial<IKodyRule>>,
+    detectorHits?: DetectorHitIndex,
+): string[] {
+    if (!detectorHits?.size) return [];
+    const entries: string[] = [];
+    rules.forEach((r, i) => {
+        if (!r.uuid) return;
+        const lines = detectorHits.get(r.uuid)?.get(file.filename);
+        if (lines?.length) entries.push(`- rule [${i + 1}] -> line(s) ${lines.join(', ')}`);
+    });
+    if (!entries.length) return [];
+    return [
+        `<Candidates>`,
+        `A cheap regex pre-filter flagged these lines. It matches raw text one line at a time and knows NOTHING else — not the file's language, not whether the line is a comment, not whether it sits inside a string, a heredoc, or a block of another language embedded in this file.`,
+        ...entries,
+        `Treat every candidate as a QUESTION, not a finding. Report it only if that line genuinely violates that rule in THIS file, judged in its real language and context; otherwise say nothing about it. Rejecting candidates is the normal outcome and needs no explanation. Violations the pre-filter missed are still yours to report.`,
+        `</Candidates>`,
+        ``,
+    ];
+}
+
 function fileShardUser(
     file: FileChange,
     rules: Array<Partial<IKodyRule>>,
     languageLabel?: string | null,
+    detectorHits?: DetectorHitIndex,
 ): string {
     const diff = (file as any).patchWithLinesStr ?? file.patch ?? '';
     return [
@@ -278,9 +336,18 @@ function fileShardUser(
         '```',
         `</File>`,
         ``,
+        ...candidateLines(file, rules, detectorHits),
         ...languageInstructionLines(languageLabel),
-        `Return ONLY JSON (ruleId is the rule's [n] number):`,
-        `{"violations":[{"ruleId":<n>,"relevantLinesStart":<line>,"relevantLinesEnd":<line>,"existingCode":"<offending code>","suggestionContent":"WHAT/WHY/HOW","oneSentenceSummary":"<short>"}]}`,
+        // `improvedCode` and `language` are REQUIRED by the wire schema but were
+        // missing from this template, so models filled them with null and every
+        // sharded kody-rules finding shipped without a fix to apply and without
+        // a language for the diff block. Issue #1831 requires a detector-derived
+        // finding to carry an applicable `improvedCode`; since detector findings
+        // now come through this same shard, asking for it here fixes the whole
+        // stream at once. `existingCode` is called out explicitly because models
+        // otherwise copy the line WITH its `<n> +` diff prefix.
+        `Return ONLY JSON (ruleId is the rule's [n] number). "existingCode" is the offending code EXACTLY as it appears in the file — strip the line-number and '+' prefix the diff adds. "improvedCode" is that same code rewritten to satisfy the rule, ready to apply; use null only when the fix cannot be expressed as a replacement for those lines. "language" is the file's language (e.g. "ruby", "typescript").`,
+        `{"violations":[{"ruleId":<n>,"relevantLinesStart":<line>,"relevantLinesEnd":<line>,"language":"<lang>","existingCode":"<offending code>","improvedCode":"<fixed code or null>","suggestionContent":"WHAT/WHY/HOW","oneSentenceSummary":"<short>"}]}`,
     ].join('\n');
 }
 
@@ -355,10 +422,18 @@ function matchesPathPattern(filePath: string, pattern: string): boolean {
 function rulesForFile(
     file: FileChange,
     rules: Array<Partial<IKodyRule>>,
+    detectorHits?: DetectorHitIndex,
 ): Array<Partial<IKodyRule>> {
-    return rules.filter(
-        (r) => !r.path || matchesPathPattern(file.filename, r.path),
-    );
+    return rules.filter((r) => {
+        if (r.path && !matchesPathPattern(file.filename, r.path)) return false;
+        // A rule carrying a compiled detector is judged only where the detector
+        // fired. Without this the T0 pre-filter would buy nothing — a mechanical
+        // rule would shard every file, exactly like a semantic one.
+        if (r.detector && r.uuid) {
+            return !!detectorHits?.get(r.uuid)?.has(file.filename);
+        }
+        return true;
+    });
 }
 
 const isPrLevel = (r: Partial<IKodyRule>) =>
@@ -622,11 +697,19 @@ export async function judgeKodyRulesSharded(
         prBody,
         logger,
         languageLabel,
+        detectorHits,
     } = input;
     const concurrency = input.concurrency ?? 4;
 
-    const fileRules = rules.filter((r) => !isPrLevel(r));
-    const prRules = rules.filter(isPrLevel);
+    // A rule whose detector fired NOWHERE in this PR is not judged at all —
+    // that is the entire cost saving of the T0 pre-filter (issue #1831), and it
+    // covers PR-scope detector rules too, which `rulesForFile` never sees.
+    const judgeable = rules.filter(
+        (r) => !r.detector || !r.uuid || !!detectorHits?.get(r.uuid)?.size,
+    );
+
+    const fileRules = judgeable.filter((r) => !isPrLevel(r));
+    const prRules = judgeable.filter(isPrLevel);
 
     let shardsRun = 0;
     let shardsErrored = 0;
@@ -634,7 +717,10 @@ export async function judgeKodyRulesSharded(
 
     // ── file-scope shards: one per changed file that has applicable rules ────
     const fileShards = changedFiles
-        .map((file) => ({ file, applicable: rulesForFile(file, fileRules) }))
+        .map((file) => ({
+            file,
+            applicable: rulesForFile(file, fileRules, detectorHits),
+        }))
         .filter((s) => s.applicable.length > 0);
 
     const perFile = await mapLimit(
@@ -649,7 +735,12 @@ export async function judgeKodyRulesSharded(
             try {
                 const vs = await runJudge({
                     system: SHARD_SYSTEM_PROMPT,
-                    user: fileShardUser(file, applicable, languageLabel),
+                    user: fileShardUser(
+                        file,
+                        applicable,
+                        languageLabel,
+                        detectorHits,
+                    ),
                     filename: file.filename,
                     ruleUuids,
                 });

--- a/libs/code-review/infrastructure/agents/providers/kody-rules-agent.provider.spec.ts
+++ b/libs/code-review/infrastructure/agents/providers/kody-rules-agent.provider.spec.ts
@@ -521,27 +521,43 @@ describe('KodyRulesAgentProvider.execute — sharded end-to-end (#1449)', () => 
         expect(call.user).not.toContain('Respond in');
     });
 
-    it('mechanical path: detector regex fires with ZERO LLM calls', async () => {
-        const { provider, judge } = makeProvider([]);
-        const out = await provider.execute(
-            input({
-                kodyRules: [
+    // ── #1831: the detector routes, it does not publish ──────────────────────
+    // It used to emit a finding per regex hit with no LLM anywhere in the path.
+    // Measured on 40 real polyglot PRs, one Ruby-scoped rule published 614
+    // comments that way and not one was a true violation; in production the
+    // path rejected at 44.6% thumbs-down against the judge's 6.2%.
+
+    const mechanicalRule = {
+        uuid: 'no-console',
+        title: 'no console',
+        rule: 'no console.log',
+        status: 'active',
+        severity: 'high',
+        path: '**/*.ts',
+        detector: {
+            type: 'regex',
+            pattern: 'console\\.(log|warn|error)\\(',
+        },
+    };
+
+    it('mechanical path: a detector hit is CONFIRMED by the judge before it ships', async () => {
+        const { provider, judge } = makeProvider([
+            {
+                violations: [
                     {
-                        uuid: 'no-console',
-                        title: 'no console',
-                        rule: 'no console.log',
-                        status: 'active',
-                        severity: 'high',
-                        path: '**/*.ts',
-                        detector: {
-                            type: 'regex',
-                            pattern: 'console\\.(log|warn|error)\\(',
-                        },
+                        ruleId: 1,
+                        relevantLinesStart: 10,
+                        existingCode: 'console.log(1)',
+                        suggestionContent: 'use the logger',
+                        oneSentenceSummary: 'no console',
                     },
                 ],
-            }) as any,
+            },
+        ]);
+        const out = await provider.execute(
+            input({ kodyRules: [mechanicalRule] }) as any,
         );
-        expect(judge).not.toHaveBeenCalled();
+        expect(judge).toHaveBeenCalledTimes(1);
         expect(out.suggestions).toHaveLength(1);
         expect((out.suggestions[0] as any).brokenKodyRulesIds).toEqual([
             'no-console',
@@ -549,15 +565,67 @@ describe('KodyRulesAgentProvider.execute — sharded end-to-end (#1449)', () => 
         expect(out.suggestions[0].relevantLinesStart).toBe(10);
     });
 
-    it('mixed: detector + judge merge into one output (one LLM call)', async () => {
+    it('mechanical path: a detector hit the judge REJECTS never reaches the PR', async () => {
+        // The whole point. The regex matched, the judge looked at the file and
+        // said no — e.g. the line is a comment, or JS embedded in an .erb, or
+        // SQL inside a heredoc. Before #1831 this shipped regardless.
+        const { provider, judge } = makeProvider([{ violations: [] }]);
+        const out = await provider.execute(
+            input({ kodyRules: [mechanicalRule] }) as any,
+        );
+        expect(judge).toHaveBeenCalledTimes(1);
+        expect(out.suggestions).toHaveLength(0);
+    });
+
+    it('mechanical path: the shard prompt offers the hit as a candidate to reject, not as a finding', async () => {
+        const { provider, judge } = makeProvider([{ violations: [] }]);
+        await provider.execute(input({ kodyRules: [mechanicalRule] }) as any);
+        const user = judge.mock.calls[0][0].user as string;
+        expect(user).toContain('<Candidates>');
+        expect(user).toContain('rule [1] -> line(s) 10');
+        // Anti-rubber-stamp: the model must be told the pre-filter is blind and
+        // that rejecting is a normal outcome. Without this the confirmation
+        // step degrades into a confirmation bias.
+        expect(user).toContain('QUESTION, not a finding');
+        expect(user).toMatch(/Rejecting candidates is the normal outcome/);
+    });
+
+    it('mechanical path: a detector that matches nothing costs no LLM call at all', async () => {
+        // The cost argument for T0 survives the fix: files the regex did not hit
+        // never reach a model, so a precise detector is still nearly free.
+        const { provider, judge } = makeProvider([]);
+        const out = await provider.execute(
+            input({
+                kodyRules: [
+                    {
+                        ...mechanicalRule,
+                        detector: { type: 'regex', pattern: 'debugger' },
+                    },
+                ],
+            }) as any,
+        );
+        expect(judge).not.toHaveBeenCalled();
+        expect(out.suggestions).toHaveLength(0);
+    });
+
+    it('mixed: mechanical and semantic rules share ONE shard for the file', async () => {
+        // Both rules apply to src/a.ts and the detector fired there, so they are
+        // batched into a single call — the mechanical rule rides along on a
+        // shard the semantic rule was paying for anyway.
         const { provider, judge } = makeProvider([
             {
                 violations: [
                     {
-                        ruleId: 1, // semantic shard's only rule: no-any (detector rule is not sharded)
+                        ruleId: 2, // no-any
                         relevantLinesStart: 11,
                         suggestionContent: 'avoid any',
                         oneSentenceSummary: 'no any',
+                    },
+                    {
+                        ruleId: 1, // no-console, confirmed from the candidate
+                        relevantLinesStart: 10,
+                        suggestionContent: 'use the logger',
+                        oneSentenceSummary: 'no console',
                     },
                 ],
             },
@@ -588,7 +656,7 @@ describe('KodyRulesAgentProvider.execute — sharded end-to-end (#1449)', () => 
                 ],
             }) as any,
         );
-        expect(judge).toHaveBeenCalledTimes(1); // only the semantic rule
+        expect(judge).toHaveBeenCalledTimes(1); // one shard, both rules
         const ids = out.suggestions
             .map((s: any) => s.brokenKodyRulesIds?.[0])
             .sort();

--- a/libs/code-review/infrastructure/agents/providers/kody-rules-agent.provider.ts
+++ b/libs/code-review/infrastructure/agents/providers/kody-rules-agent.provider.ts
@@ -337,8 +337,16 @@ export class KodyRulesAgentProvider extends BaseCodeReviewAgentProvider {
             // (wire-schema 400 / provider outage / model unavailability) are in
             // the shard warn logs.
             if (shardsRun > 0 && shardsErrored === shardsRun) {
+                // Since #1831 a mechanical rule is confirmed by this same judge,
+                // so a T0-only org reaches this escalation for the first time.
+                // That is correct — the judge failing now genuinely means those
+                // rules were NOT applied, where before the regex had already
+                // decided — but the message must not claim "semantic" rules the
+                // org may not have.
+                const kind =
+                    semanticRules.length > 0 ? 'Kody Rules' : 'mechanical Kody Rules';
                 throw new Error(
-                    `Kody Rules could not be evaluated: all ${shardsRun} rule check(s) failed to run. Your semantic Kody Rules were not applied to this PR.`,
+                    `Kody Rules could not be evaluated: all ${shardsRun} rule check(s) failed to run. Your ${kind} were not applied to this PR.`,
                 );
             }
 

--- a/libs/code-review/infrastructure/agents/providers/kody-rules-agent.provider.ts
+++ b/libs/code-review/infrastructure/agents/providers/kody-rules-agent.provider.ts
@@ -23,7 +23,7 @@ import {
 } from '@libs/code-review/infrastructure/agents/collaborators/kody-rules-sharded.judge';
 import { resolveLanguageLabel } from '@libs/code-review/infrastructure/agents/prompts/prompt-builder';
 import { ExternalReferenceLoaderService } from '@libs/kodyRules/infrastructure/adapters/services/externalReferenceLoader.service';
-import { buildDetectorViolations } from '@libs/code-review/infrastructure/agents/collaborators/kody-rules-detector.compiler';
+import { buildDetectorCandidates } from '@libs/code-review/infrastructure/agents/collaborators/kody-rules-detector.compiler';
 import {
     ReviewAgentIdentity,
     ReviewAgentInput,
@@ -144,25 +144,55 @@ export class KodyRulesAgentProvider extends BaseCodeReviewAgentProvider {
         // gpt-5.4-mini / kimi at ~same-or-lower cost.
         const startTime = Date.now();
 
-        // Route each rule by its compiled shape (issue #1449):
-        //   T0 mechanical (has a `detector`) → deterministic regex over added
-        //     lines, ZERO LLM (the only part that stays free under any BYOK).
-        //   T1/T2 semantic (no detector) → the sharded single-shot LLM judge.
+        // Route each rule by its compiled shape (issue #1449, reshaped by #1831):
+        //   T0 mechanical (has a `detector`) → the regex runs in code and
+        //     ROUTES: it decides which (rule, file) pairs are worth an LLM
+        //     call. It no longer publishes anything on its own.
+        //   T1/T2 semantic (no detector) → the sharded single-shot LLM judge,
+        //     over every path-applicable file, exactly as before.
+        //
+        // Both streams then meet in the SAME judge, so a mechanical rule gets
+        // the same "does this really violate the rule, in this file's language
+        // and context?" question a semantic one gets. The detector publishing
+        // straight to the PR is what produced a 44.6% thumbs-down rate against
+        // the judge's 6.2% (issue #1831): a regex cannot see that the line it
+        // matched is JavaScript inside an .erb template, SQL inside a heredoc,
+        // or simply a language the rule was never about.
         const mechanicalRules = rules.filter((r) => r.detector);
-        const semanticRules = rules.filter((r) => !r.detector);
 
-        // T0 — run compiled detectors in code.
-        const detectorViolations = buildDetectorViolations(
+        // T0 — run compiled detectors in code. Pure code, no LLM: this is still
+        // the cheap part, it just yields candidates instead of comments.
+        const detectorHits = buildDetectorCandidates(
             mechanicalRules,
             input.changedFiles,
         );
+        const rulesWithHits = mechanicalRules.filter(
+            (r) => r.uuid && detectorHits.get(r.uuid)?.size,
+        ).length;
+        const candidateCount = [...detectorHits.values()].reduce(
+            (n, perFile) =>
+                n +
+                [...perFile.values()].reduce((m, lines) => m + lines.length, 0),
+            0,
+        );
 
-        // T1/T2 — semantic rules via the LLM judge (skip the model entirely when
-        // every applicable rule is mechanical — pure-T0 reviews cost nothing).
+        const semanticRules = rules.filter((r) => !r.detector);
+
+        // Every rule the judge could have something to say about: the semantic
+        // ones always, plus the mechanical ones whose detector actually fired.
+        // A mechanical rule that matched nothing costs nothing — no shard is
+        // created for it — which is what keeps T0's cost argument intact.
+        const judgeRules = [
+            ...semanticRules,
+            ...mechanicalRules.filter(
+                (r) => r.uuid && detectorHits.get(r.uuid)?.size,
+            ),
+        ];
+
         let judgeViolations: ShardViolation[] = [];
         let shardsRun = 0;
         let shardsErrored = 0;
-        if (semanticRules.length > 0) {
+        if (judgeRules.length > 0) {
             const { byokConfig, main } = await resolveReviewAgentModel(
                 input,
                 this.permissionValidationService,
@@ -187,7 +217,7 @@ export class KodyRulesAgentProvider extends BaseCodeReviewAgentProvider {
                 input.languageResultPrompt,
             );
             this.shardLogger.log({
-                message: `[AGENT] ${this.getIdentity().name} (sharded) using model: ${main.modelName} for PR#${input.prNumber} (${semanticRules.length} semantic, ${mechanicalRules.length} mechanical rules)`,
+                message: `[AGENT] ${this.getIdentity().name} (sharded) using model: ${main.modelName} for PR#${input.prNumber} (${semanticRules.length} semantic, ${mechanicalRules.length} mechanical rules; ${rulesWithHits} with detector hits -> ${candidateCount} candidate line(s) to confirm)`,
                 context: this.getIdentity().name,
             });
 
@@ -233,7 +263,7 @@ export class KodyRulesAgentProvider extends BaseCodeReviewAgentProvider {
             // T2a — inline the rule's own `sourcePath` (IDE-sync / centralized)
             // via the sandbox read so the judge sees the full convention.
             let rulesForJudge = await inlineRuleReferences(
-                semanticRules,
+                judgeRules,
                 input.remoteCommands?.read?.bind(input.remoteCommands),
                 this.shardLogger,
             );
@@ -270,8 +300,9 @@ export class KodyRulesAgentProvider extends BaseCodeReviewAgentProvider {
                 // Sanitized span input: shape only, never the file patches.
                 {
                     prNumber: input.prNumber,
-                    semanticRules: rulesForJudge.length,
+                    semanticRules: semanticRules.length,
                     mechanicalRules: mechanicalRules.length,
+                    detectorCandidates: candidateCount,
                     changedFiles: input.changedFiles?.length ?? 0,
                 },
                 () =>
@@ -283,6 +314,7 @@ export class KodyRulesAgentProvider extends BaseCodeReviewAgentProvider {
                         prBody: input.prBody,
                         logger: this.shardLogger,
                         languageLabel,
+                        detectorHits,
                     }),
             );
             judgeViolations = result.violations;
@@ -333,11 +365,10 @@ export class KodyRulesAgentProvider extends BaseCodeReviewAgentProvider {
             }
         }
 
-        // Merge both streams; downstream mapping/verify/dedup are identical.
-        const allViolations: ShardViolation[] = [
-            ...detectorViolations,
-            ...judgeViolations,
-        ];
+        // One stream now: everything the judge confirmed. Detector hits reach
+        // the PR only through it (issue #1831), so downstream mapping / verify /
+        // dedup see a single, uniformly-confirmed set of findings.
+        const allViolations: ShardViolation[] = [...judgeViolations];
 
         // Reuse the shared finding→CodeSuggestion mapping (ruleUuid
         // reconciliation, path canonicalization, kody-rule severity) so verify
@@ -361,7 +392,7 @@ export class KodyRulesAgentProvider extends BaseCodeReviewAgentProvider {
 
         const durationMs = Date.now() - startTime;
         this.shardLogger.log({
-            message: `[AGENT] ${this.getIdentity().name} (sharded) done for PR#${input.prNumber}: ${mapped.suggestions.length} suggestions (${detectorViolations.length} from ${mechanicalRules.length} detectors, ${judgeViolations.length} from ${shardsRun} shards${shardsErrored ? `, ${shardsErrored} errored` : ''}) in ${durationMs}ms`,
+            message: `[AGENT] ${this.getIdentity().name} (sharded) done for PR#${input.prNumber}: ${mapped.suggestions.length} suggestions (${judgeViolations.length} confirmed across ${shardsRun} shards${shardsErrored ? `, ${shardsErrored} errored` : ''}; ${candidateCount} detector candidate(s) offered) in ${durationMs}ms`,
             context: this.getIdentity().name,
         });
 

--- a/libs/ee/kodyRules/service/kody-rule-detector-compiler.service.spec.ts
+++ b/libs/ee/kodyRules/service/kody-rule-detector-compiler.service.spec.ts
@@ -109,7 +109,7 @@ describe('KodyRuleDetectorCompilerService.compileAndSave (#1449 T0)', () => {
             pattern: 'console\\.(log|warn|error)\\(',
         });
         const result = await svc.compileAndSave(org, 'r1', mechanicalRule);
-        expect(result).toEqual({ compiled: true });
+        expect(result).toEqual({ compiled: true, scoped: false });
     });
 
     it('returns { compiled: false } and threads the decline reason back out', async () => {
@@ -314,7 +314,7 @@ describe('CONTRACT A: output-shape zoo — never persists a wrong detector, alwa
         const [, , detector] =
             kodyRulesService.updateRuleDetector.mock.calls[0];
         expect(detector.pattern).toBe(validD.pattern);
-        expect(res).toEqual({ compiled: true });
+        expect(res).toEqual({ compiled: true, scoped: false });
     });
 
     it('A13 tolerates extra unknown keys alongside the right ones (persists, no crash)', async () => {
@@ -327,7 +327,7 @@ describe('CONTRACT A: output-shape zoo — never persists a wrong detector, alwa
         });
         const res = await svc.compileAndSave(org, 'r1', gatedRule);
         expect(kodyRulesService.updateRuleDetector).toHaveBeenCalledTimes(1);
-        expect(res).toEqual({ compiled: true });
+        expect(res).toEqual({ compiled: true, scoped: false });
     });
 
     it('A17 a null model output on an edited rule CLEARS the stale detector (no silent keep)', async () => {
@@ -355,13 +355,13 @@ describe('CONTRACT A: recoverable payloads the service silently drops (#1786 kno
         const { svc, kodyRulesService } = make({ result: validD });
         const res = await svc.compileAndSave(org, 'r1', gatedRule);
         expect(kodyRulesService.updateRuleDetector).toHaveBeenCalledTimes(1);
-        expect(res).toEqual({ compiled: true });
+        expect(res).toEqual({ compiled: true, scoped: false });
     });
     it.failing('A7 repairs a stringified-JSON envelope and persists', async () => {
         const { svc, kodyRulesService } = make(JSON.stringify(validD));
         const res = await svc.compileAndSave(org, 'r1', gatedRule);
         expect(kodyRulesService.updateRuleDetector).toHaveBeenCalledTimes(1);
-        expect(res).toEqual({ compiled: true });
+        expect(res).toEqual({ compiled: true, scoped: false });
     });
     it.failing('A8 repairs markdown-fenced JSON and persists', async () => {
         const { svc, kodyRulesService } = make(
@@ -369,7 +369,7 @@ describe('CONTRACT A: recoverable payloads the service silently drops (#1786 kno
         );
         const res = await svc.compileAndSave(org, 'r1', gatedRule);
         expect(kodyRulesService.updateRuleDetector).toHaveBeenCalledTimes(1);
-        expect(res).toEqual({ compiled: true });
+        expect(res).toEqual({ compiled: true, scoped: false });
     });
     it.failing(
         'A11 aliases case/convention-mismatched keys and persists',
@@ -382,7 +382,7 @@ describe('CONTRACT A: recoverable payloads the service silently drops (#1786 kno
             expect(kodyRulesService.updateRuleDetector).toHaveBeenCalledTimes(
                 1,
             );
-            expect(res).toEqual({ compiled: true });
+            expect(res).toEqual({ compiled: true, scoped: false });
         },
     );
     it.failing(
@@ -552,7 +552,7 @@ describe('CONTRACT D: input variants into the service boundary', () => {
             examples: [{ isCorrect: false, snippet: 'console.log(x)' }],
         });
         expect(kodyRulesService.updateRuleDetector).toHaveBeenCalledTimes(1);
-        expect(res).toEqual({ compiled: true });
+        expect(res).toEqual({ compiled: true, scoped: false });
     });
     it('D38 duplicate examples do not change the compile decision (idempotent)', async () => {
         const { svc, kodyRulesService } = make(validD);
@@ -566,7 +566,7 @@ describe('CONTRACT D: input variants into the service boundary', () => {
             ],
         });
         expect(kodyRulesService.updateRuleDetector).toHaveBeenCalledTimes(1);
-        expect(res).toEqual({ compiled: true });
+        expect(res).toEqual({ compiled: true, scoped: false });
     });
     it('D39 a null example entry fails safe (no throw past boundary, no persist)', async () => {
         // buildCompilerUserPrompt (compiler.ts:74, `ex.isCorrect`) crashes on a
@@ -612,7 +612,7 @@ describe('CONTRACT D: input variants into the service boundary', () => {
             expect(kodyRulesService.updateRuleDetector).toHaveBeenCalledTimes(
                 1,
             );
-            expect(res).toEqual({ compiled: true });
+            expect(res).toEqual({ compiled: true, scoped: false });
         },
     );
     it('D39 undefined examples array is treated as no labeled signal, not a crash', async () => {
@@ -639,7 +639,7 @@ describe('CONTRACT D: input variants into the service boundary', () => {
                 { isCorrect: true, snippet: 'const tea = 1' },
             ],
         });
-        expect(res).toEqual({ compiled: true });
+        expect(res).toEqual({ compiled: true, scoped: false });
         const [, , detector] =
             kodyRulesService.updateRuleDetector.mock.calls[0];
         expect(detector.pattern).toBe('café');

--- a/libs/ee/kodyRules/service/kody-rule-detector-compiler.service.ts
+++ b/libs/ee/kodyRules/service/kody-rule-detector-compiler.service.ts
@@ -54,7 +54,7 @@ export class KodyRuleDetectorCompilerService
         organizationAndTeamData: OrganizationAndTeamData,
         ruleUuid: string,
         rule: Partial<IKodyRule>,
-    ): Promise<{ compiled: boolean; declineReason?: string }> {
+    ): Promise<{ compiled: boolean; declineReason?: string; scoped?: boolean }> {
         try {
             // native: resolve the kody-rules (codeReview) task to a `{main}`
             // carrier for runStructuredReviewCall. A non-v2/managed/BLOCKED
@@ -99,9 +99,16 @@ export class KodyRuleDetectorCompilerService
                 this.logger.log({
                     message: `Compiled T0 detector for rule ${ruleUuid}`,
                     context: KodyRuleDetectorCompilerService.name,
-                    metadata: { ruleUuid, pattern: detector.pattern },
+                    metadata: {
+                        ruleUuid,
+                        pattern: detector.pattern,
+                        extensions: detector.extensions,
+                    },
                 });
-                return { compiled: true };
+                return {
+                    compiled: true,
+                    scoped: !!detector.extensions?.length,
+                };
             }
             // Edited rule that used to be mechanical but no longer is:
             // clear the stale detector so review stops using it.

--- a/libs/ee/kodyRules/service/kody-rule-detector-compiler.service.ts
+++ b/libs/ee/kodyRules/service/kody-rule-detector-compiler.service.ts
@@ -100,6 +100,7 @@ export class KodyRuleDetectorCompilerService
                     message: `Compiled T0 detector for rule ${ruleUuid}`,
                     context: KodyRuleDetectorCompilerService.name,
                     metadata: {
+                        organizationAndTeamData,
                         ruleUuid,
                         pattern: detector.pattern,
                         extensions: detector.extensions,

--- a/libs/kodyRules/application/use-cases/backfill-rule-detectors.use-case.ts
+++ b/libs/kodyRules/application/use-cases/backfill-rule-detectors.use-case.ts
@@ -24,6 +24,18 @@ export interface BackfillDetectorsResult {
     errored: number;
     /** rules not eligible (inactive / memory / already have a detector) */
     skipped: number;
+    /**
+     * #1831 recompile accounting — only meaningful with `onlyMissing: false`,
+     * which is how the fleet-wide re-scope sweep is run.
+     */
+    /** rules that HAD a detector and came back with a language scope. */
+    rescoped: number;
+    /** rules that HAD a detector and lost it (cosmetic / no longer compiles). */
+    disabled: number;
+    /** of those, the ones declined specifically as linter-owned formatting. */
+    disabledCosmetic: number;
+    /** rules that kept a detector but STILL carry no language scope. */
+    stillUnscoped: number;
 }
 
 /**
@@ -87,6 +99,10 @@ export class BackfillRuleDetectorsUseCase {
             declined: 0,
             errored: 0,
             skipped: all.length - target.length,
+            rescoped: 0,
+            disabled: 0,
+            disabledCosmetic: 0,
+            stillUnscoped: 0,
         };
 
         const concurrency = Math.max(1, opts.concurrency ?? 3);
@@ -103,16 +119,37 @@ export class BackfillRuleDetectorsUseCase {
                             rule.uuid,
                             rule,
                         );
-                        if (r.compiled) res.compiled++;
-                        else if (r.declineReason === 'error') res.errored++;
-                        else res.declined++;
+                        // Did this rule arrive with a detector? That is what
+                        // makes it part of the #1831 fleet — the 424 unscoped
+                        // detectors already armed across 129 orgs — as opposed
+                        // to a rule being given a detector for the first time.
+                        const hadDetector = !!rule.detector;
+                        if (r.compiled) {
+                            res.compiled++;
+                            if (hadDetector && r.scoped) res.rescoped++;
+                            if (!r.scoped) res.stillUnscoped++;
+                        } else if (r.declineReason === 'error') {
+                            res.errored++;
+                        } else {
+                            res.declined++;
+                            // compileAndSave already cleared the stale detector;
+                            // count it so the sweep can report what it disarmed.
+                            if (hadDetector) {
+                                res.disabled++;
+                                if (r.declineReason === 'cosmetic') {
+                                    res.disabledCosmetic++;
+                                }
+                            }
+                        }
                     }
                 },
             ),
         );
 
         this.logger.log({
-            message: `Detector backfill complete for org`,
+            message: onlyMissing
+                ? `Detector backfill complete for org`
+                : `Detector re-scope sweep complete for org: ${res.rescoped} re-scoped, ${res.disabled} disarmed (${res.disabledCosmetic} cosmetic), ${res.stillUnscoped} still unscoped`,
             context: BackfillRuleDetectorsUseCase.name,
             metadata: { organizationAndTeamData, ...res },
         });

--- a/libs/kodyRules/domain/contracts/kody-rule-detector-compiler.contract.ts
+++ b/libs/kodyRules/domain/contracts/kody-rule-detector-compiler.contract.ts
@@ -11,10 +11,14 @@ export interface IKodyRuleDetectorCompiler {
      * Compile the rule and persist the detector if the gate passes; clear a
      * stale detector when an edited rule no longer compiles. Best-effort — a
      * failure leaves the rule semantic. Returns whether a detector was stored.
+     *
+     * `scoped` reports whether the stored detector carries a language scope
+     * (issue #1831), so a backfill sweep can tell a re-scoped detector from one
+     * that is still unscoped without re-reading every rule.
      */
     compileAndSave(
         organizationAndTeamData: OrganizationAndTeamData,
         ruleUuid: string,
         rule: Partial<IKodyRule>,
-    ): Promise<{ compiled: boolean; declineReason?: string }>;
+    ): Promise<{ compiled: boolean; declineReason?: string; scoped?: boolean }>;
 }

--- a/libs/kodyRules/domain/interfaces/kodyRules.interface.ts
+++ b/libs/kodyRules/domain/interfaces/kodyRules.interface.ts
@@ -250,6 +250,22 @@ export interface IKodyRuleDetector {
     compiledBy?: string;
     /** short rationale from the compiler. */
     reason?: string;
+    /**
+     * File extensions the rule's OWN TEXT scopes it to, lowercase and
+     * dot-prefixed (e.g. ['.rb', '.erb']). Emitted by the compiler when the
+     * rule names a language, absent when the rule is language-agnostic.
+     *
+     * Why (issue #1831): a regex has no notion of language, so a Ruby-only
+     * rule ("Ruby does not require semicolons") compiled to `;\s*$` matched
+     * every JS/SCSS/YAML line in the PR — 93.6% of its hits on a real
+     * polyglot corpus were on files the rule does not even apply to. This is
+     * a COST filter, not the safety net: a candidate outside these extensions
+     * is dropped before it costs an LLM call. The safety net is that no
+     * candidate is published without the judge confirming it.
+     *
+     * Absent/empty = no extension filter (unchanged behavior).
+     */
+    extensions?: string[];
 }
 
 export interface IKodyRulesInheritance {


### PR DESCRIPTION
Closes #1831.

## What was wrong

A compiled kody-rule detector emitted a PR comment for **every regex hit, with no LLM anywhere in the path**. Production measured that at a **44.6% thumbs-down rate** against 6.2% for the same rules on the LLM judge — 1.5% of delivered suggestions, 18% of every thumbs-down in the product.

I reproduced it offline before changing anything, against 40 real merged PRs harvested from polyglot Ruby repos (discourse, mastodon, forem, chatwoot, gitlab). One rule — the real one from the incident, *"Ruby does not require semicolons"*, compiled to `;\s*(?:#.*)?$` with an empty `path`:

| | before | after |
|---|---|---|
| comments published | **606** | **0** |
| on the wrong language | 567 (93.6%) | 0 |
| files reaching a model | 0 (no LLM at all) | 4 of 400 (1.0%) |

`.tsx:280 .scss:128 .jsx:112 .erb:37 .js:21 .gjs:14 .ts:12 .rb:2` — and of the two that were not simply the wrong language, the `.erb` hits were **JavaScript embedded in a template** and the `.rb` hits were **SQL inside a `<<~SQL` heredoc** in a migration. Not one true violation in the whole corpus. The repro independently rediscovered both shapes the issue had found by hand, in a different repo from the customer's.

## The change

A regex cannot see the things that make those hits wrong — the file's language, a comment, a heredoc, a second language embedded in the file. So the regex no longer decides. **It routes.**

Three layers, each of which alone would have prevented the incident:

1. **The compiler declines linter-owned formatting** — semicolons, quote style, blank lines, indentation, line length, statements per line. Checked deterministically *before* the compile call, because "is this cosmetic?" is exactly the judgment a weak BYOK model gets wrong, and the whole T0 safety argument rests on the gate not trusting the model. This rule dies here.
2. **Language scope** — the compiler emits `extensions` when the rule's own text names a language, and a detector only runs on those. 606 candidates → 39, for free. This is a *cost* filter, not the safety net: the 424 unscoped detectors already armed across 129 orgs stay unscoped until they are recompiled, and layer 3 covers them meanwhile.
3. **`buildDetectorViolations` → `buildDetectorCandidates`** — it now returns *where* each detector fired and nothing else. Those `(rule, file)` pairs go to the sharded judge that already handles semantic rules, which sees the whole file diff and confirms or drops each candidate. **There is no longer a code path from a regex hit to a published suggestion.**

The cost argument survives. A file the regex did not hit never reaches a model, so a precise detector is still nearly free; a noisy one costs in proportion to its noise, which is the right incentive.

## The counter-check matters more than the headline

"0 published" is worthless if the pipeline just stopped finding things. So: a real `no-console` rule over real PRs produced **12 candidates — 7 genuine calls and 5 inside comments** (`*   console.log(...)` in JSDoc, one `// console.log(...)`). The judge published **exactly the 7**.

The anti-rubber-stamp wording in the candidate block has its own test. Handing a model a list of pre-flagged lines invites it to confirm them, which would reproduce the very bug this replaces — so the prompt states what the pre-filter is blind to and names rejection as the expected outcome.

## Also fixed, affecting every kody-rules finding

The shard's return template never asked for `improvedCode` or `language`, though the wire schema **required both** — so models filled them with `null` and every sharded kody-rules comment shipped with no fix to apply and no language for the diff block. It also now tells the model to strip the `<n> +` diff prefix, which was leaking into `existingCode` (`"+  console.log("`).

`improvedCode` stays nullable on purpose. This is where I did **not** follow the issue's acceptance criterion "includes an applicable `improvedCode` or the hit is dropped": for *"use the structured logger"* the model correctly returns `null` — it does not know the project's logger — and dropping a genuine `console.log` finding over that is worse than shipping it with prose only. When the fix *is* a line rewrite it comes out clean:

```
existingCode  : "    return false if deactivated_at == nil"
improvedCode  : "    return false if deactivated_at.nil?"
```

Happy to add the drop if you disagree — it's a one-line `if`.

## Backfill

`BackfillRuleDetectorsUseCase` already recompiles with `onlyMissing: false` and clears a detector that no longer compiles. It now reports, per org, how many were **re-scoped**, **disarmed** (and how many of those as cosmetic), and how many **still carry no scope**.

## Testing

- **76 suites / 1494 tests** green across `kody-rules|kodyRules|finding-mapper|sharded|agent-review`.
- Rewrote the two tests that pinned the old contract (*"detector regex fires with ZERO LLM calls"* — that was the bug).
- Added the issue's acceptance criteria as regression, using the real shapes the repro found: the Ruby rule against `.js/.md/.scss/.yml`, the SQL heredoc, the embedded-JS `.erb`, cosmetic declines, and extension normalization.
- A shard with no detector rules produces a **byte-identical prompt** to before, so orgs with no T0 rules see no change.

New harness in `evals/kody-rules/`: `harvest-polyglot-cases.js` (the old corpus was `.ts/.tsx` only, so it could not show this bug at all), `detector-fp-repro.js` (drives the *shipped* engine code, so it measures the change rather than a model of it), the positive control, and both baselines.

## Not done here

- Running the re-scope sweep against production.
- The library import still discards the entry's `language` (`AddLibraryKodyRulesDto` copies 8 fields; `IKodyRule` has no such field). Became redundant as a defence — the compiler derives extensions from the rule text — but the hole is still there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N3DastMLyzWm5bAU3U1P6j
