### PR TITLE
fix(platform): stop leaking the NO_TASK_MCP sentinel into PR comments

### DIFF
--- a/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.spec.ts
+++ b/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.spec.ts
@@ -16,6 +16,10 @@ describe('ChatWithKodyFromGitUseCase', () => {
         addReactionToComment: jest.Mock;
         getPullRequestReviewComment: jest.Mock;
         createResponseToComment: jest.Mock;
+        createIssueComment: jest.Mock;
+        updateIssueComment: jest.Mock;
+        updateResponseToComment: jest.Mock;
+        removeReactionsFromComment: jest.Mock;
         getCloneParams: jest.Mock;
     };
     let conversationAgentUseCase: {
@@ -48,6 +52,10 @@ describe('ChatWithKodyFromGitUseCase', () => {
             addReactionToComment: jest.fn().mockResolvedValue(undefined),
             getPullRequestReviewComment: jest.fn().mockResolvedValue([]),
             createResponseToComment: jest.fn().mockResolvedValue({ id: 999 }),
+            createIssueComment: jest.fn().mockResolvedValue({ id: 998 }),
+            updateIssueComment: jest.fn().mockResolvedValue(undefined),
+            updateResponseToComment: jest.fn().mockResolvedValue(undefined),
+            removeReactionsFromComment: jest.fn().mockResolvedValue(undefined),
             getCloneParams: jest.fn().mockResolvedValue(undefined),
         };
         conversationAgentUseCase = {
@@ -205,6 +213,55 @@ describe('ChatWithKodyFromGitUseCase', () => {
                     }),
                 }),
             }),
+        );
+    });
+
+    // Regression: __NO_TASK_MCP__ is an internal marker the agent returns
+    // when no task-management MCP is connected — it must NEVER reach a PR
+    // comment verbatim. The pipeline path already guards it; this is the
+    // explicit @kody -v business-logic command path, which had no guard.
+    // Exercises the private handler directly — the full webhook dispatch
+    // (ack/reaction/posting branching) is covered by the other tests in this
+    // file; this one isolates the translation itself.
+    it('translates the NO_TASK_MCP sentinel into a readable message instead of returning it raw', async () => {
+        businessRulesValidationAgentUseCase.execute.mockResolvedValueOnce(
+            '__NO_TASK_MCP__',
+        );
+
+        const response = await (useCase as any).handleBusinessLogicValidation(
+            {
+                prepareContext: { userQuestion: '@kody -v business-logic' },
+                organizationAndTeamData: {
+                    organizationId: 'org-1',
+                    teamId: 'team-1',
+                },
+                thread: undefined,
+            },
+        );
+
+        expect(response).not.toBe('__NO_TASK_MCP__');
+        expect(response).not.toContain('__NO_TASK_MCP__');
+        expect(response).toMatch(/no task-management mcp/i);
+    });
+
+    it('passes through a real business-logic result unchanged', async () => {
+        businessRulesValidationAgentUseCase.execute.mockResolvedValueOnce(
+            '## Business Rules Validation\n\nStatus: Issues Found',
+        );
+
+        const response = await (useCase as any).handleBusinessLogicValidation(
+            {
+                prepareContext: { userQuestion: '@kody -v business-logic' },
+                organizationAndTeamData: {
+                    organizationId: 'org-1',
+                    teamId: 'team-1',
+                },
+                thread: undefined,
+            },
+        );
+
+        expect(response).toBe(
+            '## Business Rules Validation\n\nStatus: Issues Found',
         );
     });
 

--- a/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
+++ b/libs/platform/application/use-cases/codeManagement/chatWithKodyFromGit.use-case.ts
@@ -3,6 +3,7 @@ import { createLogger } from '@libs/core/log/logger';
 import { Inject, Injectable, Optional } from '@nestjs/common';
 
 import { BusinessRulesValidationAgentUseCase } from '@libs/agents/application/use-cases/business-rules-validation-agent.use-case';
+import { BusinessRulesValidationAgentProvider } from '@libs/agents/infrastructure/services/agents/business-rules-validation/businessRulesValidationAgent';
 import { ConversationAgentUseCase } from '@libs/agents/application/use-cases/conversation-agent.use-case';
 import { PlatformType } from '@libs/core/domain/enums/platform-type.enum';
 import { OrganizationAndTeamData } from '@libs/core/infrastructure/config/types/general/organizationAndTeamData';
