### PR TITLE
fix(platformData): cap embedded diffs below MongoDB's 16MB BSON ceiling (#1841)

### DIFF
--- a/libs/platformData/domain/pullRequests/contracts/pullRequests.repository.ts
+++ b/libs/platformData/domain/pullRequests/contracts/pullRequests.repository.ts
@@ -236,6 +236,17 @@ export interface IPullRequestsRepository {
         totalChanges: number;
     }>;
 
+    /**
+     * Server-side sum of the UTF-8 bytes embedded in `files[].patch` for one
+     * PR (`$strLenBytes`). Lets the caller enforce the aggregate embedded-diff
+     * budget against ground truth after a write instead of trusting a
+     * potentially stale in-memory read of `existingPR.files` (#1841).
+     */
+    computeEmbeddedPatchBytes(
+        prUuid: string,
+        organizationId: string,
+    ): Promise<number>;
+
     /** Generates a stable id for file/suggestion sub-documents. */
     newSubDocumentId(): string;
 

--- a/libs/platformData/domain/pullRequests/interfaces/pullRequests.interface.ts
+++ b/libs/platformData/domain/pullRequests/interfaces/pullRequests.interface.ts
@@ -193,6 +193,13 @@ export interface IFile {
         generateSuggestions: string;
         safeguard: string;
     };
