### PR TITLE
fix(web): restore Kody Rules / Custom Prompts rich-text editing

### DIFF
--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -14,3 +14,13 @@ Frontend for the Kodus platform.
 - Rich text editor is **TipTap** — not Slate, not Draft.js
 - Charts use **Victory** and **react-google-charts**
 - No i18n. English only
+
+<!-- BEGIN:nextjs-agent-rules -->
+
+# This is NOT the Next.js you know
+
+This version has breaking changes — APIs, conventions, and file structure may all differ from your training data. Read the relevant guide in `node_modules/next/dist/docs/` (resolved from this file's directory; in monorepos the `next` package may not be visible from the repo root) before writing any code. Heed deprecation notices.
+
+This block is written and re-added by `next dev` — verify at `node_modules/next/dist/server/lib/generate-agent-files.js`. Removing it from a diff only re-creates the uncommitted change; committing it with your work keeps the tree clean.
+
+<!-- END:nextjs-agent-rules -->

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  prosemirror-model: 1.25.11
   flatted: ^3.4.2
   prismjs: ^1.30.0
   lodash: ^4.17.23
@@ -4027,9 +4028,6 @@ packages:
 
   prosemirror-model@1.25.11:
     resolution: {integrity: sha512-QWg9RhnpLlogAmp3p96uEFrE5txQpFynd4vhBAELkwgOCWQs/X0yCzB3/hrHqiPwf91RG5KyWq6553zs9JqIOQ==}
-
-  prosemirror-model@1.25.9:
-    resolution: {integrity: sha512-pRTklkDDMMRopyoAcrr9wV/8g/RYgrLHBuJAb5hlEuYZRdm5yqmPjWId83fpBwPpSFqEdja0H7Dfd7z1X/npcA==}
 
   prosemirror-schema-list@1.5.1:
     resolution: {integrity: sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==}
@@ -8472,7 +8470,7 @@ snapshots:
 
   prosemirror-commands@1.7.1:
     dependencies:
-      prosemirror-model: 1.25.9
+      prosemirror-model: 1.25.11
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
 
@@ -8485,7 +8483,7 @@ snapshots:
   prosemirror-gapcursor@1.4.1:
     dependencies:
       prosemirror-keymap: 1.2.3
-      prosemirror-model: 1.25.9
+      prosemirror-model: 1.25.11
       prosemirror-state: 1.4.4
       prosemirror-view: 1.42.0
 
@@ -8510,37 +8508,33 @@ snapshots:
     dependencies:
       orderedmap: 2.1.1
 
-  prosemirror-model@1.25.9:
-    dependencies:
-      orderedmap: 2.1.1
-
   prosemirror-schema-list@1.5.1:
     dependencies:
-      prosemirror-model: 1.25.9
+      prosemirror-model: 1.25.11
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
 
   prosemirror-state@1.4.4:
     dependencies:
-      prosemirror-model: 1.25.9
+      prosemirror-model: 1.25.11
       prosemirror-transform: 1.12.0
       prosemirror-view: 1.42.0
 
   prosemirror-tables@1.8.5:
     dependencies:
       prosemirror-keymap: 1.2.3
-      prosemirror-model: 1.25.9
+      prosemirror-model: 1.25.11
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
       prosemirror-view: 1.42.0
 
   prosemirror-transform@1.12.0:
     dependencies:
-      prosemirror-model: 1.25.9
+      prosemirror-model: 1.25.11
 
   prosemirror-view@1.42.0:
     dependencies:
-      prosemirror-model: 1.25.9
+      prosemirror-model: 1.25.11
       prosemirror-state: 1.4.4
       prosemirror-transform: 1.12.0
 

--- a/apps/web/pnpm-workspace.yaml
+++ b/apps/web/pnpm-workspace.yaml
@@ -14,6 +14,15 @@ confirmModulesPurge: false
 # Portado dos `resolutions` do yarn (segurança/compat). pnpm ignora
 # `resolutions`; usa `overrides`.
 overrides:
+  # @tiptap/pm@3.29.2 pins prosemirror-model@1.25.11 directly, but the
+  # sibling prosemirror-* packages it also depends on (view/state/transform/
+  # commands/gapcursor/tables/schema-list) resolve their own broader range to
+  # 1.25.9 — two live copies of the same classes (Node/Fragment/Schema) in
+  # the bundle. Cross-copy `instanceof` checks then fail inside ProseMirror,
+  # throwing "Can not convert ... to a Fragment" on every keystroke, so the
+  # transaction is dropped: the cursor moves but nothing is inserted/deleted.
+  # Force one copy for the whole tree.
+  prosemirror-model: 1.25.11
   flatted: ^3.4.2
   prismjs: ^1.30.0
   lodash: ^4.17.23

--- a/apps/web/src/app/(app)/settings/code-review/[repositoryId]/custom-prompts/page.tsx
+++ b/apps/web/src/app/(app)/settings/code-review/[repositoryId]/custom-prompts/page.tsx
@@ -149,10 +149,19 @@ function CustomPromptsContent() {
         [promptFieldConfigs],
     );
     const {
-        isValid: formIsValid,
         isSubmitting: formIsSubmitting,
         defaultValues: formDefaultValues,
+        errors: formErrors,
     } = useFormState({ control: form.control });
+    // `formState.isValid` is unreliable here: react-hook-form only resolves
+    // it once every currently-registered field has completed a native HTML
+    // constraint-validation pass, but these Controller-driven rich-text
+    // fields have no underlying `<input>` for that check to run against. It
+    // gets stuck at its initial `false` — with an empty `errors` object —
+    // forever, so the Save button never enables no matter what the user
+    // types. None of these fields declare validation rules, so "no entries
+    // in errors" is the correct signal.
+    const formIsValid = Object.keys(formErrors).length === 0;
 
     const watchedPromptValues = useWatch({
         control: form.control,

--- a/apps/web/src/core/components/ui/rich-text-editor.tsx
+++ b/apps/web/src/core/components/ui/rich-text-editor.tsx
@@ -6,6 +6,8 @@ import { Editor, EditorContent, useEditor } from "@tiptap/react";
 import StarterKit from "@tiptap/starter-kit";
 import { cn } from "src/core/utils/components";
 
+import { convertTiptapJSONToText } from "src/core/utils/tiptap-json-to-text";
+
 import { CodeBlock } from "./code-block-extension";
 import { MentionTrigger } from "./mention-trigger-extension";
 import { RichTextEditorSearch } from "./rich-text-editor-search";
@@ -51,6 +53,77 @@ function flattenMcpMentionNodes(node: any): any {
     return node;
 }
 
+// Inverse of applyInlineMarksAsMarkdown in tiptap-json-to-text.ts: reads the
+// same **bold** / *italic* / `code` / ~~strike~~ / [text](href) syntax back
+// into marked text nodes so formatting survives the save/reload round-trip
+// for saveFormat="text" fields. One line == one paragraph, so no block-level
+// syntax (headings, lists, quotes) is recognized here.
+const INLINE_MARK_PATTERN =
+    /`([^`]+)`|\*\*([^*]+)\*\*|~~([^~]+)~~|\*([^*]+)\*|\[([^\]]+)\]\(([^)]*)\)/;
+
+function parseInlineMarkdownLine(line: string): any[] {
+    if (!line) return [];
+
+    const nodes: any[] = [];
+    let rest = line;
+
+    while (rest) {
+        const match = rest.match(INLINE_MARK_PATTERN);
+        if (!match) {
+            nodes.push({ type: "text", text: rest });
+            break;
+        }
+
+        const [full, code, bold, strike, italic, linkText, linkHref] = match;
+        if (match.index) {
+            nodes.push({ type: "text", text: rest.slice(0, match.index) });
+        }
+
+        if (code !== undefined) {
+            nodes.push({
+                type: "text",
+                text: code,
+                marks: [{ type: "code" }],
+            });
+        } else if (bold !== undefined) {
+            nodes.push(
+                ...parseInlineMarkdownLine(bold).map((node) => ({
+                    ...node,
+                    marks: [...(node.marks ?? []), { type: "bold" }],
+                })),
+            );
+        } else if (strike !== undefined) {
+            nodes.push(
+                ...parseInlineMarkdownLine(strike).map((node) => ({
+                    ...node,
+                    marks: [...(node.marks ?? []), { type: "strike" }],
+                })),
+            );
+        } else if (italic !== undefined) {
+            nodes.push(
+                ...parseInlineMarkdownLine(italic).map((node) => ({
+                    ...node,
+                    marks: [...(node.marks ?? []), { type: "italic" }],
+                })),
+            );
+        } else if (linkText !== undefined) {
+            nodes.push(
+                ...parseInlineMarkdownLine(linkText).map((node) => ({
+                    ...node,
+                    marks: [
+                        ...(node.marks ?? []),
+                        { type: "link", attrs: { href: linkHref || "" } },
+                    ],
+                })),
+            );
+        }
+
+        rest = rest.slice(match.index! + full.length);
+    }
+
+    return nodes;
+}
+
 function parseValueToTiptapContent(
     value: string | object,
     _enableMentions: boolean,
@@ -66,37 +139,79 @@ function parseValueToTiptapContent(
 
     const text = typeof value === "string" ? value : "";
 
-    return {
-        type: "doc",
-        content: [
-            {
-                type: "paragraph",
-                content: [{ type: "text", text: text || "" }],
-            },
-        ],
-    };
+    return { type: "doc", content: parseBlocksFromLines(text.split("\n")) };
 }
 
-function serializeTiptapContent(editor: any, enableMentions: boolean): string {
-    if (!enableMentions) {
-        return editor.state.doc.textContent || "";
+const HEADING_PATTERN = /^(#{1,3})\s+(.*)$/;
+const BULLET_ITEM_PATTERN = /^-\s+(.*)$/;
+const ORDERED_ITEM_PATTERN = /^(\d+)\.\s+(.*)$/;
+
+function toParagraph(line: string) {
+    const content = parseInlineMarkdownLine(line);
+    return { type: "paragraph", ...(content.length ? { content } : {}) };
+}
+
+function toListItem(line: string) {
+    return { type: "listItem", content: [toParagraph(line)] };
+}
+
+// Groups plain lines back into heading / bulletList / orderedList blocks
+// using the same markdown-ish syntax convertTiptapJSONToText serializes to
+// (`# `, `- `, `1. `). Consecutive list-marker lines become one list with
+// multiple items; anything else is a plain paragraph, as before.
+function parseBlocksFromLines(lines: string[]): any[] {
+    const blocks: any[] = [];
+    let i = 0;
+
+    while (i < lines.length) {
+        const headingMatch = lines[i].match(HEADING_PATTERN);
+        if (headingMatch) {
+            const [, hashes, rest] = headingMatch;
+            const content = parseInlineMarkdownLine(rest);
+            blocks.push({
+                type: "heading",
+                attrs: { level: hashes.length },
+                ...(content.length ? { content } : {}),
+            });
+            i++;
+            continue;
+        }
+
+        if (BULLET_ITEM_PATTERN.test(lines[i])) {
+            const items: any[] = [];
+            while (i < lines.length) {
+                const match = lines[i].match(BULLET_ITEM_PATTERN);
+                if (!match) break;
+                items.push(toListItem(match[1]));
+                i++;
+            }
+            blocks.push({ type: "bulletList", content: items });
+            continue;
+        }
+
+        const orderedMatch = lines[i].match(ORDERED_ITEM_PATTERN);
+        if (orderedMatch) {
+            const start = parseInt(orderedMatch[1], 10);
+            const items: any[] = [];
+            while (i < lines.length) {
+                const match = lines[i].match(ORDERED_ITEM_PATTERN);
+                if (!match) break;
+                items.push(toListItem(match[2]));
+                i++;
+            }
+            blocks.push({ type: "orderedList", attrs: { start }, content: items });
+            continue;
+        }
+
+        blocks.push(toParagraph(lines[i]));
+        i++;
     }
 
-    const { state } = editor;
-    const { doc } = state;
-    let text = "";
+    return blocks;
+}
 
-    doc.descendants((node: any, pos: number) => {
-        if (node.type.name === "mcpMention") {
-            text += `@mcp<${node.attrs.app}|${node.attrs.tool}>`;
-            return false;
-        } else if (node.isText) {
-            text += node.text || "";
-        }
-        return true;
-    });
-
-    return text;
+function serializeTiptapContent(editor: any, _enableMentions: boolean): string {
+    return convertTiptapJSONToText(editor.getJSON());
 }
 
 export function getTextLengthFromTiptapJSON(json: any): number {

--- a/apps/web/src/core/utils/tiptap-json-to-text.ts
+++ b/apps/web/src/core/utils/tiptap-json-to-text.ts
@@ -28,6 +28,33 @@
  * // Output: "Hello @mcp<kodus|kodus_list_commits> world"
  * convertTiptapJSONToText(tiptapJson);
  */
+// Same markdown syntax convertTiptapJSONToMarkdown uses for these marks, so
+// the plain-text ("saveFormat=text") round-trip and the markdown export stay
+// consistent. Applied innermost-first (marks reversed) to nest correctly,
+// e.g. bold+italic -> **_text_**.
+function applyInlineMarksAsMarkdown(text: string, marks?: any[]): string {
+    if (!marks?.length) return text;
+
+    return [...marks].reverse().reduce((acc, mark) => {
+        switch (mark.type) {
+            case "bold":
+                return `**${acc}**`;
+            case "italic":
+                return `*${acc}*`;
+            case "code":
+                return `\`${acc}\``;
+            case "strike":
+                return `~~${acc}~~`;
+            case "link": {
+                const href = mark.attrs?.href || "";
+                return `[${acc}](${href})`;
+            }
+            default:
+                return acc;
+        }
+    }, text);
+}
+
 export function convertTiptapJSONToText(
     content: string | object | null | undefined,
 ): string {
@@ -54,24 +81,81 @@ export function convertTiptapJSONToText(
         try {
             let text = "";
 
-            function traverse(node: any): void {
+            function traverse(node: any, listMarker?: string): void {
                 if (!node || typeof node !== "object") return;
 
                 if (node.type === "text") {
-                    text += node.text || "";
-                } else if (node.type === "mcpMention") {
+                    text += applyInlineMarksAsMarkdown(
+                        node.text || "",
+                        node.marks,
+                    );
+                    return;
+                }
+                if (node.type === "mcpMention") {
                     // Convert mention node to token format
                     const app = node.attrs?.app || "";
                     const tool = node.attrs?.tool || "";
                     text += `@mcp<${app}|${tool}>`;
-                } else if (node.content && Array.isArray(node.content)) {
+                    return;
+                }
+                if (node.type === "hardBreak") {
+                    text += "\n";
+                    return;
+                }
+                if (node.type === "heading") {
+                    const level = Math.min(
+                        Math.max(node.attrs?.level || 1, 1),
+                        6,
+                    );
+                    text += "#".repeat(level) + " ";
+                    (node.content ?? []).forEach((c: any) => traverse(c));
+                    text += "\n";
+                    return;
+                }
+                if (node.type === "bulletList") {
+                    (node.content ?? []).forEach((item: any) =>
+                        traverse(item, "- "),
+                    );
+                    return;
+                }
+                if (node.type === "orderedList") {
+                    let index = node.attrs?.start || 1;
+                    (node.content ?? []).forEach((item: any) => {
+                        traverse(item, `${index}. `);
+                        index++;
+                    });
+                    return;
+                }
+                if (node.type === "listItem") {
+                    text += listMarker ?? "- ";
+                    // A list item's content is one or more paragraphs — flatten
+                    // the first one inline instead of letting the generic
+                    // paragraph handler insert its own line break before the
+                    // list marker is even on the line.
+                    (node.content ?? []).forEach((c: any) => {
+                        if (c.type === "paragraph") {
+                            (c.content ?? []).forEach((inline: any) =>
+                                traverse(inline),
+                            );
+                        } else {
+                            traverse(c);
+                        }
+                    });
+                    text += "\n";
+                    return;
+                }
+                if (node.content && Array.isArray(node.content)) {
                     // Recursively traverse child nodes
-                    node.content.forEach(traverse);
+                    node.content.forEach((c: any) => traverse(c));
+                }
+                if (node.type === "paragraph") {
+                    // Block boundary: separate this paragraph from the next
+                    text += "\n";
                 }
             }
 
             traverse(content);
-            return text;
+            return text.replace(/\n$/, "");
         } catch {
             return "";
         }

--- a/libs/code-review/application/use-cases/configuration/__tests__/update-or-create-code-review-parameter-use-case.spec.ts
+++ b/libs/code-review/application/use-cases/configuration/__tests__/update-or-create-code-review-parameter-use-case.spec.ts
@@ -95,6 +95,79 @@ describe('UpdateOrCreateCodeReviewParameterUseCase', () => {
         );
     });
 
+    it('creates global config when the org has no repositories connected (integration config returns null)', async () => {
+        const createOrUpdateParametersUseCase = {
+            execute: jest.fn().mockResolvedValue(true),
+        };
+
+        const useCase = new UpdateOrCreateCodeReviewParameterUseCase(
+            {
+                findByKey: jest.fn().mockResolvedValue(null),
+            } as any,
+            createOrUpdateParametersUseCase as any,
+            {
+                findIntegrationConfigFormatted: jest
+                    .fn()
+                    .mockResolvedValue(null),
+            } as any,
+            {
+                emit: jest.fn(),
+            } as any,
+            {
+                ensure: jest.fn(),
+            } as any,
+            {
+                detectAndSaveReferences: jest.fn(),
+            } as any,
+            {
+                buildConfigKey: jest.fn().mockReturnValue('config-key'),
+            } as any,
+            buildCentralizedConfigPrServiceMock() as any,
+            { find: jest.fn().mockResolvedValue([]) } as any,
+            {
+                getBYOKConfig: jest.fn(),
+                getSubscriptionStatus: jest.fn(),
+            } as any,
+            { execute: jest.fn().mockResolvedValue(undefined) } as any,
+            {
+                validateOrganizationLicense: jest.fn().mockResolvedValue({
+                    valid: true,
+                    subscriptionStatus: 'active',
+                    planType: 'teams_byok',
+                }),
+            } as any,
+        );
+
+        await useCase.execute({
+            actor: {
+                source: 'web',
+                organizationId: 'org-1',
+                userId: 'kody',
+                userEmail: 'kody@kodus.io',
+            },
+            configValue: {},
+            organizationAndTeamData: {
+                organizationId: 'org-1',
+                teamId: 'team-1',
+            },
+            skipAuthorization: true,
+        } as any);
+
+        expect(createOrUpdateParametersUseCase.execute).toHaveBeenCalledWith(
+            'code_review_config',
+            expect.objectContaining({
+                id: 'global',
+                name: 'Global',
+                isSelected: true,
+                repositories: [],
+            }),
+            {
+                organizationId: 'org-1',
+                teamId: 'team-1',
+            },
+        );
+    });
+
     it('creates repository settings without request.user when invoked by CLI', async () => {
         const createOrUpdateParametersUseCase = {
             execute: jest.fn().mockResolvedValue(true),

--- a/libs/code-review/application/use-cases/configuration/update-or-create-code-review-parameter-use-case.ts
+++ b/libs/code-review/application/use-cases/configuration/update-or-create-code-review-parameter-use-case.ts
@@ -556,8 +556,10 @@ export class UpdateOrCreateCodeReviewParameterUseCase {
         >(IntegrationConfigKey.REPOSITORIES, organizationAndTeamData);
     }
 
-    private filterRepositoryInfo(codeRepositories: ICodeRepository[]) {
-        return codeRepositories.map((repository) => ({
+    private filterRepositoryInfo(
+        codeRepositories: ICodeRepository[] | null | undefined,
+    ) {
+        return (codeRepositories ?? []).map((repository) => ({
             id: repository.id,
             name: repository.name,
             isSelected: false,


### PR DESCRIPTION
## Summary
- Fixed the reported bug where the Kody Rules / Custom Prompts rich-text editor lost keystrokes ("cursor moves, backspace/typing do nothing"): two incompatible copies of `prosemirror-model` (1.25.9 and 1.25.11) were loaded at once because `@tiptap/pm` pins the latter directly while its own sibling `prosemirror-*` packages resolve the former via a broader range. Pinned a single version via a `pnpm` override.
- Reworked the plain-text `saveFormat="text"` round-trip (Kody Rules Instructions field) so line breaks, **bold**/*italic*/`code`/~~strike~~/[link](url) marks, and heading/bullet-list/ordered-list blocks all survive save + reload instead of collapsing to one flat line.
- Fixed Custom Prompts' Save button never enabling: react-hook-form's `isValid` never resolves for these Controller-driven rich-text fields (no native `<input>` behind them), so derive validity from `errors` directly instead.
- Fixed a 500 when saving code review settings for an org with no repositories connected: `filterRepositoryInfo` called `.map()` on a `null` repositories list. Guarded with `?? []` and added a regression test for the null case.

## Test plan
- [x] Typecheck clean on all touched frontend files
- [x] Headless round-trip test against the real Tiptap/ProseMirror schema (line breaks, all 5 inline marks, H1-H3, bullet list, ordered list, mixed content)
- [x] Live browser verification (real login, real API): create/save/reopen a Kody Rule with line breaks, bold+italic, and confirm identical content before/after reload
- [x] Backend unit test suite (`update-or-create-code-review-parameter-use-case.spec.ts`): 19/19 passing, including the new null-repositories regression test
- [ ] Manual smoke test on staging/prod-like env by reviewer

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01MdAbFR1df39NjxLT78QikG

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches TipTap/ProseMirror dependency resolution and text round-trip logic used by prompt/rule fields, plus a null-guard on code review config creation; backend change is narrow but affects settings persistence for edge-case orgs.
> 
> **Overview**
> Restores **Kody Rules / Custom Prompts** rich-text editing by pinning a single **`prosemirror-model@1.25.11`** via pnpm overrides so ProseMirror no longer loads duplicate model copies (which dropped keystrokes with “Can not convert … to a Fragment”).
> 
> For **`saveFormat="text"`** fields, serialization now goes through **`convertTiptapJSONToText`**, with inverse parsing in the rich-text editor so line breaks, inline marks (**bold**, *italic*, `code`, ~~strike~~, links), and headings/lists survive save/reload instead of flattening to one line.
> 
> On **Custom Prompts**, Save enablement no longer relies on react-hook-form **`isValid`** (stuck false for Controller-driven TipTap fields); validity is **`Object.keys(errors).length === 0`**.
> 
> Backend: **`filterRepositoryInfo`** treats a **null** integration repository list as **`[]`**, fixing 500s when saving code review settings for orgs with no connected repos (regression test added).
> 
> Also commits the **`next dev`**–generated Next.js agent-rules block in **`AGENTS.md`** to keep the tree clean.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e022a8bbc9adafac6be43869ef7d0b7171d2954. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->