@@ -45,6 +46,18 @@ const ACKNOWLEDGMENT_MESSAGES = {
     MARKDOWN_SUFFIX: '<!-- kody-codereview -->\n&#8203;',
     BUSINESS_LOGIC_INVALID_CONTEXT:
         'The "@kody -v business-logic" command can only be used in the general PR conversation, not in code suggestions or inline comments. Please use it in the main PR discussion thread.',
+    // The agent returns NO_TASK_MCP_SENTINEL (an internal marker, never meant
+    // to reach a user) when no task-management MCP is connected. The
+    // AUTOMATIC pipeline path (BusinessLogicValidationStage) already checks
+    // for it and skips silently — this EXPLICIT command path has no silent
+    // option (an explicit ask deserves a visible reply, same reasoning as
+    // CONVERSATION_PLAN_GATE_MESSAGE below), so it must translate the
+    // sentinel into this message instead of ever posting it raw.
+    BUSINESS_LOGIC_NO_TASK_MCP:
+        'No task-management MCP (Jira, GitHub Issues, Linear, Notion, ' +
+        'ClickUp, etc.) is connected for this organization, so business ' +
+        'rules validation has nothing to compare the PR against. Connect ' +
+        'one in the Kodus settings to use this command.',
 } as const;
 
 /**
@@ -2097,7 +2110,20 @@ export class ChatWithKodyFromGitUseCase {
         organizationAndTeamData: OrganizationAndTeamData;
         thread: any;
     }): Promise<string> {
-        return await this.businessRulesValidationAgentUseCase.execute(context);
+        const result =
+            await this.businessRulesValidationAgentUseCase.execute(context);
+
+        // NO_TASK_MCP_SENTINEL is an internal marker, never meant to reach a
+        // PR comment — the pipeline path guards it, this explicit-command
+        // path did not (#leak: it was reaching users verbatim as literal
+        // "__NO_TASK_MCP__" text). Translate it into a readable message.
+        if (
+            result === BusinessRulesValidationAgentProvider.NO_TASK_MCP_SENTINEL
+        ) {
+            return ACKNOWLEDGMENT_MESSAGES.BUSINESS_LOGIC_NO_TASK_MCP;
+        }
+
+        return result;
     }
 
     private async handleConversation(context: {

--- a/libs/platform/application/use-cases/codeManagement/trigger-business-validation.use-case.ts
+++ b/libs/platform/application/use-cases/codeManagement/trigger-business-validation.use-case.ts
@@ -123,14 +123,29 @@ export class TriggerBusinessValidationUseCase implements IUseCase {
             executionContext,
         });
 
-        const result = await this.businessRulesValidationAgentProvider.execute({
-            organizationAndTeamData,
-            thread: this.createThread({
+        const agentResult =
+            await this.businessRulesValidationAgentProvider.execute({
                 organizationAndTeamData,
-                context: executionContext,
-            }),
-            prepareContext,
-        });
+                thread: this.createThread({
+                    organizationAndTeamData,
+                    context: executionContext,
+                }),
+                prepareContext,
+            });
+
+        // NO_TASK_MCP_SENTINEL is an internal marker (never meant to reach a
+        // user) that the pipeline path silently swallows. This CLI-triggered
+        // path returns `result` straight through the API response to the
+        // `kodus` CLI's stdout, so leaving it unguarded here surfaces the raw
+        // "__NO_TASK_MCP__" string to whoever ran the command.
+        const result =
+            agentResult ===
+            BusinessRulesValidationAgentProvider.NO_TASK_MCP_SENTINEL
+                ? 'No task-management MCP (Jira, GitHub Issues, Linear, Notion, ' +
+                  'ClickUp, etc.) is connected for this organization, so ' +
+                  'business rules validation has nothing to compare the PR ' +
+                  'against. Connect one in the Kodus settings to use this command.'
+                : agentResult;
 
         if (executionContext.mode === 'pull_request') {
             return {


### PR DESCRIPTION
## Problem

Found live in QA while testing #1770's fix — a `__NO_TASK_MCP__` comment appeared raw on a real GitHub PR after running `@kody -v business-logic`:
https://github.com/Wellington01/xfile-review-fixtures/pull/186#issuecomment-5638927922

`BusinessRulesValidationAgentProvider.NO_TASK_MCP_SENTINEL` (`'__NO_TASK_MCP__'`) is an internal marker the agent returns when no task-management MCP is connected, meant to let a caller skip silently. `BusinessLogicValidationStage` (the automatic pipeline path, runs on PR open) already checks for it and skips with no comment.

Two OTHER callers of the same agent never checked for it:
1. `chatWithKodyFromGit.use-case.ts` → `handleBusinessLogicValidation` (the `@kody -v business-logic` command) — posts the agent's raw return value directly as the PR comment body.
2. `trigger-business-validation.use-case.ts` (the `kodus pr business-validation` CLI path) — returns the raw value straight through the API response to CLI stdout.

## Fix

Both paths now check for the sentinel and translate it into a readable message ("No task-management MCP ... is connected ... Connect one in the Kodus settings") instead of ever surfacing the raw internal string. Silence isn't right for either path (unlike the automatic pipeline) — both are explicit asks, so a visible reply is correct, just not the internal marker.

## Verification
- `npx tsc --noEmit -p tsconfig.json` — no new errors on either touched file.
- `chatWithKodyFromGit.use-case.spec.ts` — 15/15 green, including 2 new regression tests (sentinel translated / real result passes through unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C2MsZiTKDrpX2umMUMpRea