### PR TITLE
fix(analytics): scope Token Usage repository filter by span repositoryId

### DIFF
--- a/libs/agent-harness/infrastructure/ai-sdk/ai-sdk-agent-runner.ts
+++ b/libs/agent-harness/infrastructure/ai-sdk/ai-sdk-agent-runner.ts
@@ -231,10 +231,10 @@ export class AiSdkAgentRunner implements AgentRunner {
             }
         };
 
-        // PR/team for cost attribution: the code-review finder opts these in via
-        // `runtimeContext`; other callers hand over raw `telemetryMetadata`.
+        // PR/team/repo for cost attribution: the code-review finder opts these in
+        // via `runtimeContext`; other callers hand over raw `telemetryMetadata`.
         const runMeta = (input.runtimeContext ?? input.telemetryMetadata) as
-            | { pullRequestId?: number; teamId?: string }
+            | { pullRequestId?: number; teamId?: string; repositoryId?: string }
             | undefined;
 
         try {
@@ -256,11 +256,13 @@ export class AiSdkAgentRunner implements AgentRunner {
                     agentName: spec.agentName ?? spec.id,
                     ...(spec.phase ? { phase: spec.phase } : {}),
                     source: 'harness',
-                    // Per-PR / per-team cost attribution. organizationId reaches
-                    // the span via LLM.run's own param above, but prNumber/teamId
-                    // ride the cost attrs — without threading them the biggest
-                    // spans (the agent loop) record prNumber undefined, so per-PR
-                    // cost in the dashboard misses the finder/verify entirely.
+                    // Per-PR / per-team / per-repo cost attribution. organizationId
+                    // reaches the span via LLM.run's own param above, but
+                    // prNumber/teamId/repositoryId ride the cost attrs — without
+                    // threading them the biggest spans (the agent loop) record
+                    // prNumber/repositoryId undefined, so per-PR cost in the
+                    // dashboard misses the finder/verify entirely, and the Token
+                    // Usage repository filter can't scope by repo at all (#1882).
                     // The code-review finder opts these values in through
                     // `runtimeContext` (via toAiSdkTelemetryArgs); other callers
                     // pass raw `telemetryMetadata`. Read both.
@@ -268,6 +270,9 @@ export class AiSdkAgentRunner implements AgentRunner {
                         ? { prNumber: runMeta.pullRequestId }
                         : {}),
                     ...(runMeta?.teamId ? { teamId: runMeta.teamId } : {}),
+                    ...(runMeta?.repositoryId
+                        ? { repositoryId: runMeta.repositoryId }
+                        : {}),
                 },
                 system: spec.systemPrompt,
                 messages,

--- a/libs/analytics/application/use-cases/usage/tokens-developer.use-case.spec.ts
+++ b/libs/analytics/application/use-cases/usage/tokens-developer.use-case.spec.ts
@@ -1,0 +1,150 @@
+import { TokensByDeveloperUseCase } from './tokens-developer.use-case';
+import { TokenUsageQueryContract } from '@libs/analytics/domain/token-usage/types/tokenUsage.types';
+
+/**
+ * Regression coverage for issue #1882: the by-developer view used to map
+ * usage rows to a developer via `findManyByNumbers(numbers, organizationId)`
+ * — org + number only, no repository — then keyed a `Map<number, PR>` by
+ * `pr.number`. When two PRs on different repositories shared a number,
+ * whichever document the batch fetch returned last silently overwrote the
+ * other in the map, so every usage row for that number attributed to one
+ * PR's author only.
+ *
+ * Fixed by keying on `${repositoryId}|${number}` and using
+ * `findManyByNumbersAndRepositoryIds` for usage rows that carry a
+ * `repositoryId` (every row from #1882 onward). Rows without one (written
+ * before the fix) still fall back to the old org+number lookup.
+ */
+describe('TokensByDeveloperUseCase — repository scope (#1882)', () => {
+    const baseQuery = (
+        over: Partial<TokenUsageQueryContract> = {},
+    ): TokenUsageQueryContract =>
+        ({
+            organizationId: 'org-1',
+            start: new Date('2026-06-01'),
+            end: new Date('2026-06-30'),
+            byok: true,
+            ...over,
+        }) as TokenUsageQueryContract;
+
+    const setup = () => {
+        const tokenUsageService = {
+            getUsageByPr: jest.fn(),
+            getDailyUsageByPr: jest.fn(),
+        };
+        const pullRequestsService = {
+            findManyByNumbers: jest.fn().mockResolvedValue([]),
+            findManyByNumbersAndRepositoryIds: jest.fn().mockResolvedValue([]),
+        };
+        const cacheService = {
+            getFromCache: jest.fn().mockResolvedValue(null),
+            addToCache: jest.fn(),
+        };
+        const useCase = new TokensByDeveloperUseCase(
+            tokenUsageService as any,
+            pullRequestsService as any,
+            cacheService as any,
+        );
+        return { useCase, tokenUsageService, pullRequestsService, cacheService };
+    };
+
+    it('two PRs sharing a number across repos attribute to their own, distinct developer', async () => {
+        const { useCase, tokenUsageService, pullRequestsService } = setup();
+
+        // repo A's PR #1 (alice) and repo B's PR #1 (bob) both have usage in
+        // the window — the by-PR read now carries repositoryId alongside
+        // the bare number.
+        tokenUsageService.getUsageByPr.mockResolvedValue([
+            {
+                prNumber: 1,
+                repositoryId: 'repo-a',
+                model: 'gpt-4o',
+                input: 10,
+                output: 5,
+                total: 15,
+                outputReasoning: 0,
+            },
+            {
+                prNumber: 1,
+                repositoryId: 'repo-b',
+                model: 'gpt-4o',
+                input: 2,
+                output: 1,
+                total: 3,
+                outputReasoning: 0,
+            },
+        ]);
+        pullRequestsService.findManyByNumbersAndRepositoryIds.mockResolvedValue(
+            [
+                {
+                    number: 1,
+                    repository: { id: 'repo-a' },
+                    user: { username: 'alice' },
+                },
+                {
+                    number: 1,
+                    repository: { id: 'repo-b' },
+                    user: { username: 'bob' },
+                },
+            ],
+        );
+
+        const result = await useCase.execute(baseQuery(), false);
+
+        expect(result).toHaveLength(2);
+        expect(result.find((r) => r.total === 15)?.developer).toBe('alice');
+        expect(result.find((r) => r.total === 3)?.developer).toBe('bob');
+    });
+
+    it('looks up PRs by (number, repositoryId), not by number alone', async () => {
+        const { useCase, tokenUsageService, pullRequestsService } = setup();
+
+        tokenUsageService.getUsageByPr.mockResolvedValue([
+            {
+                prNumber: 1,
+                repositoryId: 'repo-a',
+                model: 'gpt-4o',
+                input: 1,
+                output: 1,
+                total: 2,
+                outputReasoning: 0,
+            },
+        ]);
+
+        await useCase.execute(baseQuery({ repositoryId: 'repo-a' }), false);
+
+        expect(
+            pullRequestsService.findManyByNumbersAndRepositoryIds,
+        ).toHaveBeenCalledWith(
+            [{ number: 1, repositoryId: 'repo-a' }],
+            'org-1',
+        );
+        expect(pullRequestsService.findManyByNumbers).not.toHaveBeenCalled();
+    });
+
+    it('falls back to the org+number lookup for legacy rows with no repositoryId', async () => {
+        const { useCase, tokenUsageService, pullRequestsService } = setup();
+
+        tokenUsageService.getUsageByPr.mockResolvedValue([
+            {
+                prNumber: 7,
+                model: 'gpt-4o',
+                input: 1,
+                output: 1,
+                total: 2,
+                outputReasoning: 0,
+            },
+        ]);
+        pullRequestsService.findManyByNumbers.mockResolvedValue([
+            { number: 7, user: { username: 'carol' }, organizationId: 'org-1' },
+        ]);
+
+        const result = await useCase.execute(baseQuery(), false);
+
+        expect(pullRequestsService.findManyByNumbers).toHaveBeenCalledWith(
+            [7],
+            'org-1',
+        );
+        expect(result[0].developer).toBe('carol');
+    });
+});

--- a/libs/analytics/application/use-cases/usage/tokens-developer.use-case.ts
+++ b/libs/analytics/application/use-cases/usage/tokens-developer.use-case.ts
@@ -112,27 +112,61 @@ export class TokensByDeveloperUseCase {
         return result;
     }
 
+    /**
+     * Keyed by `${repositoryId}|${number}`, NOT the bare number (#1882): PR
+     * numbers are unique per repository, not per org, so two PRs on
+     * different repos sharing a number would otherwise collapse onto one
+     * map entry — whichever the batch fetch returned last silently "won"
+     * and every usage row for that number attributed to its author.
+     *
+     * Usage rows carry `repositoryId` only from #1882 onward — rows from
+     * before that (no repositoryId on the row) fall back to the org+number
+     * lookup, same as before the fix, and key under `''|${number}`.
+     */
     private async getPullRequestsMap(
-        usages: { prNumber: number }[],
+        usages: { prNumber: number; repositoryId?: string }[],
         organizationId: string,
-    ): Promise<Map<number, IPullRequestUserMapping>> {
-        // Get unique PR numbers
-        const uniquePrNumbers = [...new Set(usages.map((u) => u.prNumber))];
+    ): Promise<Map<string, IPullRequestUserMapping>> {
+        const pullRequestsMap = new Map<string, IPullRequestUserMapping>();
 
-        if (uniquePrNumbers.length === 0) {
-            return new Map();
+        const scoped = usages.filter((u) => u.repositoryId);
+        const legacy = usages.filter((u) => !u.repositoryId);
+
+        const scopedCriteria = [
+            ...new Map(
+                scoped.map((u) => [
+                    `${u.repositoryId}|${u.prNumber}`,
+                    { number: u.prNumber, repositoryId: u.repositoryId! },
+                ]),
+            ).values(),
+        ];
+        const legacyNumbers = [...new Set(legacy.map((u) => u.prNumber))];
+
+        const [scopedPrs, legacyPrs] = await Promise.all([
+            scopedCriteria.length
+                ? this.pullRequestsService.findManyByNumbersAndRepositoryIds(
+                      scopedCriteria,
+                      organizationId,
+                  )
+                : Promise.resolve([]),
+            legacyNumbers.length
+                ? this.pullRequestsService.findManyByNumbers(
+                      legacyNumbers,
+                      organizationId,
+                  )
+                : Promise.resolve([]),
+        ]);
+
+        for (const pr of scopedPrs) {
+            if (!pr.repository?.id) continue;
+            pullRequestsMap.set(`${pr.repository.id}|${pr.number}`, {
+                number: pr.number,
+                user: pr.user,
+                organizationId,
+            });
         }
-
-        // PERF: Batch fetch all PRs in a single query instead of N+1
-        const pullRequests = await this.pullRequestsService.findManyByNumbers(
-            uniquePrNumbers,
-            organizationId,
-        );
-
-        // Build map from results
-        const pullRequestsMap = new Map<number, IPullRequestUserMapping>();
-        for (const pr of pullRequests) {
-            pullRequestsMap.set(pr.number, pr);
+        for (const pr of legacyPrs) {
+            pullRequestsMap.set(`|${pr.number}`, pr);
         }
 
         return pullRequestsMap;
@@ -140,10 +174,12 @@ export class TokensByDeveloperUseCase {
 
     private mapUsagesWithDevelopers(
         usages: (UsageByPrResultContract | DailyUsageByPrResultContract)[],
-        pullRequestsMap: Map<number, IPullRequestUserMapping>,
+        pullRequestsMap: Map<string, IPullRequestUserMapping>,
     ) {
         return usages.map((usage) => {
-            const pr = pullRequestsMap.get(usage.prNumber);
+            const pr = pullRequestsMap.get(
+                `${usage.repositoryId ?? ''}|${usage.prNumber}`,
+            );
             const developer = pr?.user?.username || 'unknown';
 
             return {

--- a/libs/analytics/domain/token-usage/types/tokenUsage.types.ts
+++ b/libs/analytics/domain/token-usage/types/tokenUsage.types.ts
@@ -7,16 +7,15 @@ export type TokenUsageQueryContract = {
     timezone?: string; // for day bucketing
     developer?: string;
     /**
-     * Scope to one repository. Usage spans don't carry a repository id, so
-     * the service resolves this to the repo's PR numbers (`prNumbers`) and
-     * the read matches `attributes.prNumber ∈ prNumbers` — same join the
-     * by-developer view already relies on (PR numbers are assumed unique
-     * enough within an org; a cross-repo number collision over-includes,
-     * matching the existing by-developer behavior).
+     * Scope to one repository. Matched directly against `attributes.repositoryId`
+     * on the usage span (#1882 fix) — every usage span now carries its own
+     * repository id, so this no longer goes through the collision-prone
+     * `attributes.prNumber` join (two repos can both have a PR #1). Spans
+     * written before this field existed carry no `repositoryId` and simply
+     * won't match a repository-scoped read; the org-wide (unscoped) view is
+     * unaffected.
      */
     repositoryId?: string;
-    /** Internal: PR numbers resolved from `repositoryId`. */
-    prNumbers?: number[];
     byok: boolean;
 };
 
@@ -59,6 +58,10 @@ export interface DailyUsageResultContract extends BaseUsageContract {
 
 export interface UsageByPrResultContract extends BaseUsageContract {
     prNumber: number;
+    /** Repository the PR belongs to. `undefined` for spans written before
+     *  #1882 (no repository id stamped) — those rows still group by number
+     *  alone, same as before. */
+    repositoryId?: string;
 }
 
 export interface DailyUsageByPrResultContract extends UsageByPrResultContract {

--- a/libs/analytics/infrastructure/adapters/repositories/schemas/observabilityTelemetry.model.ts
+++ b/libs/analytics/infrastructure/adapters/repositories/schemas/observabilityTelemetry.model.ts
@@ -43,3 +43,11 @@ ObservabilityTelemetryModelSchema.index(
     },
     { background: true },
 );
+ObservabilityTelemetryModelSchema.index(
+    {
+        'attributes.organizationId': 1,
+        'attributes.repositoryId': 1,
+        timestamp: -1,
+    },
+    { background: true },
+);

--- a/libs/analytics/infrastructure/adapters/repositories/tokenUsage.repository.spec.ts
+++ b/libs/analytics/infrastructure/adapters/repositories/tokenUsage.repository.spec.ts
@@ -1,4 +1,129 @@
 import { TokenUsageRepository } from './tokenUsage.repository';
+import { TokenUsageQueryContract } from '@libs/analytics/domain/token-usage/types/tokenUsage.types';
+
+/**
+ * Regression coverage for issue #1882: the repository filter used to scope
+ * on `attributes.prNumber` (or the `prNumbers` list the service pre-resolved)
+ * — PR numbers are unique per repository, not per org, so two repositories
+ * that happen to share a number were indistinguishable to Mongo. Fixed by
+ * matching `attributes.repositoryId` directly, since every usage span now
+ * carries its own repository id.
+ *
+ * `_tuMatch` is pure (it only reads its `query` argument), so we exercise it
+ * off the prototype without wiring the repository's Mongo deps — same pattern
+ * as the `_tierExpr` suite below. A tiny in-memory interpreter re-implements
+ * just enough of Mongo's `$match` semantics ($in / $gte+$lte / $type / eq) to
+ * evaluate the real match object against fixture span documents, so these
+ * tests exercise the actual production match-builder, not a re-description
+ * of it.
+ */
+function applyMongoMatch(
+    doc: Record<string, any>,
+    match: Record<string, any>,
+): boolean {
+    const get = (obj: any, path: string) =>
+        path.split('.').reduce((v, k) => v?.[k], obj);
+    return Object.entries(match).every(([key, cond]) => {
+        const value = get(doc, key);
+        if (cond && typeof cond === 'object' && !(cond instanceof Date)) {
+            if ('$in' in cond) return cond.$in.includes(value);
+            if ('$type' in cond) return typeof value === 'number';
+            if ('$gte' in cond || '$lte' in cond) {
+                if ('$gte' in cond && !(value >= cond.$gte)) return false;
+                if ('$lte' in cond && !(value <= cond.$lte)) return false;
+                return true;
+            }
+        }
+        return value === cond;
+    });
+}
+
+describe('TokenUsageRepository._tuMatch — repository scope (#1882)', () => {
+    const tuMatch = (query: TokenUsageQueryContract) =>
+        (TokenUsageRepository.prototype as any)['_tuMatch'].call(
+            Object.create(TokenUsageRepository.prototype),
+            query,
+        );
+
+    const baseQuery = (
+        over: Partial<TokenUsageQueryContract> = {},
+    ): TokenUsageQueryContract =>
+        ({
+            organizationId: 'org-1',
+            start: new Date('2026-06-01'),
+            end: new Date('2026-06-30'),
+            byok: true,
+            ...over,
+        }) as TokenUsageQueryContract;
+
+    it('two repositories that happen to share a PR number produce DIFFERENT Mongo matches', () => {
+        const matchScopedToRepoA = tuMatch(baseQuery({ repositoryId: 'repo-a' }));
+        const matchScopedToRepoB = tuMatch(baseQuery({ repositoryId: 'repo-b' }));
+
+        expect(matchScopedToRepoA).not.toEqual(matchScopedToRepoB);
+        // `_tuMatch` keys are literal dotted strings (Mongo's own convention),
+        // not a nested object — so this reads the flat key directly.
+        expect(matchScopedToRepoA['attributes.repositoryId']).toBe('repo-a');
+        expect(matchScopedToRepoB['attributes.repositoryId']).toBe('repo-b');
+    });
+
+    it('filtering by repository A excludes a span whose review actually ran on repository B', () => {
+        // Minimal fixture from the issue: repo A and repo B both have a PR #1;
+        // the usage span was produced by a review of repo B's PR #1.
+        const spanFromRepoB = {
+            attributes: {
+                organizationId: 'org-1',
+                prNumber: 1,
+                repositoryId: 'repo-b',
+                tu: { isByok: true },
+            },
+            timestamp: new Date('2026-06-15'),
+        };
+
+        const matchForRepoA = tuMatch(baseQuery({ repositoryId: 'repo-a' }));
+        const matchForRepoB = tuMatch(baseQuery({ repositoryId: 'repo-b' }));
+
+        expect(applyMongoMatch(spanFromRepoB, matchForRepoA)).toBe(false);
+        expect(applyMongoMatch(spanFromRepoB, matchForRepoB)).toBe(true);
+    });
+
+    it('a span with no prNumber (only pullRequestId) still matches its own repository filter', () => {
+        // Per the issue: "some secondary passes stamp only organizationId, or
+        // pullRequestId instead of prNumber" — those used to be invisible once
+        // a repo filter narrowed the match to `attributes.prNumber: {$in:[...]}`.
+        // The fix scopes on repositoryId alone, so these are no longer dropped.
+        const spanWithoutPrNumber = {
+            attributes: {
+                organizationId: 'org-1',
+                pullRequestId: 'some-pr-doc-id',
+                repositoryId: 'repo-a',
+                tu: { isByok: true },
+            },
+            timestamp: new Date('2026-06-15'),
+        };
+
+        const matchScopedToRepoA = tuMatch(baseQuery({ repositoryId: 'repo-a' }));
+
+        expect(applyMongoMatch(spanWithoutPrNumber, matchScopedToRepoA)).toBe(
+            true,
+        );
+    });
+
+    it('a span written before this fix (no attributes.repositoryId) does not match any repository filter', () => {
+        const legacySpan = {
+            attributes: {
+                organizationId: 'org-1',
+                prNumber: 1,
+                tu: { isByok: true },
+            },
+            timestamp: new Date('2026-06-15'),
+        };
+
+        const matchScopedToRepoA = tuMatch(baseQuery({ repositoryId: 'repo-a' }));
+
+        expect(applyMongoMatch(legacySpan, matchScopedToRepoA)).toBe(false);
+    });
+});
 
 /**
  * Regression coverage for the tier expression the aggregation pipelines share.

--- a/libs/analytics/infrastructure/adapters/repositories/tokenUsage.repository.ts
+++ b/libs/analytics/infrastructure/adapters/repositories/tokenUsage.repository.ts
@@ -32,6 +32,7 @@ type RawAggRow = {
     cacheWrite: number;
     date?: string;
     prNumber?: number;
+    repositoryId?: string;
     review?: string;
     startedAt?: Date;
     area?: string;
@@ -269,10 +270,15 @@ export class TokenUsageRepository implements ITokenUsageRepository {
                 : { 'attributes.tu.sys': false }),
         };
         if (query.prNumber) match['attributes.prNumber'] = query.prNumber;
-        // Repository scope, pre-resolved to PR numbers by the service. An
-        // empty list is a repo with no PRs → matches nothing, by design.
-        else if (query.prNumbers)
-            match['attributes.prNumber'] = { $in: query.prNumbers };
+        // Repository scope: matched directly against the span's own
+        // `attributes.repositoryId` (#1882) — NOT via a PR-number lookup.
+        // PR numbers are unique per repository, not per org, so joining on
+        // `attributes.prNumber` alone let a repository filter pull in spend
+        // from any other repo whose PR numbers happened to collide. Spans
+        // written before this field existed carry no repositoryId and simply
+        // don't match — the org-wide (unscoped) view is unaffected.
+        else if (query.repositoryId)
+            match['attributes.repositoryId'] = query.repositoryId;
         else if (prOnly)
             // `{$type:'number'}` — NOT `{$exists:true,$ne:null}`: $exists in the
             // match forces a FETCH of every candidate doc (docsExamined=1.27M,
@@ -460,16 +466,23 @@ export class TokenUsageRepository implements ITokenUsageRepository {
         const rows = await this._tuRows(
             query,
             thresholds,
-            { pr: '$attributes.prNumber' },
-            { prNumber: '$_id.pr' },
+            // Grouping on repositoryId too (not just the number) keeps two
+            // PRs on different repos that happen to share a number distinct
+            // — the collision #1882 flagged in the by-PR chart/table.
+            { pr: '$attributes.prNumber', repositoryId: '$attributes.repositoryId' },
+            { prNumber: '$_id.pr', repositoryId: '$_id.repositoryId' },
             true,
         );
 
         const merged = this._mergeTierRows<UsageByPrResultContract>(
             rows,
             thresholds,
-            (r) => `${r.prNumber}|${r.model}`,
-            (base, row) => ({ ...base, prNumber: row.prNumber! }),
+            (r) => `${r.repositoryId ?? ''}|${r.prNumber}|${r.model}`,
+            (base, row) => ({
+                ...base,
+                prNumber: row.prNumber!,
+                repositoryId: row.repositoryId,
+            }),
         );
         merged.sort((a, b) =>
             a.prNumber === b.prNumber
@@ -488,6 +501,7 @@ export class TokenUsageRepository implements ITokenUsageRepository {
             thresholds,
             {
                 prNumber: '$attributes.prNumber',
+                repositoryId: '$attributes.repositoryId',
                 date: {
                     $dateToString: {
                         format: '%Y-%m-%d',
@@ -496,17 +510,22 @@ export class TokenUsageRepository implements ITokenUsageRepository {
                     },
                 },
             },
-            { prNumber: '$_id.prNumber', date: '$_id.date' },
+            {
+                prNumber: '$_id.prNumber',
+                repositoryId: '$_id.repositoryId',
+                date: '$_id.date',
+            },
             true,
         );
 
         const merged = this._mergeTierRows<DailyUsageByPrResultContract>(
             rows,
             thresholds,
-            (r) => `${r.prNumber}|${r.date}|${r.model}`,
+            (r) => `${r.repositoryId ?? ''}|${r.prNumber}|${r.date}|${r.model}`,
             (base, row) => ({
                 ...base,
                 prNumber: row.prNumber!,
+                repositoryId: row.repositoryId,
                 date: row.date!,
             }),
         );
@@ -631,6 +650,7 @@ export class TokenUsageRepository implements ITokenUsageRepository {
                 model: '$attributes.tu.model',
                 tier: this._tierExpr(thresholds),
                 pr: '$attributes.prNumber',
+                repositoryId: '$attributes.repositoryId',
                 area: { $ifNull: ['$attributes.tu.area', AREA_FALLBACK] },
                 task: taskExpr({ $ifNull: ['$attributes.tu.area', AREA_FALLBACK] }),
                 date: {
@@ -698,7 +718,15 @@ export class TokenUsageRepository implements ITokenUsageRepository {
                     daily: groupProject({ date: '$date' }, { date: '$_id.date' }),
                     byPr: [
                         prPresent,
-                        ...groupProject({ pr: '$pr' }, { prNumber: '$_id.pr' }),
+                        // Grouped by repositoryId too — two PRs on different
+                        // repos sharing a number stay distinct (#1882).
+                        ...groupProject(
+                            { pr: '$pr', repositoryId: '$repositoryId' },
+                            {
+                                prNumber: '$_id.pr',
+                                repositoryId: '$_id.repositoryId',
+                            },
+                        ),
                     ],
                     byArea: groupProject(
                         { area: '$area' },
@@ -797,8 +825,12 @@ export class TokenUsageRepository implements ITokenUsageRepository {
         const byPr = this._mergeTierRows<UsageByPrResultContract>(
             rows.byPr,
             thresholds,
-            (r) => `${r.prNumber}|${r.model}`,
-            (base, row) => ({ ...base, prNumber: row.prNumber! }),
+            (r) => `${r.repositoryId ?? ''}|${r.prNumber}|${r.model}`,
+            (base, row) => ({
+                ...base,
+                prNumber: row.prNumber!,
+                repositoryId: row.repositoryId,
+            }),
         ).sort((a, b) =>
             a.prNumber === b.prNumber
                 ? a.model.localeCompare(b.model)

--- a/libs/analytics/infrastructure/adapters/services/tokenUsage.service.spec.ts
+++ b/libs/analytics/infrastructure/adapters/services/tokenUsage.service.spec.ts
@@ -2,11 +2,12 @@ import { TokenUsageService } from './tokenUsage.service';
 import { TokenUsageQueryContract } from '@libs/analytics/domain/token-usage/types/tokenUsage.types';
 
 /**
- * The service is the single choke point where a `repositoryId` filter is
- * resolved to the repo's PR numbers (spans carry no repo id) and threaded to
- * the Mongo read as `prNumbers`. Every read path must go through it.
+ * The service is a thin pass-through to the repository (#1882 fix): usage
+ * spans now carry their own `attributes.repositoryId`, so a `repositoryId`
+ * filter no longer needs resolving to the repo's PR numbers here — it rides
+ * the query unchanged and the repository's `_tuMatch` matches it directly.
  */
-describe('TokenUsageService — repository scope', () => {
+describe('TokenUsageService', () => {
     const baseQuery = (over: Partial<TokenUsageQueryContract> = {}) =>
         ({
             organizationId: 'org-1',
@@ -16,98 +17,33 @@ describe('TokenUsageService — repository scope', () => {
             ...over,
         }) as TokenUsageQueryContract;
 
-    const setup = (opts: { cacheHit?: number[] } = {}) => {
+    const setup = () => {
         const repository = {
             getSummary: jest.fn().mockResolvedValue({}),
             getUsageByReview: jest.fn().mockResolvedValue([]),
             getUsageOverview: jest.fn().mockResolvedValue({}),
         };
-        const pullRequestsService = {
-            findNumbersByRepositoryId: jest
-                .fn()
-                .mockResolvedValue([101, 202, 303]),
-        };
-        // Default: cache miss (pass-through), so per-call assertions hold.
-        const cacheService = {
-            getFromCache: jest.fn().mockResolvedValue(opts.cacheHit ?? null),
-            addToCache: jest.fn(),
-        };
-        const service = new TokenUsageService(
-            repository as any,
-            pullRequestsService as any,
-            cacheService as any,
-        );
-        return { service, repository, pullRequestsService, cacheService };
+        const service = new TokenUsageService(repository as any);
+        return { service, repository };
     };
 
-    it('resolves repositoryId → PR numbers and scopes the read with them', async () => {
-        const { service, repository, pullRequestsService } = setup();
+    it('forwards a repository-scoped query to the repository unchanged', async () => {
+        const { service, repository } = setup();
 
-        await service.getSummary(baseQuery({ repositoryId: 'repo-alpha' }));
+        const query = baseQuery({ repositoryId: 'repo-alpha' });
+        await service.getSummary(query);
 
-        expect(pullRequestsService.findNumbersByRepositoryId).toHaveBeenCalledWith(
-            'org-1',
-            'repo-alpha',
-            new Date('2026-06-30'),
-        );
-        expect(repository.getSummary).toHaveBeenCalledWith(
-            expect.objectContaining({ prNumbers: [101, 202, 303] }),
-        );
+        expect(repository.getSummary).toHaveBeenCalledWith(query);
     });
 
-    it('does not resolve PRs when no repositoryId is set', async () => {
-        const { service, repository, pullRequestsService } = setup();
+    it('forwards an unscoped query unchanged on every read path', async () => {
+        const { service, repository } = setup();
 
-        await service.getSummary(baseQuery());
+        const query = baseQuery();
+        await service.getUsageByReview(query);
+        await service.getUsageOverview(query);
 
-        expect(
-            pullRequestsService.findNumbersByRepositoryId,
-        ).not.toHaveBeenCalled();
-        expect(repository.getSummary).toHaveBeenCalledWith(
-            expect.not.objectContaining({ prNumbers: expect.anything() }),
-        );
-    });
-
-    it('applies the scope on every read path (e.g. by-review, overview)', async () => {
-        const { service, repository, pullRequestsService } = setup();
-
-        await service.getUsageByReview(baseQuery({ repositoryId: 'r' }));
-        await service.getUsageOverview(baseQuery({ repositoryId: 'r' }));
-
-        expect(
-            pullRequestsService.findNumbersByRepositoryId,
-        ).toHaveBeenCalledTimes(2);
-        expect(repository.getUsageByReview).toHaveBeenCalledWith(
-            expect.objectContaining({ prNumbers: [101, 202, 303] }),
-        );
-        expect(repository.getUsageOverview).toHaveBeenCalledWith(
-            expect.objectContaining({ prNumbers: [101, 202, 303] }),
-        );
-    });
-
-    it('reuses a memoized resolution instead of re-querying (cache hit)', async () => {
-        const { service, repository, pullRequestsService } = setup({
-            cacheHit: [55, 66],
-        });
-
-        await service.getSummary(baseQuery({ repositoryId: 'repo-alpha' }));
-
-        expect(
-            pullRequestsService.findNumbersByRepositoryId,
-        ).not.toHaveBeenCalled();
-        expect(repository.getSummary).toHaveBeenCalledWith(
-            expect.objectContaining({ prNumbers: [55, 66] }),
-        );
-    });
-
-    it('an empty PR list (repo with no PRs) still scopes — matching nothing', async () => {
-        const { service, repository, pullRequestsService } = setup();
-        pullRequestsService.findNumbersByRepositoryId.mockResolvedValue([]);
-
-        await service.getSummary(baseQuery({ repositoryId: 'empty-repo' }));
-
-        expect(repository.getSummary).toHaveBeenCalledWith(
-            expect.objectContaining({ prNumbers: [] }),
-        );
+        expect(repository.getUsageByReview).toHaveBeenCalledWith(query);
+        expect(repository.getUsageOverview).toHaveBeenCalledWith(query);
     });
 });

--- a/libs/analytics/infrastructure/adapters/services/tokenUsage.service.ts
+++ b/libs/analytics/infrastructure/adapters/services/tokenUsage.service.ts
@@ -13,121 +13,70 @@ import {
     UsageByReviewResultContract,
     UsageSummaryContract,
 } from '@libs/analytics/domain/token-usage/types/tokenUsage.types';
-import {
-    IPullRequestsService,
-    PULL_REQUESTS_SERVICE_TOKEN,
-} from '@libs/platformData/domain/pullRequests/contracts/pullRequests.service.contracts';
-import { CacheService } from '@libs/core/cache/cache.service';
 import { Inject, Injectable } from '@nestjs/common';
 
-// One Token Usage page load fans out to several reads (overview + by-review /
-// by-developer). Memoize the repo→PR resolution briefly so the same filter
-// doesn't re-run findNumbersByRepositoryId once per read. Keyed by
-// org|repo|window-end, so a different window or repo misses.
-const REPO_SCOPE_TTL_MS = 60 * 1000;
-
+/**
+ * Thin pass-through to the repository. Repository scoping used to be resolved
+ * here (a `repositoryId` → the repo's PR numbers, since usage spans carried
+ * no repository id at all), but every usage span now carries its own
+ * `attributes.repositoryId` (#1882 fix) — the repository's `_tuMatch` matches
+ * it directly, so `query.repositoryId` rides through unchanged and this class
+ * has nothing left to resolve.
+ */
 @Injectable()
 export class TokenUsageService implements ITokenUsageService {
     constructor(
         @Inject(TOKEN_USAGE_REPOSITORY_TOKEN)
         private readonly repository: ITokenUsageRepository,
-
-        @Inject(PULL_REQUESTS_SERVICE_TOKEN)
-        private readonly pullRequestsService: IPullRequestsService,
-
-        private readonly cacheService: CacheService,
     ) {}
 
-    /**
-     * Usage spans carry no repository id, so a repository filter resolves to
-     * the repo's PR numbers here (single choke point for every read path)
-     * and the Mongo match scopes `attributes.prNumber` with them. A repo
-     * with no PRs yields an empty list, which matches nothing — correct.
-     *
-     * The resolution is memoized (short TTL) so the several reads of one page
-     * load share a single findNumbersByRepositoryId query.
-     */
-    private async withRepositoryScope(
-        query: TokenUsageQueryContract,
-    ): Promise<TokenUsageQueryContract> {
-        if (!query.repositoryId || query.prNumbers) return query;
-
-        const cacheKey = [
-            'usage:repo-scope',
-            query.organizationId,
-            query.repositoryId,
-            query.end.getTime(),
-        ].join('|');
-        let prNumbers =
-            await this.cacheService.getFromCache<number[]>(cacheKey);
-        if (!prNumbers) {
-            prNumbers = await this.pullRequestsService.findNumbersByRepositoryId(
-                query.organizationId,
-                query.repositoryId,
-                query.end,
-            );
-            await this.cacheService.addToCache(
-                cacheKey,
-                prNumbers,
-                REPO_SCOPE_TTL_MS,
-            );
-        }
-        return { ...query, prNumbers };
+    getSummary(query: TokenUsageQueryContract): Promise<UsageSummaryContract> {
+        return this.repository.getSummary(query);
     }
 
-    async getSummary(
-        query: TokenUsageQueryContract,
-    ): Promise<UsageSummaryContract> {
-        return this.repository.getSummary(await this.withRepositoryScope(query));
-    }
-
-    async getSummaryByModel(
+    getSummaryByModel(
         query: TokenUsageQueryContract,
     ): Promise<BaseUsageContract[]> {
-        return this.repository.getSummaryByModel(await this.withRepositoryScope(query));
+        return this.repository.getSummaryByModel(query);
     }
 
-    async getDailyUsage(
+    getDailyUsage(
         query: TokenUsageQueryContract,
     ): Promise<DailyUsageResultContract[]> {
-        return this.repository.getDailyUsage(await this.withRepositoryScope(query));
+        return this.repository.getDailyUsage(query);
     }
 
-    async getUsageByPr(
+    getUsageByPr(
         query: TokenUsageQueryContract,
     ): Promise<UsageByPrResultContract[]> {
-        return this.repository.getUsageByPr(await this.withRepositoryScope(query));
+        return this.repository.getUsageByPr(query);
     }
 
-    async getDailyUsageByPr(
+    getDailyUsageByPr(
         query: TokenUsageQueryContract,
     ): Promise<DailyUsageByPrResultContract[]> {
-        return this.repository.getDailyUsageByPr(await this.withRepositoryScope(query));
+        return this.repository.getDailyUsageByPr(query);
     }
 
-    async getUsageByReview(
+    getUsageByReview(
         query: TokenUsageQueryContract,
     ): Promise<UsageByReviewResultContract[]> {
-        return this.repository.getUsageByReview(await this.withRepositoryScope(query));
+        return this.repository.getUsageByReview(query);
     }
 
-    async getUsageByArea(
+    getUsageByArea(
         query: TokenUsageQueryContract,
     ): Promise<UsageByAreaResultContract[]> {
-        return this.repository.getUsageByArea(await this.withRepositoryScope(query));
+        return this.repository.getUsageByArea(query);
     }
 
-    async getModelCredentialPairs(
+    getModelCredentialPairs(
         query: TokenUsageQueryContract,
     ): Promise<Array<{ model: string; credentialId: string }>> {
-        return this.repository.getModelCredentialPairs(
-            await this.withRepositoryScope(query),
-        );
+        return this.repository.getModelCredentialPairs(query);
     }
 
-    async getUsageOverview(query: TokenUsageQueryContract) {
-        return this.repository.getUsageOverview(
-            await this.withRepositoryScope(query),
-        );
+    getUsageOverview(query: TokenUsageQueryContract) {
+        return this.repository.getUsageOverview(query);
     }
 }

--- a/libs/code-review/pipeline/stages/agent-review.stage.ts
+++ b/libs/code-review/pipeline/stages/agent-review.stage.ts
@@ -2003,13 +2003,16 @@ export class AgentReviewStage extends BasePipelineStage<CodeReviewPipelineContex
                 organizationId: telemetryMeta?.organizationId,
                 telemetryMetadata: telemetryMeta,
                 // Parity with the old recordAgentRunUsage: the dedup span keeps
-                // its type + per-PR/team attribution (the model/credential keys
-                // are derived from the slot inside LLM.run).
+                // its type + per-PR/team/repo attribution (the model/credential
+                // keys are derived from the slot inside LLM.run).
                 attrs: {
                     type: dedupSlot ? 'byok' : 'system',
                     prNumber,
                     ...(telemetryMeta?.teamId
                         ? { teamId: telemetryMeta.teamId }
+                        : {}),
+                    ...(telemetryMeta?.repositoryId
+                        ? { repositoryId: telemetryMeta.repositoryId }
                         : {}),
                 },
             })) as any;

--- a/libs/core/infrastructure/database/mongo/token-usage/ensure-indexes.ts
+++ b/libs/core/infrastructure/database/mongo/token-usage/ensure-indexes.ts
@@ -42,6 +42,11 @@ const DEAD_INDEXES = [
     // area aggregation stays covered).
     'tu_cover_byok_v2',
     'tu_cover_sys_v2',
+    // v3 covers, superseded by *_v4 (which add attributes.repositoryId so the
+    // repository-scoped read — #1882 — stays covered instead of matching on
+    // the collision-prone attributes.prNumber alone).
+    'tu_cover_byok_v3',
+    'tu_cover_sys_v3',
 ];
 
 type Logger = (msg: string) => void;
@@ -52,7 +57,7 @@ export async function ensureTokenUsageIndexes(
 ): Promise<void> {
     const c = db.collection(COLLECTION);
 
-    log('[token-usage-indexes] building tu_cover_byok_v3…');
+    log('[token-usage-indexes] building tu_cover_byok_v4…');
     await c.createIndex(
         {
             'attributes.organizationId': 1,
@@ -60,18 +65,19 @@ export async function ensureTokenUsageIndexes(
             timestamp: 1,
             'attributes.tu.model': 1,
             'attributes.prNumber': 1,
+            'attributes.repositoryId': 1,
             'attributes.tu.area': 1,
             'attributes.tu.route': 1,
             correlationId: 1,
             ...SUM_KEYS,
         },
         {
-            name: 'tu_cover_byok_v3',
+            name: 'tu_cover_byok_v4',
             partialFilterExpression: { 'attributes.tu.isByok': true },
         },
     );
 
-    log('[token-usage-indexes] building tu_cover_sys_v3…');
+    log('[token-usage-indexes] building tu_cover_sys_v4…');
     await c.createIndex(
         {
             'attributes.organizationId': 1,
@@ -79,13 +85,14 @@ export async function ensureTokenUsageIndexes(
             timestamp: 1,
             'attributes.tu.model': 1,
             'attributes.prNumber': 1,
+            'attributes.repositoryId': 1,
             'attributes.tu.area': 1,
             'attributes.tu.route': 1,
             correlationId: 1,
             ...SUM_KEYS,
         },
         {
-            name: 'tu_cover_sys_v3',
+            name: 'tu_cover_sys_v4',
             partialFilterExpression: { 'attributes.tu.sys': { $exists: true } },
         },
     );
@@ -106,7 +113,7 @@ export async function dropTokenUsageIndexes(
     log: Logger = () => {},
 ): Promise<void> {
     const c = db.collection(COLLECTION);
-    for (const name of ['tu_cover_byok_v3', 'tu_cover_sys_v3']) {
+    for (const name of ['tu_cover_byok_v4', 'tu_cover_sys_v4']) {
         try {
             await c.dropIndex(name);
             log(`[token-usage-indexes] dropped ${name}`);

--- a/libs/core/infrastructure/database/typeorm/migrations/2026091000000000-TokenUsageRepositoryIdMongo.ts
+++ b/libs/core/infrastructure/database/typeorm/migrations/2026091000000000-TokenUsageRepositoryIdMongo.ts
@@ -1,0 +1,53 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+import {
+    mongoMigrationClient,
+    mongoMigrationsSkipped,
+} from '../../mongo/mongo-migration-client';
+import { ensureTokenUsageIndexes } from '../../mongo/token-usage/ensure-indexes';
+
+/**
+ * MongoDB migration (TypeORM runner — Postgres ledger, once per instance, on
+ * boot). Fixes #1882: the Token Usage repository filter scoped spend by
+ * `attributes.prNumber` alone — PR numbers are unique per repository, not per
+ * org, so two repositories sharing a number leaked each other's spend.
+ *
+ * Builds the `tu_cover_*_v4` covering indexes (v3 keys + `attributes.repositoryId`,
+ * now written on every usage span — see `buildUsageSpanAttributes`) and drops
+ * the superseded v3 covers.
+ *
+ * No backfill: historical spans were never stamped with a repository id and
+ * there is no source to derive one from after the fact (same accepted gap as
+ * #1238). They simply won't match a repository-scoped read going forward —
+ * the org-wide (unscoped) view is unaffected.
+ *
+ * `transaction = false`: index builds aren't transactional with Postgres
+ * anyway (same rationale as the earlier tu migrations).
+ */
+export class TokenUsageRepositoryIdMongo2026091000000000
+    implements MigrationInterface
+{
+    name = 'TokenUsageRepositoryIdMongo2026091000000000';
+    transaction = false;
+
+    public async up(_queryRunner: QueryRunner): Promise<void> {
+        if (mongoMigrationsSkipped()) {
+            console.log(
+                '[TokenUsageRepositoryIdMongo] skipped (SKIP_MONGO_MIGRATIONS=true)',
+            );
+            return;
+        }
+        const log = (m: string) => console.log(m);
+        const { db, close } = await mongoMigrationClient();
+        try {
+            await ensureTokenUsageIndexes(db, log);
+        } finally {
+            await close();
+        }
+    }
+
+    public async down(_queryRunner: QueryRunner): Promise<void> {
+        // The v4 indexes supersede the v3 ones (already dropped on the way
+        // up); recreating v3 on rollback would just burn an index build.
+    }
+}

--- a/libs/core/log/observability.service.ts
+++ b/libs/core/log/observability.service.ts
@@ -78,6 +78,10 @@ interface UsageSpanInput {
     organizationId?: string;
     teamId?: string;
     prNumber?: number;
+    /** Repository the call ran against — the Token Usage repository filter's
+     *  scoping key (#1882). PR numbers alone can't disambiguate repos: they're
+     *  unique per repository, not per org. */
+    repositoryId?: string;
     steps?: number;
     toolCalls?: number;
     finishReason?: string;
@@ -127,6 +131,7 @@ function buildUsageSpanAttributes(p: UsageSpanInput): Record<string, any> {
         ...(p.organizationId && { organizationId: p.organizationId }),
         ...(p.teamId && { teamId: p.teamId }),
         ...(p.prNumber != null && { prNumber: p.prNumber }),
+        ...(p.repositoryId && { repositoryId: p.repositoryId }),
         ...(p.steps != null && { steps: p.steps }),
         ...(p.toolCalls != null && { toolCalls: p.toolCalls }),
         ...(p.finishReason && { finishReason: p.finishReason }),
@@ -444,6 +449,7 @@ export class ObservabilityService implements OnModuleInit {
                 organizationId: a.organizationId as string | undefined,
                 teamId: a.teamId as string | undefined,
                 prNumber: a.prNumber as number | undefined,
+                repositoryId: a.repositoryId as string | undefined,
                 source: a.source as string | undefined,
                 durationMs: Date.now() - startedAt,
                 finishReason,
@@ -531,6 +537,9 @@ export class ObservabilityService implements OnModuleInit {
         organizationId?: string;
         teamId?: string;
         prNumber?: number;
+        /** Repository the call ran against — the Token Usage repository filter's
+         *  scoping key (#1882). */
+        repositoryId?: string;
         steps?: number;
         toolCalls?: number;
         finishReason?: string;
@@ -558,6 +567,7 @@ export class ObservabilityService implements OnModuleInit {
                     organizationId: params.organizationId,
                     teamId: params.teamId,
                     prNumber: params.prNumber,
+                    repositoryId: params.repositoryId,
                     steps: params.steps,
                     toolCalls: params.toolCalls,
                     finishReason: params.finishReason,


### PR DESCRIPTION
## Summary

Fixes #1882. The Token Usage repository filter scoped spend by `attributes.prNumber` alone (or a repo-resolved PR-number list) instead of the repository itself. PR numbers are unique per repository, not per org, so two repos sharing a number leaked each other's spend into every by-repo view: total, by-PR chart, unique-PR counts, and developer attribution.

- Stamp `repositoryId` on every usage span (write path): the harness loop and the dedup one-shot call already had it available in `telemetryMetadata`, just weren't reading/forwarding it — same choke points `prNumber` already goes through (`ai-sdk-agent-runner.ts`, `observability.service.ts`, `agent-review.stage.ts`).
- Match/group directly on `attributes.repositoryId` instead of resolving a repo to its PR-number list (`tokenUsage.repository.ts`); `tokenUsage.service.ts` simplifies to a thin pass-through since the resolution machinery is now dead.
- By-PR grouping now includes `repositoryId` in its key, so two PRs sharing a number stay distinct even in the unfiltered/org-wide view.
- Developer attribution (`tokens-developer.use-case.ts`) keys by `(repositoryId, number)` via the existing `findManyByNumbersAndRepositoryIds` (already used by the Pull Requests screen), falling back to the old org+number lookup only for legacy rows with no `repositoryId`.
- New `tu_cover_*_v4` Mongo index (+ migration) adds `attributes.repositoryId` to the covering index so the repo-scoped read stays index-covered.

No backfill: historical spans have no `repositoryId` and won't match a repository-scoped read — same accepted tradeoff as #1238. The org-wide (unscoped) view is unaffected.

## Verification

- Unit tests (repository match-builder, service, developer-attribution use case) updated to assert correct isolation instead of documenting the collision; 537 tests pass across analytics/observability/agent-harness/code-review-pipeline.
- Real MongoDB validation: seeded colliding-PR fixtures directly, confirmed correct isolation (repo A / repo B / org-wide totals) and confirmed the repo-scoped query is index-covered (`totalDocsExamined: 0`) via `explain()`.
- Live browser verification against a real dev org (real login), before/after:
  - Before fix: repo filter showed 46.0K tokens (16.0K real + 30.0K leaked from a colliding-PR span tagged to a different repo).
  - After fix: repo filter showed 16.0K (correct); unfiltered "All repositories" view stayed at 46.0K in both cases.

## Known follow-ups (out of scope here)

- A handful of other one-shot LLM call sites (safeguard, suggestion-validator, kody-rules judge, documentation-search) also set `prNumber` in their span attrs; I didn't audit whether each has `repositoryId` in scope. The harness loop + dedup path (fixed here) covers the dominant share of review spend.
- Frontend isn't touched — `repositoryId` on `UsageByPrResultContract` is additive/optional. Surfacing it in the UI (e.g. disambiguating `#42` labels by repo name) is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011M4HXxv4hXUWY4CLAQocBp