+    // Unified diff persisted for review context. Written at save-time and
+    // consume a shared aggregate budget so the PR document stays under
+    // MongoDB's 16 MB BSON ceiling; `patchTruncated` marks a diff that was
+    // capped (the patch carries a trailing marker) rather than persisted whole
+    // (#1841).
+    patch?: string;
+    patchTruncated?: boolean;
 }
 
 export interface IPullRequestUser {

--- a/libs/platformData/domain/pullRequests/utils/diff-budget.spec.ts
+++ b/libs/platformData/domain/pullRequests/utils/diff-budget.spec.ts
@@ -1,18 +1,30 @@
 import {
-    MAX_PATCH_CHARS_PER_FILE,
-    MAX_TOTAL_EMBEDDED_PATCH_CHARS,
+    MAX_PATCH_BYTES_PER_FILE,
+    MAX_TOTAL_EMBEDDED_PATCH_BYTES,
     TRUNCATED_DIFF_MARKER,
     budgetPatchForPersist,
     clampPatchForPersist,
+    clampPatchForPersistWithFlag,
+    utf8ByteLength,
 } from './diff-budget';
 
 describe('diff-budget (#1841)', () => {
+    describe('utf8ByteLength', () => {
+        it('counts UTF-8 bytes, not UTF-16 code units', () => {
+            expect(utf8ByteLength('abc')).toBe(3);
+            // CJK: 3 bytes per char in UTF-8, 1 code unit in UTF-16.
+            expect(utf8ByteLength('漢字')).toBe(6);
+            // Emoji outside the BMP: 4 bytes, 2 UTF-16 code units.
+            expect(utf8ByteLength('😀')).toBe(4);
+        });
+    });
+
     describe('budgetPatchForPersist', () => {
         it('passes a patch that fits the per-file cap through unchanged', () => {
             const patch = 'x'.repeat(1000);
             const result = budgetPatchForPersist(
                 patch,
-                MAX_TOTAL_EMBEDDED_PATCH_CHARS,
+                MAX_TOTAL_EMBEDDED_PATCH_BYTES,
             );
             expect(result.patch).toBe(patch);
             expect(result.truncated).toBe(false);
@@ -27,19 +39,43 @@ describe('diff-budget (#1841)', () => {
         });
 
         it('truncates a patch that exceeds the per-file cap, keeping a leading window plus the marker', () => {
-            const patch = 'h'.repeat(MAX_PATCH_CHARS_PER_FILE + 50_000);
+            const patch = 'h'.repeat(MAX_PATCH_BYTES_PER_FILE + 50_000);
             const result = budgetPatchForPersist(
                 patch,
-                MAX_TOTAL_EMBEDDED_PATCH_CHARS,
+                MAX_TOTAL_EMBEDDED_PATCH_BYTES,
             );
             expect(result.truncated).toBe(true);
-            expect(result.patch.length).toBeLessThanOrEqual(
-                MAX_PATCH_CHARS_PER_FILE,
+            expect(utf8ByteLength(result.patch)).toBeLessThanOrEqual(
+                MAX_PATCH_BYTES_PER_FILE,
             );
             // the marker is present and the leading bytes survived
             expect(result.patch.endsWith(TRUNCATED_DIFF_MARKER)).toBe(true);
             expect(result.patch.startsWith('h'.repeat(100))).toBe(true);
-            expect(result.consumed).toBe(result.patch.length);
+            expect(result.consumed).toBe(utf8ByteLength(result.patch));
+        });
+
+        it('keeps the produced patch within the byte allocation for multibyte (CJK) diffs', () => {
+            // A char-count budget would let this through: `.length` is a third
+            // of the real byte size, so a 3-byte/char diff measured in UTF-16
+            // units understates its BSON footprint by ~3x.
+            const cjk = '漢'.repeat(MAX_PATCH_BYTES_PER_FILE); // 3x the cap in bytes
+            const result = budgetPatchForPersist(cjk, MAX_PATCH_BYTES_PER_FILE);
+            expect(result.truncated).toBe(true);
+            expect(utf8ByteLength(result.patch)).toBeLessThanOrEqual(
+                MAX_PATCH_BYTES_PER_FILE,
+            );
+            expect(result.patch.endsWith(TRUNCATED_DIFF_MARKER)).toBe(true);
+            expect(result.consumed).toBe(utf8ByteLength(result.patch));
+        });
+
+        it('never splits a surrogate pair when truncating', () => {
+            const emoji = '😀'.repeat(MAX_PATCH_BYTES_PER_FILE); // 4 bytes each
+            const result = budgetPatchForPersist(emoji, 1000);
+            // No lone surrogate may survive: the body must round-trip cleanly.
+            expect(
+                /[\uD800-\uDBFF](?![\uDC00-\uDFFF])/.test(result.patch),
+            ).toBe(false);
+            expect(utf8ByteLength(result.patch)).toBeLessThanOrEqual(1000);
         });
 
         it('respects a tight remaining aggregate budget even for one patch', () => {
@@ -47,7 +83,7 @@ describe('diff-budget (#1841)', () => {
             const remaining = 2000;
             const result = budgetPatchForPersist(patch, remaining);
             expect(result.truncated).toBe(true);
-            expect(result.patch.length).toBeLessThanOrEqual(remaining);
+            expect(utf8ByteLength(result.patch)).toBeLessThanOrEqual(remaining);
         });
 
         it('drops the diff when even the marker no longer fits the remaining budget', () => {
@@ -73,7 +109,10 @@ describe('diff-budget (#1841)', () => {
             const big = 'a'.repeat(300_000); // > per-file cap
             const r1 = budgetPatchForPersist(big, 500_000);
             expect(r1.truncated).toBe(true);
-            const r2 = budgetPatchForPersist('b'.repeat(500_000), 500_000 - r1.consumed);
+            const r2 = budgetPatchForPersist(
+                'b'.repeat(500_000),
+                500_000 - r1.consumed,
+            );
             expect(r2.truncated).toBe(true);
             expect(r1.consumed + r2.consumed).toBeLessThanOrEqual(500_000);
         });
@@ -81,14 +120,39 @@ describe('diff-budget (#1841)', () => {
 
     describe('clampPatchForPersist', () => {
         it('passes a small patch through unchanged', () => {
-            const patch = 'y'.repeat(MAX_PATCH_CHARS_PER_FILE - 1);
+            const patch = 'y'.repeat(MAX_PATCH_BYTES_PER_FILE - 1);
             expect(clampPatchForPersist(patch)).toBe(patch);
         });
 
         it('truncates an oversized patch and appends the marker', () => {
-            const clamped = clampPatchForPersist('y'.repeat(MAX_PATCH_CHARS_PER_FILE * 2));
-            expect(clamped.length).toBeLessThanOrEqual(MAX_PATCH_CHARS_PER_FILE);
+            const clamped = clampPatchForPersist(
+                'y'.repeat(MAX_PATCH_BYTES_PER_FILE * 2),
+            );
+            expect(utf8ByteLength(clamped)).toBeLessThanOrEqual(
+                MAX_PATCH_BYTES_PER_FILE,
+            );
             expect(clamped.endsWith(TRUNCATED_DIFF_MARKER)).toBe(true);
+        });
+
+        it('clamps by bytes for a multibyte patch', () => {
+            const clamped = clampPatchForPersist(
+                '漢'.repeat(MAX_PATCH_BYTES_PER_FILE),
+            );
+            expect(utf8ByteLength(clamped)).toBeLessThanOrEqual(
+                MAX_PATCH_BYTES_PER_FILE,
+            );
+            expect(clamped.endsWith(TRUNCATED_DIFF_MARKER)).toBe(true);
+        });
+
+        it('reports the truncation flag so the repository can mirror it', () => {
+            expect(clampPatchForPersistWithFlag('y'.repeat(10)).truncated).toBe(
+                false,
+            );
+            const clamped = clampPatchForPersistWithFlag(
+                'y'.repeat(MAX_PATCH_BYTES_PER_FILE * 2),
+            );
+            expect(clamped.truncated).toBe(true);
+            expect(clamped.patch.endsWith(TRUNCATED_DIFF_MARKER)).toBe(true);
         });
     });
 });

--- a/libs/platformData/domain/pullRequests/utils/diff-budget.spec.ts
+++ b/libs/platformData/domain/pullRequests/utils/diff-budget.spec.ts
@@ -1,0 +1,94 @@
+import {
+    MAX_PATCH_CHARS_PER_FILE,
+    MAX_TOTAL_EMBEDDED_PATCH_CHARS,
+    TRUNCATED_DIFF_MARKER,
+    budgetPatchForPersist,
+    clampPatchForPersist,
+} from './diff-budget';
+
+describe('diff-budget (#1841)', () => {
+    describe('budgetPatchForPersist', () => {
+        it('passes a patch that fits the per-file cap through unchanged', () => {
+            const patch = 'x'.repeat(1000);
+            const result = budgetPatchForPersist(
+                patch,
+                MAX_TOTAL_EMBEDDED_PATCH_CHARS,
+            );
+            expect(result.patch).toBe(patch);
+            expect(result.truncated).toBe(false);
+            expect(result.consumed).toBe(1000);
+        });
+
+        it('passes through an empty patch with zero cost', () => {
+            const result = budgetPatchForPersist('', 100);
+            expect(result.patch).toBe('');
+            expect(result.truncated).toBe(false);
+            expect(result.consumed).toBe(0);
+        });
+
+        it('truncates a patch that exceeds the per-file cap, keeping a leading window plus the marker', () => {
+            const patch = 'h'.repeat(MAX_PATCH_CHARS_PER_FILE + 50_000);
+            const result = budgetPatchForPersist(
+                patch,
+                MAX_TOTAL_EMBEDDED_PATCH_CHARS,
+            );
+            expect(result.truncated).toBe(true);
+            expect(result.patch.length).toBeLessThanOrEqual(
+                MAX_PATCH_CHARS_PER_FILE,
+            );
+            // the marker is present and the leading bytes survived
+            expect(result.patch.endsWith(TRUNCATED_DIFF_MARKER)).toBe(true);
+            expect(result.patch.startsWith('h'.repeat(100))).toBe(true);
+            expect(result.consumed).toBe(result.patch.length);
+        });
+
+        it('respects a tight remaining aggregate budget even for one patch', () => {
+            const patch = 'z'.repeat(10_000);
+            const remaining = 2000;
+            const result = budgetPatchForPersist(patch, remaining);
+            expect(result.truncated).toBe(true);
+            expect(result.patch.length).toBeLessThanOrEqual(remaining);
+        });
+
+        it('drops the diff when even the marker no longer fits the remaining budget', () => {
+            const patch = 'z'.repeat(10_000);
+            const result = budgetPatchForPersist(patch, 10);
+            expect(result).toEqual({
+                patch: '',
+                truncated: true,
+                consumed: 0,
+            });
+        });
+
+        it('drops the diff when the aggregate budget is already exhausted', () => {
+            const result = budgetPatchForPersist('z'.repeat(100), 0);
+            expect(result).toEqual({
+                patch: '',
+                truncated: true,
+                consumed: 0,
+            });
+        });
+
+        it('keeps the cumulative consumed sum within the aggregate budget', () => {
+            const big = 'a'.repeat(300_000); // > per-file cap
+            const r1 = budgetPatchForPersist(big, 500_000);
+            expect(r1.truncated).toBe(true);
+            const r2 = budgetPatchForPersist('b'.repeat(500_000), 500_000 - r1.consumed);
+            expect(r2.truncated).toBe(true);
+            expect(r1.consumed + r2.consumed).toBeLessThanOrEqual(500_000);
+        });
+    });
+
+    describe('clampPatchForPersist', () => {
+        it('passes a small patch through unchanged', () => {
+            const patch = 'y'.repeat(MAX_PATCH_CHARS_PER_FILE - 1);
+            expect(clampPatchForPersist(patch)).toBe(patch);
+        });
+
+        it('truncates an oversized patch and appends the marker', () => {
+            const clamped = clampPatchForPersist('y'.repeat(MAX_PATCH_CHARS_PER_FILE * 2));
+            expect(clamped.length).toBeLessThanOrEqual(MAX_PATCH_CHARS_PER_FILE);
+            expect(clamped.endsWith(TRUNCATED_DIFF_MARKER)).toBe(true);
+        });
+    });
+});

--- a/libs/platformData/domain/pullRequests/utils/diff-budget.ts
+++ b/libs/platformData/domain/pullRequests/utils/diff-budget.ts
@@ -1,0 +1,80 @@
+// Budgets for the unified diffs that get embedded into the `pullRequests`
+// MongoDB document via `files[].patch`. MongoDB hard-caps a single BSON
+// document at 16 MB (16_777_216 bytes). A PR that accumulates many large file
+// patches (release/promotion PRs, big refactors) pushes the embedded array past
+// that ceiling; the persist then throws `MongoBulkWriteError ... larger than
+// 16777216`, and the review fails with a misleading "Unable to load or resolve
+// the review configuration" instead of a diff-aware result (#1841).
+//
+// These constants bound the embedded diff payload so the document stays well
+// under the cap, degrading diff coverage (with a visible truncation marker on
+// the affected file) rather than failing the whole review.
+export const MAX_PATCH_CHARS_PER_FILE = 200_000;
+
+// Headroom budget below the 16 MB BSON ceiling reserved for the rest of the
+// document (suggestions, commits, metadata). 8 MB of embedded diffs leaves
+// ample room for the non-diff payload even on very large PRs.
+export const MAX_TOTAL_EMBEDDED_PATCH_CHARS = 8_000_000;
+
+// Appended to a truncated diff body so downstream code and the reviewing LLM
+// can tell the diff was capped rather than silently treating it as complete.
+export const TRUNCATED_DIFF_MARKER =
+    '\n---\n// diff truncated: the embedded-diff budget was exceeded; run the review with a narrower diff (e.g. per-commit) or split the PR into smaller PRs.\n';
+
+export interface PatchBudgetResult {
+    patch: string;
+    truncated: boolean;
+    consumed: number;
+}
+
+/**
+ * Cap a single patch to `MAX_PATCH_CHARS_PER_FILE` and to the caller's
+ * remaining aggregate budget. Returns the patch to persist (optionally a
+ * leading window of the original plus `TRUNCATED_DIFF_MARKER`), whether it was
+ * truncated, and how many characters of the aggregate budget it consumed.
+ *
+ * When even the marker would not fit (aggregate budget exhausted for this
+ * file), the patch is dropped entirely — the file still persists with its
+ * metadata/suggestions and is filtered out of diff-based review downstream.
+ */
+export function budgetPatchForPersist(
+    patch: string,
+    remainingTotalBudget: number,
+): PatchBudgetResult {
+    if (!patch) {
+        return { patch: '', truncated: false, consumed: 0 };
+    }
+    const allowance = Math.min(
+        MAX_PATCH_CHARS_PER_FILE,
+        Math.max(0, remainingTotalBudget),
+    );
+    if (patch.length <= allowance) {
+        return { patch, truncated: false, consumed: patch.length };
+    }
+    if (allowance < TRUNCATED_DIFF_MARKER.length) {
+        return { patch: '', truncated: true, consumed: 0 };
+    }
+    const bodyLen = allowance - TRUNCATED_DIFF_MARKER.length;
+    return {
+        patch: `${patch.slice(0, bodyLen)}${TRUNCATED_DIFF_MARKER}`,
+        truncated: true,
+        consumed: allowance,
+    };
+}
+
+/**
+ * Last-resort clamp applied in the repository: no single `files[].patch`
+ * written by any path may exceed `MAX_PATCH_CHARS_PER_FILE`, so a future
+ * caller that bypasses the service-level aggregate budget can never embed an
+ * unbounded patch on its own.
+ */
+export function clampPatchForPersist(patch: string): string {
+    if (patch.length <= MAX_PATCH_CHARS_PER_FILE) {
+        return patch;
+    }
+    if (MAX_PATCH_CHARS_PER_FILE <= TRUNCATED_DIFF_MARKER.length) {
+        return '';
+    }
+    const bodyLen = MAX_PATCH_CHARS_PER_FILE - TRUNCATED_DIFF_MARKER.length;
+    return `${patch.slice(0, bodyLen)}${TRUNCATED_DIFF_MARKER}`;
+}

--- a/libs/platformData/domain/pullRequests/utils/diff-budget.ts
+++ b/libs/platformData/domain/pullRequests/utils/diff-budget.ts
@@ -9,17 +9,75 @@
 // These constants bound the embedded diff payload so the document stays well
 // under the cap, degrading diff coverage (with a visible truncation marker on
 // the affected file) rather than failing the whole review.
-export const MAX_PATCH_CHARS_PER_FILE = 200_000;
+//
+// IMPORTANT: every budget here is expressed in **bytes**, not JS string length.
+// `String#length` counts UTF-16 code units, while the 16 MB BSON ceiling is in
+// UTF-8 bytes. A multibyte diff (CJK is ~3 bytes/char) measured by `.length`
+// can reach 16-24 MB while still "fitting" an 8M-char budget, and the write
+// blows up with the very MongoBulkWriteError this fix exists to prevent.
+// `Buffer.byteLength(patch, 'utf8')` (via `utf8ByteLength`) is the unit that
+// matches BSON.
+export const MAX_PATCH_BYTES_PER_FILE = 200_000;
 
 // Headroom budget below the 16 MB BSON ceiling reserved for the rest of the
 // document (suggestions, commits, metadata). 8 MB of embedded diffs leaves
 // ample room for the non-diff payload even on very large PRs.
-export const MAX_TOTAL_EMBEDDED_PATCH_CHARS = 8_000_000;
+export const MAX_TOTAL_EMBEDDED_PATCH_BYTES = 8_000_000;
 
 // Appended to a truncated diff body so downstream code and the reviewing LLM
 // can tell the diff was capped rather than silently treating it as complete.
 export const TRUNCATED_DIFF_MARKER =
     '\n---\n// diff truncated: the embedded-diff budget was exceeded; run the review with a narrower diff (e.g. per-commit) or split the PR into smaller PRs.\n';
+
+/**
+ * UTF-8 byte length of a string — the unit MongoDB's BSON ceiling is measured
+ * in (and therefore the unit every budget in this module uses). Falls back to
+ * `String#length` where `Buffer` is unavailable so this stays usable in any
+ * runtime the service is bundled for.
+ */
+export function utf8ByteLength(value: string): number {
+    if (!value) {
+        return 0;
+    }
+    if (typeof Buffer !== 'undefined') {
+        return Buffer.byteLength(value, 'utf8');
+    }
+    return value.length;
+}
+
+/**
+ * Longest prefix of `value` whose UTF-8 byte length does not exceed
+ * `maxBytes`. Never splits a surrogate pair (which would emit a lone
+ * surrogate and inflate the byte count), so the returned prefix always
+ * measures <= `maxBytes`.
+ */
+function utf8Prefix(value: string, maxBytes: number): string {
+    if (maxBytes <= 0) {
+        return '';
+    }
+    if (utf8ByteLength(value) <= maxBytes) {
+        return value;
+    }
+    let lo = 0;
+    let hi = value.length;
+    while (lo < hi) {
+        const mid = Math.ceil((lo + hi) / 2);
+        if (utf8ByteLength(value.slice(0, mid)) <= maxBytes) {
+            lo = mid;
+        } else {
+            hi = mid - 1;
+        }
+    }
+    // If the boundary lands right after a high surrogate its low surrogate
+    // was excluded — drop the orphan so we never emit an invalid character.
+    if (lo > 0 && lo < value.length) {
+        const last = value.charCodeAt(lo - 1);
+        if (last >= 0xd800 && last <= 0xdbff) {
+            lo -= 1;
+        }
+    }
+    return value.slice(0, lo);
+}
 
 export interface PatchBudgetResult {
     patch: string;
@@ -28,10 +86,13 @@ export interface PatchBudgetResult {
 }
 
 /**
- * Cap a single patch to `MAX_PATCH_CHARS_PER_FILE` and to the caller's
+ * Cap a single patch to `MAX_PATCH_BYTES_PER_FILE` and to the caller's
  * remaining aggregate budget. Returns the patch to persist (optionally a
  * leading window of the original plus `TRUNCATED_DIFF_MARKER`), whether it was
- * truncated, and how many characters of the aggregate budget it consumed.
+ * truncated, and how many **bytes** of the aggregate budget it consumed.
+ *
+ * The produced patch is guaranteed to measure <= the allowance in UTF-8 bytes
+ * (marker included), so the caller can keep a byte-accurate running total.
  *
  * When even the marker would not fit (aggregate budget exhausted for this
  * file), the patch is dropped entirely — the file still persists with its
@@ -45,36 +106,59 @@ export function budgetPatchForPersist(
         return { patch: '', truncated: false, consumed: 0 };
     }
     const allowance = Math.min(
-        MAX_PATCH_CHARS_PER_FILE,
+        MAX_PATCH_BYTES_PER_FILE,
         Math.max(0, remainingTotalBudget),
     );
-    if (patch.length <= allowance) {
-        return { patch, truncated: false, consumed: patch.length };
+    const patchBytes = utf8ByteLength(patch);
+    if (patchBytes <= allowance) {
+        return { patch, truncated: false, consumed: patchBytes };
     }
-    if (allowance < TRUNCATED_DIFF_MARKER.length) {
+    const markerBytes = utf8ByteLength(TRUNCATED_DIFF_MARKER);
+    if (allowance < markerBytes) {
         return { patch: '', truncated: true, consumed: 0 };
     }
-    const bodyLen = allowance - TRUNCATED_DIFF_MARKER.length;
+    const bodyBudgetBytes = allowance - markerBytes;
+    const resultPatch = `${utf8Prefix(
+        patch,
+        bodyBudgetBytes,
+    )}${TRUNCATED_DIFF_MARKER}`;
     return {
-        patch: `${patch.slice(0, bodyLen)}${TRUNCATED_DIFF_MARKER}`,
+        patch: resultPatch,
         truncated: true,
-        consumed: allowance,
+        consumed: utf8ByteLength(resultPatch),
     };
 }
 
 /**
  * Last-resort clamp applied in the repository: no single `files[].patch`
- * written by any path may exceed `MAX_PATCH_CHARS_PER_FILE`, so a future
- * caller that bypasses the service-level aggregate budget can never embed an
- * unbounded patch on its own.
+ * written by any path may exceed `MAX_PATCH_BYTES_PER_FILE` **bytes**, so a
+ * future caller that bypasses the service-level aggregate budget can never
+ * embed an unbounded patch on its own.
  */
 export function clampPatchForPersist(patch: string): string {
-    if (patch.length <= MAX_PATCH_CHARS_PER_FILE) {
-        return patch;
+    return clampPatchForPersistWithFlag(patch).patch;
+}
+
+/**
+ * Same as `clampPatchForPersist`, but also reports whether the patch had to be
+ * truncated. The repository uses the flag to mirror `patchTruncated: true`
+ * onto the sub-document, so a clamp applied at the storage layer is never
+ * silently stale.
+ */
+export function clampPatchForPersistWithFlag(patch: string): {
+    patch: string;
+    truncated: boolean;
+} {
+    if (utf8ByteLength(patch) <= MAX_PATCH_BYTES_PER_FILE) {
+        return { patch, truncated: false };
     }
-    if (MAX_PATCH_CHARS_PER_FILE <= TRUNCATED_DIFF_MARKER.length) {
-        return '';
+    const markerBytes = utf8ByteLength(TRUNCATED_DIFF_MARKER);
+    if (MAX_PATCH_BYTES_PER_FILE <= markerBytes) {
+        return { patch: '', truncated: true };
     }
-    const bodyLen = MAX_PATCH_CHARS_PER_FILE - TRUNCATED_DIFF_MARKER.length;
-    return `${patch.slice(0, bodyLen)}${TRUNCATED_DIFF_MARKER}`;
+    const bodyBudgetBytes = MAX_PATCH_BYTES_PER_FILE - markerBytes;
+    return {
+        patch: `${utf8Prefix(patch, bodyBudgetBytes)}${TRUNCATED_DIFF_MARKER}`,
+        truncated: true,
+    };
 }

--- a/libs/platformData/infrastructure/adapters/repositories/pullRequests.repository.spec.ts
+++ b/libs/platformData/infrastructure/adapters/repositories/pullRequests.repository.spec.ts
@@ -1,5 +1,9 @@
 import { PullRequestsRepository } from './pullRequests.repository';
 import type { OrganizationAndTeamData } from '@libs/core/infrastructure/config/types/general/organizationAndTeamData';
+import {
+    MAX_PATCH_BYTES_PER_FILE,
+    TRUNCATED_DIFF_MARKER,
+} from '@libs/platformData/domain/pullRequests/utils/diff-budget';
 
 /**
  * Regression coverage for the cross-organization data leak that allowed
@@ -162,6 +166,61 @@ describe('PullRequestsRepository — multi-tenant filter coverage', () => {
                 'files.id': 'file-id-1',
                 'organizationId': 'org-A',
             });
+        });
+    });
+
+    describe('translateFileBulkOp (updateFile) — storage-level patch clamp', () => {
+        function translate(prUuid: string, data: Record<string, unknown>) {
+            return (repo as any).translateFileBulkOp(prUuid, 'org-A', {
+                kind: 'updateFile',
+                fileId: 'file-1',
+                data,
+            }) as {
+                updateOne: {
+                    filter: Record<string, unknown>;
+                    update: { $set: Record<string, unknown> };
+                };
+            };
+        }
+
+        it('escalates patchTruncated when the storage clamp cuts the patch (a later `false` in the same payload cannot clobber it)', async () => {
+            // Overwhelm MAX_PATCH_BYTES_PER_FILE so the storage-level clamp
+            // truncates the patch and must mark it truncated. The payload
+            // carries an explicit `patchTruncated: false` AFTER `patch` in
+            // insertion order; pre-fix the generic `$set[files.$.patchTruncated]`
+            // line would overwrite the escalation and the sub-document would
+            // claim a capped diff is complete (#1841).
+            const huge = 'a'.repeat(MAX_PATCH_BYTES_PER_FILE + 10);
+            const doc = translate('pr-uuid-clamp', {
+                status: 'modified',
+                patch: huge,
+                patchTruncated: false,
+            });
+
+            const flat = Object.keys(doc.updateOne.update.$set);
+            expect(flat).toContain('files.$.patchTruncated');
+            expect(doc.updateOne.update.$set['files.$.patchTruncated']).toBe(
+                true,
+            );
+            expect(doc.updateOne.update.$set['files.$.patch']).toContain(
+                TRUNCATED_DIFF_MARKER,
+            );
+        });
+
+        it('passes through the payload patchTruncated when the storage clamp does not cut the patch', async () => {
+            const small = 'a'.repeat(100);
+            const doc = translate('pr-uuid-noclamp', {
+                status: 'modified',
+                patch: small,
+                patchTruncated: false,
+            });
+
+            // No clamp fired, so the payload's explicit `false` flows through
+            // unchanged — the flag reflects the actual diff completeness.
+            expect(
+                doc.updateOne.update.$set['files.$.patchTruncated'],
+            ).toBe(false);
+            expect(doc.updateOne.update.$set['files.$.patch']).toBe(small);
         });
     });
 

--- a/libs/platformData/infrastructure/adapters/repositories/pullRequests.repository.ts
+++ b/libs/platformData/infrastructure/adapters/repositories/pullRequests.repository.ts
@@ -1666,6 +1666,13 @@ export class PullRequestsRepository implements IPullRequestsRepository {
                     }> as any,
                 );
                 const $set: Record<string, unknown> = {};
+                // Storage-level clamp escalation is collected in a local flag
+                // and applied AFTER the loop: a `patchTruncated: false` entry
+                // processed later in the same iteration would otherwise clobber
+                // the escalation via the generic `$set[...]` line below,
+                // leaving a capped diff's sub-document claiming it is complete
+                // (#1841).
+                let patchWasClamped = false;
                 for (const [k, v] of Object.entries(sanitized)) {
                     // Last-resort per-file clamp: a future caller that
                     // bypasses the service-level aggregate budget can never
@@ -1678,12 +1685,13 @@ export class PullRequestsRepository implements IPullRequestsRepository {
                     if (k === 'patch' && typeof v === 'string') {
                         const clamped = clampPatchForPersistWithFlag(v);
                         $set['files.$.patch'] = clamped.patch;
-                        if (clamped.truncated) {
-                            $set['files.$.patchTruncated'] = true;
-                        }
+                        patchWasClamped = clamped.truncated;
                         continue;
                     }
                     $set[`files.$.${k}`] = v;
+                }
+                if (patchWasClamped) {
+                    $set['files.$.patchTruncated'] = true;
                 }
                 return {
                     updateOne: {

--- a/libs/platformData/infrastructure/adapters/repositories/pullRequests.repository.ts
+++ b/libs/platformData/infrastructure/adapters/repositories/pullRequests.repository.ts
@@ -28,6 +28,7 @@ import {
 import { PullRequestsEntity } from '@libs/platformData/domain/pullRequests/entities/pullRequests.entity';
 import { DeliveryStatus } from '@libs/platformData/domain/pullRequests/enums/deliveryStatus.enum';
 import { ImplementationStatus } from '@libs/platformData/domain/pullRequests/enums/implementationStatus.enum';
+import { clampPatchForPersist } from '@libs/platformData/domain/pullRequests/utils/diff-budget';
 import { UNRESOLVED_RANK_BONUS } from '@libs/platformData/domain/pullRequests/deep-link-rank';
 
 @Injectable()
@@ -1612,6 +1613,14 @@ export class PullRequestsRepository implements IPullRequestsRepository {
                 );
                 const $set: Record<string, unknown> = {};
                 for (const [k, v] of Object.entries(sanitized)) {
+                    // Last-resort per-file clamp: a future caller that
+                    // bypasses the service-level aggregate budget can never
+                    // embed a single unbounded patch that pushes the document
+                    // past MongoDB's 16 MB BSON ceiling (#1841).
+                    if (k === 'patch' && typeof v === 'string') {
+                        $set['files.$.patch'] = clampPatchForPersist(v);
+                        continue;
+                    }
                     $set[`files.$.${k}`] = v;
                 }
                 return {

--- a/libs/platformData/infrastructure/adapters/repositories/pullRequests.repository.ts
+++ b/libs/platformData/infrastructure/adapters/repositories/pullRequests.repository.ts
@@ -28,7 +28,7 @@ import {
 import { PullRequestsEntity } from '@libs/platformData/domain/pullRequests/entities/pullRequests.entity';
 import { DeliveryStatus } from '@libs/platformData/domain/pullRequests/enums/deliveryStatus.enum';
 import { ImplementationStatus } from '@libs/platformData/domain/pullRequests/enums/implementationStatus.enum';
-import { clampPatchForPersist } from '@libs/platformData/domain/pullRequests/utils/diff-budget';
+import { clampPatchForPersistWithFlag } from '@libs/platformData/domain/pullRequests/utils/diff-budget';
 import { UNRESOLVED_RANK_BONUS } from '@libs/platformData/domain/pullRequests/deep-link-rank';
 
 @Injectable()
@@ -1570,6 +1570,60 @@ export class PullRequestsRepository implements IPullRequestsRepository {
         };
     }
 
+    /**
+     * Server-side sum of the UTF-8 bytes actually embedded in
+     * `files[].patch` for one PR. Uses `$strLenBytes` (which counts UTF-8
+     * bytes, exactly like `Buffer.byteLength` and BSON) so the caller gets
+     * ground truth on how close the document is to MongoDB's 16 MB ceiling,
+     * without transferring the patches themselves.
+     *
+     * The service uses this to *enforce* the aggregate embedded-diff budget
+     * after a write: the in-memory seed derived from a previously-read
+     * `existingPR.files` can be stale under concurrent syncs, so the write is
+     * only considered settled once this server-side total is back under the
+     * cap (#1841).
+     */
+    async computeEmbeddedPatchBytes(
+        prUuid: string,
+        organizationId: string,
+    ): Promise<number> {
+        if (!organizationId) {
+            throw new Error(
+                'computeEmbeddedPatchBytes requires organizationId for tenant isolation',
+            );
+        }
+        // Aggregation does NOT auto-cast string → ObjectId the way standard
+        // query operators do — mirror `computeFileTotals`.
+        const match: Record<string, unknown> = {
+            organizationId,
+            ...(mongoose.Types.ObjectId.isValid(prUuid)
+                ? { _id: new mongoose.Types.ObjectId(prUuid) }
+                : { _id: prUuid }),
+        };
+        const result = await this.pullRequestsModel
+            .aggregate<{ embeddedPatchBytes: number }>([
+                { $match: match },
+                {
+                    $project: {
+                        _id: 0,
+                        embeddedPatchBytes: {
+                            $sum: {
+                                $map: {
+                                    input: { $ifNull: ['$files.patch', []] },
+                                    as: 'p',
+                                    in: {
+                                        $strLenBytes: { $ifNull: ['$$p', ''] },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            ])
+            .exec();
+        return result?.[0]?.embeddedPatchBytes ?? 0;
+    }
+
     private translateFileBulkOp(
         prUuid: string,
         organizationId: string,
@@ -1616,9 +1670,17 @@ export class PullRequestsRepository implements IPullRequestsRepository {
                     // Last-resort per-file clamp: a future caller that
                     // bypasses the service-level aggregate budget can never
                     // embed a single unbounded patch that pushes the document
-                    // past MongoDB's 16 MB BSON ceiling (#1841).
+                    // past MongoDB's 16 MB BSON ceiling (#1841). When this
+                    // storage-level clamp actually cuts the patch we mirror
+                    // `patchTruncated: true` so the flag can never be stale
+                    // (service already writes an explicit boolean; we only
+                    // ever escalate it here).
                     if (k === 'patch' && typeof v === 'string') {
-                        $set['files.$.patch'] = clampPatchForPersist(v);
+                        const clamped = clampPatchForPersistWithFlag(v);
+                        $set['files.$.patch'] = clamped.patch;
+                        if (clamped.truncated) {
+                            $set['files.$.patchTruncated'] = true;
+                        }
                         continue;
                     }
                     $set[`files.$.${k}`] = v;

--- a/libs/platformData/infrastructure/adapters/repositories/schemas/pullRequests.model.ts
+++ b/libs/platformData/infrastructure/adapters/repositories/schemas/pullRequests.model.ts
@@ -72,6 +72,7 @@ export class PullRequestsModel extends CoreDocument {
         added?: number;
         deleted?: number;
         changes?: number;
+        patchTruncated?: boolean;
         reviewMode: ReviewModeResponse;
         codeReviewModelUsed: {
             generateSuggestions: string;

--- a/libs/platformData/infrastructure/adapters/services/pullRequests.service.bulk-file-changes.spec.ts
+++ b/libs/platformData/infrastructure/adapters/services/pullRequests.service.bulk-file-changes.spec.ts
@@ -1,4 +1,9 @@
 import { PullRequestsService } from './pullRequests.service';
+import {
+    MAX_PATCH_CHARS_PER_FILE,
+    MAX_TOTAL_EMBEDDED_PATCH_CHARS,
+    TRUNCATED_DIFF_MARKER,
+} from '@libs/platformData/domain/pullRequests/utils/diff-budget';
 
 /**
  * Regression tests for issue #1107 — `aggregateAndSaveDataStructure`
@@ -682,9 +687,13 @@ describe('PullRequestsService — #1107 bulk file changes', () => {
                 makeExistingFile('docs/notpng.md'),      // ".md" — MUST keep patch
             ];
             const existingPR = { uuid: 'pr-uuid-case', files: existingFiles };
-            const huge = 'X'.repeat(1024 * 1024);
+            // Patch sized below the per-file embedded-diff budget so it is
+            // stored verbatim (only binary extensions are stripped). The new
+            // per-file/aggregate caps from #1841 are covered by the dedicated
+            // budget tests below.
+            const medium = 'X'.repeat(MAX_PATCH_CHARS_PER_FILE - 1000);
             const changedFiles = existingFiles.map((f) =>
-                makeChangedFile(f.path, { patch: huge }),
+                makeChangedFile(f.path, { patch: medium }),
             );
 
             await callHandleExisting({ existingPR, changedFiles });
@@ -701,8 +710,8 @@ describe('PullRequestsService — #1107 bulk file changes', () => {
 
             expect(byFile('docs/HERO.PNG').data.patch).toBe('');
             expect(byFile('design/Logo.Jpeg').data.patch).toBe('');
-            expect(byFile('src/png-utils.ts').data.patch).toBe(huge);
-            expect(byFile('docs/notpng.md').data.patch).toBe(huge);
+            expect(byFile('src/png-utils.ts').data.patch).toBe(medium);
+            expect(byFile('docs/notpng.md').data.patch).toBe(medium);
         });
 
         it('addFile op does NOT carry `patch` either (defense in depth — locks down today\'s behavior)', async () => {
@@ -753,6 +762,85 @@ describe('PullRequestsService — #1107 bulk file changes', () => {
             // + op envelope overhead. Should comfortably fit in <100KB total.
             expect(serializedSize).toBeLessThan(100 * 1024);
             expect(opsArg.length).toBe(100);
+        });
+    });
+
+    // ─────────────────────────────────────────────────────────
+    // C) Embedded-diff budget (#1841) — MongoDB 16MB BSON ceiling
+    // ─────────────────────────────────────────────────────────
+    describe('handleExistingPullRequest — embedded-diff budget (#1841)', () => {
+        it('caps a patch that exceeds the per-file limit and marks it truncated', async () => {
+            const existingPR = {
+                uuid: 'pr-budget-1',
+                files: [makeExistingFile('src/big.ts')],
+            };
+            const oversized = 'b'.repeat(MAX_PATCH_CHARS_PER_FILE * 2);
+            await callHandleExisting({
+                existingPR,
+                changedFiles: [makeChangedFile('src/big.ts', { patch: oversized })],
+            });
+
+            const ops = pullRequestsRepository.bulkApplyFileChanges.mock
+                .calls[0][2];
+            const updateOp = ops.find((op: any) => op.kind === 'updateFile');
+            expect(updateOp).toBeDefined();
+            const patch = updateOp.data.patch;
+            expect(patch.length).toBeLessThanOrEqual(MAX_PATCH_CHARS_PER_FILE);
+            expect(patch.endsWith(TRUNCATED_DIFF_MARKER)).toBe(true);
+            expect(updateOp.data.patchTruncated).toBe(true);
+        });
+
+        it('deducts the already-embedded diff from the aggregate budget, dropping later diffs when it is exhausted', async () => {
+            // Leave only a sliver above the marker length so the first file
+            // gets a truncated stub and the second is dropped entirely once
+            // the aggregate budget runs out. Existing rationale: the document
+            // already holds MAX_TOTAL - (marker + 50) chars of embedded diff.
+            const leftover = TRUNCATED_DIFF_MARKER.length + 50;
+            const alreadyEmbedded = MAX_TOTAL_EMBEDDED_PATCH_CHARS - leftover;
+            const existingPR = {
+                uuid: 'pr-budget-2',
+                files: [
+                    makeExistingFile('src/first.ts', {
+                        patch: 'a'.repeat(alreadyEmbedded),
+                    }),
+                    makeExistingFile('src/second.ts'),
+                ],
+            };
+
+            await callHandleExisting({
+                existingPR,
+                changedFiles: [
+                    makeChangedFile('src/first.ts', {
+                        patch: 'c'.repeat(1000),
+                    }),
+                    makeChangedFile('src/second.ts', {
+                        patch: 'd'.repeat(2000),
+                    }),
+                ],
+            });
+
+            const ops = pullRequestsRepository.bulkApplyFileChanges.mock
+                .calls[0][2];
+            const updateOps = ops.filter(
+                (op: any) => op.kind === 'updateFile',
+            );
+            // first.ts is truncated to the sliver of budget left (marker kept),
+            // and the embedded size stays bounded.
+            const firstOp = updateOps.find(
+                (op: any) => op.data.patch && op.data.patch.length > 0,
+            );
+            expect(firstOp).toBeDefined();
+            expect(firstOp.data.patchTruncated).toBe(true);
+            expect(firstOp.data.patch.endsWith(TRUNCATED_DIFF_MARKER)).toBe(
+                true,
+            );
+            expect(firstOp.data.patch.length).toBeLessThanOrEqual(leftover);
+            // second.ts is dropped once the aggregate budget is exhausted.
+            const secondOp = updateOps.find(
+                (op: any) => op.data.patch === '',
+            );
+            expect(secondOp).toBeDefined();
+            expect(secondOp.data.patchTruncated).toBe(true);
         });
     });
 });

--- a/libs/platformData/infrastructure/adapters/services/pullRequests.service.bulk-file-changes.spec.ts
+++ b/libs/platformData/infrastructure/adapters/services/pullRequests.service.bulk-file-changes.spec.ts
@@ -1,7 +1,7 @@
 import { PullRequestsService } from './pullRequests.service';
 import {
-    MAX_PATCH_CHARS_PER_FILE,
-    MAX_TOTAL_EMBEDDED_PATCH_CHARS,
+    MAX_PATCH_BYTES_PER_FILE,
+    MAX_TOTAL_EMBEDDED_PATCH_BYTES,
     TRUNCATED_DIFF_MARKER,
 } from '@libs/platformData/domain/pullRequests/utils/diff-budget';
 
@@ -38,6 +38,7 @@ describe('PullRequestsService — #1107 bulk file changes', () => {
         updateFile: jest.Mock;
         bulkApplyFileChanges: jest.Mock;
         computeFileTotals: jest.Mock;
+        computeEmbeddedPatchBytes: jest.Mock;
         newSubDocumentId: jest.Mock;
         update: jest.Mock;
     };
@@ -110,6 +111,7 @@ describe('PullRequestsService — #1107 bulk file changes', () => {
                 totalDeleted: 0,
                 totalChanges: 0,
             }),
+            computeEmbeddedPatchBytes: jest.fn().mockResolvedValue(0),
             newSubDocumentId: jest.fn(() => nextId()),
             update: jest.fn(async (entity: any, patch: any) => ({
                 ...entity,
@@ -691,7 +693,7 @@ describe('PullRequestsService — #1107 bulk file changes', () => {
             // stored verbatim (only binary extensions are stripped). The new
             // per-file/aggregate caps from #1841 are covered by the dedicated
             // budget tests below.
-            const medium = 'X'.repeat(MAX_PATCH_CHARS_PER_FILE - 1000);
+            const medium = 'X'.repeat(MAX_PATCH_BYTES_PER_FILE - 1000);
             const changedFiles = existingFiles.map((f) =>
                 makeChangedFile(f.path, { patch: medium }),
             );
@@ -774,7 +776,7 @@ describe('PullRequestsService — #1107 bulk file changes', () => {
                 uuid: 'pr-budget-1',
                 files: [makeExistingFile('src/big.ts')],
             };
-            const oversized = 'b'.repeat(MAX_PATCH_CHARS_PER_FILE * 2);
+            const oversized = 'b'.repeat(MAX_PATCH_BYTES_PER_FILE * 2);
             await callHandleExisting({
                 existingPR,
                 changedFiles: [makeChangedFile('src/big.ts', { patch: oversized })],
@@ -785,25 +787,113 @@ describe('PullRequestsService — #1107 bulk file changes', () => {
             const updateOp = ops.find((op: any) => op.kind === 'updateFile');
             expect(updateOp).toBeDefined();
             const patch = updateOp.data.patch;
-            expect(patch.length).toBeLessThanOrEqual(MAX_PATCH_CHARS_PER_FILE);
+            expect(patch.length).toBeLessThanOrEqual(
+                MAX_PATCH_BYTES_PER_FILE,
+            );
             expect(patch.endsWith(TRUNCATED_DIFF_MARKER)).toBe(true);
             expect(updateOp.data.patchTruncated).toBe(true);
         });
 
-        it('deducts the already-embedded diff from the aggregate budget, dropping later diffs when it is exhausted', async () => {
-            // Leave only a sliver above the marker length so the first file
-            // gets a truncated stub and the second is dropped entirely once
-            // the aggregate budget runs out. Existing rationale: the document
-            // already holds MAX_TOTAL - (marker + 50) chars of embedded diff.
-            const leftover = TRUNCATED_DIFF_MARKER.length + 50;
-            const alreadyEmbedded = MAX_TOTAL_EMBEDDED_PATCH_CHARS - leftover;
+        it('measures the per-file cap in UTF-8 bytes, not UTF-16 code units (multibyte diff)', async () => {
+            // `'漢'.repeat(N).length === N` but its BSON footprint is 3·N, so a
+            // char-count cap would let this 600 KB patch through untouched.
+            const cjk = '漢'.repeat(MAX_PATCH_BYTES_PER_FILE);
             const existingPR = {
-                uuid: 'pr-budget-2',
+                uuid: 'pr-budget-bytes',
+                files: [makeExistingFile('src/cjk.ts')],
+            };
+            await callHandleExisting({
+                existingPR,
+                changedFiles: [makeChangedFile('src/cjk.ts', { patch: cjk })],
+            });
+
+            const ops = pullRequestsRepository.bulkApplyFileChanges.mock
+                .calls[0][2];
+            const updateOp = ops.find((op: any) => op.kind === 'updateFile');
+            expect(
+                Buffer.byteLength(updateOp.data.patch, 'utf8'),
+            ).toBeLessThanOrEqual(MAX_PATCH_BYTES_PER_FILE);
+            expect(updateOp.data.patchTruncated).toBe(true);
+        });
+
+        it('re-credits the replaced patch before billing the new one (no double count on updateFile)', async () => {
+            // The doc already holds a nearly-full embedded budget in one file,
+            // and the sync *replaces* that same file with a tiny patch. Because
+            // updateFile `$set`s `files.$.patch`, the old bytes are freed — the
+            // new small patch must NOT be truncated by a double-counted seed.
+            const leftover = TRUNCATED_DIFF_MARKER.length + 50;
+            const alreadyEmbedded = MAX_TOTAL_EMBEDDED_PATCH_BYTES - leftover;
+            const existingPR = {
+                uuid: 'pr-budget-recredit',
                 files: [
                     makeExistingFile('src/first.ts', {
                         patch: 'a'.repeat(alreadyEmbedded),
                     }),
-                    makeExistingFile('src/second.ts'),
+                ],
+            };
+
+            await callHandleExisting({
+                existingPR,
+                changedFiles: [
+                    makeChangedFile('src/first.ts', {
+                        patch: 'c'.repeat(1000),
+                    }),
+                ],
+            });
+
+            const ops = pullRequestsRepository.bulkApplyFileChanges.mock
+                .calls[0][2];
+            const updateOp = ops.find((op: any) => op.kind === 'updateFile');
+            expect(updateOp.data.patch).toBe('c'.repeat(1000));
+            expect(updateOp.data.patchTruncated).toBe(false);
+        });
+
+        it('writes patchTruncated explicitly so a stale `true` is cleared once the patch fits again', async () => {
+            const existingPR = {
+                uuid: 'pr-budget-stale',
+                files: [
+                    makeExistingFile('src/small.ts', {
+                        patch: 'x'.repeat(100),
+                        patchTruncated: true,
+                    }),
+                ],
+            };
+
+            await callHandleExisting({
+                existingPR,
+                changedFiles: [
+                    makeChangedFile('src/small.ts', { patch: 'y'.repeat(50) }),
+                ],
+            });
+
+            const ops = pullRequestsRepository.bulkApplyFileChanges.mock
+                .calls[0][2];
+            const updateOp = ops.find((op: any) => op.kind === 'updateFile');
+            // Must be present and false — omitting the key would leave the
+            // stale `true` in Mongo (the repository only $sets present keys).
+            expect(updateOp.data).toHaveProperty('patchTruncated', false);
+        });
+
+        it('deducts untouched embedded diffs from the aggregate budget, truncating then dropping our updates', async () => {
+            // `src/keep.ts` is NOT part of this sync, so its embedded diff keeps
+            // consuming the aggregate budget (it is not re-credited). That
+            // leaves only a sliver for our two updateFiles: the first is
+            // truncated to the remaining bytes (marker kept) and the second is
+            // dropped entirely.
+            const leftover = TRUNCATED_DIFF_MARKER.length + 50;
+            const keepBytes = MAX_TOTAL_EMBEDDED_PATCH_BYTES - leftover;
+            const existingPR = {
+                uuid: 'pr-budget-2',
+                files: [
+                    makeExistingFile('src/keep.ts', {
+                        patch: 'a'.repeat(keepBytes),
+                    }),
+                    makeExistingFile('src/first.ts', {
+                        patch: 'x'.repeat(10),
+                    }),
+                    makeExistingFile('src/second.ts', {
+                        patch: 'y'.repeat(10),
+                    }),
                 ],
             };
 
@@ -841,6 +931,55 @@ describe('PullRequestsService — #1107 bulk file changes', () => {
             );
             expect(secondOp).toBeDefined();
             expect(secondOp.data.patchTruncated).toBe(true);
+        });
+
+        it('re-verifies the embedded byte total after the write and retries with a tighter budget when a concurrent sync pushed the doc over the cap', async () => {
+            const existingPR = {
+                uuid: 'pr-budget-verify',
+                files: [
+                    makeExistingFile('src/first.ts', {
+                        patch: 'a'.repeat(10),
+                    }),
+                ],
+            };
+
+            // First ground-truth read reports the document over the cap (as if
+            // another sync spent the budget concurrently); the retry settles it.
+            pullRequestsRepository.computeEmbeddedPatchBytes
+                .mockResolvedValueOnce(
+                    MAX_TOTAL_EMBEDDED_PATCH_BYTES + 100_000,
+                )
+                .mockResolvedValueOnce(0);
+
+            await callHandleExisting({
+                existingPR,
+                changedFiles: [
+                    makeChangedFile('src/first.ts', {
+                        patch: 'z'.repeat(100_000),
+                    }),
+                ],
+            });
+
+            expect(
+                pullRequestsRepository.computeEmbeddedPatchBytes,
+            ).toHaveBeenCalledWith('pr-budget-verify', 'org-1');
+            // Initial write + one tightening retry.
+            expect(
+                pullRequestsRepository.bulkApplyFileChanges,
+            ).toHaveBeenCalledTimes(2);
+
+            const retryOps =
+                pullRequestsRepository.bulkApplyFileChanges.mock.calls[1][2];
+            expect(retryOps).toHaveLength(1);
+            expect(retryOps[0].kind).toBe('updateFile');
+            // Budget was clamped to 0 => the patch is dropped and the bytes are
+            // freed so the next ground-truth read can settle under the cap.
+            expect(retryOps[0].data.patch).toBe('');
+            expect(retryOps[0].data.patchTruncated).toBe(true);
+            // The retry must never duplicate the non-idempotent addFile ops.
+            expect(
+                retryOps.filter((op: any) => op.kind === 'addFile'),
+            ).toHaveLength(0);
         });
     });
 });

--- a/libs/platformData/infrastructure/adapters/services/pullRequests.service.bulk-file-changes.spec.ts
+++ b/libs/platformData/infrastructure/adapters/services/pullRequests.service.bulk-file-changes.spec.ts
@@ -981,5 +981,75 @@ describe('PullRequestsService — #1107 bulk file changes', () => {
                 retryOps.filter((op: any) => op.kind === 'addFile'),
             ).toHaveLength(0);
         });
+
+        it('subtracts the bytes of patch ops that FAILED the first bulk write from the retry budget (no double-charge)', async () => {
+            // Two updateFile ops (a: 100 KB, b: 50 KB). The first bulk write
+            // REJECTS the first op (its opIndex is in `errors` → per-op write
+            // hit the document-ceiling rejection this PR targets), while the
+            // other lands. Pre-fix, `ourPatchBytes` still counted the rejected
+            // op's bytes as embedded, inflating the retry budget by exactly
+            // `failedBytes` and re-writing past the ceiling.
+            const existingPR = {
+                uuid: 'pr-budget-failedop',
+                files: [
+                    makeExistingFile('src/a.ts', { patch: 'x'.repeat(10) }),
+                    makeExistingFile('src/b.ts', { patch: 'y'.repeat(10) }),
+                ],
+            };
+            // The failed op's bytes (100 KB) are NOT in the doc; ground truth
+            // is only ~10 KB over budget from the landed op + overhead.
+            pullRequestsRepository.bulkApplyFileChanges
+                .mockResolvedValueOnce({
+                    attempted: 2,
+                    modified: 1,
+                    errors: [
+                        {
+                            opIndex: 0,
+                            code: undefined,
+                            message: 'Resulting document larger than 16777216',
+                        },
+                    ],
+                })
+                .mockResolvedValueOnce({
+                    attempted: 2,
+                    modified: 0,
+                    errors: [],
+                });
+            pullRequestsRepository.computeEmbeddedPatchBytes
+                .mockResolvedValueOnce(
+                    MAX_TOTAL_EMBEDDED_PATCH_BYTES + 10_000,
+                )
+                .mockResolvedValueOnce(0);
+
+            await callHandleExisting({
+                existingPR,
+                changedFiles: [
+                    makeChangedFile('src/a.ts', { patch: 'z'.repeat(100_000) }),
+                    makeChangedFile('src/b.ts', { patch: 'w'.repeat(50_000) }),
+                ],
+            });
+
+            // Initial write + one tightening retry.
+            expect(
+                pullRequestsRepository.bulkApplyFileChanges,
+            ).toHaveBeenCalledTimes(2);
+
+            // The failed op (opIndex 0) was re-credited: it counts 0 bytes
+            // toward `ourPatchBytes`, so the retry budget is clamped well under
+            // the 150 KB we intended, not inflated to (150 KB − 100 KB) + slack.
+            const retryOps =
+                pullRequestsRepository.bulkApplyFileChanges.mock.calls[1][2];
+            const retryPatchBytes = retryOps.reduce(
+                (sum: number, op: any) =>
+                    sum + Buffer.byteLength(op.data.patch ?? '', 'utf8'),
+                0,
+            );
+            // 50 KB landed (b) + ~10 KB overhead → retry must carve only the
+            // ~10 KB overflow, NOT hand back the 100 KB that never persisted.
+            expect(retryPatchBytes).toBeLessThan(60_000);
+            expect(
+                retryOps.filter((op: any) => op.kind === 'addFile'),
+            ).toHaveLength(0);
+        });
     });
 });

--- a/libs/platformData/infrastructure/adapters/services/pullRequests.service.ts
+++ b/libs/platformData/infrastructure/adapters/services/pullRequests.service.ts
@@ -1260,6 +1260,14 @@ export class PullRequestsService implements IPullRequestsService {
             let totalNewSuggestions = 0;
             // Bytes of patch written by *this* batch (sum of `consumed`).
             let ourPatchBytes = 0;
+            // Patch bytes contributed by each op slot in `ops`, so the
+            // post-write enforcement pass can reconcile `ourPatchBytes`
+            // against the ops that actually landed: a patch op that was
+            // rejected in the bulk write (its opIndex appears in
+            // `bulkResult.errors`) never persisted its bytes, so counting
+            // them as embedded would inflate the retry budget by exactly
+            // the failed bytes (#1841).
+            const patchBytesByOpIndex = new Map<number, number>();
 
             for (const file of changedFiles ?? []) {
                 const filename: string | undefined = file?.filename;
@@ -1331,6 +1339,11 @@ export class PullRequestsService implements IPullRequestsService {
                     remainingTotalPatchBudget -= budgeted.consumed;
                     ourPatchBytes += budgeted.consumed;
 
+                    // Record the op slot that carries this patch payload so
+                    // the post-write enforcement pass can tell which patch
+                    // ops persisted vs. were rejected (#1841).
+                    patchBytesByOpIndex.set(ops.length, budgeted.consumed);
+
                     ops.push({
                         kind: 'updateFile',
                         fileId: existing.id,
@@ -1388,6 +1401,20 @@ export class PullRequestsService implements IPullRequestsService {
                     );
             }
 
+            // Reconcile `ourPatchBytes` with what actually landed. A patch op
+            // that the bulk write rejected (its opIndex is in
+            // `bulkResult.errors`) never persisted its bytes, so it must not
+            // count as embedded when we compute the retry budget below —
+            // otherwise we'd hand ourselves a budget inflated by exactly the
+            // failed bytes and re-write past the ceiling the enforcement pass
+            // exists to keep (#1841).
+            let failedPatchBytes = 0;
+            for (const e of bulkResult.errors) {
+                failedPatchBytes +=
+                    patchBytesByOpIndex.get(e.opIndex) ?? 0;
+            }
+            ourPatchBytes = Math.max(0, ourPatchBytes - failedPatchBytes);
+
             // Enforce the aggregate embedded-diff ceiling against ground truth
             // *after* the write. The in-memory seed above comes from a read of
             // `existingPR.files` that can be stale — two syncs firing at once
@@ -1419,6 +1446,7 @@ export class PullRequestsService implements IPullRequestsService {
                             metadata: {
                                 pullRequestNumber: pullRequest?.number,
                                 prUuid: existingPR.uuid,
+                                organizationId,
                             },
                         });
                         break;
@@ -1442,6 +1470,7 @@ export class PullRequestsService implements IPullRequestsService {
                                 embeddedPatchBytes: embeddedNow,
                                 maxTotalPatchBytes:
                                     MAX_TOTAL_EMBEDDED_PATCH_BYTES,
+                                organizationId,
                             },
                         });
                         break;
@@ -1474,6 +1503,7 @@ export class PullRequestsService implements IPullRequestsService {
                             prUuid: existingPR.uuid,
                             embeddedPatchBytes: embeddedNow,
                             tightenedBudgetBytes: tightened,
+                            organizationId,
                         },
                     });
 

--- a/libs/platformData/infrastructure/adapters/services/pullRequests.service.ts
+++ b/libs/platformData/infrastructure/adapters/services/pullRequests.service.ts
@@ -19,7 +19,8 @@ import {
 } from '@libs/platformData/domain/pullRequests/interfaces/pullRequests.interface';
 import {
     budgetPatchForPersist,
-    MAX_TOTAL_EMBEDDED_PATCH_CHARS,
+    utf8ByteLength,
+    MAX_TOTAL_EMBEDDED_PATCH_BYTES,
 } from '@libs/platformData/domain/pullRequests/utils/diff-budget';
 import { PlatformType, PullRequestState } from '@libs/core/domain/enums';
 import { Repository } from '@libs/core/infrastructure/config/types/general/codeReview.type';
@@ -414,6 +415,13 @@ export class PullRequestsService implements IPullRequestsService {
 
     computeFileTotals(prUuid: string, organizationId: string) {
         return this.pullRequestsRepository.computeFileTotals(
+            prUuid,
+            organizationId,
+        );
+    }
+
+    computeEmbeddedPatchBytes(prUuid: string, organizationId: string) {
+        return this.pullRequestsRepository.computeEmbeddedPatchBytes(
             prUuid,
             organizationId,
         );
@@ -1185,19 +1193,64 @@ export class PullRequestsService implements IPullRequestsService {
                 });
             }
 
-            // Seed the aggregate diff budget with the bytes the document already
-            // carries from prior syncs, so the whole `pullRequests` document —
-            // not just this batch — stays under MongoDB's 16 MB BSON ceiling.
-            const existingEmbeddedPatchChars =
+            // Seed the aggregate diff budget with the bytes the document
+            // already carries from prior syncs, so the whole `pullRequests`
+            // document — not just this batch — stays under MongoDB's 16 MB
+            // BSON ceiling. Measured in UTF-8 bytes (the unit BSON/Mongo use),
+            // never in JS string length: a CJK-heavy diff measured in UTF-16
+            // code units understates its real footprint ~3× (#1841).
+            const existingEmbeddedPatchBytes =
                 existingPR.files?.reduce(
                     (sum, f) =>
-                        sum + ((f as { patch?: string }).patch?.length ?? 0),
+                        sum + utf8ByteLength((f as { patch?: string }).patch),
                     0,
                 ) ?? 0;
             let remainingTotalPatchBudget = Math.max(
                 0,
-                MAX_TOTAL_EMBEDDED_PATCH_CHARS - existingEmbeddedPatchChars,
+                MAX_TOTAL_EMBEDDED_PATCH_BYTES - existingEmbeddedPatchBytes,
             );
+
+            // Patch-bearing updateFile payloads, kept aside so the post-write
+            // verification pass below can re-budget *only* these. Re-emitting
+            // the non-idempotent addFile/addSuggestions ops on a retry would
+            // duplicate sub-documents.
+            const patchUpdates: Array<{
+                fileId: string;
+                rawPatch: string;
+                fields: Partial<
+                    Omit<
+                        IFile,
+                        'id' | 'suggestions' | 'patch' | 'patchTruncated'
+                    >
+                >;
+            }> = [];
+
+            const budgetPatchUpdates = (
+                budget: number,
+            ): { updateOps: FileBulkOp[]; consumed: number } => {
+                let remaining = budget;
+                const updateOps: FileBulkOp[] = [];
+                for (const pu of patchUpdates) {
+                    const budgeted = budgetPatchForPersist(
+                        pu.rawPatch,
+                        remaining,
+                    );
+                    remaining -= budgeted.consumed;
+                    updateOps.push({
+                        kind: 'updateFile',
+                        fileId: pu.fileId,
+                        data: {
+                            ...pu.fields,
+                            patch: budgeted.patch,
+                            // Always write the flag explicitly: a file that
+                            // was truncated on an earlier sync must not keep a
+                            // stale `true` once its patch fits again (#1841).
+                            patchTruncated: !!budgeted.truncated,
+                        },
+                    });
+                }
+                return { updateOps, consumed: budget - remaining };
+            };
 
             const ops: FileBulkOp[] = [];
             const seenInBatch = new Set<string>();
@@ -1205,6 +1258,8 @@ export class PullRequestsService implements IPullRequestsService {
             let skippedInvalidChangedFiles = 0;
             let newFilesCount = 0;
             let totalNewSuggestions = 0;
+            // Bytes of patch written by *this* batch (sum of `consumed`).
+            let ourPatchBytes = 0;
 
             for (const file of changedFiles ?? []) {
                 const filename: string | undefined = file?.filename;
@@ -1236,19 +1291,26 @@ export class PullRequestsService implements IPullRequestsService {
                     // the bytes already embedded on existing files. Oversized
                     // diffs are truncated (with a visible marker) or dropped,
                     // never failing the review (#1841).
-                    const budgeted = budgetPatchForPersist(
+                    //
+                    // updateFile *replaces* `files.$.patch` ($set), so the
+                    // bytes the old patch contributed to the seed must be
+                    // re-credited before the replacement is billed — otherwise
+                    // the same file is charged twice and later files get
+                    // needlessly truncated/dropped (#1841).
+                    remainingTotalPatchBudget += utf8ByteLength(
+                        (existing as { patch?: string }).patch,
+                    );
+                    const rawPatch =
                         PullRequestsService.sanitizePatchForPersist(
                             filename,
                             file.patch,
-                        ),
-                        remainingTotalPatchBudget,
-                    );
-                    remainingTotalPatchBudget -= budgeted.consumed;
-                    const fileFields = {
-                        patch: budgeted.patch,
-                        ...(budgeted.truncated
-                            ? { patchTruncated: true }
-                            : {}),
+                        );
+                    const fields: Partial<
+                        Omit<
+                            IFile,
+                            'id' | 'suggestions' | 'patch' | 'patchTruncated'
+                        >
+                    > = {
                         status: file.status ?? '',
                         added: file.additions ?? 0,
                         deleted: file.deletions ?? 0,
@@ -1257,11 +1319,28 @@ export class PullRequestsService implements IPullRequestsService {
                         codeReviewModelUsed: file.codeReviewModelUsed ?? '',
                         updatedAt: new Date().toISOString(),
                     };
+                    patchUpdates.push({
+                        fileId: existing.id,
+                        rawPatch,
+                        fields,
+                    });
+                    const budgeted = budgetPatchForPersist(
+                        rawPatch,
+                        remainingTotalPatchBudget,
+                    );
+                    remainingTotalPatchBudget -= budgeted.consumed;
+                    ourPatchBytes += budgeted.consumed;
 
                     ops.push({
                         kind: 'updateFile',
                         fileId: existing.id,
-                        data: fileFields,
+                        data: {
+                            ...fields,
+                            patch: budgeted.patch,
+                            // Explicit, not conditional: a file whose patch is
+                            // no longer capped must clear any stale flag (#1841).
+                            patchTruncated: !!budgeted.truncated,
+                        },
                     });
 
                     if (newSuggestionsForFile.length > 0) {
@@ -1307,6 +1386,109 @@ export class PullRequestsService implements IPullRequestsService {
                         organizationId,
                         ops,
                     );
+            }
+
+            // Enforce the aggregate embedded-diff ceiling against ground truth
+            // *after* the write. The in-memory seed above comes from a read of
+            // `existingPR.files` that can be stale — two syncs firing at once
+            // each see the same "remaining" budget and can both spend it,
+            // overshooting the cap even though each individual write looked
+            // safe (#1841). So we re-read the real byte total server-side and,
+            // if the document is over the cap, shrink and re-write only our
+            // patch updates (bounded retries). Files we did not touch, and
+            // patches added by a concurrent writer, are never rewritten.
+            if (patchUpdates.length > 0) {
+                const MAX_BUDGET_ENFORCEMENT_PASSES = 3;
+                for (
+                    let pass = 0;
+                    pass < MAX_BUDGET_ENFORCEMENT_PASSES;
+                    pass++
+                ) {
+                    let embeddedNow: number;
+                    try {
+                        embeddedNow =
+                            await this.pullRequestsRepository.computeEmbeddedPatchBytes(
+                                existingPR.uuid,
+                                organizationId,
+                            );
+                    } catch (error) {
+                        this.logger.warn({
+                            message: `Skipped embedded-diff ceiling verification for PR#${pullRequest?.number}`,
+                            context: PullRequestsService.name,
+                            error,
+                            metadata: {
+                                pullRequestNumber: pullRequest?.number,
+                                prUuid: existingPR.uuid,
+                            },
+                        });
+                        break;
+                    }
+
+                    const overflow =
+                        embeddedNow - MAX_TOTAL_EMBEDDED_PATCH_BYTES;
+                    if (overflow <= 0) {
+                        break; // under the cap — settled
+                    }
+                    if (ourPatchBytes <= 0) {
+                        // The overflow is not ours to reclaim (a concurrent
+                        // writer or a pre-existing oversized document). Log and
+                        // leave it rather than thrash.
+                        this.logger.warn({
+                            message: `pullRequests doc for PR#${pullRequest?.number} is over the embedded-diff ceiling but this batch owns none of it`,
+                            context: PullRequestsService.name,
+                            metadata: {
+                                pullRequestNumber: pullRequest?.number,
+                                prUuid: existingPR.uuid,
+                                embeddedPatchBytes: embeddedNow,
+                                maxTotalPatchBytes:
+                                    MAX_TOTAL_EMBEDDED_PATCH_BYTES,
+                            },
+                        });
+                        break;
+                    }
+
+                    // Keep every embedded byte that is not ours; hand our
+                    // patches the remainder. Always strictly shrinks because
+                    // `embeddedNow > MAX` implies `tightened < ourPatchBytes`.
+                    const tightened = Math.max(
+                        0,
+                        MAX_TOTAL_EMBEDDED_PATCH_BYTES -
+                            (embeddedNow - ourPatchBytes),
+                    );
+                    if (tightened >= ourPatchBytes) {
+                        break; // cannot make progress
+                    }
+
+                    const { updateOps, consumed } =
+                        budgetPatchUpdates(tightened);
+                    if (updateOps.length === 0) {
+                        break;
+                    }
+                    ourPatchBytes = consumed;
+
+                    this.logger.warn({
+                        message: `Embedded-diff ceiling exceeded after write for PR#${pullRequest?.number}; retrying with a tighter budget`,
+                        context: PullRequestsService.name,
+                        metadata: {
+                            pullRequestNumber: pullRequest?.number,
+                            prUuid: existingPR.uuid,
+                            embeddedPatchBytes: embeddedNow,
+                            tightenedBudgetBytes: tightened,
+                        },
+                    });
+
+                    const retryResult =
+                        await this.pullRequestsRepository.bulkApplyFileChanges(
+                            existingPR.uuid,
+                            organizationId,
+                            updateOps,
+                        );
+                    bulkResult = {
+                        attempted: bulkResult.attempted + retryResult.attempted,
+                        modified: bulkResult.modified + retryResult.modified,
+                        errors: [...bulkResult.errors, ...retryResult.errors],
+                    };
+                }
             }
 
             if (bulkResult.errors.length > 0) {

--- a/libs/platformData/infrastructure/adapters/services/pullRequests.service.ts
+++ b/libs/platformData/infrastructure/adapters/services/pullRequests.service.ts
@@ -17,6 +17,10 @@ import {
     ISuggestionByPR,
     SuggestionCountsBySeverity,
 } from '@libs/platformData/domain/pullRequests/interfaces/pullRequests.interface';
+import {
+    budgetPatchForPersist,
+    MAX_TOTAL_EMBEDDED_PATCH_CHARS,
+} from '@libs/platformData/domain/pullRequests/utils/diff-budget';
 import { PlatformType, PullRequestState } from '@libs/core/domain/enums';
 import { Repository } from '@libs/core/infrastructure/config/types/general/codeReview.type';
 import { OrganizationAndTeamData } from '@libs/core/infrastructure/config/types/general/organizationAndTeamData';
@@ -1181,6 +1185,20 @@ export class PullRequestsService implements IPullRequestsService {
                 });
             }
 
+            // Seed the aggregate diff budget with the bytes the document already
+            // carries from prior syncs, so the whole `pullRequests` document —
+            // not just this batch — stays under MongoDB's 16 MB BSON ceiling.
+            const existingEmbeddedPatchChars =
+                existingPR.files?.reduce(
+                    (sum, f) =>
+                        sum + ((f as { patch?: string }).patch?.length ?? 0),
+                    0,
+                ) ?? 0;
+            let remainingTotalPatchBudget = Math.max(
+                0,
+                MAX_TOTAL_EMBEDDED_PATCH_CHARS - existingEmbeddedPatchChars,
+            );
+
             const ops: FileBulkOp[] = [];
             const seenInBatch = new Set<string>();
             let duplicateChangedFiles = 0;
@@ -1212,11 +1230,25 @@ export class PullRequestsService implements IPullRequestsService {
                 const existing = existingByPath.get(filename);
 
                 if (existing) {
-                    const fileFields = {
-                        patch: PullRequestsService.sanitizePatchForPersist(
+                    // Cap the union of embedded diffs so this PR document stays
+                    // well under MongoDB's 16 MB BSON ceiling. Shares a running
+                    // aggregate budget across all files in the batch, seeded by
+                    // the bytes already embedded on existing files. Oversized
+                    // diffs are truncated (with a visible marker) or dropped,
+                    // never failing the review (#1841).
+                    const budgeted = budgetPatchForPersist(
+                        PullRequestsService.sanitizePatchForPersist(
                             filename,
                             file.patch,
                         ),
+                        remainingTotalPatchBudget,
+                    );
+                    remainingTotalPatchBudget -= budgeted.consumed;
+                    const fileFields = {
+                        patch: budgeted.patch,
+                        ...(budgeted.truncated
+                            ? { patchTruncated: true }
+                            : {}),
                         status: file.status ?? '',
                         added: file.additions ?? 0,
                         deleted: file.deletions ?? 0,


### PR DESCRIPTION
Fixes #1841

## Problem
A very large PR is persisted as a single `pullRequests` MongoDB document that embeds every file's unified diff. When the aggregate passes MongoDB's hard 16 MB per-document BSON ceiling, the write is rejected (`MongoBulkWriteError ... Resulting document after update is larger than 16777216`) and the whole review fails with a misleading **"Code Review Skipped — Unable to load or resolve the review configuration"**. This is a structural ceiling — it can't be fixed with more memory or a longer timeout.

## Fix — bound the embedded diff, don't fail the review
The document always stays under the cap; oversized diffs degrade (with a visible marker) instead of breaking the run.

- **`diff-budget` util** (new): `MAX_PATCH_CHARS_PER_FILE` (200 000) plus a shared **aggregate** `MAX_TOTAL_EMBEDDED_PATCH_CHARS` (8 MB — headroom below the 16 MB BSON cap for the rest of the doc: suggestions, commits, metadata). `budgetPatchForPersist` truncates an oversized patch to its per-file/aggregate allowance (keeping a leading window **plus a visible marker**) or drops it once the aggregate budget is spent.
- **`PullRequestsService.handleExistingPullRequest`**: seeds a running aggregate budget with the bytes **already embedded** on the doc's existing files (so the whole document, not just this batch, is bounded), then routes every `updateFile` patch through the budget. Capped files are flagged `patchTruncated: true`.
- **Repository `translateFileBulkOp`**: last-resort per-file clamp on any `files.$.patch` written by any path — a future caller that bypasses the service budget still cannot embed an unbounded patch.
- **Types**: `IFile` + `PullRequestsModel.files` now type `patch?` / `patchTruncated?`.

Net: a release/Promotion PR over 16 MB now reviews with diff coverage trimmed at the tail (each affected file carries the marker), instead of failing with no result at all.

## Validation
- `diff-budget.spec.ts` (9): per-file cap, aggregate budget, drop-on-exhaustion, marker presence, cumulative-consumed ≤ budget, repo clamp.
- `pullRequests.service.bulk-file-changes.spec.ts`: 2 new wiring tests — (a) a 2×-cap patch is truncated + marked, (b) an already-embedded doc (budget ~exhausted) truncates the first file and **drops** the next. Adjusted one pre-existing case that asserted an oversized text patch is stored verbatim — the behaviour #1841 intentionally bounds.
- **30/30 pass**; `tsc` clean on all touched files; `eslint` clean. **RED verified**: stashing the service wiring makes both budget tests fail (the cap is not a no-op).

## Scope left / notes
- The secondary **RabbitMQ 30-min ack-timeout re-loop** from the issue (dead-letter/cap + `consumer_timeout`) is a separate concern and out of scope here — should be its own PR.
- "Fail closed with an explicit status" is now moot for document-size (we never fail); still applies to genuinely-unreviewable PRs and is separate.
- Constants are deliberate (no env-tuning), matching the existing `MAX_FILES_PER_SAVE` policy in the same file.