### PR TITLE
fix(e2e): confirm route absence before tolerating a GET 404 in the RBAC release-gap guard

### DIFF
--- a/tests/e2e/scenarios/rbac-authorization.ts
+++ b/tests/e2e/scenarios/rbac-authorization.ts
@@ -101,9 +101,12 @@ async function hit(
 // Guards run before handlers. With a definitely-invalid bearer token the
 // JwtAuthGuard answers 401 when a route EXISTS (it is found and rejects the
 // token) and the router answers 404 when it is ABSENT. Either way no handler
-// runs, so this probe has zero side effects — it is the mutation analogue of
-// the GET branch's owner canary, used to attribute a deny-role 404 to a
-// release gap only when the route is genuinely missing (#1696, rbac:146).
+// runs, so this probe has zero side effects. Used to confirm a 404 is a
+// genuine release gap rather than a normal handler-level 404 (a denied
+// mutation that shouldn't have reached the handler at all, or — on the GET
+// side — an allowed request whose dummy :param id has no matching resource,
+// the same "downstream 404 still reflects allowed by policy" case the owner
+// canary already tolerates for every other status) (#1696, rbac:146).
 const UNAUTHENTICATED_PROBE_TOKEN = "orca-rbac-probe-invalid-token";
 
 async function routeExists(
@@ -189,12 +192,19 @@ export const rbacAuthorization: Scenario = {
             const ownerStatus = await hit(ctx.target, entry, tokenOf("owner"));
             if (ownerStatus === 404 && ALLOW_MISSING_ROUTE) {
                 // Route added on main but absent from the released image
-                // (scheduled-matrix-only narrow case #1696).
-                missingEndpoints.add(`GET ${entry.urlPath}`);
-                releaseGapSkipped.push(
-                    `GET ${entry.urlPath} (404 — route not in tested release image)`,
-                );
-                continue;
+                // (scheduled-matrix-only narrow case #1696). Confirm the route
+                // is genuinely absent first — a route that EXISTS but 404s for
+                // owner (e.g. the dummy :param id has no matching resource,
+                // same as any other allowed GET) must fall through to the
+                // normal checks below instead of skipping this endpoint's RBAC
+                // verification entirely. The GET analogue of rbac:146.
+                if (!(await routeExists(ctx.target, entry))) {
+                    missingEndpoints.add(`GET ${entry.urlPath}`);
+                    releaseGapSkipped.push(
+                        `GET ${entry.urlPath} (404 — route not in tested release image)`,
+                    );
+                    continue;
+                }
             }
             if (ownerStatus === 401 || ownerStatus === 403) {
                 tierSkipped.push(


### PR DESCRIPTION
## Summary

Follow-up to #1820. That PR added `routeExists()` (an invalid-bearer-token probe: 401 if the route exists, 404 if it doesn't) to the mutation deny-role loop, so a route that EXISTS but wrongly 404s a denied role isn't silently swallowed as a "release gap" (rbac:146, addressed in 5959201). The GET branch's owner canary got the same `RBAC_ALLOW_MISSING_ROUTE` tolerance but not the same disambiguation — any `ownerStatus === 404` was accepted as a release gap outright.

## Problem

A route that exists and legitimately 404s for `owner` is expected behavior, already documented in the file itself: "PolicyGuard runs before validation, so a downstream 400/404 on a dummy id still reflects 'allowed by policy'". `concreteUrl()` replaces every `:param` with the literal `"1"`, so any GET endpoint taking a path param can 404 for owner simply because that dummy id doesn't match a real resource — not because the route is missing.

7 GET entries in the current manifest carry a `:param` (`issues/:id`, `cli-reviews/:executionUuid`, `workflow-queue/jobs/:jobId`, etc.). Whichever of those already 404 for owner on the dummy id were skipping RBAC verification for every non-owner role, on **every** scheduled cron run, indefinitely — not the narrow release-gap window the tolerance was meant for, but a standing blind spot with no failing test to ever surface it.

## Fix

Reuse the `routeExists()` probe already added for the mutation branch: only treat the owner 404 as a release gap when the route is confirmed genuinely absent. When it exists, fall through to the normal `tierSkipped` / per-role checks instead of skipping the entry — the same disambiguation rbac:146 already applies on the mutation side.

## Validation

`tsc -p tests/e2e/tsconfig.json --noEmit` → 0 errors. This is a live e2e scenario (provisioned matrix, same as #1820), so it's validated by typecheck + logic review here and exercised by the scheduled run itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2QKErmrpJG5gWZUytSBNc