### PR TITLE
fix(repositories): make delete/update criteria join-safe like #1894

### DIFF
--- a/libs/identity/infrastructure/adapters/repositories/auth.repository.deactivateRefreshToken.spec.ts
+++ b/libs/identity/infrastructure/adapters/repositories/auth.repository.deactivateRefreshToken.spec.ts
@@ -1,0 +1,54 @@
+import { AuthRepository } from './auth.repository';
+
+/**
+ * Guards the fix for the same TypeORM defect as #1894
+ * (user-notification.repository): `Repository.update()` can't resolve a
+ * nested relation path in its criteria — `update({ user: { uuid } }, ...)`
+ * throws "Cannot find alias for relation at user" on the real query builder,
+ * a failure an in-memory mock of `update()` never reproduces. `deactivateRefreshToken`
+ * has no current caller (dead code), but carries the exact same shape as the
+ * bug fixed elsewhere — fixed here too so it isn't a trap if ever wired up.
+ */
+describe('AuthRepository.deactivateRefreshToken — join-safe update', () => {
+    const makeRepo = (found: any) => {
+        const findOne = jest.fn().mockResolvedValue(found);
+        const update = jest.fn().mockResolvedValue({ affected: found ? 1 : 0 });
+        const repo = new AuthRepository({
+            findOne,
+            update,
+        } as any);
+        return { repo, findOne, update };
+    };
+
+    it('scopes via findOne, then updates by the record\'s own flat uuid', async () => {
+        const { repo, update } = makeRepo({
+            uuid: 'auth-1',
+            refreshToken: 'token-abc',
+            user: { uuid: 'user-1' },
+        });
+
+        await repo.deactivateRefreshToken({ uuid: 'user-1' });
+
+        expect(update).toHaveBeenCalledWith(
+            { uuid: 'auth-1' },
+            { refreshToken: 'token-abc' },
+        );
+    });
+
+    it('is a no-op when nothing matches (does not call update)', async () => {
+        const { repo, update } = makeRepo(undefined);
+
+        await repo.deactivateRefreshToken({ uuid: 'user-1' });
+
+        expect(update).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when no uuid is provided', async () => {
+        const { repo, findOne, update } = makeRepo(undefined);
+
+        await repo.deactivateRefreshToken({});
+
+        expect(findOne).not.toHaveBeenCalled();
+        expect(update).not.toHaveBeenCalled();
+    });
+});

