### PR TITLE
fix(byok): Bedrock connection test and model listing

### DIFF
--- a/apps/api/src/controllers/organizationParameters.controller.ts
+++ b/apps/api/src/controllers/organizationParameters.controller.ts
@@ -250,13 +250,15 @@ export class OrganizationParametersController {
                 provider: { type: 'string' },
                 apiKey: { type: 'string' },
                 baseURL: { type: 'string' },
+                awsBearerToken: { type: 'string' },
+                awsRegion: { type: 'string' },
             },
         },
     })
     @ApiOperation({
         summary: 'List models with a candidate key',
         description:
-            "Live-list a provider's models using a just-typed (unsaved) API key + base URL — for the connect form, before the credential is saved. The key travels in the body (never a query string). Falls back to the org's saved credential when no key is supplied. Strict: an http provider with a candidate key does a live `/models` call and surfaces the error instead of a curated placeholder.",
+            "Live-list a provider's models using a just-typed (unsaved) credential — for the connect form, before it's saved. The credential travels in the body (never a query string): `apiKey`(+`baseURL`) for most providers, `awsBearerToken`(+`awsRegion`) for Amazon Bedrock, which never authenticates with an apiKey. Falls back to the org's saved credential when none is supplied. Strict: an http provider with a candidate credential does a live `/models` call and surfaces the error instead of a curated placeholder.",
     })
     @ApiOkResponse({ type: OrganizationProviderModelsResponseDto })
     public async listModelsWithKey(
@@ -265,13 +267,20 @@ export class OrganizationParametersController {
             provider: string;
             apiKey?: string;
             baseURL?: string;
+            awsBearerToken?: string;
+            awsRegion?: string;
         },
     ): Promise<ModelResponse> {
         const organizationId = this.request?.user?.organization?.uuid;
         return await this.getModelsByProviderUseCase.execute(
             body.provider,
             organizationId ? { organizationId } : undefined,
-            { apiKey: body.apiKey, baseURL: body.baseURL },
+            {
+                apiKey: body.apiKey,
+                baseURL: body.baseURL,
+                awsBearerToken: body.awsBearerToken,
+                awsRegion: body.awsRegion,
+            },
         );
     }
 

--- a/apps/web/src/features/ee/byok/_components/_modals/edit-key/_components/models.spec.tsx
+++ b/apps/web/src/features/ee/byok/_components/_modals/edit-key/_components/models.spec.tsx
@@ -7,6 +7,9 @@ import { ByokModelSelect } from "./models";
 
 // A live-listing provider so, unlocked, the component would try to render the
 // picker (which we assert it does NOT when the model is in use in Routing).
