### PR TITLE
fix(llm): classify 5xx phrasing as TRANSIENT for BYOK fallback (#1875)

### DIFF
--- a/libs/llm/error-classifier.spec.ts
+++ b/libs/llm/error-classifier.spec.ts
@@ -226,6 +226,24 @@ describe('classifyLLMError', () => {
             );
         });
 
+        it.each([
+            // An AI_RetryError (SDK retries exhausted) embeds the last attempt
+            // as text with NO status field — the default RetryError is a plain
+            // Error. These must still classify as transient so the configured
+            // BYOK fallback cascades instead of failing the whole review (#1875).
+            'Failed after 4 attempts. Last error: AI_APICallError: Bad Gateway',
+            'Last error: AI_APICallError: 502 Bad Gateway',
+            'Upstream error: service unavailable',
+            'Proxy returned 530 (Bad Gateway) from Cloudflare',
+            'An upstream error occurred: internal server error',
+            'gateway timeout while waiting for the model to respond',
+        ])('5xx phrasing without a status (%s) → TRANSIENT', (msg) => {
+            // No `status`/`statusCode` on the error — message-string fallback only.
+            const err = new Error(msg);
+            const info = classifyLLMError(err);
+            expect(info.category).toBe(LlmErrorCategory.TRANSIENT);
+        });
+
         it('unrecognized message → UNKNOWN', () => {
             const err = new Error('something weird happened in the SDK');
             expect(classifyLLMError(err).category).toBe(

--- a/libs/llm/error-classifier.spec.ts
+++ b/libs/llm/error-classifier.spec.ts
@@ -244,6 +244,19 @@ describe('classifyLLMError', () => {
             expect(info.category).toBe(LlmErrorCategory.TRANSIENT);
         });
 
+        it.each([
+            // A 5xx-like number embedded in a larger number is not a status:
+            // substring checks used to read "5032" as a 503 and flip a permanent
+            // failure to TRANSIENT, defeating the purpose of the fallback.
+            'The input token count (5032) exceeds the maximum allowed for this model',
+            'Request id req_5301 rejected by the gateway',
+        ])('bare digit inside a larger number (%s) → not TRANSIENT', (msg) => {
+            const err = new Error(msg);
+            expect(classifyLLMError(err).category).not.toBe(
+                LlmErrorCategory.TRANSIENT,
+            );
+        });
+
         it('unrecognized message → UNKNOWN', () => {
             const err = new Error('something weird happened in the SDK');
             expect(classifyLLMError(err).category).toBe(

--- a/libs/llm/error-classifier.ts
+++ b/libs/llm/error-classifier.ts
@@ -394,11 +394,10 @@ function matchByMessage(lower: string): LlmErrorCategory {
         lower.includes('service unavailable') ||
         lower.includes('internal server error') ||
         // Status numbers can appear as text without a status field (Cloudflare's
-        // 530 over a 5xx, proxy passthrough).
-        lower.includes('502') ||
-        lower.includes('503') ||
-        lower.includes('504') ||
-        lower.includes('530')
+        // 530 over a 5xx, proxy passthrough). Word boundaries keep bare digits
+        // inside larger numbers (token counts like "5032", ids) from being read
+        // as an HTTP status and wrongly marking a permanent error TRANSIENT.
+        /\b(?:502|503|504|530)\b/.test(lower)
     ) {
         return LlmErrorCategory.TRANSIENT;
     }

--- a/libs/llm/error-classifier.ts
+++ b/libs/llm/error-classifier.ts
@@ -382,7 +382,23 @@ function matchByMessage(lower: string): LlmErrorCategory {
         lower.includes('network error') ||
         lower.includes('fetch failed') ||
         lower.includes('timeout') ||
-        lower.includes('aborted')
+        lower.includes('aborted') ||
+        // Common 5xx phrasings. `matchByMessage` is the fallback when no HTTP
+        // status reached the classifier — e.g. an AI_RetryError (SDK retries
+        // exhausted) whose embedded text "Last error: AI_APICallError: Bad
+        // Gateway" carries no status (the default RetryError is a plain Error).
+        // Without these, a real upstream outage classifies UNKNOWN and the
+        // configured BYOK fallback is never tried (#1875).
+        lower.includes('bad gateway') ||
+        lower.includes('gateway timeout') ||
+        lower.includes('service unavailable') ||
+        lower.includes('internal server error') ||
+        // Status numbers can appear as text without a status field (Cloudflare's
+        // 530 over a 5xx, proxy passthrough).
+        lower.includes('502') ||
+        lower.includes('503') ||
+        lower.includes('504') ||
+        lower.includes('530')
     ) {
         return LlmErrorCategory.TRANSIENT;
     }


### PR DESCRIPTION
Fixes #1875

## Problem
The agent-based review path defeats the runtime model failover (`primary → fallback`) on a transient upstream outage. When the main provider dies with a 5xx, the AI SDK wraps retry exhaustion in an `AI_RetryError` whose default shape is a **plain `Error`** — `message: 'Failed after 4 attempts. Last error: AI_APICallError: Bad Gateway'`, with **no `status`/`statusCode`/`cause`**. So `classifyLLMError` reads no HTTP status, and `matchByMessage` — which knew `econnreset`/`etimedout`/`socket hang up`/`fetch failed`/`timeout`/`aborted` but **not** `bad gateway`/`service unavailable` → labelled it `UNKNOWN`. `shouldFailoverToNextModel` deliberately never cascades `UNKNOWN`, so the org's configured BYOK fallback is never tried and a transient infra outage fails the whole agent review with a misleading `❌`.

The asymmetry is the tell: the **summary** step cascades (`matchByHttpStatus` sees status 502 on the raw `APICallError` it throws), the **agent** steps don't (status stripped by the RetryError wrap).

## Fix
Extend the **TRANSIENT message vocabulary** in `matchByMessage` with the common 5xx phrasings — `bad gateway`, `gateway timeout`, `service unavailable`, `internal server error`, plus the status texts `502`/`503`/`504`/`530` (Cloudflare's code-over-5xx). This mirrors the reliable `matchByHttpStatus` half (`status >= 500` → TRANSIENT) for the message-only fallback path, so a status-less RetryError-embedded 5xx now classifies TRANSIENT → `shouldFailoverToNextModel` cascades → the BYOK fallback runs. Redundant for errors that DO carry a status (those were already handled); it only closes the message-only gap.

## Testing
- `error-classifier.spec.ts` — new `it.each` over status-less 5xx phrasings (incl. the exact `'Failed after 4 attempts. Last error: AI_APICallError: Bad Gateway'` from the report) → **TRANSIENT**. TDD verified: **RED** on the old vocabulary (5 failed), **GREEN** with the fix — **60/60** suite pass, `eslint` clean.