--- a/libs/identity/infrastructure/adapters/repositories/auth.repository.ts
+++ b/libs/identity/infrastructure/adapters/repositories/auth.repository.ts
@@ -106,12 +106,14 @@ export class AuthRepository implements IAuthRepository {
         const authSelected = await this.authRepository.findOne(findOneOptions);
 
         if (authSelected) {
+            // TypeORM's UpdateQueryBuilder can't resolve a nested relation
+            // path in its criteria — `update({ user: { uuid } }, ...)` throws
+            // "Cannot find alias for relation at user" on the real query
+            // builder (same root cause as the markAsRead/markAllAsRead 500
+            // fixed in #1894). The record is already scoped by the `findOne`
+            // above, so update by its own flat `uuid` instead.
             await this.authRepository.update(
-                {
-                    user: {
-                        uuid: authSelected.user.uuid,
-                    },
-                },
+                { uuid: authSelected.uuid },
                 {
                     refreshToken: authSelected.refreshToken,
                 },

--- a/libs/notifications/infrastructure/repositories/routing-rule.repository.spec.ts
+++ b/libs/notifications/infrastructure/repositories/routing-rule.repository.spec.ts
@@ -1,0 +1,90 @@
+import { In } from 'typeorm';
+import { RoutingRuleRepository } from './routing-rule.repository';
+
+/**
+ * Guards the fix for the same TypeORM defect as #1894
+ * (user-notification.repository): `Repository.delete()` can't resolve a
+ * nested relation path in its criteria — `delete({ organization: { uuid } })`
+ * throws "Cannot find alias for relation at organization" on the real query
+ * builder, a failure an in-memory mock of `delete()` never reproduces. The
+ * fix scopes ids via `find` (which does support nested criteria) and deletes
+ * by a flat `uuid`/`In(ids)` predicate.
+ */
+describe('RoutingRuleRepository — delete passes stay join-safe', () => {
+    const makeRepo = (rows: Array<{ uuid: string }>) => {
+        const find = jest.fn().mockResolvedValue(rows);
+        const deleteFn = jest.fn().mockResolvedValue({ affected: rows.length });
+        const repo = new RoutingRuleRepository({
+            find,
+            delete: deleteFn,
+        } as any);
+        return { repo, find, deleteFn };
+    };
+
+    describe('deleteByOrganization', () => {
+        it('scopes via find, deletes every matched uuid with a flat In(ids), and returns the count', async () => {
+            const { repo, find, deleteFn } = makeRepo([
+                { uuid: 'r-1' },
+                { uuid: 'r-2' },
+            ]);
+
+            const result = await repo.deleteByOrganization('org-1');
+
+            expect(result).toBe(2);
+            expect(find).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: { organization: { uuid: 'org-1' } },
+                }),
+            );
+            expect(deleteFn).toHaveBeenCalledWith({
+                uuid: In(['r-1', 'r-2']),
+            });
+        });
+
+        it('is a no-op when nothing matches (does not call delete)', async () => {
+            const { repo, deleteFn } = makeRepo([]);
+
+            const result = await repo.deleteByOrganization('org-1');
+
+            expect(result).toBe(0);
+            expect(deleteFn).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('deleteByOrgEventRole', () => {
+        it('scopes via find on (org, event, role), deletes by flat In(ids), and returns the count', async () => {
+            const { repo, find, deleteFn } = makeRepo([{ uuid: 'r-3' }]);
+
+            const result = await repo.deleteByOrgEventRole(
+                'org-1',
+                'pr.opened',
+                'developer',
+            );
+
+            expect(result).toBe(1);
+            expect(find).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    where: {
+                        organization: { uuid: 'org-1' },
+                        event: 'pr.opened',
+                        role: 'developer',
+                    },
+                }),
+            );
+            expect(deleteFn).toHaveBeenCalledWith({ uuid: In(['r-3']) });
+        });
+
+        it('is a no-op when nothing matches (does not call delete)', async () => {
+            const { repo, deleteFn } = makeRepo([]);
+
+            const result = await repo.deleteByOrgEventRole(
+                'org-1',
+                'pr.opened',
+                'developer',
+            );
+
+            expect(result).toBe(0);
+            expect(deleteFn).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/libs/notifications/infrastructure/repositories/routing-rule.repository.ts
+++ b/libs/notifications/infrastructure/repositories/routing-rule.repository.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { In, Repository } from 'typeorm';
 
 import { mapSimpleModelToEntity } from '@libs/core/infrastructure/repositories/mappers';
 
@@ -117,11 +117,22 @@ export class RoutingRuleRepository implements IRoutingRuleRepository {
         return results;
     }
 
+    // TypeORM's DeleteQueryBuilder can't resolve a nested relation path in its
+    // criteria — `delete({ organization: { uuid } })` throws "Cannot find
+    // alias for relation at organization" (same root cause as the
+    // markAsRead/markAllAsRead 500 fixed in #1894). `find` supports nested
+    // criteria, so scope the ids there first and delete by a flat `In(ids)`.
     async deleteByOrganization(organizationId: string): Promise<number> {
-        const result = await this.repo.delete({
-            organization: { uuid: organizationId },
+        const rows = await this.repo.find({
+            select: { uuid: true },
+            where: { organization: { uuid: organizationId } },
         });
-        return result.affected ?? 0;
+        if (rows.length === 0) {
+            return 0;
+        }
+        const ids = rows.map((row) => row.uuid);
+        await this.repo.delete({ uuid: In(ids) });
+        return ids.length;
     }
 
     async deleteByOrgEventRole(
@@ -129,11 +140,19 @@ export class RoutingRuleRepository implements IRoutingRuleRepository {
         event: string,
         role: string,
     ): Promise<number> {
-        const result = await this.repo.delete({
-            organization: { uuid: organizationId },
-            event,
-            role,
+        const rows = await this.repo.find({
+            select: { uuid: true },
+            where: {
+                organization: { uuid: organizationId },
+                event,
+                role,
+            },
         });
-        return result.affected ?? 0;
+        if (rows.length === 0) {
+            return 0;
+        }
+        const ids = rows.map((row) => row.uuid);
+        await this.repo.delete({ uuid: In(ids) });
+        return ids.length;
     }
 }

--- a/libs/organization/infrastructure/adapters/repositories/parameters.repository.deleteByTeamId.spec.ts
+++ b/libs/organization/infrastructure/adapters/repositories/parameters.repository.deleteByTeamId.spec.ts
@@ -1,0 +1,49 @@
+import { In } from 'typeorm';
+import { ParametersRepository } from './parameters.repository';
+
+/**
+ * Guards the fix for the same TypeORM defect as #1894
+ * (user-notification.repository): `Repository.delete()` can't resolve a
+ * nested relation path in its criteria — `delete({ team: { uuid } })` throws
+ * "Cannot find alias for relation at team" on the real query builder, a
+ * failure an in-memory mock of `delete()` never reproduces. The fix scopes
+ * ids via `find` (which does support nested criteria) and deletes by a flat
+ * `uuid`/`In(ids)` predicate.
+ */
+describe('ParametersRepository.deleteByTeamId — join-safe delete', () => {
+    const makeRepo = (rows: Array<{ uuid: string }>) => {
+        const find = jest.fn().mockResolvedValue(rows);
+        const deleteFn = jest.fn().mockResolvedValue({ affected: rows.length });
+        const repo = new ParametersRepository({
+            find,
+            delete: deleteFn,
+        } as any);
+        return { repo, find, deleteFn };
+    };
+
+    it('scopes via find on the team relation, then deletes by a flat In(ids)', async () => {
+        const { repo, find, deleteFn } = makeRepo([
+            { uuid: 'p-1' },
+            { uuid: 'p-2' },
+        ]);
+
+        await repo.deleteByTeamId('team-1');
+
+        expect(find).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { team: { uuid: 'team-1' } },
+            }),
+        );
+        expect(deleteFn).toHaveBeenCalledWith({
+            uuid: In(['p-1', 'p-2']),
+        });
+    });
+
+    it('is a no-op when nothing matches (does not call delete)', async () => {
+        const { repo, deleteFn } = makeRepo([]);
+
+        await repo.deleteByTeamId('team-1');
+
+        expect(deleteFn).not.toHaveBeenCalled();
+    });
+});

--- a/libs/organization/infrastructure/adapters/repositories/parameters.repository.ts
+++ b/libs/organization/infrastructure/adapters/repositories/parameters.repository.ts
@@ -3,6 +3,7 @@ import { InjectRepository } from '@nestjs/typeorm';
 import {
     FindManyOptions,
     FindOneOptions,
+    In,
     Repository,
     UpdateQueryBuilder,
 } from 'typeorm';
@@ -185,10 +186,21 @@ export class ParametersRepository implements IParametersRepository {
         await this.parametersRepository.delete(uuid);
     }
 
+    // TypeORM's DeleteQueryBuilder can't resolve a nested relation path in its
+    // criteria — `delete({ team: { uuid } })` throws "Cannot find alias for
+    // relation at team" (same root cause as the markAsRead/markAllAsRead 500
+    // fixed in #1894). `find` supports nested criteria, so scope the ids there
+    // first and delete by a flat `In(ids)`.
     async deleteByTeamId(teamId: string): Promise<void> {
-        await this.parametersRepository.delete({
-            team: { uuid: teamId },
+        const rows = await this.parametersRepository.find({
+            select: { uuid: true },
+            where: { team: { uuid: teamId } },
         });
+        if (rows.length === 0) {
+            return;
+        }
+        const ids = rows.map((row) => row.uuid);
+        await this.parametersRepository.delete({ uuid: In(ids) });
     }
 
     async findByKey<K extends ParametersKey>(


### PR DESCRIPTION
## Summary

Same root cause fixed in #1894 for `user-notification.repository`'s `markAsRead`/`markAllAsRead`, found while auditing the codebase for the same shape elsewhere: TypeORM's Update/DeleteQueryBuilder can't resolve a nested relation path in its criteria (`{ organization: { uuid } } }`) — it throws `Cannot find alias for relation at organization` on the real query builder. Only `find()`/`findAndCount()` support nested relation criteria; `update()`/`delete()` don't.

## Problem

Three more repositories carry the identical pattern, none covered by a spec that would catch it (a mocked `update()`/`delete()` never reproduces the real query builder's failure — same reason #1894's original spec missed it):

- `RoutingRuleRepository.deleteByOrganization` / `deleteByOrgEventRole` — called from `RoutingRuleService.resetToDefaults()` and the per-event/role override-revert path. Both 500 on every call.
- `ParametersRepository.deleteByTeamId` — called from the onboarding `join-organization` use case. Also 500s.
- `AuthRepository.deactivateRefreshToken` — same shape in `update()`, but dead code today (no call sites anywhere in the repo). Fixed anyway so it isn't a trap if ever wired up.

## Fix

Each method now scopes the affected ids via a `find()` on the same criteria (which does support the relation), then writes by a flat `uuid`/`In(ids)` predicate — join-safe on the real query builder. Same pattern as #1894.

## Test plan

- New regression specs for all three, asserting the write receives a flat predicate rather than the nested one: RED confirmed against the pre-fix shape (7 failures across the 3 files), GREEN with the fix (9/9).
- `eslint` on all 6 changed/added files: clean.
- Full-repo `tsc` (via `pnpm typecheck`): the 6 files touched here appear in zero of the ~4800 pre-existing error lines — no new type errors introduced. The scoped `typecheck-libs-gate.sh` (TS2304 under `libs/`) also passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2QKErmrpJG5gWZUytSBNc