### PR TITLE
fix(llm): send x-opencode-session header for OpenCode Go BYOK reviews

### DIFF
--- a/libs/llm/managed-slot.spec.ts
+++ b/libs/llm/managed-slot.spec.ts
@@ -248,6 +248,27 @@ describe('resolveManagedSlot — env → managed slot / inline exception', () =>
         );
     });
 
+    it('env openai_compat pointed at OpenCode Go (opencode.ai/zen) → INLINE exception carries an x-opencode-session header (issue #1880)', () => {
+        process.env.API_LLM_PROVIDER_MODEL = 'deepseek-v4-flash';
+        process.env.API_OPEN_AI_API_KEY = 'sk-x';
+        process.env.API_OPENAI_FORCE_BASE_URL = 'https://opencode.ai/zen/go/v1';
+
+        resolveManagedSlot('x', {});
+
+        const call = (createOpenAICompatible as jest.Mock).mock.calls.at(-1)![0];
+        expect(call.headers['x-opencode-session']).toMatch(/^[0-9a-f]{32}$/);
+    });
+
+    it('env openai_compat pointed anywhere else (default api.openai.com) never carries an x-opencode-session header', () => {
+        process.env.API_LLM_PROVIDER_MODEL = 'llama-3.3-70b';
+        process.env.API_OPEN_AI_API_KEY = 'sk-x';
+
+        resolveManagedSlot('x', {});
+
+        const call = (createOpenAICompatible as jest.Mock).mock.calls.at(-1)![0];
+        expect(call).not.toHaveProperty('headers');
+    });
+
     it('cloud + fireworks default model → INLINE fireworks (the managed default)', () => {
         process.env.API_FIREWORKS_API_KEY = 'fw-key';
         const r = resolveManagedSlot(

--- a/libs/llm/managed-slot.ts
+++ b/libs/llm/managed-slot.ts
@@ -14,10 +14,7 @@ import { BYOKProvider } from '@libs/llm/model-providers';
 import type { NormalizedModel } from '@libs/llm/byok-config';
 import { DEFAULT_MODEL } from './byok-defaults';
 import { vertexModelFromAdc } from './model-builders';
-import {
-    isOpenCodeGoBaseUrl,
-    openCodeSessionId,
-} from './providers/openai';
+import { isOpenCodeGoBaseUrl, openCodeSessionId } from './opencode-go';
 
 // Model-name protocol patterns, used by the self-hosted / trial default-model
 // resolution below (the BYOK provider builders moved to the provider modules

--- a/libs/llm/managed-slot.ts
+++ b/libs/llm/managed-slot.ts
@@ -14,6 +14,10 @@ import { BYOKProvider } from '@libs/llm/model-providers';
 import type { NormalizedModel } from '@libs/llm/byok-config';
 import { DEFAULT_MODEL } from './byok-defaults';
 import { vertexModelFromAdc } from './model-builders';
+import {
+    isOpenCodeGoBaseUrl,
+    openCodeSessionId,
+} from './providers/openai';
 
 // Model-name protocol patterns, used by the self-hosted / trial default-model
 // resolution below (the BYOK provider builders moved to the provider modules
@@ -349,6 +353,11 @@ export function resolveManagedSlot(
                 // 'self-hosted', default baseURL api.openai.com, raw
                 // structuredOutputs opt-in — the openai_compatible provider
                 // module can't reproduce this without changing its BYOK behavior.
+                // This is also the ONE config shape with no BYOK ids at all
+                // (no byokModelId, no credentialId), so a self-hosted install
+                // pointed at OpenCode Go (issue #1880) needs the same
+                // x-opencode-session header attached here — the provider
+                // module's build() never runs on this inline path.
                 return {
                     kind: 'inline',
                     model: createOpenAICompatible({
@@ -357,6 +366,16 @@ export function resolveManagedSlot(
                         baseURL: env.baseURL,
                         supportsStructuredOutputs:
                             options.structuredOutputs === true,
+                        ...(isOpenCodeGoBaseUrl(env.baseURL)
+                            ? {
+                                  headers: {
+                                      'x-opencode-session': openCodeSessionId({
+                                          model: envMode,
+                                          baseURL: env.baseURL,
+                                      }),
+                                  },
+                              }
+                            : {}),
                     })(envMode),
                 };
             case 'vertex_adc': {

--- a/libs/llm/opencode-go.spec.ts
+++ b/libs/llm/opencode-go.spec.ts
@@ -20,6 +20,24 @@ describe('isOpenCodeGoBaseUrl', () => {
         expect(isOpenCodeGoBaseUrl(undefined)).toBe(false);
     });
 
+    it('is anchored to the actual host, not a substring anywhere in the URL', () => {
+        // A prior version was a bare `/opencode\.ai\/zen/i.test(baseURL)`
+        // substring scan — these two would have matched it, attaching the
+        // header to an upstream that is not OpenCode Go at all.
+        expect(isOpenCodeGoBaseUrl('https://notopencode.ai/zen/v1')).toBe(
+            false,
+        );
+        expect(
+            isOpenCodeGoBaseUrl(
+                'https://gw.corp.example/opencode.ai/zen/v1',
+            ),
+        ).toBe(false);
+        // Same host, unrelated path — still no match.
+        expect(isOpenCodeGoBaseUrl('https://opencode.ai/other')).toBe(false);
+        // A malformed / non-absolute baseURL degrades to false, not a throw.
+        expect(isOpenCodeGoBaseUrl('not a url')).toBe(false);
+    });
+
     it('matches bare opencode.ai/zen/v1 too (no "/go" segment) — a real shape in production, not just the documented /zen/go/v1 form', () => {
         // libs/llm/testing/__fixtures__/byok-prod-shapes.json has live orgs on
         // exactly this bare shape (kimi-k2.5, minimax-m3-free) alongside the

--- a/libs/llm/opencode-go.spec.ts
+++ b/libs/llm/opencode-go.spec.ts
@@ -1,4 +1,5 @@
 import { isOpenCodeGoBaseUrl, openCodeSessionId } from './opencode-go';
+import PROD_SHAPES from './testing/__fixtures__/byok-prod-shapes.json';
 
 const HEX32 = /^[0-9a-f]{32}$/;
 
@@ -19,9 +20,26 @@ describe('isOpenCodeGoBaseUrl', () => {
         expect(isOpenCodeGoBaseUrl(undefined)).toBe(false);
     });
 
-    it('does not match "zen" without "go" — the session-header requirement is scoped to the Go tier, not the whole Zen portal', () => {
-        expect(isOpenCodeGoBaseUrl('https://opencode.ai/zen')).toBe(false);
-        expect(isOpenCodeGoBaseUrl('https://opencode.ai/zen/v1')).toBe(false);
+    it('matches bare opencode.ai/zen/v1 too (no "/go" segment) — a real shape in production, not just the documented /zen/go/v1 form', () => {
+        // libs/llm/testing/__fixtures__/byok-prod-shapes.json has live orgs on
+        // exactly this bare shape (kimi-k2.5, minimax-m3-free) alongside the
+        // /zen/go/v1 ones — a prior commit narrowed the match to require
+        // "/go" and would have silently dropped the header for these.
+        expect(isOpenCodeGoBaseUrl('https://opencode.ai/zen/v1')).toBe(true);
+    });
+
+    it('matches EVERY real opencode.ai baseURL shape in the production corpus — a regression guard against re-narrowing the match', () => {
+        const opencodeShapes = (
+            PROD_SHAPES as Array<{ baseURL?: string }>
+        ).filter((shape) => shape.baseURL?.includes('opencode.ai'));
+
+        // Fails loud if the fixture ever stops carrying an opencode.ai shape —
+        // a passing-by-vacuity corpus test is worse than no test at all.
+        expect(opencodeShapes.length).toBeGreaterThan(0);
+
+        for (const shape of opencodeShapes) {
+            expect(isOpenCodeGoBaseUrl(shape.baseURL)).toBe(true);
+        }
     });
 });
 

--- a/libs/llm/opencode-go.spec.ts
+++ b/libs/llm/opencode-go.spec.ts
@@ -1,0 +1,81 @@
+import { isOpenCodeGoBaseUrl, openCodeSessionId } from './opencode-go';
+
+const HEX32 = /^[0-9a-f]{32}$/;
+
+describe('isOpenCodeGoBaseUrl', () => {
+    it('matches any opencode.ai/zen endpoint (chat completions, responses, or messages)', () => {
+        expect(isOpenCodeGoBaseUrl('https://opencode.ai/zen/go/v1')).toBe(
+            true,
+        );
+        expect(
+            isOpenCodeGoBaseUrl('https://opencode.ai/zen/go/v1/chat/completions'),
+        ).toBe(true);
+        expect(isOpenCodeGoBaseUrl('https://opencode.ai/zen/go')).toBe(true);
+    });
+
+    it('does not match an unrelated or missing baseURL', () => {
+        expect(isOpenCodeGoBaseUrl('https://api.openai.com/v1')).toBe(false);
+        expect(isOpenCodeGoBaseUrl('https://opencode.ai/docs')).toBe(false);
+        expect(isOpenCodeGoBaseUrl(undefined)).toBe(false);
+    });
+});
+
+describe('openCodeSessionId', () => {
+    it('prefers byokModelId, hashed (never sent raw)', () => {
+        const id = openCodeSessionId({
+            model: 'deepseek-v4-flash',
+            baseURL: 'https://opencode.ai/zen/go/v1',
+            byokModelId: 'model-123',
+            credentialId: 'cred-456',
+        });
+        expect(id).toMatch(HEX32);
+        expect(id).not.toContain('model-123');
+    });
+
+    it('falls back to credentialId when byokModelId is absent — different credentials never collide', () => {
+        const build = (credentialId: string) =>
+            openCodeSessionId({
+                model: 'deepseek-v4-flash',
+                baseURL: 'https://opencode.ai/zen/go/v1',
+                credentialId,
+            });
+
+        expect(build('cred-a')).not.toBe(build('cred-b'));
+        expect(build('cred-a')).toBe(build('cred-a'));
+        expect(build('cred-a')).toMatch(HEX32);
+    });
+
+    describe('last-resort HMAC fallback (neither byokModelId nor credentialId)', () => {
+        const originalCryptoKey = process.env.API_CRYPTO_KEY;
+        afterEach(() => {
+            process.env.API_CRYPTO_KEY = originalCryptoKey;
+        });
+
+        it('is stable for the same deployment and differs across deployments', () => {
+            const build = () =>
+                openCodeSessionId({
+                    model: 'deepseek-v4-flash',
+                    baseURL: 'https://opencode.ai/zen/go/v1',
+                });
+
+            process.env.API_CRYPTO_KEY = 'deployment-a-key';
+            const a1 = build();
+            const a2 = build();
+            expect(a1).toBe(a2);
+            expect(a1).toMatch(HEX32);
+
+            process.env.API_CRYPTO_KEY = 'deployment-b-key';
+            expect(build()).not.toBe(a1);
+        });
+
+        it('throws rather than silently deriving a shared, cross-deployment key when API_CRYPTO_KEY is unset', () => {
+            delete process.env.API_CRYPTO_KEY;
+            expect(() =>
+                openCodeSessionId({
+                    model: 'deepseek-v4-flash',
+                    baseURL: 'https://opencode.ai/zen/go/v1',
+                }),
+            ).toThrow(/API_CRYPTO_KEY/);
+        });
+    });
+});

--- a/libs/llm/opencode-go.spec.ts
+++ b/libs/llm/opencode-go.spec.ts
@@ -4,7 +4,7 @@ import PROD_SHAPES from './testing/__fixtures__/byok-prod-shapes.json';
 const HEX32 = /^[0-9a-f]{32}$/;
 
 describe('isOpenCodeGoBaseUrl', () => {
-    it('matches any opencode.ai/zen endpoint (chat completions, responses, or messages)', () => {
+    it('matches the opencode.ai host regardless of path — chat completions, responses, messages, or bare', () => {
         expect(isOpenCodeGoBaseUrl('https://opencode.ai/zen/go/v1')).toBe(
             true,
         );
@@ -12,11 +12,19 @@ describe('isOpenCodeGoBaseUrl', () => {
             isOpenCodeGoBaseUrl('https://opencode.ai/zen/go/v1/chat/completions'),
         ).toBe(true);
         expect(isOpenCodeGoBaseUrl('https://opencode.ai/zen/go')).toBe(true);
+        // No path restriction at all — matches jcode's own validated fix for
+        // this issue (github.com/1jehuang/jcode PR #1172), which checks only
+        // the host, never the path.
+        expect(isOpenCodeGoBaseUrl('https://opencode.ai/docs')).toBe(true);
+        expect(isOpenCodeGoBaseUrl('https://opencode.ai')).toBe(true);
+    });
+
+    it('matches an opencode.ai SUBDOMAIN too, same as jcode does', () => {
+        expect(isOpenCodeGoBaseUrl('https://api.opencode.ai/v1')).toBe(true);
     });
 
     it('does not match an unrelated or missing baseURL', () => {
         expect(isOpenCodeGoBaseUrl('https://api.openai.com/v1')).toBe(false);
-        expect(isOpenCodeGoBaseUrl('https://opencode.ai/docs')).toBe(false);
         expect(isOpenCodeGoBaseUrl(undefined)).toBe(false);
     });
 
@@ -32,8 +40,6 @@ describe('isOpenCodeGoBaseUrl', () => {
                 'https://gw.corp.example/opencode.ai/zen/v1',
             ),
         ).toBe(false);
-        // Same host, unrelated path — still no match.
-        expect(isOpenCodeGoBaseUrl('https://opencode.ai/other')).toBe(false);
         // A malformed / non-absolute baseURL degrades to false, not a throw.
         expect(isOpenCodeGoBaseUrl('not a url')).toBe(false);
     });

--- a/libs/llm/opencode-go.spec.ts
+++ b/libs/llm/opencode-go.spec.ts
@@ -18,6 +18,11 @@ describe('isOpenCodeGoBaseUrl', () => {
         expect(isOpenCodeGoBaseUrl('https://opencode.ai/docs')).toBe(false);
         expect(isOpenCodeGoBaseUrl(undefined)).toBe(false);
     });
+
+    it('does not match "zen" without "go" — the session-header requirement is scoped to the Go tier, not the whole Zen portal', () => {
+        expect(isOpenCodeGoBaseUrl('https://opencode.ai/zen')).toBe(false);
+        expect(isOpenCodeGoBaseUrl('https://opencode.ai/zen/v1')).toBe(false);
+    });
 });
 
 describe('openCodeSessionId', () => {

--- a/libs/llm/opencode-go.ts
+++ b/libs/llm/opencode-go.ts
@@ -1,0 +1,95 @@
+/**
+ * OpenCode Go (`opencode.ai/zen/go`) started enforcing an `x-opencode-session`
+ * header around 2026-09-06 — a request missing it now gets HTTP 400
+ * ("Request is missing x-opencode-session and cannot be routed efficiently")
+ * instead of being served, breaking every BYOK review configured against it
+ * (issue #1880). Their docs ask for a header that is "stable" per conversation
+ * for routing/prompt-cache locality, not a security token, so a deterministic
+ * id derived from the resolved slot is enough — no session-tracking plumbing.
+ *
+ * A dependency-free leaf (mirrors structured-output-gate.ts / base-url-hygiene.ts)
+ * so every place that can build a request AT this baseURL can import it without
+ * a cycle: the openai module (chat completions / responses), the anthropic
+ * module (OpenCode Go also exposes an Anthropic Messages-compatible endpoint),
+ * and managed-slot.ts's self-hosted `openai_compat` INLINE exception, which
+ * builds its client directly and never calls either provider module's `build()`.
+ */
+import { createHash, createHmac } from 'crypto';
+
+export function isOpenCodeGoBaseUrl(baseURL?: string): boolean {
+    return !!baseURL && /opencode\.ai\/zen/i.test(baseURL);
+}
+
+/** The handful of `NormalizedModel` fields `openCodeSessionId` actually reads
+ *  — narrowed so a caller with no full slot (managed-slot.ts's inline
+ *  self-hosted branch has no `byokModelId`/`credentialId` at all) can still
+ *  call it without fabricating one. */
+export interface OpenCodeSessionInput {
+    model: string;
+    baseURL?: string;
+    byokModelId?: string;
+    credentialId?: string;
+}
+
+/**
+ * Stable per BYOK model slot, falling back to the resolved CREDENTIAL's id
+ * when the slot carries no `byokModelId`, then to a deployment-scoped HMAC
+ * as the last resort for neither — a slot with NO BYOK config at all. Within
+ * a provider module's own `build()`, that last tier is dead: every config-based
+ * slot reaching it via byok-to-vercel.ts already carries a `credentialId`
+ * (resolve-model-slot.ts can't build one without finding a credential first).
+ * It IS reached, though — by `managed-slot.ts`'s self-hosted `openai_compat`
+ * case, which builds its `createOpenAICompatible` INLINE and never calls a
+ * provider module's `build()` at all; that is genuinely the one config shape
+ * with no BYOK ids whatsoever, so this function is exported for it to call
+ * directly.
+ *
+ * Three rejected-in-review attempts got here:
+ *  1. A process-random salt: changes on every restart/pod rotation (not
+ *     "stable"), AND identical for every org sharing the process and landing
+ *     on this fallback — doesn't fix the collision it exists to prevent,
+ *     since OpenCode Go's baseURL and model catalog are the same for
+ *     everyone.
+ *  2. Hashing the credential's own API KEY: fixed the collision (unique per
+ *     org/deployment, persisted across restarts) but CodeQL flagged it as
+ *     "password hash with insufficient computational effort" — its static
+ *     taint analysis flags ANY `createHash()` fed by a value sourced from
+ *     `apiKey`, full stop, regardless of the fact that the SAME key is
+ *     already sent to OpenCode in cleartext as the request's own Bearer
+ *     token (so the hash itself discloses nothing new to that recipient).
+ *  3. Dropping the key from the last-resort tier entirely (falling straight
+ *     to bare `model:baseURL`): reintroduced exactly the collision (1) was
+ *     meant to fix, since every self-hosted install shares that same bare
+ *     seed once it targets the same OpenCode Go model.
+ *
+ * The fix: keep secret material out of `createHash()` entirely, but still
+ * use it — as the KEY of an HMAC, which is what a secret is FOR, rather than
+ * as hashed message content. `API_CRYPTO_KEY` (libs/common/utils/crypto.ts)
+ * is already the one persisted, deployment-scoped secret every install needs
+ * for BYOK apiKey encryption, so this reuses it instead of adding a new env
+ * var — unique per self-hosted deployment, stable across restarts, and
+ * outside the specific pattern CodeQL flags. REQUIRED, not `?? ''`: a silent
+ * empty-string default would be the SAME weak key on every deployment that
+ * happens to be missing it, i.e. attempt (3)'s collision again — fail loud
+ * instead, matching crypto.ts's own fail-fast contract for this exact var.
+ *
+ * HASHED/HMAC'd rather than sent raw either way: OpenCode only needs an
+ * opaque value that stays constant call-to-call, not our internal id, so
+ * there is no reason to hand a third party a stable handle onto it.
+ */
+export function openCodeSessionId(cfg: OpenCodeSessionInput): string {
+    const id = cfg.byokModelId || cfg.credentialId;
+    if (id) {
+        return createHash('sha256').update(id).digest('hex').slice(0, 32);
+    }
+    const hmacKey = process.env.API_CRYPTO_KEY;
+    if (!hmacKey) {
+        throw new Error(
+            'API_CRYPTO_KEY is required to derive the OpenCode Go session id',
+        );
+    }
+    return createHmac('sha256', hmacKey)
+        .update(`${cfg.model}:${cfg.baseURL ?? ''}`)
+        .digest('hex')
+        .slice(0, 32);
+}

--- a/libs/llm/opencode-go.ts
+++ b/libs/llm/opencode-go.ts
@@ -17,20 +17,41 @@
 import { createHash, createHmac } from 'crypto';
 
 /**
- * Deliberately broad — matches bare `opencode.ai/zen`, not just `/zen/go`.
+ * Deliberately broad on the PATH — matches bare `/zen`, not just `/zen/go`.
  * A prior commit narrowed this to require `/go`, reasoning from OpenCode's
  * docs that the session-header requirement is scoped to the Go tier. Real
  * production BYOK configs proved that wrong: `libs/llm/testing/__fixtures__/
  * byok-prod-shapes.json` has live orgs on BOTH `opencode.ai/zen/go/v1` AND
  * bare `opencode.ai/zen/v1` (kimi-k2.5, minimax-m3-free) — the `/go` form is
  * not the only shape actually in use, docs notwithstanding. The asymmetry
- * settles it: matching too broadly costs one harmless extra header (their
- * own docs call it "recommended" for routing/cache locality, never
- * rejected); matching too narrowly means a real customer's every review
- * 400s — the exact outage #1880 is about. So: broad, on purpose.
+ * settles it: matching too broadly on the PATH costs one harmless extra
+ * header (their own docs call it "recommended" for routing/cache locality,
+ * never rejected); matching too narrowly means a real customer's every
+ * review 400s — the exact outage #1880 is about. So: broad on the path,
+ * on purpose.
+ *
+ * But NOT broad on the HOST: an earlier version of this function was a plain
+ * substring regex (`/opencode\.ai\/zen/i.test(baseURL)`), which also matches
+ * `https://notopencode.ai/zen/v1` and a corp gateway path like
+ * `https://gw.corp.example/opencode.ai/zen/v1` — attaching this header to an
+ * upstream that isn't OpenCode at all, which a strict server could 400 on an
+ * unrecognized `x-*` header (the exact failure class this exists to avoid).
+ * Parse the URL for real and anchor on the actual authority instead of
+ * scanning the whole string — same idiom base-url-hygiene.ts already uses
+ * for the same reason.
  */
 export function isOpenCodeGoBaseUrl(baseURL?: string): boolean {
-    return !!baseURL && /opencode\.ai\/zen/i.test(baseURL);
+    if (!baseURL) return false;
+    let parsed: URL;
+    try {
+        parsed = new URL(baseURL);
+    } catch {
+        return false;
+    }
+    return (
+        parsed.hostname.toLowerCase() === 'opencode.ai' &&
+        parsed.pathname.toLowerCase().startsWith('/zen')
+    );
 }
 
 /** The handful of `NormalizedModel` fields `openCodeSessionId` actually reads

--- a/libs/llm/opencode-go.ts
+++ b/libs/llm/opencode-go.ts
@@ -16,8 +16,16 @@
  */
 import { createHash, createHmac } from 'crypto';
 
+/**
+ * Matches `/go` specifically, not `opencode.ai/zen` alone: "Zen" is the
+ * broader auth/gateway portal (OpenCode's other, non-Go offerings sit behind
+ * the same host), and their docs scope the session-header requirement to the
+ * Go subscription tier — not to Zen as a whole. All three documented Go
+ * endpoints share this prefix: `/zen/go/v1/chat/completions`, `/v1/responses`,
+ * and `/v1/messages`.
+ */
 export function isOpenCodeGoBaseUrl(baseURL?: string): boolean {
-    return !!baseURL && /opencode\.ai\/zen/i.test(baseURL);
+    return !!baseURL && /opencode\.ai\/zen\/go/i.test(baseURL);
 }
 
 /** The handful of `NormalizedModel` fields `openCodeSessionId` actually reads

--- a/libs/llm/opencode-go.ts
+++ b/libs/llm/opencode-go.ts
@@ -17,28 +17,32 @@
 import { createHash, createHmac } from 'crypto';
 
 /**
- * Deliberately broad on the PATH — matches bare `/zen`, not just `/zen/go`.
- * A prior commit narrowed this to require `/go`, reasoning from OpenCode's
- * docs that the session-header requirement is scoped to the Go tier. Real
- * production BYOK configs proved that wrong: `libs/llm/testing/__fixtures__/
- * byok-prod-shapes.json` has live orgs on BOTH `opencode.ai/zen/go/v1` AND
- * bare `opencode.ai/zen/v1` (kimi-k2.5, minimax-m3-free) — the `/go` form is
- * not the only shape actually in use, docs notwithstanding. The asymmetry
- * settles it: matching too broadly on the PATH costs one harmless extra
- * header (their own docs call it "recommended" for routing/cache locality,
- * never rejected); matching too narrowly means a real customer's every
- * review 400s — the exact outage #1880 is about. So: broad on the path,
- * on purpose.
+ * HOST-only check, no path restriction — matches `jcode`'s own fix for this
+ * exact issue (github.com/1jehuang/jcode PR #1172, linked from OpenCode's own
+ * "Validated Clients" table):
  *
- * But NOT broad on the HOST: an earlier version of this function was a plain
- * substring regex (`/opencode\.ai\/zen/i.test(baseURL)`), which also matches
- * `https://notopencode.ai/zen/v1` and a corp gateway path like
- * `https://gw.corp.example/opencode.ai/zen/v1` — attaching this header to an
- * upstream that isn't OpenCode at all, which a strict server could 400 on an
- * unrecognized `x-*` header (the exact failure class this exists to avoid).
- * Parse the URL for real and anchor on the actual authority instead of
- * scanning the whole string — same idiom base-url-hygiene.ts already uses
- * for the same reason.
+ *   fn is_opencode_api_base(api_base: &str) -> bool {
+ *       matches!(url.host_str(), Some(host) if host == "opencode.ai" || host.ends_with(".opencode.ai"))
+ *   }
+ *
+ * Two things this codebase tried and rejected before landing here:
+ *  1. A plain substring regex (`/opencode\.ai\/zen/i.test(baseURL)`) — also
+ *     matches `https://notopencode.ai/zen/v1` and a corp gateway path like
+ *     `https://gw.corp.example/opencode.ai/zen/v1`, attaching the header to
+ *     an upstream that isn't OpenCode at all (a strict server could 400 on
+ *     an unrecognized `x-*` header — the exact failure class this exists to
+ *     avoid). Fixed by parsing the URL for real instead of scanning the
+ *     whole string, same idiom base-url-hygiene.ts uses for the same reason.
+ *  2. Requiring the path to start with `/zen` (or `/zen/go`) — reasoning
+ *     from OpenCode's docs that the session-header requirement is scoped to
+ *     a specific tier/path. Real production BYOK configs proved the `/go`
+ *     version wrong (`libs/llm/testing/__fixtures__/byok-prod-shapes.json`
+ *     has live orgs on bare `opencode.ai/zen/v1`, no `/go`), and jcode's own
+ *     validated fix doesn't check the path at all — just the host. Matching
+ *     on host alone is a strict superset of every real shape seen so far,
+ *     and the same asymmetry as always applies: an extra header costs
+ *     nothing (OpenCode's docs call it "recommended", never rejected); a
+ *     missed one 400s a real customer's every review.
  */
 export function isOpenCodeGoBaseUrl(baseURL?: string): boolean {
     if (!baseURL) return false;
@@ -48,10 +52,8 @@ export function isOpenCodeGoBaseUrl(baseURL?: string): boolean {
     } catch {
         return false;
     }
-    return (
-        parsed.hostname.toLowerCase() === 'opencode.ai' &&
-        parsed.pathname.toLowerCase().startsWith('/zen')
-    );
+    const host = parsed.hostname.toLowerCase();
+    return host === 'opencode.ai' || host.endsWith('.opencode.ai');
 }
 
 /** The handful of `NormalizedModel` fields `openCodeSessionId` actually reads

--- a/libs/llm/opencode-go.ts
+++ b/libs/llm/opencode-go.ts
@@ -17,15 +17,20 @@
 import { createHash, createHmac } from 'crypto';
 
 /**
- * Matches `/go` specifically, not `opencode.ai/zen` alone: "Zen" is the
- * broader auth/gateway portal (OpenCode's other, non-Go offerings sit behind
- * the same host), and their docs scope the session-header requirement to the
- * Go subscription tier — not to Zen as a whole. All three documented Go
- * endpoints share this prefix: `/zen/go/v1/chat/completions`, `/v1/responses`,
- * and `/v1/messages`.
+ * Deliberately broad — matches bare `opencode.ai/zen`, not just `/zen/go`.
+ * A prior commit narrowed this to require `/go`, reasoning from OpenCode's
+ * docs that the session-header requirement is scoped to the Go tier. Real
+ * production BYOK configs proved that wrong: `libs/llm/testing/__fixtures__/
+ * byok-prod-shapes.json` has live orgs on BOTH `opencode.ai/zen/go/v1` AND
+ * bare `opencode.ai/zen/v1` (kimi-k2.5, minimax-m3-free) — the `/go` form is
+ * not the only shape actually in use, docs notwithstanding. The asymmetry
+ * settles it: matching too broadly costs one harmless extra header (their
+ * own docs call it "recommended" for routing/cache locality, never
+ * rejected); matching too narrowly means a real customer's every review
+ * 400s — the exact outage #1880 is about. So: broad, on purpose.
  */
 export function isOpenCodeGoBaseUrl(baseURL?: string): boolean {
-    return !!baseURL && /opencode\.ai\/zen\/go/i.test(baseURL);
+    return !!baseURL && /opencode\.ai\/zen/i.test(baseURL);
 }
 
 /** The handful of `NormalizedModel` fields `openCodeSessionId` actually reads

--- a/libs/llm/providers/anthropic/anthropic.spec.ts
+++ b/libs/llm/providers/anthropic/anthropic.spec.ts
@@ -137,6 +137,52 @@ describe('anthropicModule capability ↔ behavior (D-05)', () => {
     });
 });
 
+describe('anthropicModule x-opencode-session header (issue #1880 — OpenCode Go also exposes /v1/messages)', () => {
+    const HEX32 = /^[0-9a-f]{32}$/;
+
+    it('anthropic_compatible pointed at opencode.ai/zen gets the header', () => {
+        const model = anthropicModule.build({
+            provider: 'anthropic_compatible',
+            model: 'claude-sonnet-4-5-20250929',
+            apiKey: 'test-key',
+            baseURL: 'https://opencode.ai/zen/go',
+            byokModelId: 'model-123',
+        } as any) as any;
+
+        expect(model.config.headers()['x-opencode-session']).toMatch(HEX32);
+    });
+
+    it('native anthropic pointed at opencode.ai/zen gets the header too (it also accepts a baseURL override)', () => {
+        const model = anthropicModule.build({
+            provider: 'anthropic',
+            model: 'claude-sonnet-4-5-20250929',
+            apiKey: 'test-key',
+            baseURL: 'https://opencode.ai/zen/go/v1',
+            byokModelId: 'model-123',
+        } as any) as any;
+
+        expect(model.config.headers()['x-opencode-session']).toMatch(HEX32);
+    });
+
+    it('neither branch gets the header for a normal Anthropic/compatible baseURL', () => {
+        const compatible = anthropicModule.build({
+            provider: 'anthropic_compatible',
+            model: 'claude-sonnet-4-5-20250929',
+            apiKey: 'test-key',
+            baseURL: 'https://api.moonshot.ai/v1',
+            byokModelId: 'model-123',
+        } as any) as any;
+        expect(compatible.config.headers()).not.toHaveProperty(
+            'x-opencode-session',
+        );
+
+        const native = anthropicModule.build(anthropicNativeCfg) as any;
+        expect(native.config.headers()).not.toHaveProperty(
+            'x-opencode-session',
+        );
+    });
+});
+
 describe('anthropicModule offline conformance (real boundary: build → SDK → normalize)', () => {
     it('extended-thinking fixture: reasoning === 0 through the real SDK path; output not reduced', async () => {
         const run = await runConformance(

--- a/libs/llm/providers/anthropic/brand.spec.ts
+++ b/libs/llm/providers/anthropic/brand.spec.ts
@@ -9,13 +9,16 @@
  * `@ai-sdk/anthropic` is mocked so we can capture the exact baseURL the module
  * hands the SDK without a live call (the conformance specs cover the real path).
  */
-const createAnthropicMock = jest.fn((_cfg: { baseURL?: string }) => {
-    const factory = (_model: string) => ({ id: 'stub-model' });
-    return factory;
-});
+const createAnthropicMock = jest.fn(
+    (_cfg: { baseURL?: string; headers?: Record<string, string> }) => {
+        const factory = (_model: string) => ({ id: 'stub-model' });
+        return factory;
+    },
+);
 
 jest.mock('@ai-sdk/anthropic', () => ({
-    createAnthropic: (cfg: { baseURL?: string }) => createAnthropicMock(cfg),
+    createAnthropic: (cfg: { baseURL?: string; headers?: Record<string, string> }) =>
+        createAnthropicMock(cfg),
 }));
 
 import { moonshotModule } from '../moonshot/index';
@@ -23,6 +26,9 @@ import { zaiModule } from '../zai/index';
 
 const baseURLOf = (): string =>
     createAnthropicMock.mock.calls.at(-1)?.[0]?.baseURL ?? '';
+
+const headersOf = (): Record<string, string> | undefined =>
+    createAnthropicMock.mock.calls.at(-1)?.[0]?.headers;
 
 describe('anthropicBrandModule — baseURL fallback for a key-only connect', () => {
     beforeEach(() => createAnthropicMock.mockClear());
@@ -60,5 +66,24 @@ describe('anthropicBrandModule — baseURL fallback for a key-only connect', () 
         } as any);
 
         expect(baseURLOf()).toBe('https://api.kimi.com/coding/v1');
+    });
+
+    // A brand credential (Moonshot/Z.ai) explicitly re-pointed at OpenCode Go's
+    // baseURL is an unlikely setup (nobody normally aims a "Kimi" connection at
+    // a different provider's endpoint), but `asCompatible` spreads the WHOLE cfg
+    // through unchanged before delegating to `anthropicModule.build` — so the
+    // #1880 x-opencode-session gate should still fire here exactly as it does
+    // for a plain anthropic_compatible slot, purely from that composition.
+    it('a brand config explicitly re-pointed at OpenCode Go still gets x-opencode-session (composition through asCompatible)', () => {
+        moonshotModule.build({
+            provider: 'moonshot',
+            model: 'kimi-k2.7-code',
+            apiKey: 'k',
+            baseURL: 'https://opencode.ai/zen/go',
+            byokModelId: 'model-123',
+        } as any);
+
+        expect(baseURLOf()).toBe('https://opencode.ai/zen/go/v1');
+        expect(headersOf()?.['x-opencode-session']).toMatch(/^[0-9a-f]{32}$/);
     });
 });

--- a/libs/llm/providers/anthropic/index.ts
+++ b/libs/llm/providers/anthropic/index.ts
@@ -34,6 +34,7 @@ import {
     type ModelReasoningTraits,
 } from '../kernel/reasoning-traits';
 import { normalizeSdkResult, normalizeSdkUsage } from '../kernel/usage';
+import { isOpenCodeGoBaseUrl, openCodeSessionId } from '@libs/llm/opencode-go';
 
 
 
@@ -91,12 +92,29 @@ export const anthropicModule: ProviderModule = {
                 // probe's redirect-refusing fetch) still needs the signature
                 // repair, and the repair still needs the caller's guard.
                 fetch: withThinkingSignatureRepair(opts?.fetch ?? fetch),
+                // OpenCode Go also exposes an Anthropic Messages-compatible
+                // endpoint (opencode.ai/zen/go/v1/messages) alongside its
+                // OpenAI-compatible one — the SAME `x-opencode-session`
+                // requirement the openai module works around for #1880 (see
+                // that module for the full rationale/history). Preemptive:
+                // not yet confirmed the 400 fires on this transport too, but
+                // the fix is free and shares the one exported helper pair.
+                ...(isOpenCodeGoBaseUrl(cfg.baseURL)
+                    ? {
+                          headers: {
+                              'x-opencode-session': openCodeSessionId(cfg),
+                          },
+                      }
+                    : {}),
             })(cfg.model);
         }
         return createAnthropic({
             apiKey: cfg.apiKey,
             ...(cfg.baseURL ? { baseURL: cfg.baseURL } : {}),
             ...(opts?.fetch ? { fetch: opts.fetch } : {}),
+            ...(isOpenCodeGoBaseUrl(cfg.baseURL)
+                ? { headers: { 'x-opencode-session': openCodeSessionId(cfg) } }
+                : {}),
         })(cfg.model);
     },
 

--- a/libs/llm/providers/openai/index.ts
+++ b/libs/llm/providers/openai/index.ts
@@ -68,25 +68,36 @@ function isOpenCodeGoBaseUrl(baseURL?: string): boolean {
 }
 
 /**
- * Stable per BYOK model slot. Falls back to the resolved credential's own API
- * key (plus model+baseURL) when the slot carries no `byokModelId` — legacy /
+ * Stable per BYOK model slot, falling back to the resolved CREDENTIAL's id
+ * (plus model+baseURL) when the slot carries no `byokModelId` — legacy /
  * pre-v2 BYOK configs and self-hosted env slots (resolve-model-slot.ts only
- * sets `byokModelId` for a v2 `models[]` entry). A PROCESS-RANDOM salt was
- * tried here first and rejected in review: it changes on every restart/pod
- * rotation (not stable) AND is identical for every org that shares the
- * process and lands on this fallback (doesn't fix the collision it exists to
- * prevent — OpenCode Go's baseURL and model catalog are the same for
- * everyone). The API key has neither problem: it is PERSISTED (stable across
- * restarts) and already unique per org/credential, since that's the whole
- * point of BYOK.
+ * sets `byokModelId` for a v2 `models[]` entry). Every resolved slot needs a
+ * `credentialId` to have found its API key at all, so this fallback is at
+ * least as available as the primary id.
+ *
+ * Two rejected-in-review attempts got here:
+ *  1. A process-random salt: changes on every restart/pod rotation (not
+ *     "stable"), AND identical for every org sharing the process and landing
+ *     on this fallback — doesn't fix the collision it exists to prevent,
+ *     since OpenCode Go's baseURL and model catalog are the same for
+ *     everyone.
+ *  2. The credential's own API KEY: fixed the collision (unique per org,
+ *     persisted across restarts) but CodeQL flagged it as "password hash
+ *     with insufficient computational effort" — SHA-256 is the wrong tool
+ *     for deriving anything from a real secret, however implausible brute-
+ *     force actually is here. `credentialId` gives the exact same
+ *     persisted-and-unique-per-org properties without hashing secret
+ *     material at all: it's an internal id, not a credential.
  *
  * HASHED rather than sent raw either way: OpenCode only needs an opaque value
- * that stays constant call-to-call, not our internal id or the actual key, so
- * there is no reason to hand a third party a stable handle onto either one.
+ * that stays constant call-to-call, not our internal id, so there is no
+ * reason to hand a third party a stable handle onto it.
  */
 function openCodeSessionId(cfg: ProviderBuildConfig): string {
     const seed =
-        cfg.byokModelId || `${cfg.apiKey}:${cfg.model}:${cfg.baseURL ?? ''}`;
+        cfg.byokModelId ||
+        cfg.credentialId ||
+        `${cfg.model}:${cfg.baseURL ?? ''}`;
     return createHash('sha256').update(seed).digest('hex').slice(0, 32);
 }
 

--- a/libs/llm/providers/openai/index.ts
+++ b/libs/llm/providers/openai/index.ts
@@ -53,6 +53,28 @@ function isNativeOpenAiModel(model: string): boolean {
     return isOpenAiReasoner(model) || /^(gpt|chatgpt|o[0-9])/i.test(model);
 }
 
+/**
+ * OpenCode Go (`opencode.ai/zen/go`) started enforcing an `x-opencode-session`
+ * header around 2026-09-06 — a request missing it now gets HTTP 400
+ * ("Request is missing x-opencode-session and cannot be routed efficiently")
+ * instead of being served, breaking every BYOK review configured against it
+ * (issue #1880). Their docs ask for a header that is "stable" per conversation
+ * for routing/prompt-cache locality, not a security token, so a deterministic
+ * id derived from the resolved slot is enough — no session-tracking plumbing.
+ */
+function isOpenCodeGoBaseUrl(baseURL?: string): boolean {
+    return !!baseURL && /opencode\.ai\/zen/i.test(baseURL);
+}
+
+/** Stable per BYOK credential (falls back to the model slot's own id, then the
+ *  model+baseURL pair, so even a slot missing both still sends a valid header
+ *  instead of failing to build the model at all). */
+function openCodeSessionId(cfg: ProviderBuildConfig): string {
+    return (
+        cfg.credentialId || cfg.byokModelId || `${cfg.model}:${cfg.baseURL ?? ''}`
+    );
+}
+
 // The Kimi / Moonshot never-downgrade policy (`isNeverDowngradeModel`) now lives
 // in the shared structured-output-gate leaf so the moonshot module shares the
 // SAME policy — see the import above. build() still honors it as an ADDITIVE
@@ -116,6 +138,13 @@ export const openaiModule: ProviderModule = {
                 apiKey,
                 baseURL,
                 ...(opts?.fetch ? { fetch: opts.fetch } : {}),
+                ...(isOpenCodeGoBaseUrl(baseURL)
+                    ? {
+                          headers: {
+                              'x-opencode-session': openCodeSessionId(cfg),
+                          },
+                      }
+                    : {}),
                 // OpenAI's own API REJECTS `max_tokens` on a reasoning model:
                 //
                 //   Unsupported parameter: 'max_tokens' is not supported with

--- a/libs/llm/providers/openai/index.ts
+++ b/libs/llm/providers/openai/index.ts
@@ -62,17 +62,38 @@ function isNativeOpenAiModel(model: string): boolean {
  * (issue #1880). Their docs ask for a header that is "stable" per conversation
  * for routing/prompt-cache locality, not a security token, so a deterministic
  * id derived from the resolved slot is enough — no session-tracking plumbing.
+ *
+ * Exported: `managed-slot.ts`'s self-hosted `openai_compat` case builds its
+ * model INLINE (bypassing this module's `build()` entirely — see the comment
+ * on `openCodeSessionId` below), so it needs these same two functions to
+ * cover that config shape too.
  */
-function isOpenCodeGoBaseUrl(baseURL?: string): boolean {
+export function isOpenCodeGoBaseUrl(baseURL?: string): boolean {
     return !!baseURL && /opencode\.ai\/zen/i.test(baseURL);
+}
+
+/** The handful of `NormalizedModel` fields `openCodeSessionId` actually reads
+ *  — narrowed so a caller with no full slot (managed-slot.ts's inline
+ *  self-hosted branch has no `byokModelId`/`credentialId` at all) can still
+ *  call it without fabricating one. */
+interface OpenCodeSessionInput {
+    model: string;
+    baseURL?: string;
+    byokModelId?: string;
+    credentialId?: string;
 }
 
 /**
  * Stable per BYOK model slot, falling back to the resolved CREDENTIAL's id
  * when the slot carries no `byokModelId`, then to a deployment-scoped HMAC
- * as the last resort for a slot with NEITHER (self-hosted env/managed mode —
- * resolve-model-slot.ts only sets both ids for a v2 `models[]` entry, and a
- * config-based slot can't exist without a credential in the first place).
+ * as the last resort for neither — a slot with NO BYOK config at all. Within
+ * this module's own `build()`, that last tier is dead: every config-based
+ * slot reaching it via byok-to-vercel.ts already carries a `credentialId`
+ * (resolve-model-slot.ts can't build one without finding a credential first).
+ * It IS reached, though — by `managed-slot.ts`'s self-hosted `openai_compat`
+ * case, which builds its `createOpenAICompatible` INLINE and never calls this
+ * module's `build()` at all; that is genuinely the one config shape with no
+ * BYOK ids whatsoever, so this function is exported for it to call directly.
  *
  * Three rejected-in-review attempts got here:
  *  1. A process-random salt: changes on every restart/pod rotation (not
@@ -89,30 +110,36 @@ function isOpenCodeGoBaseUrl(baseURL?: string): boolean {
  *     token (so the hash itself discloses nothing new to that recipient).
  *  3. Dropping the key from the last-resort tier entirely (falling straight
  *     to bare `model:baseURL`): reintroduced exactly the collision (1) was
- *     meant to fix, since that tier is the one place `credentialId` is
- *     genuinely absent — a self-hosted install pointing its env vars at
- *     OpenCode Go, where every "org" in that single-tenant deployment is
- *     the same customer anyway, but two SEPARATE such deployments sharing
- *     the same model choice would still collide.
+ *     meant to fix, since every self-hosted install shares that same bare
+ *     seed once it targets the same OpenCode Go model.
  *
  * The fix: keep secret material out of `createHash()` entirely, but still
  * use it — as the KEY of an HMAC, which is what a secret is FOR, rather than
  * as hashed message content. `API_CRYPTO_KEY` (libs/common/utils/crypto.ts)
- * is already the one persisted, deployment-scoped secret every install
- * needs for BYOK apiKey encryption, so this reuses it instead of adding a
- * new env var — unique per self-hosted deployment, stable across restarts,
- * and outside the specific pattern CodeQL flags.
+ * is already the one persisted, deployment-scoped secret every install needs
+ * for BYOK apiKey encryption, so this reuses it instead of adding a new env
+ * var — unique per self-hosted deployment, stable across restarts, and
+ * outside the specific pattern CodeQL flags. REQUIRED, not `?? ''`: a silent
+ * empty-string default would be the SAME weak key on every deployment that
+ * happens to be missing it, i.e. attempt (3)'s collision again — fail loud
+ * instead, matching crypto.ts's own fail-fast contract for this exact var.
  *
  * HASHED/HMAC'd rather than sent raw either way: OpenCode only needs an
  * opaque value that stays constant call-to-call, not our internal id, so
  * there is no reason to hand a third party a stable handle onto it.
  */
-function openCodeSessionId(cfg: ProviderBuildConfig): string {
+export function openCodeSessionId(cfg: OpenCodeSessionInput): string {
     const id = cfg.byokModelId || cfg.credentialId;
     if (id) {
         return createHash('sha256').update(id).digest('hex').slice(0, 32);
     }
-    return createHmac('sha256', process.env.API_CRYPTO_KEY ?? '')
+    const hmacKey = process.env.API_CRYPTO_KEY;
+    if (!hmacKey) {
+        throw new Error(
+            'API_CRYPTO_KEY is required to derive the OpenCode Go session id',
+        );
+    }
+    return createHmac('sha256', hmacKey)
         .update(`${cfg.model}:${cfg.baseURL ?? ''}`)
         .digest('hex')
         .slice(0, 32);

--- a/libs/llm/providers/openai/index.ts
+++ b/libs/llm/providers/openai/index.ts
@@ -218,10 +218,18 @@ export const openaiModule: ProviderModule = {
 
         // Native OpenAI (id 'openai'). Only pass baseURL when set — the native
         // SDK has a sensible default and an empty string throws "Invalid URL".
+        // Still gated on the SAME OpenCode Go check as the compatible branch
+        // above: 'openai' also accepts a baseURL override (e.g. Azure OpenAI
+        // proxies), so a slot pointed at opencode.ai/zen through THIS provider
+        // id needs the header too, or it 400s exactly like the compatible one
+        // did before #1880.
         return createOpenAI({
             apiKey,
             ...(baseURL ? { baseURL } : {}),
             ...(opts?.fetch ? { fetch: opts.fetch } : {}),
+            ...(isOpenCodeGoBaseUrl(baseURL)
+                ? { headers: { 'x-opencode-session': openCodeSessionId(cfg) } }
+                : {}),
         })(cfg.model);
     },
 

--- a/libs/llm/providers/openai/index.ts
+++ b/libs/llm/providers/openai/index.ts
@@ -12,7 +12,7 @@
  * normalizeUsage are declared stubs (Phase 3 owns them).
  */
 import type { LanguageModel } from 'ai';
-import { createHash } from 'crypto';
+import { createHash, randomUUID } from 'crypto';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { z } from 'zod';
@@ -68,9 +68,21 @@ function isOpenCodeGoBaseUrl(baseURL?: string): boolean {
 }
 
 /**
- * Stable per BYOK model slot (falls back to the model+baseURL pair when the
- * slot carries no `byokModelId`, e.g. a managed/env default, so even that case
- * still sends a valid header instead of failing to build the model at all).
+ * Per-process fallback salt — only mixed into the seed when a slot carries no
+ * `byokModelId` (env/managed default, i.e. self-hosted mode with no BYOK v2
+ * config). Without it every such slot would hash `model:baseURL` alone, and
+ * since every OpenCode Go customer shares the SAME baseURL and picks from the
+ * SAME small model catalog, two different orgs on that fallback would collide
+ * on an IDENTICAL session id. `byokModelId` itself is a client-generated
+ * `crypto.randomUUID()` (apps/web `byok-write.ts`), so the primary, expected
+ * path never touches this salt at all.
+ */
+const OPENCODE_FALLBACK_SALT = randomUUID();
+
+/**
+ * Stable per BYOK model slot (falls back to model+baseURL+the process salt
+ * above when the slot carries no `byokModelId`, so even that case still sends
+ * a valid, non-colliding header instead of failing to build the model at all).
  *
  * HASHED rather than sent raw: `byokModelId` is our own internal config-entry
  * id — OpenCode only needs an opaque value that stays constant call-to-call,
@@ -78,7 +90,9 @@ function isOpenCodeGoBaseUrl(baseURL?: string): boolean {
  * handle onto our internal identifiers for however long they choose to keep it.
  */
 function openCodeSessionId(cfg: ProviderBuildConfig): string {
-    const seed = cfg.byokModelId || `${cfg.model}:${cfg.baseURL ?? ''}`;
+    const seed =
+        cfg.byokModelId ||
+        `${OPENCODE_FALLBACK_SALT}:${cfg.model}:${cfg.baseURL ?? ''}`;
     return createHash('sha256').update(seed).digest('hex').slice(0, 32);
 }
 

--- a/libs/llm/providers/openai/index.ts
+++ b/libs/llm/providers/openai/index.ts
@@ -12,7 +12,7 @@
  * normalizeUsage are declared stubs (Phase 3 owns them).
  */
 import type { LanguageModel } from 'ai';
-import { createHash, randomUUID } from 'crypto';
+import { createHash } from 'crypto';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { z } from 'zod';
@@ -68,31 +68,25 @@ function isOpenCodeGoBaseUrl(baseURL?: string): boolean {
 }
 
 /**
- * Per-process fallback salt — only mixed into the seed when a slot carries no
- * `byokModelId` (env/managed default, i.e. self-hosted mode with no BYOK v2
- * config). Without it every such slot would hash `model:baseURL` alone, and
- * since every OpenCode Go customer shares the SAME baseURL and picks from the
- * SAME small model catalog, two different orgs on that fallback would collide
- * on an IDENTICAL session id. `byokModelId` itself is a client-generated
- * `crypto.randomUUID()` (apps/web `byok-write.ts`), so the primary, expected
- * path never touches this salt at all.
- */
-const OPENCODE_FALLBACK_SALT = randomUUID();
-
-/**
- * Stable per BYOK model slot (falls back to model+baseURL+the process salt
- * above when the slot carries no `byokModelId`, so even that case still sends
- * a valid, non-colliding header instead of failing to build the model at all).
+ * Stable per BYOK model slot. Falls back to the resolved credential's own API
+ * key (plus model+baseURL) when the slot carries no `byokModelId` — legacy /
+ * pre-v2 BYOK configs and self-hosted env slots (resolve-model-slot.ts only
+ * sets `byokModelId` for a v2 `models[]` entry). A PROCESS-RANDOM salt was
+ * tried here first and rejected in review: it changes on every restart/pod
+ * rotation (not stable) AND is identical for every org that shares the
+ * process and lands on this fallback (doesn't fix the collision it exists to
+ * prevent — OpenCode Go's baseURL and model catalog are the same for
+ * everyone). The API key has neither problem: it is PERSISTED (stable across
+ * restarts) and already unique per org/credential, since that's the whole
+ * point of BYOK.
  *
- * HASHED rather than sent raw: `byokModelId` is our own internal config-entry
- * id — OpenCode only needs an opaque value that stays constant call-to-call,
- * not that actual id, so there is no reason to hand a third party a stable
- * handle onto our internal identifiers for however long they choose to keep it.
+ * HASHED rather than sent raw either way: OpenCode only needs an opaque value
+ * that stays constant call-to-call, not our internal id or the actual key, so
+ * there is no reason to hand a third party a stable handle onto either one.
  */
 function openCodeSessionId(cfg: ProviderBuildConfig): string {
     const seed =
-        cfg.byokModelId ||
-        `${OPENCODE_FALLBACK_SALT}:${cfg.model}:${cfg.baseURL ?? ''}`;
+        cfg.byokModelId || `${cfg.apiKey}:${cfg.model}:${cfg.baseURL ?? ''}`;
     return createHash('sha256').update(seed).digest('hex').slice(0, 32);
 }
 

--- a/libs/llm/providers/openai/index.ts
+++ b/libs/llm/providers/openai/index.ts
@@ -12,6 +12,7 @@
  * normalizeUsage are declared stubs (Phase 3 owns them).
  */
 import type { LanguageModel } from 'ai';
+import { createHash } from 'crypto';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { z } from 'zod';
@@ -66,13 +67,19 @@ function isOpenCodeGoBaseUrl(baseURL?: string): boolean {
     return !!baseURL && /opencode\.ai\/zen/i.test(baseURL);
 }
 
-/** Stable per BYOK credential (falls back to the model slot's own id, then the
- *  model+baseURL pair, so even a slot missing both still sends a valid header
- *  instead of failing to build the model at all). */
+/**
+ * Stable per BYOK model slot (falls back to the model+baseURL pair when the
+ * slot carries no `byokModelId`, e.g. a managed/env default, so even that case
+ * still sends a valid header instead of failing to build the model at all).
+ *
+ * HASHED rather than sent raw: `byokModelId` is our own internal config-entry
+ * id — OpenCode only needs an opaque value that stays constant call-to-call,
+ * not that actual id, so there is no reason to hand a third party a stable
+ * handle onto our internal identifiers for however long they choose to keep it.
+ */
 function openCodeSessionId(cfg: ProviderBuildConfig): string {
-    return (
-        cfg.credentialId || cfg.byokModelId || `${cfg.model}:${cfg.baseURL ?? ''}`
-    );
+    const seed = cfg.byokModelId || `${cfg.model}:${cfg.baseURL ?? ''}`;
+    return createHash('sha256').update(seed).digest('hex').slice(0, 32);
 }
 
 // The Kimi / Moonshot never-downgrade policy (`isNeverDowngradeModel`) now lives

--- a/libs/llm/providers/openai/index.ts
+++ b/libs/llm/providers/openai/index.ts
@@ -12,7 +12,7 @@
  * normalizeUsage are declared stubs (Phase 3 owns them).
  */
 import type { LanguageModel } from 'ai';
-import { createHash } from 'crypto';
+import { createHash, createHmac } from 'crypto';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { z } from 'zod';
@@ -69,36 +69,53 @@ function isOpenCodeGoBaseUrl(baseURL?: string): boolean {
 
 /**
  * Stable per BYOK model slot, falling back to the resolved CREDENTIAL's id
- * (plus model+baseURL) when the slot carries no `byokModelId` — legacy /
- * pre-v2 BYOK configs and self-hosted env slots (resolve-model-slot.ts only
- * sets `byokModelId` for a v2 `models[]` entry). Every resolved slot needs a
- * `credentialId` to have found its API key at all, so this fallback is at
- * least as available as the primary id.
+ * when the slot carries no `byokModelId`, then to a deployment-scoped HMAC
+ * as the last resort for a slot with NEITHER (self-hosted env/managed mode —
+ * resolve-model-slot.ts only sets both ids for a v2 `models[]` entry, and a
+ * config-based slot can't exist without a credential in the first place).
  *
- * Two rejected-in-review attempts got here:
+ * Three rejected-in-review attempts got here:
  *  1. A process-random salt: changes on every restart/pod rotation (not
  *     "stable"), AND identical for every org sharing the process and landing
  *     on this fallback — doesn't fix the collision it exists to prevent,
  *     since OpenCode Go's baseURL and model catalog are the same for
  *     everyone.
- *  2. The credential's own API KEY: fixed the collision (unique per org,
- *     persisted across restarts) but CodeQL flagged it as "password hash
- *     with insufficient computational effort" — SHA-256 is the wrong tool
- *     for deriving anything from a real secret, however implausible brute-
- *     force actually is here. `credentialId` gives the exact same
- *     persisted-and-unique-per-org properties without hashing secret
- *     material at all: it's an internal id, not a credential.
+ *  2. Hashing the credential's own API KEY: fixed the collision (unique per
+ *     org/deployment, persisted across restarts) but CodeQL flagged it as
+ *     "password hash with insufficient computational effort" — its static
+ *     taint analysis flags ANY `createHash()` fed by a value sourced from
+ *     `apiKey`, full stop, regardless of the fact that the SAME key is
+ *     already sent to OpenCode in cleartext as the request's own Bearer
+ *     token (so the hash itself discloses nothing new to that recipient).
+ *  3. Dropping the key from the last-resort tier entirely (falling straight
+ *     to bare `model:baseURL`): reintroduced exactly the collision (1) was
+ *     meant to fix, since that tier is the one place `credentialId` is
+ *     genuinely absent — a self-hosted install pointing its env vars at
+ *     OpenCode Go, where every "org" in that single-tenant deployment is
+ *     the same customer anyway, but two SEPARATE such deployments sharing
+ *     the same model choice would still collide.
  *
- * HASHED rather than sent raw either way: OpenCode only needs an opaque value
- * that stays constant call-to-call, not our internal id, so there is no
- * reason to hand a third party a stable handle onto it.
+ * The fix: keep secret material out of `createHash()` entirely, but still
+ * use it — as the KEY of an HMAC, which is what a secret is FOR, rather than
+ * as hashed message content. `API_CRYPTO_KEY` (libs/common/utils/crypto.ts)
+ * is already the one persisted, deployment-scoped secret every install
+ * needs for BYOK apiKey encryption, so this reuses it instead of adding a
+ * new env var — unique per self-hosted deployment, stable across restarts,
+ * and outside the specific pattern CodeQL flags.
+ *
+ * HASHED/HMAC'd rather than sent raw either way: OpenCode only needs an
+ * opaque value that stays constant call-to-call, not our internal id, so
+ * there is no reason to hand a third party a stable handle onto it.
  */
 function openCodeSessionId(cfg: ProviderBuildConfig): string {
-    const seed =
-        cfg.byokModelId ||
-        cfg.credentialId ||
-        `${cfg.model}:${cfg.baseURL ?? ''}`;
-    return createHash('sha256').update(seed).digest('hex').slice(0, 32);
+    const id = cfg.byokModelId || cfg.credentialId;
+    if (id) {
+        return createHash('sha256').update(id).digest('hex').slice(0, 32);
+    }
+    return createHmac('sha256', process.env.API_CRYPTO_KEY ?? '')
+        .update(`${cfg.model}:${cfg.baseURL ?? ''}`)
+        .digest('hex')
+        .slice(0, 32);
 }
 
 // The Kimi / Moonshot never-downgrade policy (`isNeverDowngradeModel`) now lives

--- a/libs/llm/providers/openai/index.ts
+++ b/libs/llm/providers/openai/index.ts
@@ -12,7 +12,6 @@
  * normalizeUsage are declared stubs (Phase 3 owns them).
  */
 import type { LanguageModel } from 'ai';
-import { createHash, createHmac } from 'crypto';
 import { createOpenAI } from '@ai-sdk/openai';
 import { createOpenAICompatible } from '@ai-sdk/openai-compatible';
 import { z } from 'zod';
@@ -20,6 +19,7 @@ import {
     openAiCompatibleHonorsJsonSchema,
     isNeverDowngradeModel,
 } from '@libs/llm/structured-output-gate';
+import { isOpenCodeGoBaseUrl, openCodeSessionId } from '@libs/llm/opencode-go';
 import { registerProvider } from '../kernel/registry';
 import { isOpenAiReasoner, openaiReasoningConfig } from './reasoning';
 import { openAiModelListing } from './listing';
@@ -52,97 +52,6 @@ import {
  */
 function isNativeOpenAiModel(model: string): boolean {
     return isOpenAiReasoner(model) || /^(gpt|chatgpt|o[0-9])/i.test(model);
-}
-
-/**
- * OpenCode Go (`opencode.ai/zen/go`) started enforcing an `x-opencode-session`
- * header around 2026-09-06 — a request missing it now gets HTTP 400
- * ("Request is missing x-opencode-session and cannot be routed efficiently")
- * instead of being served, breaking every BYOK review configured against it
- * (issue #1880). Their docs ask for a header that is "stable" per conversation
- * for routing/prompt-cache locality, not a security token, so a deterministic
- * id derived from the resolved slot is enough — no session-tracking plumbing.
- *
- * Exported: `managed-slot.ts`'s self-hosted `openai_compat` case builds its
- * model INLINE (bypassing this module's `build()` entirely — see the comment
- * on `openCodeSessionId` below), so it needs these same two functions to
- * cover that config shape too.
- */
-export function isOpenCodeGoBaseUrl(baseURL?: string): boolean {
-    return !!baseURL && /opencode\.ai\/zen/i.test(baseURL);
-}
-
-/** The handful of `NormalizedModel` fields `openCodeSessionId` actually reads
- *  — narrowed so a caller with no full slot (managed-slot.ts's inline
- *  self-hosted branch has no `byokModelId`/`credentialId` at all) can still
- *  call it without fabricating one. */
-interface OpenCodeSessionInput {
-    model: string;
-    baseURL?: string;
-    byokModelId?: string;
-    credentialId?: string;
-}
-
-/**
- * Stable per BYOK model slot, falling back to the resolved CREDENTIAL's id
- * when the slot carries no `byokModelId`, then to a deployment-scoped HMAC
- * as the last resort for neither — a slot with NO BYOK config at all. Within
- * this module's own `build()`, that last tier is dead: every config-based
- * slot reaching it via byok-to-vercel.ts already carries a `credentialId`
- * (resolve-model-slot.ts can't build one without finding a credential first).
- * It IS reached, though — by `managed-slot.ts`'s self-hosted `openai_compat`
- * case, which builds its `createOpenAICompatible` INLINE and never calls this
- * module's `build()` at all; that is genuinely the one config shape with no
- * BYOK ids whatsoever, so this function is exported for it to call directly.
- *
- * Three rejected-in-review attempts got here:
- *  1. A process-random salt: changes on every restart/pod rotation (not
- *     "stable"), AND identical for every org sharing the process and landing
- *     on this fallback — doesn't fix the collision it exists to prevent,
- *     since OpenCode Go's baseURL and model catalog are the same for
- *     everyone.
- *  2. Hashing the credential's own API KEY: fixed the collision (unique per
- *     org/deployment, persisted across restarts) but CodeQL flagged it as
- *     "password hash with insufficient computational effort" — its static
- *     taint analysis flags ANY `createHash()` fed by a value sourced from
- *     `apiKey`, full stop, regardless of the fact that the SAME key is
- *     already sent to OpenCode in cleartext as the request's own Bearer
- *     token (so the hash itself discloses nothing new to that recipient).
- *  3. Dropping the key from the last-resort tier entirely (falling straight
- *     to bare `model:baseURL`): reintroduced exactly the collision (1) was
- *     meant to fix, since every self-hosted install shares that same bare
- *     seed once it targets the same OpenCode Go model.
- *
- * The fix: keep secret material out of `createHash()` entirely, but still
- * use it — as the KEY of an HMAC, which is what a secret is FOR, rather than
- * as hashed message content. `API_CRYPTO_KEY` (libs/common/utils/crypto.ts)
- * is already the one persisted, deployment-scoped secret every install needs
- * for BYOK apiKey encryption, so this reuses it instead of adding a new env
- * var — unique per self-hosted deployment, stable across restarts, and
- * outside the specific pattern CodeQL flags. REQUIRED, not `?? ''`: a silent
- * empty-string default would be the SAME weak key on every deployment that
- * happens to be missing it, i.e. attempt (3)'s collision again — fail loud
- * instead, matching crypto.ts's own fail-fast contract for this exact var.
- *
- * HASHED/HMAC'd rather than sent raw either way: OpenCode only needs an
- * opaque value that stays constant call-to-call, not our internal id, so
- * there is no reason to hand a third party a stable handle onto it.
- */
-export function openCodeSessionId(cfg: OpenCodeSessionInput): string {
-    const id = cfg.byokModelId || cfg.credentialId;
-    if (id) {
-        return createHash('sha256').update(id).digest('hex').slice(0, 32);
-    }
-    const hmacKey = process.env.API_CRYPTO_KEY;
-    if (!hmacKey) {
-        throw new Error(
-            'API_CRYPTO_KEY is required to derive the OpenCode Go session id',
-        );
-    }
-    return createHmac('sha256', hmacKey)
-        .update(`${cfg.model}:${cfg.baseURL ?? ''}`)
-        .digest('hex')
-        .slice(0, 32);
 }
 
 // The Kimi / Moonshot never-downgrade policy (`isNeverDowngradeModel`) now lives

--- a/libs/llm/providers/openai/openai.spec.ts
+++ b/libs/llm/providers/openai/openai.spec.ts
@@ -254,6 +254,18 @@ describe('openaiModule x-opencode-session header (issue #1880)', () => {
         const model = openaiModule.build(openaiCompatibleCfg) as any;
         expect(model.config.headers()).not.toHaveProperty('x-opencode-session');
     });
+
+    it('the native openai branch (provider "openai") gets the header too when pointed at opencode.ai/zen — it also accepts a baseURL override', () => {
+        const model = openaiModule.build({
+            provider: 'openai',
+            model: 'gpt-4o-mini',
+            apiKey: 'test-key',
+            baseURL: 'https://opencode.ai/zen/go/v1',
+            byokModelId: 'model-123',
+        } as any) as any;
+
+        expect(model.config.headers()['x-opencode-session']).toMatch(HEX32);
+    });
 });
 
 describe('openaiModule offline conformance (real boundary: build → SDK → normalize)', () => {

--- a/libs/llm/providers/openai/openai.spec.ts
+++ b/libs/llm/providers/openai/openai.spec.ts
@@ -162,6 +162,51 @@ describe('openaiModule never-downgrade capability (D-00b, Pitfall 2)', () => {
     });
 });
 
+describe('openaiModule x-opencode-session header (issue #1880)', () => {
+    it('opencode.ai/zen baseURL gets a stable x-opencode-session header derived from the credential', () => {
+        const cfg = {
+            provider: 'openai_compatible',
+            model: 'deepseek-v4-flash',
+            apiKey: 'test-key',
+            baseURL: 'https://opencode.ai/zen/go/v1',
+            credentialId: 'cred-123',
+        } as any;
+
+        const model = openaiModule.build(cfg) as any;
+        const headers = model.config.headers();
+
+        expect(headers['x-opencode-session']).toBe('cred-123');
+    });
+
+    it('falls back to byokModelId, then model+baseURL, when no credentialId is present', () => {
+        const withModelId = openaiModule.build({
+            provider: 'openai_compatible',
+            model: 'deepseek-v4-flash',
+            apiKey: 'test-key',
+            baseURL: 'https://opencode.ai/zen/go/v1',
+            byokModelId: 'model-456',
+        } as any) as any;
+        expect(withModelId.config.headers()['x-opencode-session']).toBe(
+            'model-456',
+        );
+
+        const withNeither = openaiModule.build({
+            provider: 'openai_compatible',
+            model: 'deepseek-v4-flash',
+            apiKey: 'test-key',
+            baseURL: 'https://opencode.ai/zen/go/v1',
+        } as any) as any;
+        expect(withNeither.config.headers()['x-opencode-session']).toBe(
+            'deepseek-v4-flash:https://opencode.ai/zen/go/v1',
+        );
+    });
+
+    it('a non-OpenCode openai_compatible upstream never gets the header', () => {
+        const model = openaiModule.build(openaiCompatibleCfg) as any;
+        expect(model.config.headers()).not.toHaveProperty('x-opencode-session');
+    });
+});
+
 describe('openaiModule offline conformance (real boundary: build → SDK → normalize)', () => {
     it('openai_compatible reasoning fixture: SDK-shaped result splits reasoning, output not reduced', async () => {
         const run = await runConformance(

--- a/libs/llm/providers/openai/openai.spec.ts
+++ b/libs/llm/providers/openai/openai.spec.ts
@@ -163,22 +163,57 @@ describe('openaiModule never-downgrade capability (D-00b, Pitfall 2)', () => {
 });
 
 describe('openaiModule x-opencode-session header (issue #1880)', () => {
-    it('opencode.ai/zen baseURL gets a stable x-opencode-session header derived from the credential', () => {
+    const HEX32 = /^[0-9a-f]{32}$/;
+
+    it('opencode.ai/zen baseURL gets a hashed, stable x-opencode-session header — never the raw byokModelId', () => {
         const cfg = {
             provider: 'openai_compatible',
             model: 'deepseek-v4-flash',
             apiKey: 'test-key',
             baseURL: 'https://opencode.ai/zen/go/v1',
-            credentialId: 'cred-123',
+            byokModelId: 'model-123',
         } as any;
 
-        const model = openaiModule.build(cfg) as any;
-        const headers = model.config.headers();
+        const headerA = (openaiModule.build(cfg) as any).config.headers()[
+            'x-opencode-session'
+        ];
+        const headerB = (openaiModule.build(cfg) as any).config.headers()[
+            'x-opencode-session'
+        ];
 
-        expect(headers['x-opencode-session']).toBe('cred-123');
+        expect(headerA).toMatch(HEX32);
+        expect(headerA).not.toBe('model-123');
+        expect(headerA).not.toContain('model-123');
+        // Stable across independent build() calls for the same slot.
+        expect(headerA).toBe(headerB);
     });
 
-    it('falls back to byokModelId, then model+baseURL, when no credentialId is present', () => {
+    it('a different byokModelId hashes to a different session id', () => {
+        const build = (byokModelId: string) =>
+            (
+                openaiModule.build({
+                    provider: 'openai_compatible',
+                    model: 'deepseek-v4-flash',
+                    apiKey: 'test-key',
+                    baseURL: 'https://opencode.ai/zen/go/v1',
+                    byokModelId,
+                } as any) as any
+            ).config.headers()['x-opencode-session'];
+
+        expect(build('model-123')).not.toBe(build('model-456'));
+    });
+
+    it('falls back to model+baseURL when no byokModelId is present (managed/env slot) — still hashed', () => {
+        const withoutModelId = openaiModule.build({
+            provider: 'openai_compatible',
+            model: 'deepseek-v4-flash',
+            apiKey: 'test-key',
+            baseURL: 'https://opencode.ai/zen/go/v1',
+        } as any) as any;
+        expect(withoutModelId.config.headers()['x-opencode-session']).toMatch(
+            HEX32,
+        );
+
         const withModelId = openaiModule.build({
             provider: 'openai_compatible',
             model: 'deepseek-v4-flash',
@@ -186,18 +221,8 @@ describe('openaiModule x-opencode-session header (issue #1880)', () => {
             baseURL: 'https://opencode.ai/zen/go/v1',
             byokModelId: 'model-456',
         } as any) as any;
-        expect(withModelId.config.headers()['x-opencode-session']).toBe(
-            'model-456',
-        );
-
-        const withNeither = openaiModule.build({
-            provider: 'openai_compatible',
-            model: 'deepseek-v4-flash',
-            apiKey: 'test-key',
-            baseURL: 'https://opencode.ai/zen/go/v1',
-        } as any) as any;
-        expect(withNeither.config.headers()['x-opencode-session']).toBe(
-            'deepseek-v4-flash:https://opencode.ai/zen/go/v1',
+        expect(withoutModelId.config.headers()['x-opencode-session']).not.toBe(
+            withModelId.config.headers()['x-opencode-session'],
         );
     });
 

--- a/libs/llm/providers/openai/openai.spec.ts
+++ b/libs/llm/providers/openai/openai.spec.ts
@@ -291,6 +291,26 @@ describe('openaiModule x-opencode-session header (issue #1880)', () => {
 
         expect(model.config.headers()['x-opencode-session']).toMatch(HEX32);
     });
+
+    it('the native openai branch does NOT get the header for non-OpenCode baseURLs (default and Azure/proxy overrides)', () => {
+        for (const baseURL of [
+            undefined,
+            'https://api.openai.com/v1',
+            'https://my-proxy.example/openai',
+        ]) {
+            const model = openaiModule.build({
+                provider: 'openai',
+                model: 'gpt-4o-mini',
+                apiKey: 'test-key',
+                ...(baseURL ? { baseURL } : {}),
+                byokModelId: 'model-123',
+            } as any) as any;
+
+            expect(model.config.headers()).not.toHaveProperty(
+                'x-opencode-session',
+            );
+        }
+    });
 });
 
 describe('openaiModule offline conformance (real boundary: build → SDK → normalize)', () => {

--- a/libs/llm/providers/openai/openai.spec.ts
+++ b/libs/llm/providers/openai/openai.spec.ts
@@ -227,27 +227,52 @@ describe('openaiModule x-opencode-session header (issue #1880)', () => {
         expect(buildFallback('cred-a')).not.toContain('cred-a');
     });
 
-    it('falls back to model+baseURL only when BOTH byokModelId and credentialId are absent (managed/env slot) — still hashed', () => {
-        const withNeither = openaiModule.build({
-            provider: 'openai_compatible',
-            model: 'deepseek-v4-flash',
-            apiKey: 'test-key',
-            baseURL: 'https://opencode.ai/zen/go/v1',
-        } as any) as any;
-        expect(withNeither.config.headers()['x-opencode-session']).toMatch(
-            HEX32,
-        );
+    describe('last-resort fallback (neither byokModelId nor credentialId — self-hosted env/managed slot)', () => {
+        const buildNeither = () =>
+            (
+                openaiModule.build({
+                    provider: 'openai_compatible',
+                    model: 'deepseek-v4-flash',
+                    apiKey: 'test-key',
+                    baseURL: 'https://opencode.ai/zen/go/v1',
+                } as any) as any
+            ).config.headers()['x-opencode-session'];
 
-        const withCredentialId = openaiModule.build({
-            provider: 'openai_compatible',
-            model: 'deepseek-v4-flash',
-            apiKey: 'test-key',
-            baseURL: 'https://opencode.ai/zen/go/v1',
-            credentialId: 'cred-456',
-        } as any) as any;
-        expect(withNeither.config.headers()['x-opencode-session']).not.toBe(
-            withCredentialId.config.headers()['x-opencode-session'],
-        );
+        const originalCryptoKey = process.env.API_CRYPTO_KEY;
+        afterEach(() => {
+            process.env.API_CRYPTO_KEY = originalCryptoKey;
+        });
+
+        it('is HMAC-derived (hashed, distinct from a config carrying credentialId)', () => {
+            const withNeither = buildNeither();
+            expect(withNeither).toMatch(HEX32);
+
+            const withCredentialId = (
+                openaiModule.build({
+                    provider: 'openai_compatible',
+                    model: 'deepseek-v4-flash',
+                    apiKey: 'test-key',
+                    baseURL: 'https://opencode.ai/zen/go/v1',
+                    credentialId: 'cred-456',
+                } as any) as any
+            ).config.headers()['x-opencode-session'];
+            expect(withNeither).not.toBe(withCredentialId);
+        });
+
+        it('is stable across builds for the same deployment (same API_CRYPTO_KEY)', () => {
+            process.env.API_CRYPTO_KEY = 'deployment-a-key';
+            expect(buildNeither()).toBe(buildNeither());
+        });
+
+        it('differs across deployments (different API_CRYPTO_KEY) even with identical model+baseURL — the collision two prior review rounds flagged', () => {
+            process.env.API_CRYPTO_KEY = 'deployment-a-key';
+            const deploymentA = buildNeither();
+
+            process.env.API_CRYPTO_KEY = 'deployment-b-key';
+            const deploymentB = buildNeither();
+
+            expect(deploymentA).not.toBe(deploymentB);
+        });
     });
 
     it('a non-OpenCode openai_compatible upstream never gets the header', () => {

--- a/libs/llm/providers/openai/openai.spec.ts
+++ b/libs/llm/providers/openai/openai.spec.ts
@@ -9,6 +9,7 @@
  * RED-first: written against the openai.module.ts:114-119 zero stub — the reasoning
  * assertions fail until normalize/normalizeUsage extract real values.
  */
+import { createHash } from 'crypto';
 import { openaiModule } from './index';
 import { runConformance, type ProviderFixture } from '../kernel/conformance';
 import reasoningFixture from './__fixtures__/reasoning.json';
@@ -224,6 +225,30 @@ describe('openaiModule x-opencode-session header (issue #1880)', () => {
         expect(withoutModelId.config.headers()['x-opencode-session']).not.toBe(
             withModelId.config.headers()['x-opencode-session'],
         );
+    });
+
+    it('the fallback seed is NOT the bare model+baseURL hash — a per-process salt is mixed in so two orgs sharing model+baseURL never collide across processes', () => {
+        const fallbackCfg = {
+            provider: 'openai_compatible',
+            model: 'deepseek-v4-flash',
+            apiKey: 'test-key',
+            baseURL: 'https://opencode.ai/zen/go/v1',
+        } as any;
+
+        const actual = (openaiModule.build(fallbackCfg) as any).config.headers()[
+            'x-opencode-session'
+        ];
+        const unsalted = createHash('sha256')
+            .update('deepseek-v4-flash:https://opencode.ai/zen/go/v1')
+            .digest('hex')
+            .slice(0, 32);
+
+        expect(actual).not.toBe(unsalted);
+        // Still stable across repeated builds within the same process.
+        const again = (openaiModule.build(fallbackCfg) as any).config.headers()[
+            'x-opencode-session'
+        ];
+        expect(actual).toBe(again);
     });
 
     it('a non-OpenCode openai_compatible upstream never gets the header', () => {

--- a/libs/llm/providers/openai/openai.spec.ts
+++ b/libs/llm/providers/openai/openai.spec.ts
@@ -9,7 +9,6 @@
  * RED-first: written against the openai.module.ts:114-119 zero stub — the reasoning
  * assertions fail until normalize/normalizeUsage extract real values.
  */
-import { createHash } from 'crypto';
 import { openaiModule } from './index';
 import { runConformance, type ProviderFixture } from '../kernel/conformance';
 import reasoningFixture from './__fixtures__/reasoning.json';
@@ -204,53 +203,51 @@ describe('openaiModule x-opencode-session header (issue #1880)', () => {
         expect(build('model-123')).not.toBe(build('model-456'));
     });
 
-    it('falls back to model+baseURL when no byokModelId is present (managed/env slot) — still hashed', () => {
-        const withoutModelId = openaiModule.build({
-            provider: 'openai_compatible',
-            model: 'deepseek-v4-flash',
-            apiKey: 'test-key',
-            baseURL: 'https://opencode.ai/zen/go/v1',
-        } as any) as any;
-        expect(withoutModelId.config.headers()['x-opencode-session']).toMatch(
-            HEX32,
-        );
-
-        const withModelId = openaiModule.build({
-            provider: 'openai_compatible',
-            model: 'deepseek-v4-flash',
-            apiKey: 'test-key',
-            baseURL: 'https://opencode.ai/zen/go/v1',
-            byokModelId: 'model-456',
-        } as any) as any;
-        expect(withoutModelId.config.headers()['x-opencode-session']).not.toBe(
-            withModelId.config.headers()['x-opencode-session'],
-        );
-    });
-
-    it('the fallback seed includes the credential apiKey — two orgs sharing model+baseURL never collide', () => {
-        const buildFallback = (apiKey: string) =>
+    it('falls back to credentialId when no byokModelId is present — two orgs sharing model+baseURL never collide, and never the raw credentialId', () => {
+        const buildFallback = (credentialId: string) =>
             (
                 openaiModule.build({
                     provider: 'openai_compatible',
                     model: 'deepseek-v4-flash',
-                    apiKey,
+                    apiKey: 'test-key',
                     baseURL: 'https://opencode.ai/zen/go/v1',
+                    credentialId,
                 } as any) as any
             ).config.headers()['x-opencode-session'];
 
-        // Different org (different key) → different session id, even though
-        // model + baseURL are identical (the OpenCode Go norm).
-        expect(buildFallback('org-a-key')).not.toBe(buildFallback('org-b-key'));
+        // Different org (different credential) → different session id, even
+        // though model + baseURL are identical (the OpenCode Go norm).
+        expect(buildFallback('cred-a')).not.toBe(buildFallback('cred-b'));
 
-        // Same org's key → the SAME id every time (persisted, not process state).
-        expect(buildFallback('org-a-key')).toBe(buildFallback('org-a-key'));
+        // Same org's credential → the SAME id every time (persisted, not
+        // process state).
+        expect(buildFallback('cred-a')).toBe(buildFallback('cred-a'));
+        expect(buildFallback('cred-a')).toMatch(HEX32);
+        expect(buildFallback('cred-a')).not.toBe('cred-a');
+        expect(buildFallback('cred-a')).not.toContain('cred-a');
+    });
 
-        // Still not the bare, key-less model+baseURL hash.
-        const unsalted = createHash('sha256')
-            .update('deepseek-v4-flash:https://opencode.ai/zen/go/v1')
-            .digest('hex')
-            .slice(0, 32);
-        expect(buildFallback('org-a-key')).not.toBe(unsalted);
+    it('falls back to model+baseURL only when BOTH byokModelId and credentialId are absent (managed/env slot) — still hashed', () => {
+        const withNeither = openaiModule.build({
+            provider: 'openai_compatible',
+            model: 'deepseek-v4-flash',
+            apiKey: 'test-key',
+            baseURL: 'https://opencode.ai/zen/go/v1',
+        } as any) as any;
+        expect(withNeither.config.headers()['x-opencode-session']).toMatch(
+            HEX32,
+        );
+
+        const withCredentialId = openaiModule.build({
+            provider: 'openai_compatible',
+            model: 'deepseek-v4-flash',
+            apiKey: 'test-key',
+            baseURL: 'https://opencode.ai/zen/go/v1',
+            credentialId: 'cred-456',
+        } as any) as any;
+        expect(withNeither.config.headers()['x-opencode-session']).not.toBe(
+            withCredentialId.config.headers()['x-opencode-session'],
+        );
     });
 
     it('a non-OpenCode openai_compatible upstream never gets the header', () => {

--- a/libs/llm/providers/openai/openai.spec.ts
+++ b/libs/llm/providers/openai/openai.spec.ts
@@ -227,28 +227,30 @@ describe('openaiModule x-opencode-session header (issue #1880)', () => {
         );
     });
 
-    it('the fallback seed is NOT the bare model+baseURL hash — a per-process salt is mixed in so two orgs sharing model+baseURL never collide across processes', () => {
-        const fallbackCfg = {
-            provider: 'openai_compatible',
-            model: 'deepseek-v4-flash',
-            apiKey: 'test-key',
-            baseURL: 'https://opencode.ai/zen/go/v1',
-        } as any;
+    it('the fallback seed includes the credential apiKey — two orgs sharing model+baseURL never collide', () => {
+        const buildFallback = (apiKey: string) =>
+            (
+                openaiModule.build({
+                    provider: 'openai_compatible',
+                    model: 'deepseek-v4-flash',
+                    apiKey,
+                    baseURL: 'https://opencode.ai/zen/go/v1',
+                } as any) as any
+            ).config.headers()['x-opencode-session'];
 
-        const actual = (openaiModule.build(fallbackCfg) as any).config.headers()[
-            'x-opencode-session'
-        ];
+        // Different org (different key) → different session id, even though
+        // model + baseURL are identical (the OpenCode Go norm).
+        expect(buildFallback('org-a-key')).not.toBe(buildFallback('org-b-key'));
+
+        // Same org's key → the SAME id every time (persisted, not process state).
+        expect(buildFallback('org-a-key')).toBe(buildFallback('org-a-key'));
+
+        // Still not the bare, key-less model+baseURL hash.
         const unsalted = createHash('sha256')
             .update('deepseek-v4-flash:https://opencode.ai/zen/go/v1')
             .digest('hex')
             .slice(0, 32);
-
-        expect(actual).not.toBe(unsalted);
-        // Still stable across repeated builds within the same process.
-        const again = (openaiModule.build(fallbackCfg) as any).config.headers()[
-            'x-opencode-session'
-        ];
-        expect(actual).toBe(again);
+        expect(buildFallback('org-a-key')).not.toBe(unsalted);
     });
 
     it('a non-OpenCode openai_compatible upstream never gets the header', () => {


### PR DESCRIPTION
## Summary
- OpenCode Go (`opencode.ai/zen/go`) started enforcing the `x-opencode-session` header around 2026-09-06 — any request missing it now gets HTTP 400 (`"Request is missing x-opencode-session and cannot be routed efficiently"`) instead of being served, breaking every BYOK review configured against it as an `openai_compatible` provider.
- Detects the OpenCode Go base URL in `openaiModule.build()` and attaches a stable session id derived from the resolved slot (`credentialId` → `byokModelId` → `model:baseURL`), so the header is always present without adding any new session-tracking plumbing. No other `openai_compatible` upstream is affected.

Fixes #1880

## Test plan
- [x] `openai.spec.ts` — 3 new tests: header value for a `credentialId`-bearing slot, the fallback chain, and that non-OpenCode upstreams never get the header
- [x] Full `openai.spec.ts` suite (17 tests) passes
- [x] `npx eslint` clean on the touched files
- [x] No new TypeScript errors in the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ktd7T9eqAWCuEjD917KKc