+// amazon_bedrock is included alongside it so the same suite can regression-test
+// the Bedrock-specific credential gate without affecting apiKey-based providers.
+const mockPreview = jest.fn();
 jest.mock("@services/organizationParameters/hooks", () => ({
     useSuspenseGetLLMProviders: () => ({
         providers: [
@@ -16,13 +19,15 @@ jest.mock("@services/organizationParameters/hooks", () => ({
                 listsModelsLive: true,
                 requiresBaseUrl: false,
             },
+            {
+                id: "amazon_bedrock",
+                autoListModels: true,
+                listsModelsLive: true,
+                requiresBaseUrl: false,
+            },
         ],
     }),
-    useLLMProviderModelsPreview: () => ({
-        data: [],
-        isFetching: false,
-        isError: false,
-    }),
+    useLLMProviderModelsPreview: (...args: unknown[]) => mockPreview(...args),
 }));
 
 function Harness({ lockedInUse }: { lockedInUse: boolean }) {
@@ -38,6 +43,28 @@ function Harness({ lockedInUse }: { lockedInUse: boolean }) {
         </FormProvider>
     );
 }
+
+/** Renders the live picker directly (unlocked, no stored credential) with
+ *  arbitrary form defaults — for exercising `ModelSelectLive`'s enable gate. */
+function LivePickerHarness({
+    defaultValues,
+    credentialStored = false,
+}: {
+    defaultValues: Record<string, unknown>;
+    credentialStored?: boolean;
+}) {
+    const form = useForm({ defaultValues: defaultValues as any });
+    return (
+        <FormProvider {...form}>
+            <ByokModelSelect credentialStored={credentialStored} />
+        </FormProvider>
+    );
+}
+
+beforeEach(() => {
+    mockPreview.mockReset();
+    mockPreview.mockReturnValue({ data: [], isFetching: false, isError: false });
+});
 
 describe("ByokModelSelect — lock when the model is in use in Routing", () => {
     it("locked: shows the current model read-only with the Routing hint, no search box", () => {
@@ -59,5 +86,136 @@ describe("ByokModelSelect — lock when the model is in use in Routing", () => {
     it("unlocked: renders the editable picker, not the lock hint", () => {
         render(<Harness lockedInUse={false} />);
         expect(screen.queryByText(/in use in routing/i)).not.toBeInTheDocument();
+    });
+});
+
+// Regression: commit d064c37c7 switched Bedrock from a static catalog to a live
+// `/models` call (`listsModelsLive: true`), which routes it through the SAME
+// gate every other live-listing provider uses — `hasKey` from `apiKey`. Bedrock
+// never populates `apiKey` (it authenticates with awsBearerToken / IAM), so a
+// fresh Bedrock connect got stuck on "Enter your API key to load models"
+// forever, even though the backend already serves a curated fallback for a
+// keyless Bedrock request. These pin the fix (a Bedrock-specific OR branch) and
+// guard that apiKey-based providers are untouched by it.
+describe("ByokModelSelect — Bedrock credential gate (regression: d064c37c7)", () => {
+    it("Bedrock, nothing typed, no stored credential: stays on the key prompt (no false-positive enable)", () => {
+        render(
+            <LivePickerHarness
+                defaultValues={{ provider: "amazon_bedrock", model: "" }}
+            />,
+        );
+        expect(
+            screen.getByText(/enter your api key to load models/i),
+        ).toBeInTheDocument();
+        expect(mockPreview).toHaveBeenCalledWith(
+            expect.objectContaining({ enabled: false }),
+        );
+    });
+
+    it("Bedrock, awsBearerToken typed: enables the picker and forwards the bearer token + region, not apiKey", () => {
+        render(
+            <LivePickerHarness
+                defaultValues={{
+                    provider: "amazon_bedrock",
+                    model: "",
+                    awsBearerToken: "ABSK-typed",
+                    awsRegion: "us-east-1",
+                }}
+            />,
+        );
+        expect(
+            screen.queryByText(/enter your api key to load models/i),
+        ).not.toBeInTheDocument();
+        expect(mockPreview).toHaveBeenCalledWith(
+            expect.objectContaining({
+                provider: "amazon_bedrock",
+                apiKey: undefined,
+                awsBearerToken: "ABSK-typed",
+                awsRegion: "us-east-1",
+                enabled: true,
+            }),
+        );
+    });
+
+    it("Bedrock, IAM access key + secret typed (no bearer): enables the picker (curated fallback) but forwards NO bearer token — SigV4 can't drive a live call", () => {
+        render(
+            <LivePickerHarness
+                defaultValues={{
+                    provider: "amazon_bedrock",
+                    model: "",
+                    awsAccessKeyId: "AKIA-typed",
+                    awsSecretAccessKey: "secret-typed",
+                    awsRegion: "us-east-1",
+                }}
+            />,
+        );
+        expect(
+            screen.queryByText(/enter your api key to load models/i),
+        ).not.toBeInTheDocument();
+        expect(mockPreview).toHaveBeenCalledWith(
+            expect.objectContaining({
+                awsBearerToken: undefined,
+                enabled: true,
+            }),
+        );
+    });
+
+    it("Bedrock, only IAM access key typed (no secret yet): stays on the key prompt", () => {
+        render(
+            <LivePickerHarness
+                defaultValues={{
+                    provider: "amazon_bedrock",
+                    model: "",
+                    awsAccessKeyId: "AKIA-typed",
+                }}
+            />,
+        );
+        expect(
+            screen.getByText(/enter your api key to load models/i),
+        ).toBeInTheDocument();
+    });
+
+    it("apiKey-based provider (novita) is unaffected: apiKey alone still enables, aws* fields play no role", () => {
+        render(
+            <LivePickerHarness
+                defaultValues={{
+                    provider: "novita",
+                    model: "",
+                    apiKey: "sk-typed",
+                }}
+            />,
+        );
+        expect(
+            screen.queryByText(/enter your api key to load models/i),
+        ).not.toBeInTheDocument();
+        expect(mockPreview).toHaveBeenCalledWith(
+            expect.objectContaining({
+                provider: "novita",
+                apiKey: "sk-typed",
+                awsBearerToken: undefined,
+                awsRegion: undefined,
+                enabled: true,
+            }),
+        );
+    });
+
+    it("apiKey-based provider (novita) with no apiKey: stays on the key prompt even if aws* fields happen to be set", () => {
+        // Defensive: aws* fields must never leak enable-power to a non-Bedrock
+        // provider — `isBedrock` gates them off entirely.
+        render(
+            <LivePickerHarness
+                defaultValues={{
+                    provider: "novita",
+                    model: "",
+                    awsBearerToken: "ABSK-stray",
+                }}
+            />,
+        );
+        expect(
+            screen.getByText(/enter your api key to load models/i),
+        ).toBeInTheDocument();
+        expect(mockPreview).toHaveBeenCalledWith(
+            expect.objectContaining({ enabled: false }),
+        );
     });
 });

--- a/apps/web/src/features/ee/byok/_components/_modals/edit-key/_components/models.tsx
+++ b/apps/web/src/features/ee/byok/_components/_modals/edit-key/_components/models.tsx
@@ -364,6 +364,17 @@ function useDebouncedValue<T>(value: T, ms: number): T {
  * (e.g. OpenAI). The list comes from the JUST-TYPED key — no curated placeholder.
  * Before a key exists (fresh connect) it prompts for one; a stored credential
  * (edit / add-to-connected) lists live with no typed key.
+ *
+ * Amazon Bedrock is the one live-listing provider that does NOT authenticate
+ * with `apiKey` — it uses `awsBearerToken` (live) or `awsAccessKeyId` +
+ * `awsSecretAccessKey` (IAM, can only ever reach the curated fallback — SigV4
+ * needs request signing, not a static header). Gating "do we have something to
+ * authenticate with" on `apiKey` alone left a fresh Bedrock connect stuck on
+ * "Enter your API key to load models" forever, even though the backend already
+ * serves a curated fallback for a keyless Bedrock request. Every other
+ * live-listing provider (openai, anthropic, google_gemini, open_router,
+ * novita, moonshot) keeps using `apiKey` exactly as before — this only adds a
+ * Bedrock-specific OR branch, it doesn't touch their gate.
  */
 const ModelSelectLive = ({
     onUseManual,
@@ -376,19 +387,41 @@ const ModelSelectLive = ({
 }) => {
     const form = useFormContext<EditKeyForm>();
     const provider = form.watch("provider");
+    const isBedrock = provider === "amazon_bedrock";
     const typedKeyRaw = (form.watch("apiKey") ?? "").trim();
     const typedBaseURL = (form.watch("baseURL") ?? undefined) || undefined;
     const typedKey = useDebouncedValue(typedKeyRaw, 700);
     const hasKey = typedKey.length > 0;
 
+    const typedAwsBearerRaw = (form.watch("awsBearerToken") ?? "").trim();
+    const typedAwsAccessKeyIdRaw = (
+        form.watch("awsAccessKeyId") ?? ""
+    ).trim();
+    const typedAwsSecretRaw = (form.watch("awsSecretAccessKey") ?? "").trim();
+    const typedAwsRegionRaw = (form.watch("awsRegion") ?? "").trim();
+    const typedAwsBearer = useDebouncedValue(typedAwsBearerRaw, 700);
+    const typedAwsAccessKeyId = useDebouncedValue(typedAwsAccessKeyIdRaw, 700);
+    const typedAwsSecret = useDebouncedValue(typedAwsSecretRaw, 700);
+    const typedAwsRegion = useDebouncedValue(typedAwsRegionRaw, 700);
+    const hasAwsBearer = isBedrock && typedAwsBearer.length > 0;
+    // IAM creds can't drive a live call, but typing them should still surface
+    // the curated fallback the backend already returns for a keyless request —
+    // the pre-regression behavior for this auth path.
+    const hasAwsIam =
+        isBedrock &&
+        typedAwsAccessKeyId.length > 0 &&
+        typedAwsSecret.length > 0;
+
     // List live when we have SOMETHING to authenticate with: a typed key, or a
     // stored credential the server resolves on its own. Else prompt for the key.
-    const enabled = hasKey || credentialStored;
+    const enabled = hasKey || hasAwsBearer || hasAwsIam || credentialStored;
 
     const { data, isFetching, isError } = useLLMProviderModelsPreview({
         provider,
         apiKey: hasKey ? typedKey : undefined,
         baseURL: typedBaseURL,
+        awsBearerToken: hasAwsBearer ? typedAwsBearer : undefined,
+        awsRegion: isBedrock ? typedAwsRegion || undefined : undefined,
         enabled,
     });
 

--- a/apps/web/src/lib/services/organizationParameters/fetch.ts
+++ b/apps/web/src/lib/services/organizationParameters/fetch.ts
@@ -293,6 +293,10 @@ export const previewLLMProviderModels = async (input: {
     provider: string;
     apiKey?: string;
     baseURL?: string;
+    /** Amazon Bedrock's equivalent of `apiKey` — Bedrock never authenticates
+     *  the connect form with a plain apiKey. */
+    awsBearerToken?: string;
+    awsRegion?: string;
 }): Promise<LLMProviderModel[]> => {
     const envelope = await axiosAuthorized.post<{
         data: { models: LLMProviderModel[] };

--- a/apps/web/src/lib/services/organizationParameters/hooks.ts
+++ b/apps/web/src/lib/services/organizationParameters/hooks.ts
@@ -38,18 +38,38 @@ export function useLLMProviderModelsPreview({
     provider,
     apiKey,
     baseURL,
+    awsBearerToken,
+    awsRegion,
     enabled,
 }: {
     provider: string;
     apiKey?: string;
     baseURL?: string;
+    /** Amazon Bedrock's equivalent of `apiKey` — see fetch.ts. */
+    awsBearerToken?: string;
+    awsRegion?: string;
     enabled: boolean;
 }) {
     return useQuery({
-        // Key includes apiKey/baseURL so a rotated key refetches; the value never
-        // leaves the browser's query cache (client-only, no SSR data cache).
-        queryKey: ['byok-provider-models-preview', provider, apiKey, baseURL],
-        queryFn: () => previewLLMProviderModels({ provider, apiKey, baseURL }),
+        // Key includes every credential field so a rotated key/token refetches;
+        // the value never leaves the browser's query cache (client-only, no SSR
+        // data cache).
+        queryKey: [
+            'byok-provider-models-preview',
+            provider,
+            apiKey,
+            baseURL,
+            awsBearerToken,
+            awsRegion,
+        ],
+        queryFn: () =>
+            previewLLMProviderModels({
+                provider,
+                apiKey,
+                baseURL,
+                awsBearerToken,
+                awsRegion,
+            }),
         enabled,
         staleTime: 5 * 60 * 1000,
         retry: false,

--- a/libs/llm/providers/bedrock/listing.spec.ts
+++ b/libs/llm/providers/bedrock/listing.spec.ts
@@ -163,6 +163,23 @@ describe('bedrockModelListing', () => {
         expect(models.map((m) => m.id)).toEqual(['moonshotai.kimi-k2.5']);
     });
 
+    // Regression: an EMPTY outputModalities array declares no modality at all —
+    // it must be treated the same as an absent field (keep the model), not as
+    // "does not support TEXT" (drop it).
+    it('is permissive when outputModalities is an EMPTY array (does not drop the model)', () => {
+        const models = listing().parse({
+            modelSummaries: [
+                {
+                    modelId: 'moonshotai.kimi-k2.5',
+                    modelName: 'Kimi K2.5',
+                    modelLifecycle: { status: 'ACTIVE' },
+                    outputModalities: [],
+                },
+            ],
+        });
+        expect(models.map((m) => m.id)).toEqual(['moonshotai.kimi-k2.5']);
+    });
+
     it('parse tolerates a malformed body', () => {
         expect(listing().parse({})).toEqual([]);
         expect(listing().parse(null)).toEqual([]);

--- a/libs/llm/providers/bedrock/listing.spec.ts
+++ b/libs/llm/providers/bedrock/listing.spec.ts
@@ -12,13 +12,13 @@ describe('bedrockModelListing', () => {
         expect(bedrockModelListing('openai')).toBeNull();
     });
 
-    it('builds the ListInferenceProfiles URL scoped to the user region', () => {
+    it('builds the ListFoundationModels URL scoped to the user region', () => {
         const url = listing().url({
             awsBearerToken: 'ABSK-x',
             awsRegion: 'us-east-1',
         });
         expect(url).toBe(
-            'https://bedrock.us-east-1.amazonaws.com/inference-profiles?maxResults=1000&typeEquals=SYSTEM_DEFINED',
+            'https://bedrock.us-east-1.amazonaws.com/foundation-models',
         );
     });
 
@@ -37,24 +37,84 @@ describe('bedrockModelListing', () => {
         expect(() => listing().url({ awsBearerToken: 'x' })).toThrow(/region/i);
     });
 
-    it('parses inferenceProfileSummaries → {id,name}, dropping non-ACTIVE', () => {
+    it('parses modelSummaries → {id,name}, dropping non-ACTIVE (LEGACY)', () => {
         const models = listing().parse({
-            inferenceProfileSummaries: [
+            modelSummaries: [
                 {
-                    inferenceProfileId: 'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
-                    inferenceProfileName: 'US Claude Sonnet 4.5',
-                    status: 'ACTIVE',
+                    modelId: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+                    modelName: 'Claude Sonnet 4.5',
+                    modelLifecycle: { status: 'ACTIVE' },
                 },
                 {
-                    inferenceProfileId: 'us.anthropic.dead-model-v1:0',
-                    inferenceProfileName: 'Dead',
-                    status: 'INACTIVE',
+                    modelId: 'anthropic.dead-model-v1:0',
+                    modelName: 'Dead',
+                    modelLifecycle: { status: 'LEGACY' },
                 },
             ],
         });
         expect(models.map((m) => m.id)).toEqual([
-            'us.anthropic.claude-sonnet-4-5-20250929-v1:0',
+            'anthropic.claude-sonnet-4-5-20250929-v1:0',
         ]);
+    });
+
+    // Regression: ListInferenceProfiles only ever returned Anthropic (AWS built
+    // it for Claude's cross-region routing), so a third-party marketplace model
+    // like Kimi — invoked directly by its bare id, never registered as a
+    // profile — could never appear in the picker. ListFoundationModels is the
+    // base catalog: every family lives here.
+    it('includes non-Anthropic marketplace models (e.g. Kimi) — the whole point of switching off ListInferenceProfiles', () => {
+        const models = listing().parse({
+            modelSummaries: [
+                {
+                    modelId: 'moonshotai.kimi-k2.5',
+                    modelName: 'Kimi K2.5',
+                    modelLifecycle: { status: 'ACTIVE' },
+                },
+                {
+                    modelId: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+                    modelName: 'Claude Sonnet 4.5',
+                    modelLifecycle: { status: 'ACTIVE' },
+                },
+            ],
+        });
+        expect(models.map((m) => m.id)).toEqual(
+            expect.arrayContaining([
+                'moonshotai.kimi-k2.5',
+                'anthropic.claude-sonnet-4-5-20250929-v1:0',
+            ]),
+        );
+    });
+
+    // Regression: reasoningKeyOf's regex required a geography prefix
+    // (`us.anthropic....`), which ListInferenceProfiles always sent.
+    // ListFoundationModels returns the BARE id (`anthropic....`, no prefix) —
+    // without widening the regex, a live-listed Claude model would silently
+    // lose its reasoning-capability badge even though the prefixed profile the
+    // runtime actually calls has one.
+    it('resolves reasoning caps for a BARE Claude id, same as the geography-prefixed one', () => {
+        const [bare] = listing().parse({
+            modelSummaries: [
+                {
+                    modelId: 'anthropic.claude-opus-4-1-20250805-v1:0',
+                    modelName: 'Claude Opus 4.1',
+                    modelLifecycle: { status: 'ACTIVE' },
+                },
+            ],
+        });
+        const [prefixed] = (listing().fallbackModels ?? []).filter(
+            (m) => m.id === 'us.anthropic.claude-opus-4-1-20250805-v1:0',
+        );
+        expect(bare.supportsReasoning).toBe(true);
+        expect(bare.supportsReasoning).toBe(prefixed?.supportsReasoning);
+    });
+
+    it('is permissive when modelLifecycle is absent (treats as ACTIVE)', () => {
+        const models = listing().parse({
+            modelSummaries: [
+                { modelId: 'moonshotai.kimi-k2.5', modelName: 'Kimi K2.5' },
+            ],
+        });
+        expect(models.map((m) => m.id)).toEqual(['moonshotai.kimi-k2.5']);
     });
 
     it('parse tolerates a malformed body', () => {

--- a/libs/llm/providers/bedrock/listing.spec.ts
+++ b/libs/llm/providers/bedrock/listing.spec.ts
@@ -117,6 +117,52 @@ describe('bedrockModelListing', () => {
         expect(models.map((m) => m.id)).toEqual(['moonshotai.kimi-k2.5']);
     });
 
+    // ListFoundationModels — unlike ListInferenceProfiles, which only ever
+    // returned Anthropic chat models — also lists embedding and image
+    // foundation models. None of them can serve a code review; nothing
+    // downstream filters by modality, so picking one from the dropdown would
+    // only fail once a review tries to invoke it.
+    it('excludes embedding and image models (non-TEXT outputModalities)', () => {
+        const models = listing().parse({
+            modelSummaries: [
+                {
+                    modelId: 'anthropic.claude-sonnet-4-5-20250929-v1:0',
+                    modelName: 'Claude Sonnet 4.5',
+                    modelLifecycle: { status: 'ACTIVE' },
+                    outputModalities: ['TEXT'],
+                },
+                {
+                    modelId: 'amazon.titan-embed-text-v2:0',
+                    modelName: 'Titan Embed Text v2',
+                    modelLifecycle: { status: 'ACTIVE' },
+                    outputModalities: ['EMBEDDING'],
+                },
+                {
+                    modelId: 'amazon.nova-canvas-v1:0',
+                    modelName: 'Nova Canvas',
+                    modelLifecycle: { status: 'ACTIVE' },
+                    outputModalities: ['IMAGE'],
+                },
+            ],
+        });
+        expect(models.map((m) => m.id)).toEqual([
+            'anthropic.claude-sonnet-4-5-20250929-v1:0',
+        ]);
+    });
+
+    it('is permissive when outputModalities is absent (does not drop the model)', () => {
+        const models = listing().parse({
+            modelSummaries: [
+                {
+                    modelId: 'moonshotai.kimi-k2.5',
+                    modelName: 'Kimi K2.5',
+                    modelLifecycle: { status: 'ACTIVE' },
+                },
+            ],
+        });
+        expect(models.map((m) => m.id)).toEqual(['moonshotai.kimi-k2.5']);
+    });
+
     it('parse tolerates a malformed body', () => {
         expect(listing().parse({})).toEqual([]);
         expect(listing().parse(null)).toEqual([]);

--- a/libs/llm/providers/bedrock/listing.ts
+++ b/libs/llm/providers/bedrock/listing.ts
@@ -16,9 +16,11 @@ const CURATED: Array<{ id: string; name: string }> = [
     { id: 'us.anthropic.claude-3-5-sonnet-20241022-v2:0', name: 'Claude 3.5 Sonnet v2 (us, cross-region)' },
 ];
 
-// Look up caps by the Anthropic-style suffix (after "us.anthropic.").
+// Look up caps by the Anthropic-style suffix (after "anthropic." — the
+// geography prefix, e.g. "us.", is optional: ListFoundationModels returns the
+// BARE id, ListInferenceProfiles the geography-prefixed one).
 const reasoningKeyOf = (id: string): string => {
-    const match = id.match(/^[a-z]{2,5}\.anthropic\.(.+?)-v\d+:\d+$/);
+    const match = id.match(/^(?:[a-z]{2,5}\.)?anthropic\.(.+?)-v\d+:\d+$/);
     return match ? match[1] : id;
 };
 
@@ -36,13 +38,28 @@ const AWS_REGION_RE = /^[a-z]{2}-[a-z]+-\d+$/;
 /**
  * Amazon Bedrock model listing.
  *
- * LIVE when a Bedrock API key (bearer token) + a valid region are available: hits
- * the control-plane `ListInferenceProfiles` for the user's OWN account/region, so
- * the picker shows exactly the SYSTEM_DEFINED profiles that account can invoke —
- * and never a retired one. The bearer token authenticates directly
- * (`Authorization: Bearer …`), so no SigV4 signing is needed. IAM-only creds (no
- * bearer) and the no-cred setup path fall back to {@link BEDROCK_CURATED_CATALOG}
- * via the fetcher (SigV4 can't be expressed as pure headers).
+ * LIVE when a Bedrock API key (bearer token) + a valid region are available:
+ * hits the control-plane `ListFoundationModels` for the user's OWN
+ * account/region, so the picker shows every base model that region serves —
+ * Claude, Kimi, MiniMax, Nova, Llama, etc. The bearer token authenticates
+ * directly (`Authorization: Bearer …`), so no SigV4 signing is needed.
+ * IAM-only creds (no bearer) and the no-cred setup path fall back to
+ * {@link BEDROCK_CURATED_CATALOG} via the fetcher (SigV4 can't be expressed
+ * as pure headers).
+ *
+ * Was `ListInferenceProfiles` (cross-region routing profiles) until this
+ * surfaced only Anthropic — AWS built that endpoint for Claude's cross-region
+ * routing, so a third-party marketplace model like `moonshotai.kimi-k2.5`
+ * (invoked directly by its bare id, never registered as a profile) could never
+ * appear there, no matter how valid the credential. `ListFoundationModels` is
+ * the base catalog — every invocable model lives here, profile or not.
+ *
+ * The bare id this returns for Claude generations that require a
+ * geography-prefixed profile (3.7+) is NOT wrong to list: `build()`
+ * (bedrock/index.ts) runs every model through `repairBedrockModelId()`
+ * unconditionally before invoking, which rewrites a bare 3.7+ id to the
+ * correct `us.`/`eu.`/`apac.` profile for the configured region. Picking the
+ * bare id from this dropdown still ends up calling the right profile.
  */
 const httpListing: ModelListing = {
     kind: 'http',
@@ -58,31 +75,31 @@ const httpListing: ModelListing = {
                 'A valid AWS region is required to list Bedrock models.',
             );
         }
-        // ListInferenceProfiles filters on `typeEquals` (enum SYSTEM_DEFINED |
-        // APPLICATION), NOT `type` — a wrong key is silently ignored and the call
-        // returns every profile instead of just the cross-region system ones.
-        return `https://bedrock.${region}.amazonaws.com/inference-profiles?maxResults=1000&typeEquals=SYSTEM_DEFINED`;
+        return `https://bedrock.${region}.amazonaws.com/foundation-models`;
     },
     headers: (creds) => ({
         Authorization: `Bearer ${creds.awsBearerToken ?? ''}`,
         Accept: 'application/json',
     }),
     parse: (body: unknown): CatalogModel[] => {
-        const summaries =
-            (body as { inferenceProfileSummaries?: unknown })
-                ?.inferenceProfileSummaries;
+        const summaries = (body as { modelSummaries?: unknown })
+            ?.modelSummaries;
         if (!Array.isArray(summaries)) return [];
         return summaries
             .map((s) => s as Record<string, unknown>)
-            // Only invocable profiles — a non-ACTIVE one can't be used for review.
-            .filter((s) => (s.status ?? 'ACTIVE') === 'ACTIVE')
+            // Only invocable models — LEGACY ones AWS is retiring shouldn't be
+            // offered as a fresh pick. Permissive when the field is absent
+            // rather than dropping everything on an unexpected shape.
+            .filter((s) => {
+                const lifecycle = s.modelLifecycle as
+                    | { status?: unknown }
+                    | undefined;
+                return (lifecycle?.status ?? 'ACTIVE') === 'ACTIVE';
+            })
             .map((s) => {
-                const id = typeof s.inferenceProfileId === 'string'
-                    ? s.inferenceProfileId
-                    : '';
-                const name = typeof s.inferenceProfileName === 'string'
-                    ? s.inferenceProfileName
-                    : id;
+                const id = typeof s.modelId === 'string' ? s.modelId : '';
+                const name =
+                    typeof s.modelName === 'string' ? s.modelName : id;
                 return id
                     ? catalogWithReasoning(id, name, reasoningKeyOf(id))
                     : null;

--- a/libs/llm/providers/bedrock/listing.ts
+++ b/libs/llm/providers/bedrock/listing.ts
@@ -87,14 +87,22 @@ const httpListing: ModelListing = {
         if (!Array.isArray(summaries)) return [];
         return summaries
             .map((s) => s as Record<string, unknown>)
-            // Only invocable models — LEGACY ones AWS is retiring shouldn't be
-            // offered as a fresh pick. Permissive when the field is absent
-            // rather than dropping everything on an unexpected shape.
             .filter((s) => {
+                // Only invocable models — LEGACY ones AWS is retiring shouldn't
+                // be offered as a fresh pick. Permissive when the field is
+                // absent rather than dropping everything on an unexpected shape.
                 const lifecycle = s.modelLifecycle as
                     | { status?: unknown }
                     | undefined;
-                return (lifecycle?.status ?? 'ACTIVE') === 'ACTIVE';
+                if ((lifecycle?.status ?? 'ACTIVE') !== 'ACTIVE') return false;
+                // ListFoundationModels also returns embedding models (Titan
+                // Embed, Cohere Embed) and image models (Nova Canvas, Stability)
+                // — none of them can serve a code review. Nothing downstream
+                // filters by modality, so an embedding/image id picked here
+                // would only fail once the review tries to invoke it.
+                // Permissive when the field is absent/malformed.
+                const out = s.outputModalities;
+                return !Array.isArray(out) || out.includes('TEXT');
             })
             .map((s) => {
                 const id = typeof s.modelId === 'string' ? s.modelId : '';

--- a/libs/llm/providers/bedrock/listing.ts
+++ b/libs/llm/providers/bedrock/listing.ts
@@ -100,9 +100,16 @@ const httpListing: ModelListing = {
                 // — none of them can serve a code review. Nothing downstream
                 // filters by modality, so an embedding/image id picked here
                 // would only fail once the review tries to invoke it.
-                // Permissive when the field is absent/malformed.
+                // Permissive when the field is absent/malformed — including an
+                // EMPTY array, which declares no modality at all rather than
+                // "not TEXT"; dropping it there would silently lose a model
+                // that may well serve text generation.
                 const out = s.outputModalities;
-                return !Array.isArray(out) || out.includes('TEXT');
+                return (
+                    !Array.isArray(out) ||
+                    out.length === 0 ||
+                    out.includes('TEXT')
+                );
             })
             .map((s) => {
                 const id = typeof s.modelId === 'string' ? s.modelId : '';

--- a/libs/organization/application/use-cases/organizationParameters/get-models-by-provider.use-case.spec.ts
+++ b/libs/organization/application/use-cases/organizationParameters/get-models-by-provider.use-case.spec.ts
@@ -217,6 +217,131 @@ describe('GetModelsByProviderUseCase — BYOK-aware model listing', () => {
         if (prev !== undefined) process.env.API_OPEN_AI_API_KEY = prev;
     });
 
+    // ---- Bedrock candidate (just-typed, unsaved bearer token) — regression: a
+    // fresh Bedrock connect used to be stuck on the curated fallback forever
+    // because the frontend only ever sent {apiKey, baseURL}, never a bearer
+    // token candidate. These mirror the OpenAI candidate tests above, for the
+    // field Bedrock actually authenticates with.
+
+    it('lists Bedrock live with a JUST-TYPED candidate bearer token + region — including a non-Anthropic model', async () => {
+        mockedAxios.get.mockResolvedValue({
+            data: {
+                modelSummaries: [
+                    {
+                        modelId: 'anthropic.claude-x',
+                        modelName: 'Claude X',
+                        modelLifecycle: { status: 'ACTIVE' },
+                    },
+                    {
+                        modelId: 'moonshotai.kimi-k2.5',
+                        modelName: 'Kimi K2.5',
+                        modelLifecycle: { status: 'ACTIVE' },
+                    },
+                ],
+            },
+        } as any);
+        const useCase = buildUseCase(null); // no saved config
+
+        const res = await useCase.execute(
+            BYOKProvider.AMAZON_BEDROCK,
+            { organizationId: 'org-1' },
+            { awsBearerToken: 'ABSK-typed', awsRegion: 'us-east-1' },
+        );
+
+        expect(res.exercisedCredential).toBe(true);
+        // ListFoundationModels, not ListInferenceProfiles — proves a
+        // third-party marketplace model (never a registered inference
+        // profile) now shows up too.
+        expect(res.models.map((m) => m.id)).toEqual(
+            expect.arrayContaining(['anthropic.claude-x', 'moonshotai.kimi-k2.5']),
+        );
+        const [url, cfg] = mockedAxios.get.mock.calls[0];
+        expect(url).toContain('bedrock.us-east-1.amazonaws.com');
+        expect(cfg?.headers?.Authorization).toBe('Bearer ABSK-typed');
+    });
+
+    it('is STRICT with a candidate Bedrock bearer token: a live-fetch failure throws instead of the curated fallback', async () => {
+        mockedAxios.get.mockRejectedValue(new Error('403 expired'));
+        const useCase = buildUseCase(null);
+
+        await expect(
+            useCase.execute(
+                BYOKProvider.AMAZON_BEDROCK,
+                { organizationId: 'org-1' },
+                { awsBearerToken: 'ABSK-bad', awsRegion: 'us-east-1' },
+            ),
+        ).rejects.toThrow(/Error fetching amazon_bedrock models/i);
+    });
+
+    it('a candidate Bedrock bearer token with no region surfaces the region error, not the curated fallback', async () => {
+        const useCase = buildUseCase(null);
+
+        await expect(
+            useCase.execute(
+                BYOKProvider.AMAZON_BEDROCK,
+                { organizationId: 'org-1' },
+                { awsBearerToken: 'ABSK-typed' },
+            ),
+        ).rejects.toThrow(/region/i);
+        expect(mockedAxios.get).not.toHaveBeenCalled();
+    });
+
+    // Regression: `hasCandidateCredential` originally checked only
+    // candidateKey/candidateAwsBearerToken, so testing a NEW region against an
+    // ALREADY-SAVED Bedrock bearer token (the user retypes only the region, not
+    // the token) was treated as lenient — a bad region silently degraded to the
+    // curated Claude-only fallback instead of surfacing the real region error.
+    it('is STRICT when only the region is a candidate against an already-saved Bedrock bearer token', async () => {
+        mockedAxios.get.mockRejectedValue(new Error('403 unknown region'));
+        const useCase = buildUseCase({
+            version: 2,
+            credentials: [
+                {
+                    id: 'c1',
+                    provider: 'amazon_bedrock',
+                    settings: { awsBearerToken: 'stored-token' },
+                },
+            ],
+            models: [],
+        });
+
+        await expect(
+            useCase.execute(
+                BYOKProvider.AMAZON_BEDROCK,
+                { organizationId: 'org-1' },
+                { awsRegion: 'eu-west-99' }, // no bearer candidate — reuses the saved one
+            ),
+        ).rejects.toThrow(/Error fetching amazon_bedrock models/i);
+    });
+
+    // Regression: awsBearerToken/awsRegion are Bedrock-specific fields, but the
+    // controller forwards them regardless of `provider`. Before scoping the
+    // candidate read to Bedrock, a stray awsBearerToken on another provider's
+    // request would flip the shared `hasCandidateCredential` flag — harmless
+    // today only because no non-Bedrock listing declares a fallback, but the
+    // fields must not leak into another provider's request either way.
+    it('ignores a stray awsBearerToken/awsRegion candidate for a non-Bedrock provider', async () => {
+        mockedAxios.get.mockResolvedValue({
+            data: { object: 'list', data: [{ id: 'gpt-5.4' }] },
+        } as any);
+        const useCase = buildUseCase(null);
+
+        const res = await useCase.execute(
+            BYOKProvider.OPENAI,
+            { organizationId: 'org-1' },
+            {
+                apiKey: 'sk-typed',
+                awsBearerToken: 'stray-token',
+                awsRegion: 'us-east-1',
+            } as any,
+        );
+
+        expect(res.models.map((m) => m.id)).toContain('gpt-5.4');
+        const [, cfg] = mockedAxios.get.mock.calls[0];
+        // The OpenAI call authenticates with the apiKey, not a stray Bearer.
+        expect(cfg?.headers?.Authorization).toBe('Bearer sk-typed');
+    });
+
     it('a manual-listing BRAND (Z.ai/GLM) can no longer be enumerated — the user types the model id', async () => {
         // Z.ai speaks the Anthropic protocol → no `/models` call (manual listing),
         // and there is no curated catalog to stand in. The picker falls back to

--- a/libs/organization/application/use-cases/organizationParameters/get-models-by-provider.use-case.spec.ts
+++ b/libs/organization/application/use-cases/organizationParameters/get-models-by-provider.use-case.spec.ts
@@ -291,7 +291,16 @@ describe('GetModelsByProviderUseCase — BYOK-aware model listing', () => {
     // ALREADY-SAVED Bedrock bearer token (the user retypes only the region, not
     // the token) was treated as lenient — a bad region silently degraded to the
     // curated Claude-only fallback instead of surfacing the real region error.
-    it('is STRICT when only the region is a candidate against an already-saved Bedrock bearer token', async () => {
+    // A region alone is NOT a credential candidate — the connect form seeds
+    // `awsRegion` from the saved credential on every edit of an existing
+    // Bedrock config, so it rides along on essentially every request whether
+    // or not the user typed a new one. Treating it as "the user is actively
+    // trying this credential" would flip the saved-credential path to strict
+    // on ANY edit: a lapsed saved bearer token, or a transient AWS hiccup,
+    // would 400 a user editing something unrelated (e.g. temperature) instead
+    // of degrading to the curated catalog like every other saved-credential
+    // path does.
+    it('degrades LENIENTLY (curated fallback) when only the region is a candidate against an already-saved Bedrock bearer token', async () => {
         mockedAxios.get.mockRejectedValue(new Error('403 unknown region'));
         const useCase = buildUseCase({
             version: 2,
@@ -305,13 +314,14 @@ describe('GetModelsByProviderUseCase — BYOK-aware model listing', () => {
             models: [],
         });
 
-        await expect(
-            useCase.execute(
-                BYOKProvider.AMAZON_BEDROCK,
-                { organizationId: 'org-1' },
-                { awsRegion: 'eu-west-99' }, // no bearer candidate — reuses the saved one
-            ),
-        ).rejects.toThrow(/Error fetching amazon_bedrock models/i);
+        const res = await useCase.execute(
+            BYOKProvider.AMAZON_BEDROCK,
+            { organizationId: 'org-1' },
+            { awsRegion: 'eu-west-99' }, // no bearer candidate — reuses the saved one
+        );
+
+        expect(res.exercisedCredential).toBe(false);
+        expect(res.models.length).toBeGreaterThan(0);
     });
 
     // Regression: awsBearerToken/awsRegion are Bedrock-specific fields, but the

--- a/libs/organization/application/use-cases/organizationParameters/get-models-by-provider.use-case.ts
+++ b/libs/organization/application/use-cases/organizationParameters/get-models-by-provider.use-case.ts
@@ -90,13 +90,19 @@ export class GetModelsByProviderUseCase {
         const candidateAwsRegion = isBedrockCandidate
             ? candidate?.awsRegion?.trim() || undefined
             : undefined;
-        // Any candidate makes this a "the user is actively trying THIS
-        // credential" request — strict-mode gate for both catch branches below.
-        // Region is included because a bad/unreachable region fails the live
-        // call regardless of how good the credential is — the user needs that
-        // error surfaced, not a silent degrade to the curated placeholder.
+        // A candidate CREDENTIAL makes this a "the user is actively trying
+        // THIS credential" request — strict-mode gate for both catch branches
+        // below. Region is deliberately NOT included: the connect form seeds
+        // `awsRegion` from the saved credential on every edit of an existing
+        // Bedrock config (page.client.tsx), so it rides along on essentially
+        // every request regardless of whether the user typed a new one.
+        // Counting it here would flip the saved-credential (edit form) path to
+        // strict on ANY edit — a lapsed saved bearer token or a transient AWS
+        // hiccup would 400 a user editing an unrelated field (e.g.
+        // temperature) instead of degrading to the curated catalog like every
+        // other saved-credential path does.
         const hasCandidateCredential =
-            !!candidateKey || !!candidateAwsBearerToken || !!candidateAwsRegion;
+            !!candidateKey || !!candidateAwsBearerToken;
 
         const providerModule = REGISTRY.has(provider)
             ? REGISTRY.get(provider)

--- a/libs/organization/application/use-cases/organizationParameters/get-models-by-provider.use-case.ts
+++ b/libs/organization/application/use-cases/organizationParameters/get-models-by-provider.use-case.ts
@@ -57,7 +57,20 @@ export class GetModelsByProviderUseCase {
         // supplied here, the http path is STRICT — a failed live call surfaces the
         // error instead of degrading to the curated placeholder (the user asked
         // for the real list, not a stand-in).
-        candidate?: { apiKey?: string; baseURL?: string },
+        //
+        // awsBearerToken/awsRegion are Bedrock's equivalent of `apiKey` — Bedrock
+        // never authenticates with a plain apiKey (see below), so a just-typed
+        // bearer token needs its own field to reach the live call before save.
+        // awsAccessKeyId/awsSecretAccessKey (IAM/SigV4) are deliberately NOT
+        // candidate fields: SigV4 needs request signing, not a static header, so
+        // an IAM-only connect can't be live-listed pre-save — it degrades to the
+        // curated fallback below, same as it always has.
+        candidate?: {
+            apiKey?: string;
+            baseURL?: string;
+            awsBearerToken?: string;
+            awsRegion?: string;
+        },
     ): Promise<ModelResponse> {
         if (!this.providerService.isProviderSupported(provider)) {
             throw new BadRequestException(`Unsupported provider: ${provider}`);
@@ -66,6 +79,24 @@ export class GetModelsByProviderUseCase {
         const byokProvider = provider as BYOKProvider;
         const candidateKey = candidate?.apiKey?.trim() || undefined;
         const candidateBaseURL = candidate?.baseURL?.trim() || undefined;
+        // Scoped to Bedrock: these fields mean nothing to any other provider's
+        // listing (only bedrock/listing.ts reads awsBearerToken/awsRegion), so a
+        // caller sending them alongside a different `provider` must not affect
+        // that provider's strict/lenient fallback gate below.
+        const isBedrockCandidate = byokProvider === BYOKProvider.AMAZON_BEDROCK;
+        const candidateAwsBearerToken = isBedrockCandidate
+            ? candidate?.awsBearerToken?.trim() || undefined
+            : undefined;
+        const candidateAwsRegion = isBedrockCandidate
+            ? candidate?.awsRegion?.trim() || undefined
+            : undefined;
+        // Any candidate makes this a "the user is actively trying THIS
+        // credential" request — strict-mode gate for both catch branches below.
+        // Region is included because a bad/unreachable region fails the live
+        // call regardless of how good the credential is — the user needs that
+        // error surfaced, not a silent degrade to the curated placeholder.
+        const hasCandidateCredential =
+            !!candidateKey || !!candidateAwsBearerToken || !!candidateAwsRegion;
 
         const providerModule = REGISTRY.has(provider)
             ? REGISTRY.get(provider)
@@ -115,9 +146,10 @@ export class GetModelsByProviderUseCase {
                 : undefined) ??
             listing.defaultBaseURL;
         // Amazon Bedrock authenticates the list call with a bearer token + region
-        // (never an apiKey), resolved from the org's saved credential.
-        const awsBearerToken = creds?.awsBearerToken;
-        const awsRegion = creds?.awsRegion;
+        // (never an apiKey). A just-typed candidate wins over the saved slot, same
+        // precedence as apiKey above, so a fresh connect can list live too.
+        const awsBearerToken = candidateAwsBearerToken ?? creds?.awsBearerToken;
+        const awsRegion = candidateAwsRegion ?? creds?.awsRegion;
 
         // The stand-in when the live call can't run: the http listing's own
         // fallbackModels (e.g. Bedrock's curated profiles), if the listing declares
@@ -184,11 +216,12 @@ export class GetModelsByProviderUseCase {
             };
         } catch (error) {
             // Live fetch failed (bad/expired key, provider down, parse error).
-            // STRICT when the caller supplied a candidate key: the user is trying
-            // that specific key, so surface the failure (→ the UI's "type the
-            // model id" fallback) rather than masking a bad key behind the curated
-            // list. Only the keyless/saved path degrades to the curated catalog.
-            if (!candidateKey) {
+            // STRICT when the caller supplied a candidate credential (apiKey OR,
+            // for Bedrock, a bearer token): the user is trying that specific
+            // credential, so surface the failure (→ the UI's "type the model id"
+            // fallback) rather than masking a bad key behind the curated list.
+            // Only the keyless/saved path degrades to the curated catalog.
+            if (!hasCandidateCredential) {
                 const fb = listingFallback();
                 if (fb) {
                     // Degrading to the curated list is otherwise invisible — the

--- a/libs/organization/application/use-cases/organizationParameters/test-byok-connection.use-case.spec.ts
+++ b/libs/organization/application/use-cases/organizationParameters/test-byok-connection.use-case.spec.ts
@@ -929,12 +929,59 @@ describe('slotFromInput — the persisted slot shape', () => {
             openrouterProviderOrder: ['anthropic', 'google'],
             openrouterAllowFallbacks: false,
             vertexLocation: 'global',
-            awsBearerToken: 'bt',
-            awsAccessKeyId: 'ak',
-            awsSecretAccessKey: 'sk2',
+            awsBearerToken: 'enc(bt)',
+            awsAccessKeyId: 'enc(ak)',
+            awsSecretAccessKey: 'enc(sk2)',
             awsRegion: 'us-east-1',
-            awsSessionToken: 'st',
+            awsSessionToken: 'enc(st)',
         });
+    });
+
+    // Regression: `bedrockModelFromCredentials` unconditionally decrypt()s
+    // every aws* field it receives. Forwarding the form's plaintext value
+    // straight into the slot (as apiKey used to be the only field spared from)
+    // meant `decrypt()` ran on a plaintext AWS credential — split on ':' it
+    // never produces a valid 16-byte IV, so a real Bedrock key blew up with
+    // "Invalid initialization vector" the moment a model was picked and the
+    // probe went through the runtime slot instead of the credential-only
+    // bearer/SigV4 checks.
+    it('encrypts the Bedrock aws* secrets (never hands the builder plaintext)', () => {
+        const s = slot({
+            provider: 'amazon_bedrock',
+            awsBearerToken: 'bearer-secret',
+            awsAccessKeyId: 'AKIA-secret',
+            awsSecretAccessKey: 'shh',
+            awsSessionToken: 'session-secret',
+            awsRegion: 'us-east-1',
+        });
+        expect(s.awsBearerToken).toBe('enc(bearer-secret)');
+        expect(s.awsAccessKeyId).toBe('enc(AKIA-secret)');
+        expect(s.awsSecretAccessKey).toBe('enc(shh)');
+        expect(s.awsSessionToken).toBe('enc(session-secret)');
+        // region is not a secret — passes through verbatim.
+        expect(s.awsRegion).toBe('us-east-1');
+    });
+
+    it('leaves absent Bedrock aws* fields undefined rather than encrypting an empty string', () => {
+        const s = slot({ provider: 'amazon_bedrock' });
+        expect(s.awsBearerToken).toBeUndefined();
+        expect(s.awsAccessKeyId).toBeUndefined();
+        expect(s.awsSecretAccessKey).toBeUndefined();
+        expect(s.awsSessionToken).toBeUndefined();
+    });
+
+    // Regression: gating encryption on `.trim()` truthiness (matching the
+    // downstream decrypt-side truthy check, which is on the RAW value, not its
+    // trim) left a whitespace-only secret unencrypted — `bedrockModelFromCredentials`
+    // still sees it as present (plain truthiness) and decrypts it, reproducing
+    // "Invalid initialization vector" for whitespace input specifically.
+    it('encrypts a whitespace-only Bedrock secret too, not just a value that survives trim()', () => {
+        const s = slot({
+            provider: 'amazon_bedrock',
+            awsBearerToken: '   ',
+        });
+        expect(s.awsBearerToken).toBe('enc(   )');
+        expect(s.awsBearerToken).not.toBe('   ');
     });
 });
 

--- a/libs/organization/application/use-cases/organizationParameters/test-byok-connection.use-case.ts
+++ b/libs/organization/application/use-cases/organizationParameters/test-byok-connection.use-case.ts
@@ -530,15 +530,29 @@ export class TestByokConnectionUseCase {
     }
 
     /**
-     * The form's values as the runtime slot they will become. `apiKey` is
-     * re-encrypted because a slot carries ciphertext by contract (the model build
-     * decrypts it downstream) — the probe must not be the one path that hands the
-     * builder a raw secret and quietly changes that invariant.
+     * The form's values as the runtime slot they will become. Every secret is
+     * re-encrypted because a slot carries ciphertext by contract (the model
+     * build decrypts it downstream) — the probe must not be the one path that
+     * hands the builder a raw secret and quietly changes that invariant.
+     * `apiKey` was the only field this covered; the Bedrock aws* secrets were
+     * forwarded as plaintext, and `bedrockModelFromCredentials` unconditionally
+     * decrypt()s them, so a real Bedrock credential blew up
+     * `createDecipheriv` on a plaintext value with "Invalid initialization
+     * vector" the moment a model was picked and the probe went through the
+     * runtime slot instead of the credential-only bearer/SigV4 checks.
      */
     private slotFromInput(
         input: TestByokInput,
         baseURL?: string,
     ): NormalizedModel {
+        // Encrypts whenever a value is present, even whitespace-only — gating on
+        // `.trim()` truthiness here while `bedrockModelFromCredentials` decrypts
+        // on plain truthiness would leave a whitespace-only secret unencrypted,
+        // reintroducing the exact "Invalid initialization vector" crash this
+        // method exists to prevent.
+        const encryptIfPresent = (v?: string): string | undefined =>
+            v !== undefined ? encrypt(v) : undefined;
+
         return {
             provider: input.provider as BYOKProvider,
             apiKey: encrypt(input.apiKey ?? ''),
@@ -551,11 +565,11 @@ export class TestByokConnectionUseCase {
             openrouterProviderOrder: input.openrouterProviderOrder,
             openrouterAllowFallbacks: input.openrouterAllowFallbacks,
             vertexLocation: input.vertexLocation,
-            awsBearerToken: input.awsBearerToken,
-            awsAccessKeyId: input.awsAccessKeyId,
-            awsSecretAccessKey: input.awsSecretAccessKey,
+            awsBearerToken: encryptIfPresent(input.awsBearerToken),
+            awsAccessKeyId: encryptIfPresent(input.awsAccessKeyId),
+            awsSecretAccessKey: encryptIfPresent(input.awsSecretAccessKey),
             awsRegion: input.awsRegion,
-            awsSessionToken: input.awsSessionToken,
+            awsSessionToken: encryptIfPresent(input.awsSessionToken),
         } as NormalizedModel;
     }
 


### PR DESCRIPTION
Closes #1906

## Summary
- Fixes `Connection failed - Invalid initialization vector` when testing/saving an Amazon Bedrock BYOK model with a model selected. `TestByokConnectionUseCase.slotFromInput()` encrypted `apiKey` before building the runtime slot but forwarded Bedrock's `aws*` credential fields as plaintext; every consumer decrypts those fields unconditionally, so a real credential crashed `createDecipheriv`.
- Fixes a regression (introduced in `d064c37c7`, "live Bedrock listing") where a fresh Bedrock connect's model dropdown was permanently stuck on "Enter your API key to load models", because the live-listing gate only recognized `apiKey` and Bedrock never populates that field.
- Switches Bedrock's live model listing from `ListInferenceProfiles` (Anthropic-only) to `ListFoundationModels`, so non-Anthropic marketplace models (e.g. `moonshotai.kimi-k2.5`) show up in the picker too — filtered to TEXT-output models only, since the broader endpoint also returns embedding/image models that can't serve a review.
- Extra robustness fixes surfaced by review (own pass + Kody): a whitespace-only Bedrock secret was left unencrypted; a candidate `awsRegion` was briefly added to, then removed from, the "user is actively testing this credential" strict gate (the connect form always seeds the saved region on edit, so counting it there flipped every edit of an existing Bedrock config to strict); a stray `outputModalities: []` was being treated as "not TEXT" instead of "unknown".

## Test plan
- [x] `test-byok-connection.use-case.spec.ts` — new tests for encrypting Bedrock aws* secrets (incl. whitespace-only), unaffected other providers
- [x] `get-models-by-provider.use-case.spec.ts` — new tests for candidate bearer token live-listing, strict mode on failure/missing region, cross-provider field isolation, lenient degrade on a region-only candidate against a saved credential
- [x] `models.spec.tsx` — new tests for the Bedrock-specific credential gate, regression guard for apiKey-based providers
- [x] `bedrock/listing.spec.ts` — updated for `ListFoundationModels`, new tests for non-Anthropic models, bare-id reasoning-cap resolution, and the TEXT-modality filter (incl. absent/empty-array permissiveness)
- [x] Full relevant suite green: 130+ suites, 2825+ tests
- [x] Manually reproduced the original bug locally, verified fixed end-to-end (real AWS bearer token, Test & Save succeeded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014MixAEvpmF6Ca3JQpK3MJL