### PR TITLE
fix(credits): sign a DELETE body instead of zeroing it

### DIFF
--- a/apps/web/src/features/ee/subscription/_services/billing/signature.ts
+++ b/apps/web/src/features/ee/subscription/_services/billing/signature.ts
@@ -93,7 +93,8 @@ export const billingSignatureHeader = (
     }
     const upper = method.toUpperCase();
     const timestamp = String(now);
-    const body = upper === "GET" || upper === "DELETE" ? "" : rawBody;
+    // Every method signs the bytes it sends; no body signs the empty string.
+    const body = rawBody;
     return {
         [SIGNATURE_HEADER]: createHmac("sha256", secret)
             .update(billingSignaturePayload(upper, path, timestamp, body))

--- a/libs/common/utils/billing-signature.spec.ts
+++ b/libs/common/utils/billing-signature.spec.ts
@@ -42,6 +42,26 @@ export const GOLDEN_VECTORS = [
         signature:
             '03692a4564a44ae550d2ed76e831bf783961fe94be767f3059a1293ac30c84f6',
     },
+    {
+        name: 'a query value carrying a literal "?" (split once, never twice)',
+        method: 'GET',
+        path: '/api/billing/credits/balance',
+        query: 'organizationId=o&returnTo=/byok?credits=success',
+        timestamp: '1789000000000',
+        rawBody: '',
+        signature:
+            'ca7fe2915861fc07dc4d947651841b2e4bcdd07f97ef4dafcca680a1739ca707',
+    },
+    {
+        name: 'a DELETE that carries a body (no longer signed as empty)',
+        method: 'DELETE',
+        path: '/api/billing/credits/payment-method',
+        query: 'organizationId=o',
+        timestamp: '1789000000000',
+        rawBody: JSON.stringify({ organizationId: 'o' }),
+        signature:
+            '9b9b420b6b6a7f29b6ee7fb1569f1f1e29f1376080b0faa85a0c856d1688d5e6',
+    },
 ] as const;
 
 describe('billing signature', () => {
@@ -93,27 +113,25 @@ describe('billing signature', () => {
         expect(mine).not.toBe(theirs);
     });
 
-    it('signs GET/DELETE over an empty body even if one is passed', () => {
-        for (const method of ['GET', 'DELETE']) {
-            expect(
-                billingSignatureHeaders({
-                    secret: GOLDEN_SECRET,
-                    method,
-                    path: '/api/billing/credits/payment-method',
-                    query: 'organizationId=o',
-                    rawBody: '{"ignored":true}',
-                    now: 1,
-                }),
-            ).toEqual(
-                billingSignatureHeaders({
-                    secret: GOLDEN_SECRET,
-                    method,
-                    path: '/api/billing/credits/payment-method',
-                    query: 'organizationId=o',
-                    now: 1,
-                }),
-            );
-        }
+    it('signs a DELETE body instead of zeroing it', () => {
+        const withBody = billingSignatureHeaders({
+            secret: GOLDEN_SECRET,
+            method: 'DELETE',
+            path: '/api/billing/credits/payment-method',
+            query: 'organizationId=o',
+            rawBody: '{"organizationId":"o"}',
+            now: 1,
+        });
+        const withoutBody = billingSignatureHeaders({
+            secret: GOLDEN_SECRET,
+            method: 'DELETE',
+            path: '/api/billing/credits/payment-method',
+            query: 'organizationId=o',
+            now: 1,
+        });
+        expect(withBody[BILLING_SIGNATURE_HEADER]).not.toBe(
+            withoutBody[BILLING_SIGNATURE_HEADER],
+        );
     });
 
     it('returns no headers with no secret (billing then fails closed)', () => {

--- a/libs/common/utils/billing-signature.ts
+++ b/libs/common/utils/billing-signature.ts
@@ -19,7 +19,8 @@ import { createHmac } from 'crypto';
  *     leave it out and one leaked signature reads or mutates ANY org;
  *   · the timestamp, checked by billing against a 5-minute window, so a
  *     signature that leaks stops working instead of being valid forever;
- *   · the exact body bytes that go on the wire.
+ *   · the exact body bytes that go on the wire, whatever the method (no body
+ *     signs the empty string).
  *
  * The counterpart is `src/config/utils/serviceToken.ts` in
  * kodus-service-billing. The web has its own copy of this for its server-side
@@ -94,9 +95,10 @@ export function billingSignatureHeaders(args: {
     if (!args.secret) return {};
     const method = args.method.toUpperCase();
     const timestamp = String(args.now ?? Date.now());
-    // GET/DELETE send no body, so both sides sign an empty one.
-    const rawBody =
-        method === 'GET' || method === 'DELETE' ? '' : (args.rawBody ?? '');
+    // Whatever bytes go on the wire, for EVERY method. A request with no body
+    // signs the empty string; a DELETE that DOES carry one has it covered,
+    // which the old GET/DELETE special case silently skipped.
+    const rawBody = args.rawBody ?? '';
     const signature = createHmac('sha256', args.secret)
         .update(
             billingSignaturePayload({

--- a/tests/e2e/lib/kodus-credits.ts
+++ b/tests/e2e/lib/kodus-credits.ts
@@ -38,8 +38,11 @@ export function serviceToken(
     // No body on the wire means an empty signed body — billing verifies the
     // bytes it received, and `{}` is not the same as nothing. A body IS signed
     // on any method, DELETE included.
+    // `null` too, not just `undefined`: the http helper skips a null body, so
+    // signing `JSON.stringify(null)` would cover "null" while the wire carries
+    // nothing — a 401 from the byte verifier.
     const raw =
-        body === undefined
+        body === undefined || body === null
             ? ''
             : typeof body === 'string'
               ? body

--- a/tests/e2e/lib/kodus-credits.ts
+++ b/tests/e2e/lib/kodus-credits.ts
@@ -36,9 +36,10 @@ export function serviceToken(
     const query = new URLSearchParams(parsed.search);
     query.sort();
     // No body on the wire means an empty signed body — billing verifies the
-    // bytes it received, and `{}` is not the same as nothing.
+    // bytes it received, and `{}` is not the same as nothing. A body IS signed
+    // on any method, DELETE included.
     const raw =
-        upper === 'GET' || upper === 'DELETE' || body === undefined
+        body === undefined
             ? ''
             : typeof body === 'string'
               ? body

--- a/tests/e2e/playwright/kodus-credits-auto-topup-ui.mjs
+++ b/tests/e2e/playwright/kodus-credits-auto-topup-ui.mjs
@@ -47,7 +47,7 @@ const svc = (method, url, body) => {
     const parsed = new URL(url, 'http://placeholder');
     const query = new URLSearchParams(parsed.search);
     query.sort();
-    const raw = upper === 'GET' || upper === 'DELETE' ? '' : (body ?? '');
+    const raw = body ?? '';
     const timestamp = String(Date.now());
     return {
         'x-kodus-signature': createHmac('sha256', SERVICE_SECRET)

--- a/tests/e2e/playwright/kodus-credits-checkout.mjs
+++ b/tests/e2e/playwright/kodus-credits-checkout.mjs
@@ -63,7 +63,7 @@ const svc = (method, url, body) => {
     const parsed = new URL(url, 'http://placeholder');
     const query = new URLSearchParams(parsed.search);
     query.sort();
-    const raw = upper === 'GET' || upper === 'DELETE' ? '' : (body ?? '');
+    const raw = body ?? '';
     const timestamp = String(Date.now());
     return {
         'x-kodus-signature': createHmac('sha256', SERVICE_SECRET)


### PR DESCRIPTION
Follow-up to #1892, which merged while this commit was still in flight.

Billing used to drop the body when verifying a `GET` or `DELETE` on its
`/credits/*` routes, so a DELETE payload sat **outside** the signature: a
captured signature would validate a DELETE whose body had been swapped, and a
caller that followed the documented rule and signed its DELETE body got a bare
401. Kody found it on kodustech/kodus-service-billing#51, where the verifier is
fixed to check the bytes that arrived, for every method.

This is the caller half. The shared signer, the web's copy and both harness
signers now sign the body they send whatever the verb, instead of zeroing it
for `GET`/`DELETE`.

**No behaviour changes today**: no credit call sends a body on those verbs, so
both sides were already computing an empty body — the hole was only reachable
by a future DELETE-with-payload. The two halves are therefore independent and
can ship in either order.

Two golden vectors join the table, duplicated verbatim in the billing repo's
`serviceToken.spec.ts`: a DELETE carrying a body, and a query value with a
literal `?`. Nine request shapes now pin the web's copy of the payload builder
to the backend one.

Tests: 47 green across `billing-signature`, `signature.parity` and
`billing/utils.spec`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TTpFHBnPmwD7xNN3XcFM7P
